### PR TITLE
New space for OCC

### DIFF
--- a/oc/.htaccess
+++ b/oc/.htaccess
@@ -1,0 +1,4 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^/?$ http://www.opencitations.net [R=302,L]


### PR DESCRIPTION
This space should be used for guaranteeing the persistence of the entities of the Open Citations Corpus -- see:
- http://www.nature.com/news/publishing-open-citations-1.13937
- http://www.emeraldinsight.com/doi/abs/10.1108/JD-12-2013-0166