### PR TITLE
Corrected redirection to lob

### DIFF
--- a/lob/.htaccess
+++ b/lob/.htaccess
@@ -1,2 +1,2 @@
 RewriteEngine on
-RewriteRule (.*) http://www.ligatus.org.uk/$1 [R=303,L]
+RewriteRule (.*) http://www.ligatus.org.uk/lob/$1 [R=303,L]


### PR DESCRIPTION
Apologies, the redirection needs to be to www.ligatus.org.uk/lob and not www.ligatus.org.uk .