### PR TITLE
Correct faulty URL for www.earthsystemcog.org

### DIFF
--- a/cmip6dr/.htaccess
+++ b/cmip6dr/.htaccess
@@ -1,4 +1,4 @@
 RewriteEngine on
 
-RewriteRule ^$ https://earthsystemcog.org/projects/wip/CMIP6DataRequest
+RewriteRule ^$ https://www.earthsystemcog.org/projects/wip/CMIP6DataRequest
 RewriteRule ^browse.html$ http://http://clipc-services.ceda.ac.uk/dreq/index.html

--- a/cmip6dr/README.md
+++ b/cmip6dr/README.md
@@ -1,8 +1,8 @@
 CLIPC
 =====
 
-Homepage:
-* http://w3id.org/CMIP6-dreq
+Homepage: https://www.earthsystemcog.org/projects/wip/CMIP6DataRequest
+* http://w3id.org/cmip6dr 
 
 
 Contacts:


### PR DESCRIPTION
Corrected one URL (the initial www had been omitted, which worked in the past and is now failing). Also corrected README.md