### PR TITLE
redirects to go from w3id to cedar.openmadrigal.org

### DIFF
--- a/cedar/.htaccess
+++ b/cedar/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine on
+
+RewriteRule ^cedar(.*)$ http://cedar.openmadrigal.org/showExperiment/$1 [R=302,L]

--- a/cedar/.htaccess
+++ b/cedar/.htaccess
@@ -1,3 +1,3 @@
 RewriteEngine on
 
-RewriteRule ^cedar(.*)$ http://cedar.openmadrigal.org/showExperiment/$1 [R=302,L]
+RewriteRule ^(.*)$ http://cedar.openmadrigal.org/showExperiment/$1 [R=302,L]

--- a/cedar/README.md
+++ b/cedar/README.md
@@ -1,0 +1,8 @@
+# CEDAR MADRIGAL GEOSCIENCE DATABASE URL REDIRECTION
+
+Homepage:
+* http://cedar.openmadrigal.org
+
+Contacts:
+
+* Bill Rideout <brideout@mit.edu>


### PR DESCRIPTION
We are adding the ability to cite scientific data from the CEDAR Madrigal database, and would like to allow those citations to have the option of changing the server hostname.  Thanks - Bill Rideout (brideout@mit.edu)