### PR TITLE
Added Podchaser redirect (pc namespace)

### DIFF
--- a/pc/.htaccess
+++ b/pc/.htaccess
@@ -1,0 +1,3 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^v1$ https://blog.podchaser.com/rss-spec/v1 [R=302,L]

--- a/pc/README.md
+++ b/pc/README.md
@@ -1,0 +1,10 @@
+## Podchaser RSS Spec Additions
+
+Homepage
+
+* https://www.podchaser.com
+
+Contact: 
+
+* Ben Slinger, CTO:  <ben@podchaser.com>
+* General: <contact@podchaser.com>


### PR DESCRIPTION
To be used as an XML namespace for the additions to the RSS podcast spec used by podchaser.com