### PR TITLE
Temporary URLs for credentials vocabulary, context, openbadges context

### DIFF
--- a/credentials/.htaccess
+++ b/credentials/.htaccess
@@ -1,4 +1,4 @@
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^$ http://specification.openbadges.org/vocabulary.html [R=302,L]
-RewriteRule ^v1$ http://specification.openbadges.org/v1/context.json [R=302,L]
+RewriteRule ^$ http://specification.openbadges.org/credentials/ [R=302,L]
+RewriteRule ^v1$ http://specification.openbadges.org/credentials/context.json [R=302,L]

--- a/credentials/.htaccess
+++ b/credentials/.htaccess
@@ -1,0 +1,4 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ http://specification.openbadges.org/vocabulary.html [R=302,L]
+RewriteRule ^v1$ http://specification.openbadges.org/v1/context.json [R=302,L]

--- a/openbadges/.htaccess
+++ b/openbadges/.htaccess
@@ -1,4 +1,5 @@
 Options +FollowSymLinks
 RewriteEngine on
 RewriteRule ^v1$ https://dev.truecred.com/contexts/openbadges-v1.jsonld [R=302,L]
+RewriteRule ^v1.1$ http://specification.openbadges.org/1.1/context.json [R=302,L]
 

--- a/openbadges/.htaccess
+++ b/openbadges/.htaccess
@@ -1,5 +1,6 @@
 Options +FollowSymLinks
 RewriteEngine on
+RewriteRule ^$ http://specification.openbadges.org/ [R=302,L]
 RewriteRule ^v1$ https://dev.truecred.com/contexts/openbadges-v1.jsonld [R=302,L]
 RewriteRule ^v1.1$ http://specification.openbadges.org/1.1/context.json [R=302,L]
 


### PR DESCRIPTION
A draft of the [credentials vocabulary](http://specification.openbadges.org/credentials/) is available on the Open Badges Specification site, and developers wish to start using it very soon.

SSL certificate will soon be created, but for now these redirects are to insecure pages.