### PR TITLE
Update to new imsglobal.org location, add README

### DIFF
--- a/openbadges/.htaccess
+++ b/openbadges/.htaccess
@@ -1,7 +1,9 @@
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^$ https://openbadgespec.org/ [R=302,L]
-RewriteRule ^v1$ https://openbadgespec.org/v1/context.json [R=302,L]
-RewriteRule ^v2$ https://openbadgespec.org/v2/context.json [R=302,L]
-RewriteRule ^legacy-v1$ https://dev.truecred.com/contexts/openbadges-v1.jsonld [R=302,L]
-RewriteRule ^(.*)$ https://openbadgespec.org/$1 [R=302,L]
+RewriteRule ^$ https://www.imsglobal.org/sites/default/files/Badges/OBv2p0/index.html [R=302,L]
+RewriteRule ^.*v1$ https://www.imsglobal.org/sites/default/files/Badges/OBv2p0/v1/context.json [R=302,L]
+RewriteRule ^.*v2$ https://www.imsglobal.org/sites/default/files/Badges/OBv2p0/v2/context.json [R=302,L]
+RewriteRule ^.*legacy-v1$ https://dev.truecred.com/contexts/openbadges-v1.jsonld [R=302,L]
+RewriteRule ^.*extensions/#(.*) https://www.imsglobal.org/sites/default/files/Badges/OBv2p0/extensions/index.html#$1 [R=302,L]
+RewriteRule ^.*extensions#(.*) https://www.imsglobal.org/sites/default/files/Badges/OBv2p0/extensions/index.html#$1 [R=302,L]
+RewriteRule ^(.*)$ https://www.imsglobal.org/sites/default/files/Badges/OBv2p0/$1 [R=302,L]

--- a/openbadges/README.md
+++ b/openbadges/README.md
@@ -1,0 +1,14 @@
+Open Badges
+===
+
+Homepage:
+* https://www.imsglobal.org/activity/digital-credentialing-badges
+
+Vocabularies:
+* https://w3id.org/openbadges 
+
+JSON-LD contexts:
+* https://w3id.org/openbadges/v2
+
+Contacts: 
+* Markus Gylling <mgylling@imsglobal.org>


### PR DESCRIPTION
Since January 2017, the Open Badges spec is maintained by IMS Global
Learning Consortium. The spec & context URLs are therefore changed as
we turn the openbadgespec.org site into a redirect to imsglobal.org.