### PR TITLE
Initial commit - redirect from w3id.org/env to environment.data.gov.au/def

### DIFF
--- a/env/.htaccess
+++ b/env/.htaccess
@@ -1,0 +1,3 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ https://environment.data.gov.au/def [R=302,L]


### PR DESCRIPTION
We are publishing some environmental vocabularies, currently hosted at environment.data.gov.au 
We expecting to spin off some of the more widely used vocabularies to a separate service, so would like to reserve the /env/ project for these. 
In the short-term the redirect is to environment.data.gov.au/def but this is likely to change in the medium term. 