### PR TITLE
arm: change path for lode docs

### DIFF
--- a/arm/.htaccess
+++ b/arm/.htaccess
@@ -15,21 +15,21 @@ RewriteRule ^$ https://ld4p.github.io/arm/ [R=302,L]
 
 # Version 0.1
 RewriteRule ^core/ontology/0.1/core.rdf https://ld4p.github.io/arm/core/ontology/0.1/core.rdf [R=302,L]
-RewriteRule ^core/ontology/0.1/core.html https://ld4p.github.io/arm/core/ontology/0.1/doc/lode/core.html [R=302,L]
+RewriteRule ^core/ontology/0.1/core.html https://ld4p.github.io/arm/core/ontology/0.1/core.html [R=302,L]
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^core/ontology/0.1/?$ https://ld4p.github.io/arm/core/ontology/0.1/doc/lode/core.html [R=303]
+RewriteRule ^core/ontology/0.1/?$ https://ld4p.github.io/arm/core/ontology/0.1/core.html [R=303]
 
 # Rewrite rule to serve directed HTML content from class/prop URIs
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^core/ontology/0.1/?([^/]+) https://ld4p.github.io/arm/core/ontology/0.1/doc/lode/core.html#$1 [R=303,NE]
+RewriteRule ^core/ontology/0.1/?([^/]+) https://ld4p.github.io/arm/core/ontology/0.1/core.html#$1 [R=303,NE]
 
 # Rewrite rule to serve RDF/XML content if request is not HTML
 #any non-HTML gives RDF so omit this: RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
@@ -44,21 +44,21 @@ RewriteRule ^core/ontology/core.html$ https://w3id.org/arm/core/ontology/0.1/cor
 
 # Version 0.1
 RewriteRule ^core/activity/0.1/activity.rdf https://ld4p.github.io/arm/core/ontology/0.1/activity.rdf [R=302,L]
-RewriteRule ^core/activity/0.1/activity.html https://ld4p.github.io/arm/core/ontology/0.1/doc/lode/activity.html [R=302,L]
+RewriteRule ^core/activity/0.1/activity.html https://ld4p.github.io/arm/core/ontology/0.1/activity.html [R=302,L]
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^core/activity/0.1/?$ https://ld4p.github.io/arm/core/ontology/0.1/doc/lode/activity.html [R=303]
+RewriteRule ^core/activity/0.1/?$ https://ld4p.github.io/arm/core/ontology/0.1/activity.html [R=303]
 
 # Rewrite rule to serve directed HTML content from class/prop URIs
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^core/activity/0.1/?([^/]+) https://ld4p.github.io/arm/core/ontology/0.1/doc/lode/activity.html#$1 [R=303,NE]
+RewriteRule ^core/activity/0.1/?([^/]+) https://ld4p.github.io/arm/core/ontology/0.1/activity.html#$1 [R=303,NE]
 
 # Rewrite rule to serve RDF/XML content if request is not HTML
 #any non-HTML gives RDF so omit this: RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
@@ -73,21 +73,21 @@ RewriteRule ^core/activity/activity.html$ https://w3id.org/arm/core/activity/0.1
 
 # Version 0.1
 RewriteRule ^award/ontology/0.1/award.rdf https://ld4p.github.io/arm/award/ontology/0.1/award.rdf [R=302,L]
-RewriteRule ^award/ontology/0.1/award.html https://ld4p.github.io/arm/award/ontology/0.1/doc/lode/award.html [R=302,L]
+RewriteRule ^award/ontology/0.1/award.html https://ld4p.github.io/arm/award/ontology/0.1/award.html [R=302,L]
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^award/ontology/0.1/?$ https://ld4p.github.io/arm/award/ontology/0.1/doc/lode/award.html [R=303]
+RewriteRule ^award/ontology/0.1/?$ https://ld4p.github.io/arm/award/ontology/0.1/award.html [R=303]
 
 # Rewrite rule to serve directed HTML content from class/prop URIs
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^award/ontology/0.1/?([^/]+) https://ld4p.github.io/arm/award/ontology/0.1/doc/lode/award.html#$1 [R=303,NE]
+RewriteRule ^award/ontology/0.1/?([^/]+) https://ld4p.github.io/arm/award/ontology/0.1/award.html#$1 [R=303,NE]
 
 # Rewrite rule to serve RDF/XML content if request is not HTML
 #any non-HTML gives RDF so omit this: RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
@@ -102,21 +102,21 @@ RewriteRule ^award/ontology/award.html$ https://w3id.org/arm/award/ontology/0.1/
 
 # Version 0.1
 RewriteRule ^custodial_history/ontology/0.1/custodial_history.rdf https://ld4p.github.io/arm/custodial_history/ontology/0.1/custodial_history.rdf [R=302,L]
-RewriteRule ^custodial_history/ontology/0.1/custodial_history.html https://ld4p.github.io/arm/custodial_history/ontology/0.1/doc/lode/custodial_history.html [R=302,L]
+RewriteRule ^custodial_history/ontology/0.1/custodial_history.html https://ld4p.github.io/arm/custodial_history/ontology/0.1/custodial_history.html [R=302,L]
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^custodial_history/ontology/0.1/?$ https://ld4p.github.io/arm/custodial_history/ontology/0.1/doc/lode/custodial_history.html [R=303]
+RewriteRule ^custodial_history/ontology/0.1/?$ https://ld4p.github.io/arm/custodial_history/ontology/0.1/custodial_history.html [R=303]
 
 # Rewrite rule to serve directed HTML content from class/prop URIs
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^custodial_history/ontology/0.1/?([^/]+) https://ld4p.github.io/arm/custodial_history/ontology/0.1/doc/lode/custodial_history.html#$1 [R=303,NE]
+RewriteRule ^custodial_history/ontology/0.1/?([^/]+) https://ld4p.github.io/arm/custodial_history/ontology/0.1/custodial_history.html#$1 [R=303,NE]
 
 # Rewrite rule to serve RDF/XML content if request is not HTML
 #any non-HTML gives RDF so omit this: RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
@@ -131,21 +131,21 @@ RewriteRule ^custodial_history/ontology/custodial_history.html$ https://w3id.org
 
 # Version 0.1
 RewriteRule ^measurement/ontology/0.1/measurement.rdf https://ld4p.github.io/arm/measurement/ontology/0.1/measurement.rdf [R=302,L]
-RewriteRule ^measurement/ontology/0.1/measurement.html https://ld4p.github.io/arm/measurement/ontology/0.1/doc/lode/measurement.html [R=302,L]
+RewriteRule ^measurement/ontology/0.1/measurement.html https://ld4p.github.io/arm/measurement/ontology/0.1/measurement.html [R=302,L]
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^measurement/ontology/0.1/?$ https://ld4p.github.io/arm/measurement/ontology/0.1/doc/lode/measurement.html [R=303]
+RewriteRule ^measurement/ontology/0.1/?$ https://ld4p.github.io/arm/measurement/ontology/0.1/measurement.html [R=303]
 
 # Rewrite rule to serve directed HTML content from class/prop URIs
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^measurement/ontology/0.1/?([^/]+) https://ld4p.github.io/arm/measurement/ontology/0.1/doc/lode/measurement.html#$1 [R=303,NE]
+RewriteRule ^measurement/ontology/0.1/?([^/]+) https://ld4p.github.io/arm/measurement/ontology/0.1/measurement.html#$1 [R=303,NE]
 
 # Rewrite rule to serve RDF/XML content if request is not HTML
 #any non-HTML gives RDF so omit this: RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
@@ -160,21 +160,21 @@ RewriteRule ^measurement/ontology/measurement.html$ https://w3id.org/arm/measure
 
 # Version 0.1
 RewriteRule ^core/vocabularies/arrangement/0.1/arrangement.rdf https://ld4p.github.io/arm/core/vocabularies/arrangement/0.1/arrangement.rdf [R=302,L]
-RewriteRule ^core/vocabularies/arrangement/0.1/arrangement.html https://ld4p.github.io/arm/core/vocabularies/arrangement/0.1/doc/lode/arrangement.html [R=302,L]
+RewriteRule ^core/vocabularies/arrangement/0.1/arrangement.html https://ld4p.github.io/arm/core/vocabularies/arrangement/0.1/arrangement.html [R=302,L]
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^core/vocabularies/arrangement/0.1/?$ https://ld4p.github.io/arm/core/vocabularies/arrangement/0.1/doc/lode/arrangement.html [R=303]
+RewriteRule ^core/vocabularies/arrangement/0.1/?$ https://ld4p.github.io/arm/core/vocabularies/arrangement/0.1/arrangement.html [R=303]
 
 # Rewrite rule to serve directed HTML content from class/prop URIs
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^core/vocabularies/arrangement/0.1/?([^/]+) https://ld4p.github.io/arm/core/vocabularies/arrangement/0.1/doc/lode/arrangement.html#$1 [R=303,NE]
+RewriteRule ^core/vocabularies/arrangement/0.1/?([^/]+) https://ld4p.github.io/arm/core/vocabularies/arrangement/0.1/arrangement.html#$1 [R=303,NE]
 
 # Rewrite rule to serve RDF/XML content if request is not HTML
 #any non-HTML gives RDF so omit this: RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
@@ -189,21 +189,21 @@ RewriteRule ^core/vocabularies/arrangement/arrangement.html$ https://w3id.org/ar
 
 # Version 0.1
 RewriteRule ^core/vocabularies/handwriting_type/0.1/handwriting_type.rdf https://ld4p.github.io/arm/core/vocabularies/handwriting_type/0.1/handwriting_type.rdf [R=302,L]
-RewriteRule ^core/vocabularies/handwriting_type/0.1/handwriting_type.html https://ld4p.github.io/arm/core/vocabularies/handwriting_type/0.1/doc/lode/handwriting_type.html [R=302,L]
+RewriteRule ^core/vocabularies/handwriting_type/0.1/handwriting_type.html https://ld4p.github.io/arm/core/vocabularies/handwriting_type/0.1/handwriting_type.html [R=302,L]
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^core/vocabularies/handwriting_type/0.1/?$ https://ld4p.github.io/arm/core/vocabularies/handwriting_type/0.1/doc/lode/handwriting_type.html [R=303]
+RewriteRule ^core/vocabularies/handwriting_type/0.1/?$ https://ld4p.github.io/arm/core/vocabularies/handwriting_type/0.1/handwriting_type.html [R=303]
 
 # Rewrite rule to serve directed HTML content from class/prop URIs
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^core/vocabularies/handwriting_type/0.1/?([^/]+) https://ld4p.github.io/arm/core/vocabularies/handwriting_type/0.1/doc/lode/handwriting_type.html#$1 [R=303,NE]
+RewriteRule ^core/vocabularies/handwriting_type/0.1/?([^/]+) https://ld4p.github.io/arm/core/vocabularies/handwriting_type/0.1/handwriting_type.html#$1 [R=303,NE]
 
 # Rewrite rule to serve RDF/XML content if request is not HTML
 #any non-HTML gives RDF so omit this: RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
@@ -218,21 +218,21 @@ RewriteRule ^core/vocabularies/handwriting_type/handwriting_type.html$ https://w
 
 # Version 0.1
 RewriteRule ^core/vocabularies/origin/0.1/origin.rdf https://ld4p.github.io/arm/core/vocabularies/origin/0.1/origin.rdf [R=302,L]
-RewriteRule ^core/vocabularies/origin/0.1/origin.html https://ld4p.github.io/arm/core/vocabularies/origin/0.1/doc/lode/origin.html [R=302,L]
+RewriteRule ^core/vocabularies/origin/0.1/origin.html https://ld4p.github.io/arm/core/vocabularies/origin/0.1/origin.html [R=302,L]
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^core/vocabularies/origin/0.1/?$ https://ld4p.github.io/arm/core/vocabularies/origin/0.1/doc/lode/origin.html [R=303]
+RewriteRule ^core/vocabularies/origin/0.1/?$ https://ld4p.github.io/arm/core/vocabularies/origin/0.1/origin.html [R=303]
 
 # Rewrite rule to serve directed HTML content from class/prop URIs
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^core/vocabularies/origin/0.1/?([^/]+) https://ld4p.github.io/arm/core/vocabularies/origin/0.1/doc/lode/origin.html#$1 [R=303,NE]
+RewriteRule ^core/vocabularies/origin/0.1/?([^/]+) https://ld4p.github.io/arm/core/vocabularies/origin/0.1/origin.html#$1 [R=303,NE]
 
 # Rewrite rule to serve RDF/XML content if request is not HTML
 #any non-HTML gives RDF so omit this: RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
@@ -247,21 +247,21 @@ RewriteRule ^core/vocabularies/origin/origin.html$ https://w3id.org/arm/core/voc
 
 # Version 0.1
 RewriteRule ^core/vocabularies/status/0.1/status.rdf https://ld4p.github.io/arm/core/vocabularies/status/0.1/status.rdf [R=302,L]
-RewriteRule ^core/vocabularies/status/0.1/status.html https://ld4p.github.io/arm/core/vocabularies/status/0.1/doc/lode/status.html [R=302,L]
+RewriteRule ^core/vocabularies/status/0.1/status.html https://ld4p.github.io/arm/core/vocabularies/status/0.1/status.html [R=302,L]
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^core/vocabularies/status/0.1/?$ https://ld4p.github.io/arm/core/vocabularies/status/0.1/doc/lode/status.html [R=303]
+RewriteRule ^core/vocabularies/status/0.1/?$ https://ld4p.github.io/arm/core/vocabularies/status/0.1/status.html [R=303]
 
 # Rewrite rule to serve directed HTML content from class/prop URIs
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^core/vocabularies/status/0.1/?([^/]+) https://ld4p.github.io/arm/core/vocabularies/status/0.1/doc/lode/status.html#$1 [R=303,NE]
+RewriteRule ^core/vocabularies/status/0.1/?([^/]+) https://ld4p.github.io/arm/core/vocabularies/status/0.1/status.html#$1 [R=303,NE]
 
 # Rewrite rule to serve RDF/XML content if request is not HTML
 #any non-HTML gives RDF so omit this: RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
@@ -276,21 +276,21 @@ RewriteRule ^core/vocabularies/status/status.html$ https://w3id.org/arm/core/voc
 
 # Version 0.1
 RewriteRule ^core/vocabularies/typeface/0.1/typeface.rdf https://ld4p.github.io/arm/core/vocabularies/typeface/0.1/typeface.rdf [R=302,L]
-RewriteRule ^core/vocabularies/typeface/0.1/typeface.html https://ld4p.github.io/arm/core/vocabularies/typeface/0.1/doc/lode/typeface.html [R=302,L]
+RewriteRule ^core/vocabularies/typeface/0.1/typeface.html https://ld4p.github.io/arm/core/vocabularies/typeface/0.1/typeface.html [R=302,L]
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^core/vocabularies/typeface/0.1/?$ https://ld4p.github.io/arm/core/vocabularies/typeface/0.1/doc/lode/typeface.html [R=303]
+RewriteRule ^core/vocabularies/typeface/0.1/?$ https://ld4p.github.io/arm/core/vocabularies/typeface/0.1/typeface.html [R=303]
 
 # Rewrite rule to serve directed HTML content from class/prop URIs
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^core/vocabularies/typeface/0.1/?([^/]+) https://ld4p.github.io/arm/core/vocabularies/typeface/0.1/doc/lode/typeface.html#$1 [R=303,NE]
+RewriteRule ^core/vocabularies/typeface/0.1/?([^/]+) https://ld4p.github.io/arm/core/vocabularies/typeface/0.1/typeface.html#$1 [R=303,NE]
 
 # Rewrite rule to serve RDF/XML content if request is not HTML
 #any non-HTML gives RDF so omit this: RewriteCond %{HTTP_ACCEPT} application/rdf\+xml


### PR DESCRIPTION
Update to `htaccess` for https://w3id.org/arm to change documentation paths