### PR TITLE
Inverted the rewrite rules of the SPAR Ontologies

### DIFF
--- a/spar/.htaccess
+++ b/spar/.htaccess
@@ -8,8 +8,8 @@ RewriteRule ^mediatype/(.+)$ http://www.sparontologies.net/mediatype/$1 [R=302,L
 # Mediatype dataset [end]
 
 # SPAR Ontologies - generic [start]
-RewriteRule ^(.+)\.(html|xml|json|ttl|nt)$ https://sparontologies.github.io/$1/current/$1.$2 [R=303,L]
 RewriteRule ^(.+)/([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9])\.(html|xml|json|ttl|nt)$ https://sparontologies.github.io/$1/$2/$1.$3 [R=303,L]
+RewriteRule ^(.+)\.(html|xml|json|ttl|nt)$ https://sparontologies.github.io/$1/current/$1.$2 [R=303,L]
 # SPAR Ontologies - generic [end]
 
 


### PR DESCRIPTION
The two rules for handling the redirection of the SPAR Ontologies have been inverted so as to make the version redirection working correctly.