### PR TITLE
Introducing a PermaID for Public Code

### DIFF
--- a/publiccode/.htaccess
+++ b/publiccode/.htaccess
@@ -1,0 +1,5 @@
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^(.*)$ https://publiccodenet.github.io/publiccode.yml/$1 [R=302,L]

--- a/publiccode/README.md
+++ b/publiccode/README.md
@@ -1,0 +1,9 @@
+Public Code
+===========
+
+The Public code specification is an effort to standardize and describe Open Source software for Public Administrations, so that indexing and reuse becomes simpler. The specification is hosted by the Foundation for Public Code and has been devloped in close cooperation with the Digital Transformation Team of the Italian Government.
+
+With this identifier we want to create a stable reference to use inside every document in order to uniquely reference the various versions of the standard.
+
+Contacts: 
+* Riccardo Iaconelli <riccardo@teamdigitale.governo.it>


### PR DESCRIPTION
Public Code is a specification (still under development) to describe software built by and for use by Public Administrations. This pull request creates a permanent ID to permanently track the various iterations of the standard.
