### PR TITLE
Follow The Money ontology

### DIFF
--- a/ftm/.htaccess
+++ b/ftm/.htaccess
@@ -1,0 +1,15 @@
+Header set Access-Control-Allow-Origin *
+
+AddType application/rdf+xml .rdf
+AddType application/ld+json .jsonld
+AddType text/turtle .ttl
+
+RewriteEngine On
+
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.* 
+RewriteRule ^.*$ https://alephdata.github.io/followthemoney/ns/ftm.xml [R=303,L]
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^.*$ https://alephdata.github.io/followthemoney/ns/ftm.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} ^.*application/ld\+json.* 
+RewriteRule ^.*$ https://alephdata.github.io/followthemoney/ns/ftm.jsonld [R=303,L]
+RewriteRule ^.*$ http://www.essepuntato.it/lode/owlapi/https://alephdata.github.io/followthemoney/ns/ftm.xml [R=303,L]

--- a/ftm/readme.md
+++ b/ftm/readme.md
@@ -1,0 +1,5 @@
+# Follow The Money
+
+An ontology for investigative journalism, based on the real world.
+
+See [documentation](https://alephdata.github.io/followthemoney) and [source](https://github.com/alephdata/followthemoney).


### PR DESCRIPTION
This is the RDF version of the schema used in [aleph](https://github.com/alephdata/aleph) and by [OCCRP](https://occrp.org) for modeling entities of interest in money laundering investigations and other investigative journalism projects.