### PR TITLE
fix bash-syntax in travis.yml error output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ after_script:
   - sudo cat /var/log/apache2/access.log
 
 after_failure:
-  - sudo cat /var/log/apache2/error.log > &2
+  - sudo cat /var/log/apache2/error.log >&2
 


### PR DESCRIPTION
`> &2` didn't work, but `>&2` does.. Bash is fun.