### PR TITLE
Added handling of redirect for ontologies

### DIFF
--- a/UN/.htaccess
+++ b/UN/.htaccess
@@ -1,4 +1,42 @@
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^$ https://www.un.org/ [R=301,L]
 RewriteRule ^FAO/?$ http://www.fao.org [R=301,L]
+
+# UNDO
+RewriteRule ^ontology/undo\.(html|xml|json|ttl|nt)$ https://rawgit.com/essepuntato/undo/master/ontology/current/undo.$1 [R=303,L]
+RewriteRule ^ontology/undo/([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9])\.(html|xml|json|ttl|nt)$ https://rawgit.com/essepuntato/undo/master/ontology/$1/undo.$2 [R=303,L]
+
+
+### CONFIGURATION redir ontology/data: begin ########################
+
+# Rewrite rule for no content
+RewriteRule ^(ontology/.+|data/.+)\.(html|xml|json|ttl|nt)$ - [R=404,L]
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} html
+RewriteRule ^(ontology/.+|data/.+)$ /akn/$1.html [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/xml
+RewriteRule ^(ontology/.+|data/.+)$ /akn/$1.xml [R=303,L]
+
+# Rewrite rule to serve Turtle content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
+RewriteCond %{HTTP_ACCEPT} text/ttl
+RewriteRule ^(ontology/.+|data/.+)$ /akn/$1.ttl [R=303,L]
+
+# Rewrite rule to serve Notation3 content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples [OR]
+RewriteCond %{HTTP_ACCEPT} text/plain
+RewriteRule ^(ontology/.+|data/.+)$ /akn/$1.nt [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^(ontology/.+|data/.+)$ /akn/$1.json [R=303,L]
+
+######################## CONFIGURATION redir ontology/data: end #####
+
+# Default behaviour
+RewriteRule ^(.*)$ https://www.un.org/$1 [R=301,L]

--- a/UN/README.md
+++ b/UN/README.md
@@ -1,2 +1,2 @@
 
-Contacts: ashok.hariharan@fao.org, flavio.zeni@fao.org
+Contacts: ashok.hariharan@fao.org, flavio.zeni@fao.org, essepuntato@gmail.com


### PR DESCRIPTION
The .htaccess file has been changed so as to serve the appropriate representation for ontologies according to the particular request sent by a client. In addition, the redirection for UNDO has been added.