### PR TITLE
add URLs for MapVOWL and the RMLEditor

### DIFF
--- a/mapvowl/eval17/.htaccess
+++ b/mapvowl/eval17/.htaccess
@@ -1,0 +1,5 @@
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^(.*)$ http://rml.io/data/mapvowle/$1.pdf [R=302,L]

--- a/mapvowl/eval17/README.md
+++ b/mapvowl/eval17/README.md
@@ -1,0 +1,14 @@
+# MapVOWL
+
+MapVOWL is a user-oriented visual notation for mapping rules which defines how Linked Data is generated from raw data.
+
+## Redirects
+
+| w3id.org URL | Meaning | Redirected to |
+|---|---|---|
+| https://w3id.org/mapvowl/eval17/survey | survey used during the evaluation | http://rml.io/data/mapvowle/survey.pdf|
+| https://w3id.org/mapvowl/eval17/intro | introduction to MapVOWL | http://rml.io/data/mapvowle/intro.pdf |
+
+## Contact
+- Pieter Heyvaert (pheyvaer.heyvaert@ugent.be)
+- Anastasia Dimou (anastasia.dimou@ugent.be)

--- a/rml/editor/eval17/.htaccess
+++ b/rml/editor/eval17/.htaccess
@@ -1,0 +1,6 @@
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^survey(.*)$ http://rml.io/data/rmlee/survey-$1.pdf [R=302,L]
+RewriteRule ^intro$ http://rml.io/data/rmlee/intro.pdf [R=302,L]

--- a/rml/editor/eval17/README.md
+++ b/rml/editor/eval17/README.md
@@ -1,0 +1,15 @@
+# RMLEditor
+
+The RMLEditor is a graph-based visualization tool for mapping rules that define how Linked Data is generated from multiple heterogeneous data sources.
+
+## Redirects
+
+| w3id.org URL | Meaning | Redirected to |
+|---|---|---|
+| https://w3id.org/rml/editor/eval17/survey1 | survey used during the evaluation | http://rml.io/data/rmlee/survey-1.pdf|
+| https://w3id.org/rml/editor/eval17/survey2 | survey used during the evaluation | http://rml.io/data/rmlee/survey-2.pdf|
+| https://w3id.org/rml/editor/eval17/intro | introduction to the RMLEditor | http://rml.io/data/rmlee/intro.pdf |
+
+## Contact
+- Pieter Heyvaert (pheyvaer.heyvaert@ugent.be)
+- Anastasia Dimou (anastasia.dimou@ugent.be)


### PR DESCRIPTION
For the evaluation of MapVOWL and the RMLEditor we would like to use w3id.org URLs. This in order to have stable URLs as part of our research publication.