### PR TITLE
Now redirects full path, so longer URLs can go deep into the website

### DIFF
--- a/people/matt/.htaccess
+++ b/people/matt/.htaccess
@@ -5,4 +5,4 @@ RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
 RewriteRule ^$ http://163.172.187.51/matt/foaf.rdf [R=303,L]
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
 RewriteRule ^$ http://163.172.187.51/matt/foaf.ttl [R=303,L]
-RewriteRule ^$ http://163.172.187.51/matt/ [R=303,L]
+RewriteRule ^(.*)$ http://163.172.187.51/matt/$1 [R=303,L]


### PR DESCRIPTION
Example: before this change, this URL produces 404:
```
https://w3id.org/people/matt/Dorset2017-08/
```
After the change, a document is found.