### PR TITLE
Add voldemort knowledge graph

### DIFF
--- a/voldemortkg/.htaccess
+++ b/voldemortkg/.htaccess
@@ -1,0 +1,6 @@
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ http://voldemort.exascale.info [R=302,L]
+RewriteRule ^data$ http://voldemort.exascale.info/data/ [R=302,L]

--- a/voldemortkg/README.md
+++ b/voldemortkg/README.md
@@ -1,0 +1,13 @@
+VoldemortKG
+===
+
+Homepage:
+* http://voldemort.exascale.info
+
+Datasets:
+* http://voldemort.exascale.info/data/
+
+Contacts:
+* Alberto Tonon <alberto.tonon@exascale.info>
+* Djellel Eddine Difallah <djelleleddine.difallah@exascale.info>
+* Victor Felder <victor@exascale.info>


### PR DESCRIPTION
This PR adds a permanent URL to a new knowledge graph and its dataset. Using a permanent URL is a requirement of ISWC 2016 call for papers.

We will expand the content of the homepage ASAP, the submission deadline being tomorrow.