### PR TITLE
Establishing a permanent namespace for ontologies developed in the MOEEBIUS H2020 project

### DIFF
--- a/moeebius/.htaccess
+++ b/moeebius/.htaccess
@@ -1,0 +1,26 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+
+# MOEEBIUS Ontology
+# If application looks for .ttl
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^MOEEBIUSOntology$ https://raw.githubusercontent.com/MOEEBIUS/MOEEBIUS_Ontology/master/MOEEBIUSOntology/MOEEBIUS-0.0.1.ttl [R=303]
+
+# If application looks for .html
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^MOEEBIUSOntology$ https://htmlpreview.github.io/?https://raw.githubusercontent.com/MOEEBIUS/MOEEBIUS_Ontology/master/MOEEBIUSOntology/Documentation/index-en.html [R=303]
+
+# Default provide .ttl
+RewriteRule ^MOEEBIUSOntology$ https://raw.githubusercontent.com/MOEEBIUS/MOEEBIUS_Ontology/master/MOEEBIUSOntology/MOEEBIUS-0.0.1.ttl [R=303]
+
+# Default rewrite if only namespace is accessed
+RewriteRule ^$ https://github.com/MOEEBIUS/MOEEBIUS_Ontology [R=302,L]

--- a/moeebius/README.md
+++ b/moeebius/README.md
@@ -1,0 +1,24 @@
+# Ontologies by the MOEEBIUS EU H2020 Project
+===
+
+## Acknowledgements
+
+Parts of this work have been developed with funding from the European Union's Horizon 2020 research and innovation programme under grant agreement No 680517 (MOEEBIUS)
+
+## Documentation:
+
+* https://w3id.org/moeebius/ --> https://github.com/MOEEBIUS/MOEEBIUS_Ontology
+
+## Source:
+
+* https://w3id.org/moeebius/MOEEBIUSOntology --> https://raw.githubusercontent.com/MOEEBIUS/MOEEBIUS_Ontology/master/MOEEBIUSOntology/MOEEBIUS-0.0.1.ttl
+
+## Documentation of ontology
+
+* https://w3id.org/moeebius/MOEEBIUSOntology --> https://htmlpreview.github.io/?https://raw.githubusercontent.com/MOEEBIUS/MOEEBIUS_Ontology/master/MOEEBIUSOntology/Documentation/index-en.html
+
+
+## Contact:
+
+* Georg Ferdinand Schneider <georg.schneider@th-nuernberg.de>
+* Gunnar Grün <gunnar.gruen@th-nuernberg.de>


### PR DESCRIPTION
Dear w3id.org-team,

we would like to register a new permanent identifier under the w3id.org service for ontologies developed under the MOEEBIUS H2020 project.

> https://w3id.org/moeebius/

The identifier will be used in the ontologies developed with this project. The identifier needs to be permanent as the ontologies developed are supposed to be available and accessible forever.

Best

Georg