### PR TITLE
fixed incorrect URI links in previous update

### DIFF
--- a/GDPRov/.htaccess
+++ b/GDPRov/.htaccess
@@ -1,5 +1,5 @@
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^$ http://openscience.adaptcentre.ie/projects/CDMM/GDPRov/ontology [R=302,L]
+RewriteRule ^$ https://openscience.adaptcentre.ie/ontologies/GDPRov/docs/ontology [R=302,L]
 RewriteRule ^repository$ https://opengogs.adaptcentre.ie/harsh/GDPRov [R=302,L]
 RewriteRule ^publication$ http://ceur-ws.org/Vol-1951/PrivOn2017_paper_6.pdf [R=302,L]

--- a/GDPRtEXT/.htaccess
+++ b/GDPRtEXT/.htaccess
@@ -1,6 +1,6 @@
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^$ http://openscience.adaptcentre.ie/projects/GDPRtEXT/docs/ontology [R=302,L]
+RewriteRule ^$ https://openscience.adaptcentre.ie/ontologies/GDPRtEXT/deliverables/docs/ontology [R=302,L]
 RewriteRule ^pubby$ https://purl.org/adaptcentre/openscience/resources/GDPRtEXT/gdpr-pubby [R=302,L]
 RewriteRule ^distributions$ http://openscience.adaptcentre.ie/ontologies/GDPRtEXT/deliverables/gdpr_distributions [R=302,L]
 RewriteRule ^canonical http://openscience.adaptcentre.ie/ontologies/GDPRtEXT/deliverables/gdpr [R=302,L]


### PR DESCRIPTION
Silly mistakes - the previous commit had incorrect URIs which were detected only after the commit was pushed (live).