### PR TITLE
w3id IRIs for publishing the Loupe vocabulary.

### DIFF
--- a/loupe/readme.md
+++ b/loupe/readme.md
@@ -1,0 +1,11 @@
+# IRIs for the Loupe Linked Data Profiling Tool
+
+This directory contains rules for URL redirection of IRI related to the Loupe Linked Data profiling too.
+[Loupe](http://loupe.linkeddata.es/)
+
+Content negociation for turtle, rdf/xml, and jsonld is performed through the .htaccess file.
+
+
+## Contacts
+
+- nandana@apache.org

--- a/loupe/vocab/.htaccess
+++ b/loupe/vocab/.htaccess
@@ -1,0 +1,10 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.* 
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/nandana/loupe-ontology/master/OnToology/src/ontology/loupe-ontology.owl/documentation/ontology.owl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/nandana/loupe-ontology/master/OnToology/src/ontology/loupe-ontology.owl/documentation/ontology.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} ^.*application/ld\+json.* 
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/nandana/loupe-ontology/master/OnToology/src/ontology/loupe-ontology.owl/documentation/ontology.jsonld [R=303,L]
+RewriteRule ^(.*)$ https://rawgit.com/nandana/loupe-ontology/master/OnToology/src/ontology/loupe-ontology.owl/documentation/index-en.html [R=303,L]


### PR DESCRIPTION
w3id IRIs for publishing the Loupe vocabulary.

The raw vocabulary files are stored in a Github repo.
[loupe-ontology](https://github.com/nandana/loupe-ontology)

This commit includes the .htaccess files for content negotiation and redirection.
