### PR TITLE
Add permanent identifier w3id.org/ibp/

### DIFF
--- a/ibp/.htaccess
+++ b/ibp/.htaccess
@@ -1,0 +1,5 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+RewriteRule ^$ https://github.com/TechnicalBuildingSystems/Ontologies/ [R=302,L]

--- a/ibp/README.md
+++ b/ibp/README.md
@@ -1,0 +1,16 @@
+### Ontologies by the Group Technical Building Systems from Fraunhofer Institute for Building Physics IBP
+===
+
+Documentation:
+
+* https://w3id.org/ibp/ --> https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/README.md
+
+Source:
+
+* https://github.com/TechnicalBuildingSystems/Ontologies
+
+
+Contact:
+
+* Georg Ferdinand Schneider <georg.schneider@ibp.fraunhofer.de>
+* Simone Steiger <simone.steiger@ibp.fraunhofer.de>


### PR DESCRIPTION
Dear all

it would be great to add the identifier https://w3id.org/ibp/ .

We will to publish a couple of OWL ontologies related to building automation systems and control logic. We followed the guidlines as expressed in https://github.com/perma-id/w3id.org/blob/master/README.md to file a pull request.

Instead of filing an ID for every ontology we rather file https://w3id.org/ibp/  and have submodule ontologies reference below that similar to [seas](https://github.com/perma-id/w3id.org/blob/master/seas/README.md). The project will continue in the next couple of years and  will align with work of W3C Linked Building Data Community Group [link](https://github.com/w3c-lbd-cg).

We are happy to adjust our files if required.

Best

Georg