### PR TITLE
adding verb (related to ActivityStreams and xAPI)

### DIFF
--- a/verb/.htaccess
+++ b/verb/.htaccess
@@ -1,0 +1,5 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ http://xapi.vocab.pub/verbs/adl/ [R=302,L]
+
+


### PR DESCRIPTION
To my understanding this will require using

```ttl
@prefix verb: <https://w3id.org/verb/#> .
```

```json
{
  "@context": {
    "verb": "https://w3id.org/verb/#"
  }
}
```

And one can **NOT** use it without *slash* just before *hash* (fragment) - `https://w3id.org/verb#`