### PR TITLE
Add cc, crypto currencies vocab

### DIFF
--- a/cc/.htaccess
+++ b/cc/.htaccess
@@ -1,0 +1,3 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ https://cc.rww.io/vocab [R=302,L]


### PR DESCRIPTION
Adding a template for a crypto currency vocab.

Use Case

As a publisher Alice would like to link her web page content (or app) to a bitcoin address, so that donations can be received by those that have enjoyed her work.

Model

It's only a slight overhead to model all crypto currencies so perhaps the model should be something like

URI -> crypto-currency-address -> bitcoin-address

Implementation

Use w3id.org as a switchboard, then host a locked down ontology on, say, bitcoin.rww.io

Examples

In a web page:

<meta rel="https://w3id.org/cc#bitcoin-address" href="bitcoin:1234...." />

In an html5 app:

<a rel="https://w3id.org/cc#bitcoin-address" href="bitcoin:1234...."></a>

Note: for extra granularity you can add about="#app"

For litecoins

<a rel="https://w3id.org/cc#litecoin-address" href="...."></a>
