### PR TITLE
Added redirects for novel ontologies MealyMachineOntology and MooreMa…

### DIFF
--- a/ibp/.htaccess
+++ b/ibp/.htaccess
@@ -97,5 +97,35 @@ RewriteRule ^FMUont$ https://htmlpreview.github.io/?https://raw.githubuserconten
 # Default provide .ttl
 RewriteRule ^FMUont$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/FMUont/FMUont.ttl [R=303]
 
+# MooreMachineOntology
+# If application looks for .ttl
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^MooreMachineOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/MooreMachineOntology/MooreMachineOntology.ttl [R=303]
+
+# If application looks for .html
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^MooreMachineOntology$ https://htmlpreview.github.io/?https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/MooreMachineOntology/MooreMachineOntology.html [R=303]
+
+# Default provide .ttl
+RewriteRule ^MooreMachineOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/MooreMachineOntology/MooreMachineOntology.ttl [R=303]
+
+# MealeyMachineOntology
+# If application looks for .ttl
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^MealeyMachineOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/MealeyMachineOntology/MealeyMachineOntology.ttl [R=303]
+
+# If application looks for .html
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^MealeyMachineOntology$ https://htmlpreview.github.io/?https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/MealeyMachineOntology/MealeyMachineOntology.html [R=303]
+
+# Default provide .ttl
+RewriteRule ^MealeyMachineOntology$ https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/MealeyMachineOntology/MealeyMachineOntology.ttl [R=303]
+
 # Default rewrite if only namespace is accessed
 RewriteRule ^$ https://github.com/TechnicalBuildingSystems/Ontologies/ [R=302,L]

--- a/ibp/README.md
+++ b/ibp/README.md
@@ -7,15 +7,11 @@ Documentation:
 
 Source:
 
-* https://w3id.org/ibp/CTRLont --> https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/CTRLont/CTRLont.ttl
-* https://w3id.org/ibp/StateMachineOntology --> https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/StateMachineOntology/StateMachineOntology.ttl
-* https://w3id.org/ibp/StateGraphOntology --> https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/StateGraphOntology/StateGraphOntology.ttl
-* https://w3id.org/ibp/ScheduleOntology --> https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/ScheduleOntology/ScheduleOntology.ttl
-* https://w3id.org/ibp/ConditionOntology --> https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/ConditionOntology/ConditionOntology.ttl
-* https://w3id.org/ibp/FMUont --> https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/FMUont/FMUont.ttl
+* https://w3id.org/ibp/$OntologyName$ --> https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/$OntologyName$/$OntologyName$.ttl
 
+Documentation of ontology
 
-Similar for html documentation.
+* https://w3id.org/ibp/$OntologyName$ --> https://htmlpreview.github.io/?https://raw.githubusercontent.com/TechnicalBuildingSystems/Ontologies/master/$OntologyName$/$OntologyName$.html 
 
 Contact:
 


### PR DESCRIPTION
…chineOntology

Also updated the README.md to comply to latest development

Currently the redirect for html content goes via html preview work around and is supposed to be changed soon as of [Issue](https://github.com/TechnicalBuildingSystems/Ontologies/issues/5).