### PR TITLE
Generalize CWLProv redirect for semantic versioning

### DIFF
--- a/cwl/.htaccess
+++ b/cwl/.htaccess
@@ -31,8 +31,9 @@ RewriteRule ^v(.*) http://www.commonwl.org/v$1 [R=302,L]
 # CWLProv profiles
 ## Latest
 RewriteRule ^prov(/)?$ https://github.com/common-workflow-language/cwlprov/ [R=302,L]
-## TODO: Tag 0.3.0 in cwlprov
-RewriteRule ^prov/0.3.0$ https://github.com/common-workflow-language/cwlprov/ [R=302,L]
 ## Legacy profiles - straight to Zenodo preprints
-RewriteRule ^prov/0.2.0$ https://doi.org/10.5281/zenodo.1215611 [R=302,L]
 RewriteRule ^prov/0.1.0$ https://doi.org/10.5281/zenodo.1208478 [R=302,L]
+RewriteRule ^prov/0.2.0$ https://doi.org/10.5281/zenodo.1215611 [R=302,L]
+# From 0.3.0, semantic versions in GitHub
+RewriteRule ^prov/(\d+.\d+.\d+)$ https://github.com/common-workflow-language/cwlprov/tree/$1 [R=302,L]
+


### PR DESCRIPTION
.. after which https://w3id.org/cwl/prov/0.3.0 should redirect to https://github.com/common-workflow-language/cwlprov/tree/0.3.0