### PR TITLE
Updated 'chainpoint' to use proper version number

### DIFF
--- a/chainpoint/.htaccess
+++ b/chainpoint/.htaccess
@@ -3,4 +3,4 @@ Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,
 Options +FollowSymLinks
 RewriteEngine on
 RewriteRule ^$ https://www.chainpoint.org/ [R=302,L]
-RewriteRule ^v1$ https://www.chainpoint.org/contexts/chainpoint-v1.jsonld [R=302,L]
+RewriteRule ^v2$ https://www.chainpoint.org/contexts/chainpoint-v2.jsonld [R=302,L]

--- a/chainpoint/README.md
+++ b/chainpoint/README.md
@@ -5,7 +5,7 @@ Homepage:
 * https://w3id.org/chainpoint
 
 JSON-LD contexts:
-* https://w3id.org/chainpoint/v1
+* https://w3id.org/chainpoint/v2
 
 Contacts: 
 * Jason Bukowski <jason@tierion.com>


### PR DESCRIPTION
I had used the 'v1' term in error in my previous commit. The context we will be publishing is actually the second version of our specification, and thus needs to be represented as 'v2' throughout.