### PR TITLE
Add actionize knowledge base

### DIFF
--- a/actionizekb/.htaccess
+++ b/actionizekb/.htaccess
@@ -1,0 +1,6 @@
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ http://actionizekb.exascale.info [R=302,L]
+RewriteRule ^data$ http://actionizekb.exascale.info/data/ [R=302,L]

--- a/actionizekb/README.md
+++ b/actionizekb/README.md
@@ -1,0 +1,11 @@
+ActionizeKB
+===
+
+Homepage:
+* http://actionizekb.exascale.info
+
+Datasets:
+* http://actionizekb.exascale.info/data/
+
+Contacts:
+* Alberto Tonon <alberto.tonon@exascale.info>


### PR DESCRIPTION
This PR adds a permanent URL to a new knowledge base and its dataset. Using a permanent URL is a requirement of ISWC 2016 call for papers.

We will expand the content of the homepage ASAP, the submission deadline being tomorrow.