### PR TITLE
Need a redirect persistant uri for my ontology

### DIFF
--- a/sfs-ontology/.htaccess
+++ b/sfs-ontology/.htaccess
@@ -6,7 +6,7 @@ Options -MultiViews
 # if not present in main apache config
 AddType application/rdf+xml .rdf
 AddType application/rdf+xml .owl
-AddType  application/owl+xml .owl
+AddType application/owl+xml .owl
 
 RewriteEngine on
 

--- a/sfs-ontology/.htaccess
+++ b/sfs-ontology/.htaccess
@@ -6,6 +6,7 @@ Options -MultiViews
 # if not present in main apache config
 AddType application/rdf+xml .rdf
 AddType application/rdf+xml .owl
+AddType  application/owl+xml .owl
 
 RewriteEngine on
 

--- a/sfs-ontology/.htaccess
+++ b/sfs-ontology/.htaccess
@@ -1,6 +1,23 @@
-Header set Access-Control-Allow-Origin *
-Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
 Options +FollowSymLinks
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+
 RewriteEngine on
-RewriteRule ^$ http://semantic-file-system-ontology.sf.net [R=302,L]
-RewriteRule ^v1$ http://semantic-file-system-ontology.sf.net/sfs-ontology.owl [R=302,L]
+
+#Rewrite rules for Asteroids vocabulary extension 
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*|\*/\*)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^ontology$ http://semantic-file-system-ontology.sf.net/index.htm  [R=303,NE,L]
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^ontology$ http://semantic-file-system-ontology.sf.net/sfs-ontology.owl [R=303,NE,L]
+#default response: ttl
+RewriteRule ^ontology$ http://semantic-file-system-ontology.sf.net/sfs-ontology.owl [R=303,NE,L]


### PR DESCRIPTION
Need a redirect persistant uri for my ontology. 
I have created html description of my ontology on http://semantic-file-system-ontology.sf.net/index.htm . My owl ontology is uploaded to http://semantic-file-system-ontology.sf.net/sfs-ontology.owl. 

I want to redirect "text/html" requests to index.htm  and "application/rdf+xml" requests to sfs-ontology.owl. 
