### PR TITLE
Revert v1 and v2 URLs

### DIFF
--- a/openbadges/.htaccess
+++ b/openbadges/.htaccess
@@ -1,9 +1,9 @@
 Options +FollowSymLinks
 RewriteEngine on
 RewriteRule ^$ https://www.imsglobal.org/sites/default/files/Badges/OBv2p0/index.html [R=302,L]
-RewriteRule ^.*v1$ https://www.imsglobal.org/sites/default/files/Badges/OBv2p0/v1/context.json [R=302,L]
-RewriteRule ^.*v2$ https://www.imsglobal.org/sites/default/files/Badges/OBv2p0/v2/context.json [R=302,L]
+RewriteRule ^.*v1$ https://openbadgespec.org/v1/context.json [R=302,L]
+RewriteRule ^.*v2$ https://openbadgespec.org/v2/context.json [R=302,L]
 RewriteRule ^.*legacy-v1$ https://dev.truecred.com/contexts/openbadges-v1.jsonld [R=302,L]
 RewriteRule ^.*extensions/#(.*) https://www.imsglobal.org/sites/default/files/Badges/OBv2p0/extensions/index.html#$1 [R=302,L]
 RewriteRule ^.*extensions#(.*) https://www.imsglobal.org/sites/default/files/Badges/OBv2p0/extensions/index.html#$1 [R=302,L]
-RewriteRule ^(.*)$ https://www.imsglobal.org/sites/default/files/Badges/OBv2p0/$1 [R=302,L]
+RewriteRule ^(.*)$ https://openbadgespec.org/$1 [R=302,L]


### PR DESCRIPTION
Due to unforeseen CORS policy issues on the new site, we need to revert
some of the redirects.