### PR TITLE
Addition of a new redirection entry to serve the LAAS open data project

### DIFF
--- a/laas-iot/.htaccess
+++ b/laas-iot/.htaccess
@@ -1,0 +1,5 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^/?$ https://syndream.laas.fr:8082/ [R=302,L]
+RewriteRule ^(.+)$ https://syndream.laas.fr:8082/$1 [R=302,L]

--- a/laas-iot/README.md
+++ b/laas-iot/README.md
@@ -1,0 +1,14 @@
+# LAAS open data
+
+## Presentation
+This is the redirection to the LAAS-CNRS (http://laas.fr/) open data project. This data, produced in the OPA project, is made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/. The vocabulary used for the metadata (if any) is an extension of IoT-O (https://www.irit.fr/recherches/MELODI/ontologies/IoT-O), distributed under Creative Commons Attribution 4.0 International License by LAAS-CNRS and IRIT (https://www.irit.fr/).
+
+## Services
+- Open data welcome page : https://w3id.org/laas-iot --> https://syndream.laas.fr:8082/
+- OPA vocabulary : https://w3id.org/laas-iot/adream --> https://syndream.laas.fr:8082/adream
+- Sparql endoint : https://w3id.org/laas-iot/sparql --> https://syndream.laas.fr:8082/sparql
+
+## Contacts
+- Christelle Ecrepont : christelle.ecrepont@laas.fr
+- Thierry Monteil : thierry.monteil@laas.fr
+- Nicolas Seydoux : nicolas.seydoux@laas.fr


### PR DESCRIPTION
Dear w3id.org administrators, 
I would like to issue this pull request in order to give the LAAS open data project a permanent ID, that also covers the vocabulary used to annotate the distributed data. Redirections and content negociation is performed on our side.
Best regards, 

Nicolas Seydoux