### PR TITLE
add redirect rule for text/turtle on jp-textbook

### DIFF
--- a/jp-textbook/.htaccess
+++ b/jp-textbook/.htaccess
@@ -1,4 +1,7 @@
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^(.*) https://jp-textbook.github.io/$1 [R=302,L]
 
+RewriteCond "%{HTTP_ACCEPT}" "text/turtle"
+RewriteRule ^(.+) https://jp-textbook.github.io/$1.ttl [R=302,L]
+
+RewriteRule ^(.*) https://jp-textbook.github.io/$1 [R=302,L]


### PR DESCRIPTION
This adds a content negotiation rule for "text/turtle".

raw data example:
https://jp-textbook.github.io/%E5%B0%8F%E5%AD%A6%E6%A0%A1/2010/%E7%AE%97%E6%95%B0/201.ttl
