### PR TITLE
Add new openbadges context path

### DIFF
--- a/openbadges/.htaccess
+++ b/openbadges/.htaccess
@@ -2,5 +2,6 @@ Options +FollowSymLinks
 RewriteEngine on
 RewriteRule ^$ https://openbadgespec.org/ [R=302,L]
 RewriteRule ^v1$ https://openbadgespec.org/v1/context.json [R=302,L]
+RewriteRule ^v2$ https://openbadgespec.org/v2/context.json [R=302,L]
 RewriteRule ^legacy-v1$ https://dev.truecred.com/contexts/openbadges-v1.jsonld [R=302,L]
 RewriteRule ^(.*)$ https://openbadgespec.org/$1 [R=302,L]


### PR DESCRIPTION
Open Badges has released a new context file as part of our [specification](https://github.com/openbadges/openbadges-specification/pull/99). This will add `https://w3id.org/openbadges/v2` as a redirect to the file once it is published. Thanks!

Nate Otto
Director of Technology, Badge Alliance
badgealliance.org