### PR TITLE
added default response, for some reason opening http://w3id.org/aufx/…

### DIFF
--- a/aufx/.htaccess
+++ b/aufx/.htaccess
@@ -26,4 +26,4 @@ RewriteCond %{HTTP_ACCEPT} text/turtle
 RewriteRule ^ontology/(.*) http://eecs.qmul.ac.uk/~thomasw/aufx/ontology/$1/aufx.ttl [R=303,L]
 
 # Choose the default response
-#RewriteRule ^ontology$ ontology.owl [R=303]
+RewriteRule ^ontology/(.*) http://eecs.qmul.ac.uk/~thomasw/aufx/ontology/$1/aufx.ttl [R=303,L]


### PR DESCRIPTION
…ontology/1.0 in Protege (5) gives error

any ideas why this is not working with Protege? this .htaccess works with localhost, but not with the w3id url.