### PR TITLE
neuro to enigma_hypothesis

### DIFF
--- a/disk/.htaccess
+++ b/disk/.htaccess
@@ -24,23 +24,23 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^ontology/neuro$ https://knowledgecaptureanddiscovery.github.io/DISK-Ontologies/enigma_hypothesis/release/1.0.0/index.html [R=303,L]
+RewriteRule ^ontology/enigma_hypothesis$ https://knowledgecaptureanddiscovery.github.io/DISK-Ontologies/enigma_hypothesis/release/1.0.0/index.html [R=303,L]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^ontology/neuro$ https://knowledgecaptureanddiscovery.github.io/DISK-Ontologies/enigma_hypothesis/release/1.0.0/ontology.json [R=303,L]
+RewriteRule ^ontology/enigma_hypothesis$ https://knowledgecaptureanddiscovery.github.io/DISK-Ontologies/enigma_hypothesis/release/1.0.0/ontology.json [R=303,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^ontology/neuro$ https://knowledgecaptureanddiscovery.github.io/DISK-Ontologies/enigma_hypothesis/release/1.0.0/ontology.xml [R=303,L]
+RewriteRule ^ontology/enigma_hypothesis$ https://knowledgecaptureanddiscovery.github.io/DISK-Ontologies/enigma_hypothesis/release/1.0.0/ontology.xml [R=303,L]
 
 # Rewrite rule to serve N-Triples content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^ontology/neuro$ https://knowledgecaptureanddiscovery.github.io/DISK-Ontologies/enigma_hypothesis/release/1.0.0/ontology.nt [R=303,L]
+RewriteRule ^ontology/enigma_hypothesis$ https://knowledgecaptureanddiscovery.github.io/DISK-Ontologies/enigma_hypothesis/release/1.0.0/ontology.nt [R=303,L]
 
 # Rewrite rule to serve TTL content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle 
-RewriteRule ^ontology/neuro$ https://knowledgecaptureanddiscovery.github.io/DISK-Ontologies/enigma_hypothesis/release/1.0.0/ontology.ttl [R=303,L]
+RewriteRule ^ontology/enigma_hypothesis$ https://knowledgecaptureanddiscovery.github.io/DISK-Ontologies/enigma_hypothesis/release/1.0.0/ontology.ttl [R=303,L]

--- a/disk/.htaccess
+++ b/disk/.htaccess
@@ -18,29 +18,29 @@ RewriteCond %{HTTP_ACCEPT} ^.*application/ld\+json.*
 RewriteRule ^acs2016$ http://dgarijo.github.io/ResearchObjects/acs2016/description.json [R=303,L]
 RewriteRule ^acs2016$ http://dgarijo.github.io/ResearchObjects/acs2016/ [R=303,L]
 
-#Rewrite rules neuro ontology concepts in DISK
+#Rewrite rules enigma_hypothesis ontology concepts in DISK
 # Rewrite rule for latest version.
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^ontology/neuro$ https://knowledgecaptureanddiscovery.github.io/DISK-Ontologies/neuro/release/1.0.0/index.html [R=303,L]
+RewriteRule ^ontology/neuro$ https://knowledgecaptureanddiscovery.github.io/DISK-Ontologies/enigma_hypothesis/release/1.0.0/index.html [R=303,L]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^ontology/neuro$ https://knowledgecaptureanddiscovery.github.io/DISK-Ontologies/neuro/release/1.0.0/ontology.json [R=303,L]
+RewriteRule ^ontology/neuro$ https://knowledgecaptureanddiscovery.github.io/DISK-Ontologies/enigma_hypothesis/release/1.0.0/ontology.json [R=303,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^ontology/neuro$ https://knowledgecaptureanddiscovery.github.io/DISK-Ontologies/neuro/release/1.0.0/ontology.xml [R=303,L]
+RewriteRule ^ontology/neuro$ https://knowledgecaptureanddiscovery.github.io/DISK-Ontologies/enigma_hypothesis/release/1.0.0/ontology.xml [R=303,L]
 
 # Rewrite rule to serve N-Triples content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^ontology/neuro$ https://knowledgecaptureanddiscovery.github.io/DISK-Ontologies/neuro/release/1.0.0/ontology.nt [R=303,L]
+RewriteRule ^ontology/neuro$ https://knowledgecaptureanddiscovery.github.io/DISK-Ontologies/enigma_hypothesis/release/1.0.0/ontology.nt [R=303,L]
 
 # Rewrite rule to serve TTL content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle 
-RewriteRule ^ontology/neuro$ https://knowledgecaptureanddiscovery.github.io/DISK-Ontologies/neuro/release/1.0.0/ontology.ttl [R=303,L]
+RewriteRule ^ontology/neuro$ https://knowledgecaptureanddiscovery.github.io/DISK-Ontologies/enigma_hypothesis/release/1.0.0/ontology.ttl [R=303,L]


### PR DESCRIPTION
The Neuro Ontology was renamed to the ENIGMA Hypothesis Ontology in the GitHub repository for DISK Ontologies