### PR TITLE
Update htaccess to preserve fragment identifier

### DIFF
--- a/la/.htaccess
+++ b/la/.htaccess
@@ -5,4 +5,4 @@ RewriteEngine on
 
 # Jisc Learning Analytics Ontology
 # ---------------------------------------------
-RewriteRule ^jisc/(.*)/(.*)$ https://github.com/jiscdev/xapi-vle/blob/master/vocabulary.md#$2 [R=303]
+RewriteRule ^jisc/(.*)/(.*)$ https://github.com/jiscdev/xapi-vle/blob/master/vocabulary.md#$2 [R=303,NE]


### PR DESCRIPTION
Current rule rewrites "#" as "%20". Adding the NE flag should fix that.