### PR TITLE
w3id IRIs for publishing tourism statistics of Sri Lanka.

### DIFF
--- a/sri-lanka/tourism/structure/.htaccess
+++ b/sri-lanka/tourism/structure/.htaccess
@@ -1,0 +1,10 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.* 
+RewriteRule ^(.*)$ https://tourism-data.github.io/sri-lanka/rdf/vocab/vocab.rdf [R=303,L]
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^(.*)$ https://tourism-data.github.io/sri-lanka/rdf/vocab/vocab.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} ^.*application/ld\+json.* 
+RewriteRule ^(.*)$ https://tourism-data.github.io/sri-lanka/rdf/vocab/vocab.jsonld [R=303,L]
+RewriteRule ^(.*)$ https://tourism-data.github.io/sri-lanka/rdf/vocab/vocab.ttl [R=303,L]

--- a/sri-lanka/tourism/values/.htaccess
+++ b/sri-lanka/tourism/values/.htaccess
@@ -1,0 +1,10 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.* 
+RewriteRule ^(.*)$ https://tourism-data.github.io/sri-lanka/values/$1.rdf [R=303,L]
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^(.*)$ https://tourism-data.github.io/sri-lanka/values/$1.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} ^.*application/ld\+json.* 
+RewriteRule ^(.*)$ https://tourism-data.github.io/sri-lanka/values/$1.jsonld [R=303,L]
+RewriteRule ^(.*)$ https://tourism-data.github.io/sri-lanka/values/$1.ttl [R=303,L]

--- a/sri-lanka/tourism/vocab/.htaccess
+++ b/sri-lanka/tourism/vocab/.htaccess
@@ -1,0 +1,10 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.* 
+RewriteRule ^(.*)$ https://tourism-data.github.io/sri-lanka/rdf/vocab/vocab.rdf [R=303,L]
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^(.*)$ https://tourism-data.github.io/sri-lanka/rdf/vocab/vocab.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} ^.*application/ld\+json.* 
+RewriteRule ^(.*)$ https://tourism-data.github.io/sri-lanka/rdf/vocab/vocab.jsonld [R=303,L]
+RewriteRule ^(.*)$ https://tourism-data.github.io/sri-lanka/rdf/vocab/vocab.ttl [R=303,L]


### PR DESCRIPTION
w3id IRIs for publishing tourism statistics of Sri Lanka.

The raw RDF files are stored in a Github repo.
e.g., https://github.com/tourism-data/tourism-data.github.io/tree/master/sri-lanka/values/arrivals-country-year-month

This commit includes the .htaccess files for content negotiation and redirection.

I have tested the .htacess files in a local Apache server.