### PR TITLE
Fixed .htaccess for versions and sources

### DIFF
--- a/un/.htaccess
+++ b/un/.htaccess
@@ -3,10 +3,10 @@ RewriteEngine on
 RewriteRule ^fao/?$ http://www.fao.org [R=301,L]
 
 # UNDO
-#RewriteRule ^ontology/undo\.(html|xml|json|ttl|nt)$ https://unsceb-hlcm.github.io/onto-undo/undo.$1 [R=303,L]
-#RewriteRule ^ontology/undo/([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9])\.(html|xml|json|ttl|nt)$ https://unsceb-hlcm.github.io/onto-undo/$1/undo.$2 [R=303,L]
+RewriteRule ^ontology/undo\.html$ https://unsceb-hlcm.github.io/onto-undo/index.html [R=303,L]
+RewriteRule ^ontology/undo\.(xml|json|ttl|nt)$ https://rawgit.com/unsceb-hlcm/undo/master/ontology/current/undo.$1 [R=303,L]
+RewriteRule ^ontology/undo/([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9])\.(html|xml|json|ttl|nt)$ https://rawgit.com/unsceb-hlcm/undo/master/ontology/$1/undo.$2 [R=303,L]
 RewriteRule ^repository/undo/?$ https://github.com/unsceb-hlcm/undo [R=303,L]
-RewriteRule ^ontology/undo$ https://unsceb-hlcm.github.io/onto-undo/index.html [R=303,L]
 
 # SDG
 RewriteRule ^ontology/sdg/(.*) https://sustainabledevelopment.un.org/sdg$1 [R=303,L]


### PR DESCRIPTION
The .htaccess has been modified so as to provide a correct mechanism for the content negotiation. 

When accessed by means of a browser (i.e. requesting HTML as format), the current version of UNDO redirects to the official UN document describing the ontology, available at https://unsceb-hlcm.github.io/onto-undo/index.html. Any other request (i.e. different formats and version IRI of the ontology) will be redirected to the specific file contained in the repository.