### PR TITLE
Addition of Jisc learning analytics PIRI redirects

### DIFF
--- a/la/.htaccess
+++ b/la/.htaccess
@@ -4,4 +4,4 @@ RewriteEngine on
 
 # Jisc Learning Analytics Ontology
 # ---------------------------------------------
-RewriteRule ^w3id.org/blob/master/la/jisc/.+/?$ https://github.com/jiscdev/xapi-vle/blob/master/vocabulary.md [R=303]
+RewriteRule ^wilmTap/w3id.org/blob/master/la/jisc/.+/?$ https://github.com/jiscdev/xapi-vle/blob/master/vocabulary.md [R=303]

--- a/la/.htaccess
+++ b/la/.htaccess
@@ -6,4 +6,4 @@ RewriteEngine on
 
 # Jisc Learning Analytics Ontology
 # ---------------------------------------------
-RewriteRule ^wilmTap/w3id.org/blob/master/la/jisc/.+/?$ https://github.com/jiscdev/xapi-vle/blob/master/vocabulary.md [R=303]
+RewriteRule ^jisc/.+/?$ https://github.com/jiscdev/xapi-vle/blob/master/vocabulary.md [R=303]

--- a/la/.htaccess
+++ b/la/.htaccess
@@ -1,0 +1,7 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+
+# Jisc Learning Analytics Ontology
+# ---------------------------------------------
+RewriteRule ^la/jisc/.+/?$ https://github.com/jiscdev/xapi-vle/blob/master/vocabulary.md [R=303]

--- a/la/.htaccess
+++ b/la/.htaccess
@@ -5,4 +5,4 @@ RewriteEngine on
 
 # Jisc Learning Analytics Ontology
 # ---------------------------------------------
-RewriteRule ^la/jisc/.+/?$ https://github.com/jiscdev/xapi-vle/blob/master/vocabulary.md [R=303]
+RewriteRule ^la/jisc/(.*)/(.*)$ https://github.com/jiscdev/xapi-vle/blob/master/vocabulary.md#$2 [R=303]

--- a/la/.htaccess
+++ b/la/.htaccess
@@ -1,4 +1,3 @@
-
 Header set Access-Control-Allow-Origin *
 Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
 Options +FollowSymLinks
@@ -6,4 +5,4 @@ RewriteEngine on
 
 # Jisc Learning Analytics Ontology
 # ---------------------------------------------
-RewriteRule ^jisc/.+/?$ https://github.com/jiscdev/xapi-vle/blob/master/vocabulary.md [R=303]
+RewriteRule ^la/jisc/.+/?$ https://github.com/jiscdev/xapi-vle/blob/master/vocabulary.md [R=303]

--- a/la/.htaccess
+++ b/la/.htaccess
@@ -4,4 +4,4 @@ RewriteEngine on
 
 # Jisc Learning Analytics Ontology
 # ---------------------------------------------
-RewriteRule ^la/jisc/.+/?$ https://github.com/jiscdev/xapi-vle/blob/master/vocabulary.md [R=303]
+RewriteRule ^w3id.org/blob/master/la/jisc/.+/?$ https://github.com/jiscdev/xapi-vle/blob/master/vocabulary.md [R=303]

--- a/la/.htaccess
+++ b/la/.htaccess
@@ -1,6 +1,8 @@
+
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
 Options +FollowSymLinks
 RewriteEngine on
-
 
 # Jisc Learning Analytics Ontology
 # ---------------------------------------------

--- a/la/readme.md
+++ b/la/readme.md
@@ -1,0 +1,9 @@
+This the root directory for persistent IRIs for the Jisc Learning Analytics profile.
+
+Organisation: Jisc
+
+Organisation homepage: http://jisc.ac.uk/
+
+Jisc Learning Analytics homepage: https://github.com/jiscdev/learning-analytics
+
+Contact: Wilbert Kraan, w.g.kraan@ovod.net; David Sherlock, davidsherlock163@hotmail.com

--- a/la/readme.md
+++ b/la/readme.md
@@ -7,3 +7,7 @@ Organisation homepage: http://jisc.ac.uk/
 Jisc Learning Analytics homepage: https://github.com/jiscdev/learning-analytics
 
 Contact: Wilbert Kraan, w.g.kraan@ovod.net; David Sherlock, davidsherlock163@hotmail.com
+
+Sample identifiers:
+https://w3id.org/la/jisc/extensions/courseArea
+https://w3id.org/la/jisc/extensions/applicationType


### PR DESCRIPTION
This PR adds a basic redirect of permanent IRIs of the form
https://w3id.org/la/jisc/extensions/courseArea
https://w3id.org/la/jisc/extensions/applicationType
to
https://github.com/jiscdev/xapi-vle/blob/master/vocabulary.md#courseArea
https://github.com/jiscdev/xapi-vle/blob/master/vocabulary.md#applicationType

These IRIs are used for an xAPI based vocabulary used in learning analytics JSON statements used by a consortium of vendors and universities.