### PR TITLE
DataFabric.cc's root folder. FTS ontology PURL

### DIFF
--- a/datafabric.cc/README.md
+++ b/datafabric.cc/README.md
@@ -1,0 +1,9 @@
+# DataFabric.cc's PURLs
+
+Ontologies:
+
+* [https://w3id.org/datafabric.cc/ontologies/fts#](https://w3id.org/datafabric.cc/ontologies/fts#)
+
+Contacts:
+
+* Eugene Hlyzov (https://github.com/ehlyzov)

--- a/datafabric.cc/ontologies/.htaccess
+++ b/datafabric.cc/ontologies/.htaccess
@@ -1,0 +1,3 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^fts$ https://raw.githubusercontent.com/DataFabricRus/ontology-fts/master/fts-fin-2.0.owl [R=303,L]


### PR DESCRIPTION
+ Root folder for PURLs related to DataFabric.cc projects,
+ PURL for the FTS ontology.