### PR TITLE
Add Open Badges spec and context, incorporating legacy v1 context

### DIFF
--- a/openbadges/.htaccess
+++ b/openbadges/.htaccess
@@ -3,4 +3,4 @@ RewriteEngine on
 RewriteRule ^$ https://openbadgespec.org/ [R=302,L]
 RewriteRule ^v1$ https://openbadgespec.org/v1/context.json [R=302,L]
 RewriteRule ^legacy-v1$ https://dev.truecred.com/contexts/openbadges-v1.jsonld [R=302,L]
-RewriteRule ^(.*)$ https://openbadgespec.org/$1 
+RewriteRule ^(.*)$ https://openbadgespec.org/$1 [R=302,L]

--- a/openbadges/.htaccess
+++ b/openbadges/.htaccess
@@ -1,5 +1,5 @@
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^v1$ https://dev.truecred.com/contexts/openbadges-v1.jsonld [R=302,L]
+RewriteRule ^$ http://specification.openbadges.org/ [R=302,L]
+RewriteRule ^v1$ http://specification.openbadges.org/v1/context.json [R=302,L]
 RewriteRule ^legacy-v1$ https://dev.truecred.com/contexts/openbadges-v1.jsonld [R=302,L]
-

--- a/openbadges/.htaccess
+++ b/openbadges/.htaccess
@@ -1,5 +1,6 @@
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^$ http://specification.openbadges.org/ [R=302,L]
-RewriteRule ^v1$ http://specification.openbadges.org/v1/context.json [R=302,L]
+RewriteRule ^$ https://openbadgespec.org/ [R=302,L]
+RewriteRule ^v1$ https://openbadgespec.org/v1/context.json [R=302,L]
 RewriteRule ^legacy-v1$ https://dev.truecred.com/contexts/openbadges-v1.jsonld [R=302,L]
+RewriteRule ^(.*)$ https://openbadgespec.org/$1 


### PR DESCRIPTION
The change to the ./v1 redirect here incorporates the previous version and has been tested by @dlongley . These updates should be ready to go. We'll follow up shortly to update these to HTTPS.