### PR TITLE
arm: move activity ontology

### DIFF
--- a/arm/.htaccess
+++ b/arm/.htaccess
@@ -40,34 +40,34 @@ RewriteRule ^core/ontology/?$ https://w3id.org/arm/core/ontology/0.1/ [R=302,L]
 RewriteRule ^core/ontology/core.rdf$ https://w3id.org/arm/core/ontology/0.1/core.rdf [R=302,L]
 RewriteRule ^core/ontology/core.html$ https://w3id.org/arm/core/ontology/0.1/core.html [R=302,L]
 
-### Setup for https://w3id.org/arm/core/activity
+### Setup for https://w3id.org/arm/activity/ontology
 
 # Version 0.1
-RewriteRule ^core/activity/0.1/activity.rdf https://ld4p.github.io/arm/core/ontology/0.1/activity.rdf [R=302,L]
-RewriteRule ^core/activity/0.1/activity.html https://ld4p.github.io/arm/core/ontology/0.1/activity.html [R=302,L]
+RewriteRule ^activity/ontology/0.1/activity.rdf https://ld4p.github.io/arm/activity/ontology/0.1/activity.rdf [R=302,L]
+RewriteRule ^activity/ontology/0.1/activity.html https://ld4p.github.io/arm/activity/ontology/0.1/activity.html [R=302,L]
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^core/activity/0.1/?$ https://ld4p.github.io/arm/core/ontology/0.1/activity.html [R=303]
+RewriteRule ^activity/ontology/0.1/?$ https://ld4p.github.io/arm/activity/ontology/0.1/activity.html [R=303]
 
 # Rewrite rule to serve directed HTML content from class/prop URIs
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^core/activity/0.1/?([^/]+) https://ld4p.github.io/arm/core/ontology/0.1/activity.html#$1 [R=303,NE]
+RewriteRule ^activity/ontology/0.1/?([^/]+) https://ld4p.github.io/arm/activity/ontology/0.1/activity.html#$1 [R=303,NE]
 
 # Rewrite rule to serve RDF/XML content if request is not HTML
 #any non-HTML gives RDF so omit this: RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^core/activity/0.1/?([^/]*) https://ld4p.github.io/arm/core/ontology/0.1/activity.rdf [R=303]
+RewriteRule ^activity/ontology/0.1/?([^/]*) https://ld4p.github.io/arm/activity/ontology/0.1/activity.rdf [R=303]
 
 # Unversioned -> latest version
-RewriteRule ^core/activity/?$ https://w3id.org/arm/core/activity/0.1/ [R=302,L]
-RewriteRule ^core/activity/activity.rdf$ https://w3id.org/arm/core/activity/0.1/activity.rdf [R=302,L]
-RewriteRule ^core/activity/activity.html$ https://w3id.org/arm/core/activity/0.1/activity.html [R=302,L]
+RewriteRule ^activity/ontology/?$ https://w3id.org/arm/activity/ontology/0.1/ [R=302,L]
+RewriteRule ^activity/ontology/activity.rdf$ https://w3id.org/arm/activity/ontology/0.1/activity.rdf [R=302,L]
+RewriteRule ^activity/ontology/activity.html$ https://w3id.org/arm/activity/ontology/0.1/activity.html [R=302,L]
 
 ### Setup for https://w3id.org/arm/award/ontology
 


### PR DESCRIPTION
Apologies for a second change in a few days but we want to rationalize the namespace for activity ontology as we wrap up the first phase of this project. Changes in targets _are_ already live, e.g. https://w3id.org/arm/activity/ontology/ will redirect (in browser) to  https://ld4p.github.io/arm/activity/ontology/0.1/activity.html

(re. https://github.com/LD4P/arm/issues/125#issuecomment-400024986)