### PR TITLE
added DockerPedia persistent URI

### DIFF
--- a/DockerPedia/.htaccess
+++ b/DockerPedia/.htaccess
@@ -1,0 +1,4 @@
+Options +FollowSymLinks
+RewriteEngine on
+#Set of rules for the applications (302, no Content negotiation)
+RewriteRule ^$ https://dockerpedia.inf.utfsm.cl [R=302,L]

--- a/DockerPedia/README.md
+++ b/DockerPedia/README.md
@@ -1,0 +1,7 @@
+# Permanent identifier space for the DockerPedia data service and resource
+
+This space concerns the DockerPedia data resource, which is a data resource with annotated Docker images from DockerHub. The data contains information about packages within an image, security issues, etc.
+
+This project is managed by the Semantic Web Lab, Informatics Department, Universidad Técnica federico Santa María, Chile
+
+The responsible for this space is Carlos Buil-Aranda, @cbuil


### PR DESCRIPTION
added DockerPedia persistent URI: https://dockerpedia.inf.utfsm.cl 