### PR TITLE
Link to FuhSen ontology online documentation

### DIFF
--- a/eis/vocabs/.htaccess
+++ b/eis/vocabs/.htaccess
@@ -33,7 +33,7 @@ RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^fuhsen$ https://github.com/LiDaKrA/Ontology/blob/master/Documentation/  [R=303,NE,L]
+RewriteRule ^fuhsen$ https://github.com/collarad/w3id.org.git  [R=303,NE,L]
 RewriteCond %{HTTP_ACCEPT} ^.*text/owl-manchester.* 
 RewriteRule ^fuhsen$ https://raw.githubusercontent.com/LiDaKrA/Ontology/master/Implementation/fuhsen.omn [R=303,NE,L]
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 

--- a/eis/vocabs/.htaccess
+++ b/eis/vocabs/.htaccess
@@ -33,7 +33,7 @@ RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^fuhsen$ https://github.com/collarad/w3id.org.git  [R=303,NE,L]
+RewriteRule ^fuhsen$ http://lidakra.github.io/Ontology/  [R=303,NE,L]
 RewriteCond %{HTTP_ACCEPT} ^.*text/owl-manchester.* 
 RewriteRule ^fuhsen$ https://raw.githubusercontent.com/LiDaKrA/Ontology/master/Implementation/fuhsen.omn [R=303,NE,L]
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 


### PR DESCRIPTION
To allow content negotiation of the vocabulary, we need to redirect the w3id URI to the online documentation of FuhSen.