### PR TITLE
Redirection isn't working in Protege

### DIFF
--- a/ccso/.htaccess
+++ b/ccso/.htaccess
@@ -22,7 +22,7 @@ RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 RewriteRule ^ccso$ https://vkreations.github.io/CCSO/ [R=303,NE,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
 RewriteRule ^ccso$ https://vkreations.github.io/CCSO/ccso.owl [R=303,NE,L]
 
 # Rewrite rule to serve turtle content from the vocabulary URI if requested


### PR DESCRIPTION
The redirection works only for html.
When I type https://w3id.org/ccso/ccso in browser, it redirects to https://github.com/Vkreations/CCSO/index.html
but when I chose _Open from URL_ in _Protege_, and type https://w3id.org/ccso/ccso
it shows the following error:

> Load Error: OntologyID(OntologyIRI(<https://w3id.org/ccso/ccso>) VersionIRI(<null>))
> sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target

On the other hand, when I type in Protege https://github.com/Vkreations/CCSO/ccso.owl 
it opens normally.

I edited .htaccess in line 25 in order to service RDF/OWL file to application:
26 RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
27 RewriteRule ^ccso$ https://github.com/Vkreations/CCSO/ccso.0.7.owl [R=303,NE,L]