### PR TITLE
Requesting a namespace for the Lightweight Image Ontology (LIO)

### DIFF
--- a/lio/.htaccess
+++ b/lio/.htaccess
@@ -1,0 +1,6 @@
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ http://www.imagesnippets.com/lio/lio.owl [R=302,L]
+RewriteRule ^v1$ http://www.imagesnippets.com/lio/lio.owl [R=302,L]

--- a/lio/README.md
+++ b/lio/README.md
@@ -1,0 +1,8 @@
+# Lightweight Image Ontology (LIO)
+
+Contacts:
+
+* Margaret Warren [mm@zeroexp.com](mailto:mm@zeroexp.com)
+* Pat Hayes [phayes@ihmc.us](mailto:phayes@ihmc.us)
+* Michael Brunnbauer [brunni@netestate.de](mailto:brunni@netestate.de)
+


### PR DESCRIPTION
Our old namespace was http://purl.org/net/lio#. We do not trust purl.org any more.
Here is the version of the owl file that will be used after the switch: http://www.imagesnippets.com/lio/lio_new.owl

Michael Brunnbauer on behalf of Margaret Warren and Pat Hayes.