### PR TITLE
Add /rdw/ redirection

### DIFF
--- a/rdw/.htaccess
+++ b/rdw/.htaccess
@@ -1,4 +1,4 @@
 Options +FollowSymLinks
 RewriteEngine on
 RewriteRule ^$ http://www.rdw.nl/ [R=302,L]
-RewriteRule ^vehicles$ https://gist.githubusercontent.com/jaw111/9729470/raw/ac76126fa91c46b1169bda3aa3dbdef56f7973a4/gistfile1.json [R=302,L]
+RewriteRule ^vehicles$ https://gist.githubusercontent.com/jaw111/9729470/raw/gistfile1.json [R=302,L]


### PR DESCRIPTION
Added redirects for:
- `/rdw/` to http://www.rdw.nl/
- `/rdw/vehicles` to RDW Vehicles vocabulary in JSON-LD (currently a gist) https://gist.githubusercontent.com/jaw111/9729470/raw/gistfile1.json
