### PR TITLE
Add redirection to Audio Commons ontology

### DIFF
--- a/ac-ontology/.htaccess
+++ b/ac-ontology/.htaccess
@@ -1,0 +1,32 @@
+Options +FollowSymLinks
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .nt
+AddType application/ld+json .jsonld
+
+RewriteEngine on
+
+#Rewrite rules for aco
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*|\*/\*)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^aco$ http://http://www.audiocommons.org/ac-ontology/aco.html  [R=303,NE,L]
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteRule ^aco$ http://www.audiocommons.org/ac-ontology/aco.owl [R=303,NE,L]
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.*
+RewriteRule ^aco$ http://www.audiocommons.org/ac-ontology/aco.ttl [R=303,NE,L]
+RewriteCond %{HTTP_ACCEPT} ^.*application/n-triples.*
+RewriteRule ^aco$ http://www.audiocommons.org/ac-ontology/aco.nt [R=303,NE,L]
+RewriteCond %{HTTP_ACCEPT} ^.*application/ld+json.*
+RewriteRule ^aco$ http://www.audiocommons.org/ac-ontology/aco.jsonld [R=303,NE,L]
+#default response: owl
+RewriteRule ^aco$ http://www.audiocommons.org/ac-ontology/aco.owl [R=303,NE,L]

--- a/ac-ontology/README.md
+++ b/ac-ontology/README.md
@@ -1,0 +1,9 @@
+# Audio Commons Ontology
+
+Contact: Miguel Ceriani (m.ceriani AT qmul.ac.uk)
+
+Redirection to the serializations of the Audio Commons ontology.
+Audio Commons (audiocommons.org) is a project that aims at bringing Creative
+Commons audio content to the creative industries.
+The Audio Commons ontology serves as common data model to integrate multiple
+audio content repositories.


### PR DESCRIPTION
This add redirection from https://w3id.org/ac-ontology/aco to
http://www.audiocommons.org/ac-ontology/aco performing content
negotiation.
That’s the ontology we designed in the context of the European project
Audio Commons (audiocommons.org).