### PR TITLE
w3id IRIs for the Linked Fiestas dataset

### DIFF
--- a/linked-fiestas/readme.md
+++ b/linked-fiestas/readme.md
@@ -1,0 +1,17 @@
+# Linked-Fiestas: A  Knowledge Graph to Promote Cultural Tourism in Spain
+
+Linked-Fiestas is a dataset that aims at providing data of festivals and events from not so well-known regions, so spreading their cultural heritage, bringing visibility to them, and thus, increasing tourists interest. Linked-Fiestas gathers data from well-known datasets, such as DBpedia and Wikidata, and from other datasets outside the Web of Data community such as fiesta.net or spain.info.
+
+URI Patterns: https://w3id.org/linked-fiestas/resource/<id>
+
+Content negociation for turtle, rdf/xml, and jsonld is performed through the .htaccess file.
+
+
+## Contacts
+
+- nandana@apache.org
+
+
+## Reference
+
+Andrea Cimmino, Nandana Mihindukulasooriya, Freddy Priyatna and Mariano Rico. Linked-Fiestas: A  Knowledge Graph to Promote Cultural Tourism in Spain. Accepted at the 1st International Workshop on Knowledge Graphs on Travel and Tourism. 

--- a/linked-fiestas/resource/.htaccess
+++ b/linked-fiestas/resource/.htaccess
@@ -1,0 +1,10 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.* 
+RewriteRule ^(.*)$ https://nandana.github.io/linked-fiestas/resources/$1.rdf [R=303,L]
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^(.*)$ https://nandana.github.io/linked-fiestas/resources/$1.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} ^.*application/ld\+json.* 
+RewriteRule ^(.*)$ https://nandana.github.io/linked-fiestas/resources/$1.jsonld [R=303,L]
+RewriteRule ^(.*)$ https://nandana.github.io/linked-fiestas/resources/$1.ttl [R=303,L]


### PR DESCRIPTION
w3id IRIs for publishing the Linked Fiestas dataset

The raw RDF files are stored in a Github repo.
https://github.com/nandana/linked-fiestas/tree/master/resources

This commit includes the .htaccess files for content negotiation and redirection.

I have tested the .htacess files in a local Apache server.