### PR TITLE
The Audio Feature Ontology relocation to github pages

### DIFF
--- a/afo/.htaccess
+++ b/afo/.htaccess
@@ -1,4 +1,24 @@
+Options -MultiViews
+
+AddType application/rdf+xml .rdf
+AddType text/n3 .n3
+
 RewriteEngine on
 
-RewriteRule ^onto/(.*)$ http://sovarr.c4dm.eecs.qmul.ac.uk/af/ontology/$1 [R=302,L]
-RewriteRule ^vocab/(.*)$ http://sovarr.c4dm.eecs.qmul.ac.uk/af/vocabulary/$1 [R=302,L]
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^onto/(.*)$ https://semantic-audio.github.io/afo/ [R=303]
+RewriteRule ^vocab/(.*)$ https://semantic-audio.github.io/afv/ [R=303]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^onto/(.*)$ https://semantic-audio.github.io/afo/af-ontology.rdf [R=303]
+RewriteRule ^vocab/(.*)$ https://semantic-audio.github.io/afv/af-vocabulary.rdf [R=303]
+
+RewriteCond %{HTTP_ACCEPT} text/n3
+RewriteRule ^onto/(.*)$ https://semantic-audio.github.io/afo/af-ontology.n3 [R=303]
+RewriteRule ^vocab/(.*)$ https://semantic-audio.github.io/afv/af-vocabulary.n3 [R=303]
+
+RewriteRule ^onto/(.*)$ https://semantic-audio.github.io/afo/ [R=303]
+RewriteRule ^vocab/(.*)$ https://semantic-audio.github.io/afv/ [R=303]


### PR DESCRIPTION
The Audio Feature ontology framework has been relocated to Github pages 
https://w3id.org/afo/onto/1.1# -> https://semantic-audio.github.io/afo/
https://w3id.org/afo/vocab/1.1# -> https://semantic-audio.github.io/afv/