### PR TITLE
Add permanent identifier for the CitySPIN project, http://cityspin.net/

### DIFF
--- a/cityspin/.htaccess
+++ b/cityspin/.htaccess
@@ -1,0 +1,4 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ http://cityspin.net [R=302,L]
+RewriteRule ^(.*)$ http://cityspin.net/$1 [R=302,L]

--- a/cityspin/README.md
+++ b/cityspin/README.md
@@ -1,0 +1,10 @@
+CitySPIN
+===
+
+The aim of this top-level directory is to provide permanent URLs for resources (ontologies, vocabularies, etc.) created in the CitySPIN project.
+
+Homepage:
+* http://cityspin.net/
+
+Contacts: 
+* Javier D. Fernández <jfernand@wu.ac.at>


### PR DESCRIPTION
We added a permanent identifier for CitySPIN, http://cityspin.net/, an Austrian research project.