### PR TITLE
Now correctly forwards the capture.

### DIFF
--- a/ontolink/.htaccess
+++ b/ontolink/.htaccess
@@ -1,4 +1,5 @@
 Options +FollowSymLinks
 
 RewriteEngine on
-RewriteRule ^(.?)$ http://homepages.cs.ncl.ac.uk/phillip.lord/ontolink/$1 [R=302,L]
+RewriteRule ^.?$ http://homepages.cs.ncl.ac.uk/phillip.lord/ontolink/ [R=302,L]
+RewriteRule ^(.+)$ http://homepages.cs.ncl.ac.uk/phillip.lord/ontolink/$1 [R=302,L]


### PR DESCRIPTION
Previously, only the exact match was forwarding and the capture group
was not getting passed to the 302 URL.

Apologies for the second PR. I thought this was working last time, but I obviously didn't check it properly. I still don't understand why it wasn't working last time!