### PR TITLE
Switching to raw.githubusercontent on w3id.org/ibp/...

### DIFF
--- a/ibp/.htaccess
+++ b/ibp/.htaccess
@@ -10,77 +10,77 @@ AddType text/turtle .ttl
 # StateMachineOntology
 # If application looks for .ttl
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^StateMachineOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateMachineOntology/StateMachineOntology.ttl [R=303]
+RewriteRule ^StateMachineOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/StateMachineOntology/StateMachineOntology.ttl [R=303]
 
 # If application looks for .html
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^StateMachineOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateMachineOntology/StateMachineOntology.html [R=303]
+RewriteRule ^StateMachineOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/StateMachineOntology/StateMachineOntology.html [R=303]
 
 # Default provide .ttl
-RewriteRule ^StateMachineOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateMachineOntology/StateMachineOntology.ttl [R=303]
+RewriteRule ^StateMachineOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/StateMachineOntology/StateMachineOntology.ttl [R=303]
 
 # CTRLont
 # If application looks for .ttl
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^CTRLont$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/CTRLont/CTRLont.ttl [R=303]
+RewriteRule ^CTRLont$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/CTRLont/CTRLont.ttl [R=303]
 
 # If application looks for .html
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^CTRLont$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/CTRLont/CTRLont.html [R=303]
+RewriteRule ^CTRLont$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/CTRLont/CTRLont.html [R=303]
 
 # Default provide .ttl
-RewriteRule ^CTRLont$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/CTRLont/CTRLont.ttl [R=303]
+RewriteRule ^CTRLont$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/CTRLont/CTRLont.ttl [R=303]
 
 # ConditionOntology
 # If application looks for .ttl
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^ConditionOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ConditionOntology/ConditionOntology.ttl [R=303]
+RewriteRule ^ConditionOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/ConditionOntology/ConditionOntology.ttl [R=303]
 
 # If application looks for .html
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^ConditionOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ConditionOntology/ConditionOntology.html [R=303]
+RewriteRule ^ConditionOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/ConditionOntology/ConditionOntology.html [R=303]
 
 # Default provide .ttl
-RewriteRule ^ConditionOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ConditionOntology/ConditionOntology.ttl [R=303]
+RewriteRule ^ConditionOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/ConditionOntology/ConditionOntology.ttl [R=303]
 
 # ScheduleOntology
 # If application looks for .ttl
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^ScheduleOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ScheduleOntology/ScheduleOntology.ttl [R=303]
+RewriteRule ^ScheduleOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/ScheduleOntology/ScheduleOntology.ttl [R=303]
 
 # If application looks for .html
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^ScheduleOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ScheduleOntology/ScheduleOntology.html [R=303]
+RewriteRule ^ScheduleOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/ScheduleOntology/ScheduleOntology.html [R=303]
 
 # Default provide .ttl
-RewriteRule ^ScheduleOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ScheduleOntology/ScheduleOntology.ttl [R=303]
+RewriteRule ^ScheduleOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/ScheduleOntology/ScheduleOntology.ttl [R=303]
 
 # StateGraphOntology
 # If application looks for .ttl
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^StateGraphOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateGraphOntology/StateGraphOntology.ttl [R=303]
+RewriteRule ^StateGraphOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/StateGraphOntology/StateGraphOntology.ttl [R=303]
 
 # If application looks for .html
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^StateGraphOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateGraphOntology/StateGraphOntology.html [R=303]
+RewriteRule ^StateGraphOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/StateGraphOntology/StateGraphOntology.html [R=303]
 
 # Default provide .ttl
-RewriteRule ^StateGraphOntology$ https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateGraphOntology/StateGraphOntology.ttl [R=303]
+RewriteRule ^StateGraphOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/StateGraphOntology/StateGraphOntology.ttl [R=303]
 
 
 # Default rewrite if only namespace is accessed

--- a/ibp/README.md
+++ b/ibp/README.md
@@ -3,15 +3,17 @@
 
 Documentation:
 
-* https://w3id.org/ibp/ --> https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/README.md
+* https://w3id.org/ibp/ --> https://github.com/TechnicalBuildingSystems/Ontologies/
 
 Source:
 
-* https://w3id.org/ibp/CTRLont --> https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/CTRLont/CTRLont.ttl
-* https://w3id.org/ibp/StateMachineOntology --> https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateMachineOntology/StateMachineOntology.ttl
-* https://w3id.org/ibp/StateGraphOntology --> https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/StateGraphOntology/StateGraphOntology.ttl
-* https://w3id.org/ibp/ScheduleOntology --> https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ScheduleOntology/ScheduleOntology.ttl
-* https://w3id.org/ibp/ConditionOntology --> https://github.com/TechnicalBuildingSystems/Ontologies/blob/master/ConditionOntology/ConditionOntology.ttl
+* https://w3id.org/ibp/CTRLont --> https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/CTRLont/CTRLont.ttl
+* https://w3id.org/ibp/StateMachineOntology --> https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/StateMachineOntology/StateMachineOntology.ttl
+* https://w3id.org/ibp/StateGraphOntology --> https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/StateGraphOntology/StateGraphOntology.ttl
+* https://w3id.org/ibp/ScheduleOntology --> https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/ScheduleOntology/ScheduleOntology.ttl
+* https://w3id.org/ibp/ConditionOntology --> https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/ConditionOntology/ConditionOntology.ttl
+
+Similar for html documentation.
 
 Contact:
 


### PR DESCRIPTION
Dear w3id.org-team,

we switched our htaccess file to forward to raw.githubusercontent domain to enable serving ttl and html files of our ontologies seperatly.

Thanks to Daniel Garijo for suggesting this.

Best

Georg