### PR TITLE
Handling of SPAR Ontologies in GitHub

### DIFF
--- a/spar/.htaccess
+++ b/spar/.htaccess
@@ -1,6 +1,48 @@
 Header set Access-Control-Allow-Origin *
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^/?$ http://www.sparontologies.net [R=302,L]
+
+# Mediatype dataset [start]
 RewriteRule ^mediatype/?$ http://www.sparontologies.net/mediatype [R=302,L]
 RewriteRule ^mediatype/(.+)$ http://www.sparontologies.net/mediatype/$1 [R=302,L]
+# Mediatype dataset [end]
+
+# SPAR Ontologies - generic [start]
+RewriteRule ^(.+)\.(html|xml|json|ttl|nt)$ https://sparontologies.github.io/$1/current/$1.$2 [R=303,L]
+RewriteRule ^(.+)/([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9])\.(html|xml|json|ttl|nt)$ https://sparontologies.github.io/$1/$2/$1.$3 [R=303,L]
+# SPAR Ontologies - generic [end]
+
+
+### CONFIGURATION redir: begin ########################
+
+# Rewrite rule for no content
+RewriteRule ^.+\.(html|xml|json|ttl|nt)$ - [R=404,L]
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} html
+RewriteRule ^.+$ /spar/$1.html [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/xml
+RewriteRule ^.+$ /spar/$1.xml [R=303,L]
+
+# Rewrite rule to serve Turtle content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
+RewriteCond %{HTTP_ACCEPT} text/ttl
+RewriteRule ^.+$ /spar/$1.ttl [R=303,L]
+
+# Rewrite rule to serve Notation3 content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples [OR]
+RewriteCond %{HTTP_ACCEPT} text/plain
+RewriteRule ^.+$ /spar/$1.nt [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^.+$ /spar/$1.json [R=303,L]
+
+######################## CONFIGURATION redir: end #####
+
+# Default behaviour
+RewriteRule ^(.*)$ http://www.sparontologies.net/$1 [R=302,L]


### PR DESCRIPTION
The htaccess has been changed in order to handle properly SPAR Ontologies in the new GitHub repository.