### PR TITLE
Corrected mistake in htaccess in redir block

### DIFF
--- a/spar/.htaccess
+++ b/spar/.htaccess
@@ -20,27 +20,27 @@ RewriteRule ^.+\.(html|xml|json|ttl|nt)$ - [R=404,L]
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} html
-RewriteRule ^.+$ /spar/$1.html [R=303,L]
+RewriteRule ^(.+)$ /spar/$1.html [R=303,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} application/xml
-RewriteRule ^.+$ /spar/$1.xml [R=303,L]
+RewriteRule ^(.+)$ /spar/$1.xml [R=303,L]
 
 # Rewrite rule to serve Turtle content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
 RewriteCond %{HTTP_ACCEPT} text/ttl
-RewriteRule ^.+$ /spar/$1.ttl [R=303,L]
+RewriteRule ^(.+)$ /spar/$1.ttl [R=303,L]
 
 # Rewrite rule to serve Notation3 content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples [OR]
 RewriteCond %{HTTP_ACCEPT} text/plain
-RewriteRule ^.+$ /spar/$1.nt [R=303,L]
+RewriteRule ^(.+)$ /spar/$1.nt [R=303,L]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
 RewriteCond %{HTTP_ACCEPT} application/json
-RewriteRule ^.+$ /spar/$1.json [R=303,L]
+RewriteRule ^(.+)$ /spar/$1.json [R=303,L]
 
 ######################## CONFIGURATION redir: end #####
 


### PR DESCRIPTION
No regex grouping was enabled in the redir block, and it does not work properly. As a future work, one should consider to handle also the redirection in a smoother way - i.e. without so many 303 redir, but it is something that should be tested in advance.