### PR TITLE
Request of permanent id spaces for AkomaNtoso and Imperial Data Ontology

### DIFF
--- a/akn/.htaccess
+++ b/akn/.htaccess
@@ -1,0 +1,4 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^(.*)$ http://www.akomantoso.org/$1 [R=302,L]

--- a/akn/README.md
+++ b/akn/README.md
@@ -1,0 +1,5 @@
+# Permanent ID space for AkomaNtoso entities
+
+This permanent ID space has been created for providing a way to permanetly identify all the resources associated to AkomaNtoso, i.e. a set of simple technology-neutral electronic representations in XML format of parliamentary, legislative and judiciary documents, available at http://www.akomantoso.org/.
+
+The responsible for this space is Silvio Peroni, who can be contacted by email (essepuntato@gmail.com) or twitter ([@essepuntato](https://twitter.com/essepuntato)).

--- a/ido/.htaccess
+++ b/ido/.htaccess
@@ -1,0 +1,5 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ http://etna.istc.cnr.it/food/ [R=302,L]
+RewriteRule ^(.+)$ http://etna.istc.cnr.it/food/$1 [R=302,L]

--- a/ido/.htaccess
+++ b/ido/.htaccess
@@ -1,5 +1,4 @@
 Header set Access-Control-Allow-Origin *
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^$ http://etna.istc.cnr.it/food/ [R=302,L]
-RewriteRule ^(.+)$ http://etna.istc.cnr.it/food/$1 [R=302,L]
+RewriteRule ^$ http://www.essepuntato.it/2015/07/ido [R=302,L]

--- a/ido/README.md
+++ b/ido/README.md
@@ -1,0 +1,7 @@
+# Permanent identifier space for the Imperial Data Ontology
+
+The Imperial Data Ontology (IDO) is an OWL 2 DL ontology that allows the description of selling data of fashion design industries.
+
+The development of IDO is one of the outcomes of the agreement between the [University of Bologna](http://www.unibo.it/en) and [Imperial](http://www.imperialfashion.com/en/). Part of this agreement is dedicated to the use of Semantic Web technologies for the description and analysis of selling data of Imperial, and, more generally, of fashion design industries.
+
+The responsible for this space is Silvio Peroni, who can be contacted via email (essepuntato@gmail.com) and twitter ([@essepuntato](https://twitter.com/essepuntato)).


### PR DESCRIPTION
This pull request would add in the main repository two permanent ID spaces for two distinct projects, i.e.:

- /akn: it is the space dedicated to the entities related to the AkomaNtoso project;
- /ido: it is the space dedicated to a specific ontology, i.e. the Imperial Data Ontology, that is used for describing the selling data related to the fast-fashion domain.