### PR TITLE
redirection for dice group repository

### DIFF
--- a/squirrel/.htaccess
+++ b/squirrel/.htaccess
@@ -13,5 +13,6 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://varunmaitreya.github.io/Squirrel/ [R=303,L]
+RewriteRule ^$ https://github.com/dice-group/Squirrel [R=303,L]
+RewriteRule ^vocab/?$ https://varunmaitreya.github.io/squirrelontology/ [R=303,L]
 


### PR DESCRIPTION
redirection has been updated to dice group squirrel repository
vocabulary redirection changed to old location at github.com/varunmaitreya/squirrelontology/