### PR TITLE
add initial .htaccess for Value Flows vocab

### DIFF
--- a/valueflows/.htaccess
+++ b/valueflows/.htaccess
@@ -1,0 +1,4 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^\/?(.*)$ http://valueflo.ws/$1 [R=303,L]


### PR DESCRIPTION
hey folks. :cat:

for context, [Value Flows](https://github.com/valueflows/valueflows) is a *work in progress* vocab for "resource planning and accounting within fractal networks of people and groups", [we're keen for a permanent identifier with w3id.org](https://github.com/valueflows/agent/issues/23).

thanks!