### PR TITLE
Added Readme and redirect for Syntaxe du Codex Ontology

### DIFF
--- a/sdc/.htaccess
+++ b/sdc/.htaccess
@@ -1,0 +1,3 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^ontology$ https://github.com/BetaMasaheft/SyntaxeDuCodex [R=302,L]

--- a/sdc/readme.md
+++ b/sdc/readme.md
@@ -1,0 +1,5 @@
+# La Syntaxe du Codex Ontology
+
+https://w3id.org/sdc/ontology is the namespace for the ontology based on La Syntaxe du Codex for the syntactic description of manuscripts.
+
+The Ontology is under development at https://github.com/BetaMasaheft/SyntaxeDuCodex.


### PR DESCRIPTION
https://w3id.org/sdc/ontology is the namespace for the ontology based on La Syntaxe du Codex for the syntactic description of manuscripts.

The Ontology is under development at https://github.com/BetaMasaheft/SyntaxeDuCodex.