### PR TITLE
Improve context references

### DIFF
--- a/blockcerts/.htaccess
+++ b/blockcerts/.htaccess
@@ -3,6 +3,5 @@ Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,
 Options +FollowSymLinks
 RewriteEngine on
 RewriteRule ^$ http://www.blockcerts.org/ [R=302,L]
-RewriteRule ^context$ http://www.blockcerts.org/schema/1.2/context.json [R=302,L]
-
-
+RewriteRule ^v1$ http://www.blockcerts.org/schema/1.2/context.json [R=302,L]
+RewriteRule ^(.*)$ http://www.blockcerts.org/$1 [R=302,L]

--- a/blockcerts/README.md
+++ b/blockcerts/README.md
@@ -8,7 +8,7 @@ https://w3id.org/blockcerts
 
 JSON-LD contexts:
 
-https://w3id.org/blockcerts/context
+https://w3id.org/blockcerts/v1
 
 
 Contacts:


### PR DESCRIPTION
Changed 'context' rewrite to 'v1': I want blockchain certificates to be explicit about which version they are using, because the  normalization (and hash) changes with JSON LD changes.

Also include wildcard match.

w3id.org team: This should be all my changes for a while. Thanks for all your help!