### PR TITLE
added ONTOP - Ontology Platform redirecting to http://ci.emse.fr/ontop/

### DIFF
--- a/ontop/.htaccess
+++ b/ontop/.htaccess
@@ -1,0 +1,6 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+RewriteRule ^/?$ http://ci.emse.fr/ontop/ [R=302,L]
+RewriteRule ^(.+)$ http://ci.emse.fr/ontop/$1 [R=302,L]

--- a/ontop/README.md
+++ b/ontop/README.md
@@ -1,0 +1,14 @@
+Ontology Platform
+
+Specification and demonstration of Ontology Platform: Maven projects that ease the exposition of onologies and other resources.
+
+===
+
+Homepage:
+* https://w3id.org/ontop --> http://ci.emse.fr/ontop/
+
+Source:
+* https://github.com/thesmartenergy/ontop
+
+Contacts: 
+* Maxime Lefrançois <maxime.lefrancois.86@gmail.com>


### PR DESCRIPTION
added ONTOP - Ontology Platform redirecting to http://ci.emse.fr/ontop/

Project ONTOP includes:

- a STTL aka SPARQL-Template transformation that enables to automatically generate an HTML documentation for any ontology;
- a Maven plugin that automatically controls the quality of the ontologies to be published;
- a Maven project that serves the ontologies and other resources following the Web architecture design principles.