### PR TITLE
Adding CLIPC domain

### DIFF
--- a/clipc/.htaccess
+++ b/clipc/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine on
+RewriteRule ^$ http://www.clipc.eu

--- a/clipc/README.md
+++ b/clipc/README.md
@@ -1,5 +1,5 @@
-RDW
-===
+CLIPC
+=====
 
 Homepage:
 * http://w3id.org/clipc

--- a/clipc/README.md
+++ b/clipc/README.md
@@ -1,0 +1,11 @@
+RDW
+===
+
+Homepage:
+* http://w3id.org/clipc
+
+Meetings:
+* http://w3id.org/clipc/meetings/copenhagen_may2015
+
+Contacts:
+* Martin Juckes <martin.juckes@stfc.ac.uk>

--- a/clipc/meetings/.htaccess
+++ b/clipc/meetings/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine on
+RewriteRule ^copenhagen_may2015$ http://www.clipc.eu/media/clipc/org/documents/meeting%20reports/clipc_eea_may2015_notes_revised.pdf


### PR DESCRIPTION
Hello,

I would like to add a CLIPC domain. CLIPC is a collaborative project building a climate information platform. Further details are on www.clipc.eu. Our project web site will evolve during the project, we need the permanent URLs to provide durable references to reference documents (reports etc).