### PR TITLE
redirect for linked data vocabularies

### DIFF
--- a/vsat/.htaccess
+++ b/vsat/.htaccess
@@ -1,3 +1,3 @@
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule (.*) http://asdfghjkl1234567/linked/$1 [R=302,L]
+RewriteRule (.*) http://asdfghjkl1234567.com/linked/$1 [R=302,L]

--- a/vsat/.htaccess
+++ b/vsat/.htaccess
@@ -1,0 +1,3 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule (.*) http://asdfghjkl1234567/linked/$1 [R=302,L]

--- a/vsat/README.md
+++ b/vsat/README.md
@@ -2,3 +2,14 @@ Linked data url reditrection
 ============================
 
 A permanent home for anchoring linked data URIs for vocabularies pertaining to VSAT networks
+
+contact 
+-------
+
+alan.robson@viasat.com
+
+Intent
+------
+
+To pubish a collection of linked data vocabularies for network management purposes with a specific focus
+on specifying threshold events for timeseries data.

--- a/vsat/README.md
+++ b/vsat/README.md
@@ -1,7 +1,7 @@
 Linked data url reditrection
 ============================
 
-A permanent home for anchoring linked data URIs for vocabularies pertaining to VSAT networks
+A permanent home for anchoring linked data URIs for vocabularies pertaining to VSAT networks at https://w3id.org/vsat/...
 
 contact 
 -------

--- a/vsat/README.md
+++ b/vsat/README.md
@@ -1,0 +1,4 @@
+Linked data url reditrection
+============================
+
+A permanent home for anchoring linked data URIs for vocabularies pertaining to VSAT networks


### PR DESCRIPTION
Please consider merging this into w3id.org and giving my linked data vocabularies a permanent place to call home on the web. 

There is not much to see now, but I will be to adding vocabularies for network management. The destination domain is hosted by godaddy and should respond to a get request at <http://asdfghjkl1234567.com/linked/index.html> (I know, not a catchy domain but it was available and I can remember it)

An actual test vocabulary (not my vocabulary, but a placeholder) can be downloaded from <http://asdfghjkl1234567.com/linked/vocab/aggregate/0/aggregate.ttl> and if I get my wish also from http(s)://w3id/vocab/aggregate/0/aggregate.ttl soon as well though I'll probably refactor the URLS later to make them less clunky.

Many thanks

Alan
