### PR TITLE
Revision of w3id.org/ibp

### DIFF
--- a/ibp/.htaccess
+++ b/ibp/.htaccess
@@ -12,7 +12,7 @@ AddType text/turtle .ttl
 RewriteCond %{HTTP_ACCEPT} text/turtle
 RewriteRule ^StateMachineOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateMachineOntology/StateMachineOntology.ttl [R=303]
 
-If application looks for .html
+# If application looks for .html
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
@@ -27,7 +27,7 @@ RewriteRule ^StateMachineOntology$ https://github.com/TechnicalBuildingSystems/O
 RewriteCond %{HTTP_ACCEPT} text/turtle
 RewriteRule ^CTRLont$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/CTRLont/CTRLont.ttl [R=303]
 
-If application looks for .html
+# If application looks for .html
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
@@ -42,7 +42,7 @@ RewriteRule ^CTRLont$ https://github.com/TechnicalBuildingSystems/Ontologies/blo
 RewriteCond %{HTTP_ACCEPT} text/turtle
 RewriteRule ^ConditionOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ConditionOntology/ConditionOntology.ttl [R=303]
 
-If application looks for .html
+# If application looks for .html
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
@@ -57,7 +57,7 @@ RewriteRule ^ConditionOntology$ https://github.com/TechnicalBuildingSystems/Onto
 RewriteCond %{HTTP_ACCEPT} text/turtle
 RewriteRule ^ScheduleOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ScheduleOntology/ScheduleOntology.ttl [R=303]
 
-If application looks for .html
+# If application looks for .html
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
@@ -72,7 +72,7 @@ RewriteRule ^ScheduleOntology$ https://github.com/TechnicalBuildingSystems/Ontol
 RewriteCond %{HTTP_ACCEPT} text/turtle
 RewriteRule ^StateGraphOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateGraphOntology/StateGraphOntology.ttl [R=303]
 
-If application looks for .html
+# If application looks for .html
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]

--- a/ibp/.htaccess
+++ b/ibp/.htaccess
@@ -2,4 +2,86 @@ Header set Access-Control-Allow-Origin *
 Options +FollowSymLinks
 RewriteEngine on
 
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+
+# StateMachineOntology
+# If application looks for .ttl
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^ibp/StateMachineOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateMachineOntology/StateMachineOntology.ttl [R=303]
+
+If application looks for .html
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^ibp/StateMachineOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateMachineOntology/StateMachineOntology.html [R=303]
+
+# Default provide .ttl
+RewriteRule ^ibp/StateMachineOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateMachineOntology/StateMachineOntology.ttl [R=303]
+
+# CTRLont
+# If application looks for .ttl
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^ibp/CTRLont$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/CTRLont/CTRLont.ttl [R=303]
+
+If application looks for .html
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^ibp/CTRLont$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/CTRLont/CTRLont.html [R=303]
+
+# Default provide .ttl
+RewriteRule ^ibp/CTRLont$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/CTRLont/CTRLont.ttl [R=303]
+
+# ConditionOntology
+# If application looks for .ttl
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^ibp/ConditionOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ConditionOntology/ConditionOntology.ttl [R=303]
+
+If application looks for .html
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^ibp/ConditionOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ConditionOntology/ConditionOntology.html [R=303]
+
+# Default provide .ttl
+RewriteRule ^ibp/ConditionOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ConditionOntology/ConditionOntology.ttl [R=303]
+
+# ScheduleOntology
+# If application looks for .ttl
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^ibp/ScheduleOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ScheduleOntology/ScheduleOntology.ttl [R=303]
+
+If application looks for .html
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^ibp/ScheduleOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ScheduleOntology/ScheduleOntology.html [R=303]
+
+# Default provide .ttl
+RewriteRule ^ibp/ScheduleOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ScheduleOntology/ScheduleOntology.ttl [R=303]
+
+# StateGraphOntology
+# If application looks for .ttl
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^ibp/StateGraphOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateGraphOntology/StateGraphOntology.ttl [R=303]
+
+If application looks for .html
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^ibp/StateGraphOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateGraphOntology/StateGraphOntology.html [R=303]
+
+# Default provide .ttl
+RewriteRule ^ibp/StateGraphOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateGraphOntology/StateGraphOntology.ttl [R=303]
+
+
+# Default rewrite if only namespace is accessed
 RewriteRule ^$ https://github.com/TechnicalBuildingSystems/Ontologies/ [R=302,L]

--- a/ibp/.htaccess
+++ b/ibp/.htaccess
@@ -10,77 +10,77 @@ AddType text/turtle .ttl
 # StateMachineOntology
 # If application looks for .ttl
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^ibp/StateMachineOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateMachineOntology/StateMachineOntology.ttl [R=303]
+RewriteRule ^StateMachineOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateMachineOntology/StateMachineOntology.ttl [R=303]
 
 If application looks for .html
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^ibp/StateMachineOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateMachineOntology/StateMachineOntology.html [R=303]
+RewriteRule ^StateMachineOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateMachineOntology/StateMachineOntology.html [R=303]
 
 # Default provide .ttl
-RewriteRule ^ibp/StateMachineOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateMachineOntology/StateMachineOntology.ttl [R=303]
+RewriteRule ^StateMachineOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateMachineOntology/StateMachineOntology.ttl [R=303]
 
 # CTRLont
 # If application looks for .ttl
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^ibp/CTRLont$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/CTRLont/CTRLont.ttl [R=303]
+RewriteRule ^CTRLont$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/CTRLont/CTRLont.ttl [R=303]
 
 If application looks for .html
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^ibp/CTRLont$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/CTRLont/CTRLont.html [R=303]
+RewriteRule ^CTRLont$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/CTRLont/CTRLont.html [R=303]
 
 # Default provide .ttl
-RewriteRule ^ibp/CTRLont$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/CTRLont/CTRLont.ttl [R=303]
+RewriteRule ^CTRLont$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/CTRLont/CTRLont.ttl [R=303]
 
 # ConditionOntology
 # If application looks for .ttl
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^ibp/ConditionOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ConditionOntology/ConditionOntology.ttl [R=303]
+RewriteRule ^ConditionOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ConditionOntology/ConditionOntology.ttl [R=303]
 
 If application looks for .html
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^ibp/ConditionOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ConditionOntology/ConditionOntology.html [R=303]
+RewriteRule ^ConditionOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ConditionOntology/ConditionOntology.html [R=303]
 
 # Default provide .ttl
-RewriteRule ^ibp/ConditionOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ConditionOntology/ConditionOntology.ttl [R=303]
+RewriteRule ^ConditionOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ConditionOntology/ConditionOntology.ttl [R=303]
 
 # ScheduleOntology
 # If application looks for .ttl
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^ibp/ScheduleOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ScheduleOntology/ScheduleOntology.ttl [R=303]
+RewriteRule ^ScheduleOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ScheduleOntology/ScheduleOntology.ttl [R=303]
 
 If application looks for .html
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^ibp/ScheduleOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ScheduleOntology/ScheduleOntology.html [R=303]
+RewriteRule ^ScheduleOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ScheduleOntology/ScheduleOntology.html [R=303]
 
 # Default provide .ttl
-RewriteRule ^ibp/ScheduleOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ScheduleOntology/ScheduleOntology.ttl [R=303]
+RewriteRule ^ScheduleOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ScheduleOntology/ScheduleOntology.ttl [R=303]
 
 # StateGraphOntology
 # If application looks for .ttl
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^ibp/StateGraphOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateGraphOntology/StateGraphOntology.ttl [R=303]
+RewriteRule ^StateGraphOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateGraphOntology/StateGraphOntology.ttl [R=303]
 
 If application looks for .html
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^ibp/StateGraphOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateGraphOntology/StateGraphOntology.html [R=303]
+RewriteRule ^StateGraphOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateGraphOntology/StateGraphOntology.html [R=303]
 
 # Default provide .ttl
-RewriteRule ^ibp/StateGraphOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateGraphOntology/StateGraphOntology.ttl [R=303]
+RewriteRule ^StateGraphOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateGraphOntology/StateGraphOntology.ttl [R=303]
 
 
 # Default rewrite if only namespace is accessed

--- a/ibp/README.md
+++ b/ibp/README.md
@@ -7,8 +7,11 @@ Documentation:
 
 Source:
 
-* https://github.com/TechnicalBuildingSystems/Ontologies
-
+* https://w3id.org/ibp/CTRLont --> https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/CTRLont/CTRLont.ttl
+* https://w3id.org/ibp/StateMachineOntology --> https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateMachineOntology/StateMachineOntology.ttl
+* https://w3id.org/ibp/StateGraphOntology --> https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateGraphOntology/StateGraphOntology.ttl
+* https://w3id.org/ibp/ScheduleOntology --> https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ScheduleOntology/ScheduleOntology.ttl
+* https://w3id.org/ibp/ConditionOntology --> https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ConditionOntology/ConditionOntology.ttl
 
 Contact:
 


### PR DESCRIPTION
We revised the rewrite rules of w3id.org/ibp

Added now rewrite rules dependend on the content type (ttl/html)

Also added rules for each hosted ontology