### PR TITLE
Updated temporary URI for tree ontology

### DIFF
--- a/tree/.htaccess
+++ b/tree/.htaccess
@@ -2,4 +2,4 @@ Header set Access-Control-Allow-Origin *
 Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^.*$ https://cdn.rawgit.com/pietercolpaert/TreeOntology/master/tree.ttl [R=303,L]
+RewriteRule ^.*$ https://rawgit.com/pietercolpaert/TreeOntology/master/tree.ttl [R=303,L]


### PR DESCRIPTION
Apparently the CDN version of rawgit will never update the file, even if it changed on git. Updated the rawgit to the development version. Will re-locate to my own  server once the ontology is in a more advanced state (working on implementations atm).