### PR TITLE
adding redirections to ontologies and projects from the thesmartenergy organization 

### DIFF
--- a/lindt/.htaccess
+++ b/lindt/.htaccess
@@ -1,0 +1,5 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^/?$ http://ci.emse.fr/lindt/ [R=302,L]
+RewriteRule ^(.+)$ http://ci.emse.fr/lindt/$1 [R=302,L]

--- a/lindt/README.md
+++ b/lindt/README.md
@@ -1,0 +1,15 @@
+Linked Datatypes Ontology and Library
+The Linked Datatype Ontology, and multiple Linked Datatypes
+===
+
+Homepage:
+* https://w3id.org/lindt/ --> http://ci.emse.fr/lindt/
+
+Paper:
+* http://ci.emse.fr/lindt/LefrancoisZimmermann-ESWC2016-Supporting.pdf
+
+Source:
+* https://github.com/thesmartenergy/lindt-site
+
+Contacts: 
+* Maxime Lefrançois <maxime.lefrancois.86@gmail.com>

--- a/multidimensional-quantity/.htaccess
+++ b/multidimensional-quantity/.htaccess
@@ -1,0 +1,5 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^/?$ http://ci.emse.fr/multidimensional-quantity/ [R=302,L]
+RewriteRule ^(.+)$ http://ci.emse.fr/multidimensional-quantity/$1 [R=302,L]

--- a/multidimensional-quantity/README.md
+++ b/multidimensional-quantity/README.md
@@ -1,0 +1,12 @@
+Multidimensional Quantity Ontology
+The web API that exposes the domain-configurable Multi Dimensional Quantity Ontology
+===
+
+Homepage:
+* https://w3id.org/multidimensional-quantity --> http://ci.emse.fr/multidimensional-quantity
+
+Source:
+* https://github.com/thesmartenergy/mdq-ontology-site
+
+Contacts: 
+* Maxime Lefrançois <maxime.lefrancois.86@gmail.com>

--- a/sparql-generate/.htaccess
+++ b/sparql-generate/.htaccess
@@ -1,5 +1,5 @@
 Header set Access-Control-Allow-Origin *
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^/?$ http://ci.emse.fr/sparql-generate/ [R=302,L]
-RewriteRule ^(.+)$ http://ci.emse.fr/sparql-generate/$1 [R=302,L]
+RewriteRule ^/?$ http://thesmartenergy.github.io/sparql-generate-jena/ [R=302,L]
+RewriteRule ^(.+)$ http://thesmartenergy.github.io/sparql-generate-jena/$1 [R=302,L]

--- a/sparql-generate/README.md
+++ b/sparql-generate/README.md
@@ -2,10 +2,13 @@ SPARQL-Generate
 ===
 
 Homepage:
-* https://w3id.org/sparql-generate
+* https://w3id.org/sparql-generate --> http://thesmartenergy.github.io/sparql-generate-jena
+
+Specification:
+* https://w3id.org/sparql-generate/spec.html --> http://thesmartenergy.github.io/sparql-generate-jena
 
 Implementations:
-* over Apache Jena: http://thesmartenergy.github.io/sparql-generate-jena
+* over Apache Jena: https://github.com/thesmartenergy/sparql-generate-jena
 
 Contacts: 
 * Maxime Lefrançois <maxime.lefrancois.86@gmail.com>


### PR DESCRIPTION
Short description of the changes:

**lindt** - The Linked Datatypes Specification and Library. 
Redirects to http://ci.emse.fr/lindt/
website for paper that will be presented at ESWC 2016:
Maxime Lefrançois, Antoine Zimmermann, [Supporting Arbitrary Custom Datatypes in RDF and SPARQL](http://ci.emse.fr/lindt/LefrancoisZimmermann-ESWC2016-Supporting.pdf), In Proc. Extended Semantic Web Conference, ESWC, May 2016, Heraklion, Crete, Greece

**sparql-generate** - SPARQL-Generate.
Redirects to http://thesmartenergy.github.io/sparql-generate-jena/
Consists of:
- An extension of SPARQL 1.1 - that enables to interpret RDF Literals as RDF Graphs. 
- A protocol - that enables a server (resp. client) to tell the client (resp. server) how the content+mime it sends (= a RDF Literal) may be interpreted as a RDF Graph

**multidimensional-quantity** - The Multidimensional Quantity Ontology.
Redirects to http://ci.emse.fr/multidimensional-quantity/
Consists of:
- An ontology for multidimensional quantities, formally specified
- A vocabulary based on this ontology for the Energy domain
This project uses SPARQL-Generate to interpret the vocabulary configuration file (JSON) as RDF, and LINDT for datatypes for physical quantities.
