### PR TITLE
Adding improved visualiation of HTML Ontology documentation

### DIFF
--- a/ibp/.htaccess
+++ b/ibp/.htaccess
@@ -17,7 +17,7 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^StateMachineOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/StateMachineOntology/StateMachineOntology.html [R=303]
+RewriteRule ^StateMachineOntology$ https://htmlpreview.github.io/?https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/StateMachineOntology/StateMachineOntology.html [R=303]
 
 # Default provide .ttl
 RewriteRule ^StateMachineOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/StateMachineOntology/StateMachineOntology.ttl [R=303]
@@ -32,7 +32,7 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^CTRLont$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/CTRLont/CTRLont.html [R=303]
+RewriteRule ^CTRLont$ https://htmlpreview.github.io/?https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/CTRLont/CTRLont.html [R=303]
 
 # Default provide .ttl
 RewriteRule ^CTRLont$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/CTRLont/CTRLont.ttl [R=303]
@@ -47,7 +47,7 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^ConditionOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/ConditionOntology/ConditionOntology.html [R=303]
+RewriteRule ^ConditionOntology$ https://htmlpreview.github.io/?https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/ConditionOntology/ConditionOntology.html [R=303]
 
 # Default provide .ttl
 RewriteRule ^ConditionOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/ConditionOntology/ConditionOntology.ttl [R=303]
@@ -62,7 +62,7 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^ScheduleOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/ScheduleOntology/ScheduleOntology.html [R=303]
+RewriteRule ^ScheduleOntology$ https://htmlpreview.github.io/?https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/ScheduleOntology/ScheduleOntology.html [R=303]
 
 # Default provide .ttl
 RewriteRule ^ScheduleOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/ScheduleOntology/ScheduleOntology.ttl [R=303]
@@ -77,7 +77,7 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^StateGraphOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/StateGraphOntology/StateGraphOntology.html [R=303]
+RewriteRule ^StateGraphOntology$ https://htmlpreview.github.io/?https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/StateGraphOntology/StateGraphOntology.html [R=303]
 
 # Default provide .ttl
 RewriteRule ^StateGraphOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/StateGraphOntology/StateGraphOntology.ttl [R=303]
@@ -92,7 +92,7 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^FMUont$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/FMUont/FMUont.html [R=303]
+RewriteRule ^FMUont$ https://htmlpreview.github.io/?https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/FMUont/FMUont.html [R=303]
 
 # Default provide .ttl
 RewriteRule ^FMUont$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/FMUont/FMUont.ttl [R=303]


### PR DESCRIPTION
Revision of htaccess to improve the redirect to the HTML code by adding https://htmlpreview.github.io/?