### PR TITLE
Added CWL permalinks

### DIFF
--- a/cwl/.htaccess
+++ b/cwl/.htaccess
@@ -1,9 +1,5 @@
 RewriteEngine on
 
-# NOTE: We use rawgit.com for JSON-LD context and Turtle file,
-# for correct Content-Type, but common-workflow-language.github.io
-# for the textual spec and home page
-
 # Current draft (FIXME: Should use cdn.rawgit.com once draft is released)
 RewriteRule ^$ http://www.commonwl.org/v1.0/ [R=302,L]
 RewriteRule ^salad/context$ http://www.commonwl.org/v1.0/salad-context.json [R=302,L]
@@ -26,3 +22,7 @@ RewriteRule ^v(.*)/context http://www.commonwl.org/v$1/cwl-context.json [R=302,L
 RewriteRule ^v(.*)/cwl.ttl http://www.commonwl.org/v$1/cwl.ttl [R=302,L]
 RewriteRule ^v(.*)/salad.ttl http://www.commonwl.org/v$1/salad.ttl [R=302,L]
 RewriteRule ^v(.*) http://www.commonwl.org/v$1 [R=302,L]
+
+# https://github.com/common-workflow-language/cwlviewer/wiki/Permalinks
+ReWriteRule ^view/git/(.*) https://view.commonwl.org/git/$1 [R=302,L]
+ReWriteRule ^view(/)?$ https://github.com/common-workflow-language/cwlviewer/wiki/Permalinks [R=303,L]

--- a/cwl/README.md
+++ b/cwl/README.md
@@ -25,6 +25,10 @@ Ontology:
 * https://w3id.org/cwl/v1.0/cwl.ttl (for owl:import)
 * https://w3id.org/cwl/v1.0/salad.ttl (for owl:import)
 
+Permalinks:
+* https://w3id.org/cwl/view/
+* https://w3id.org/cwl/view/git/933bf2a1a1cce32d88f88f136275535da9df0954/workflows/hello/hello.cwl#main
+
 References:
 * http://www.commonwl.org/
 * https://github.com/common-workflow-language/common-workflow-language


### PR DESCRIPTION
Note that these are not live yet on https://view.commonwl.org/

See common-workflow-language/cwlviewer#146 and https://github.com/common-workflow-language/cwlviewer/wiki/Permalinks