### PR TITLE
Check README/.htaccess using travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: bash
+
+before_install:  
+  - sudo apt-get -qq update
+
+install:
+  - sudo apt-get -qq install linkchecker apache2
+
+before_script:
+  - sudo sed -i '/<\/VirtualHost/ i\ <Directory /var/www/>\n  AllowOverride All\n </Directory>' /etc/apache2/sites-enabled/*
+  - sudo cp -r * /var/www/
+  - sudo a2enmod rewrite
+  - sudo service apache2 restart
+  - mkdir -p ~/.linkchecker
+  - echo -e "[filtering]\nignorewarnings=http-moved-permanent,http-empty-content" > ~/.linkchecker/linkcheckerrc
+  - sudo tail -f /var/log/apache2/error.log >&2 &
+
+script:
+  - cat $(find . -name 'README.md') | 
+    grep https://w3id.org | 
+    sed 's,.*https://w3id.org/,http://localhost/,'  |
+    sed 's,[ )].*,,' > checking-uris.txt ; 
+    echo "About to test locally:" ; cat checking-uris.txt | sed s,http://localhost,https://w3id.org,
+  - cat checking-uris.txt | linkchecker --stdin -r 0
+
+after_script:
+  - sudo cat /var/log/apache2/access.log
+
+after_failure:
+  - sudo cat /var/log/apache2/error.log > &2
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Permanent Identifiers for the Web
 =================================
 
+[![Build Status](https://travis-ci.org/perma-id/w3id.org.svg)](https://travis-ci.org/perma-id/w3id.org)
+
 This repository holds the website source code for https://w3id.org/
 
 The purpose of w3id.org is to provide a secure, permanent URL re-direction
@@ -44,11 +46,16 @@ Adding a Permanent Identifier to w3id.org
 For the technically savvy, the preferred way to create the redirect yourself is
 by following these steps:
 
-1. Fork this source code repository.
-2. Add a new re-direct entry. Look in the '/security/.htaccess' file for a
-   simple example.
-3. Commit your changes and submit a pull request.
-4. w3id.org administrators will review your pull request and merge it if 
+1. Fork the [perma-id/w3id.org](https://github.com/perma-id/w3id.org) 
+   source code repository.
+2. Add a new re-direct entry. For a simple example, see
+   [security/.htaccess](security/.htaccess) 
+3. (Optional) Add a `README.md` detailing contact persons and 
+   (a subset of) your permanent identifiers. For an example, 
+   see [rdw/README.md](rdw/README.md)
+4. Commit your changes and submit a 
+   [pull request](https://github.com/perma-id/w3id.org/pulls).
+5. w3id.org administrators will review your pull request and merge it if 
    everything looks correct. Once the pull request is merged, the changes go
    live immediately.
 
@@ -57,3 +64,21 @@ You can also send a request to add a redirect to the
 mailing list. Make sure to include the URL that you want on w3id.org, the
 URL that you want to redirect to, and the HTTP code that you want to use
 when redirecting. An administrator will then create the redirect for you.
+
+Link checking
+-------------
+A simple [Travis-CI](https://travis-ci.org/perma-id/w3id.org) job 
+(see [.travis.yml](.travis.yml)) will extract all https://w3id.org/ 
+URIs from `*/README.md` and check them with
+[linkchecker](https://wummel.github.io/linkchecker/) - 
+in theory this will catch two kinds of errors: 
+
+1. Following a redirection gives a `404 Not Found` 
+2. An error in `.htaccess` causes a `500 Server Error`.
+
+Note that this only checks URIs that are listed in the `README.md` files.
+
+Travis might comment on your Pull Request if this test reveals an error - 
+check its output logs to ensure the errors are not caused by 
+your modification.
+

--- a/bundle/.htaccess
+++ b/bundle/.htaccess
@@ -1,4 +1,5 @@
 RewriteEngine on
+
 RewriteRule ^$ https://researchobject.github.io/specifications/bundle/ [R=302,L]
 RewriteRule ^draft(.*) https://researchobject.github.io/specifications/bundle/draft$1 [R=302,L]
 RewriteRule ^(20\d\d)(.*) https://researchobject.github.io/specifications/bundle/$1$2 [R=302,L]


### PR DESCRIPTION
This adds a `.travis.yml` for testing the `.htaccess` files at https://travis-ci.org/perma-id/w3id.org

As a `perma-id` organization member on Github you would also need to enable this at https://travis-ci.org/profile - 

Travis will also be able to add comments to pull requests to say if it passes the tests.

The test is described in https://github.com/stain/w3id.org/tree/travis-checker#link-checking - basically only URIs that are directly mentioned as `https://w3id.org/something` in the found `README.md` files are checked,  at http://localhost/ on the temporary Travis instance (Apache 2 in Ubuntu Precise).

I have added a new [step 3](https://github.com/stain/w3id.org/tree/travis-checker#adding-a-permanent-identifier-to-w3idorg) to the top-level README to suggest adding `*/README.md` for new pull requests.

Examples: 

All OK (this patch): https://travis-ci.org/stain/w3id.org/builds/41382536#log-container
404 at destination: https://travis-ci.org/stain/w3id.org/builds/41371490
500 (messed up .htaccess syntax): https://travis-ci.org/stain/w3id.org/builds/41372440

If there's an error, Apache's `error.log` is also shown - which is very useful on `.htaccess` errors..

Note that if there is no mention of a URI sub-tree in any README.md, then it is not tested (and the .htaccess could still be hiding errors) - allowing for redirections that deliberately are 404 or don't talk "browser-HTTP" - I believe the checker would request `Accept: text/html` :)
