### PR TITLE
Add data2services namespace

### DIFF
--- a/data2services/.htaccess
+++ b/data2services/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine on
+RewriteRule ^(.*)$ https://graphdb.dumontierlab.com/resource?uri=http://w3id.org/$1  [R=302,L]

--- a/data2services/README.md
+++ b/data2services/README.md
@@ -1,0 +1,12 @@
+Data2Services
+=======
+
+Homepage
+* http://graphdb.dumontierlab.com/
+
+Docs
+* http://github.com/MaastrichtU-IDS/data2services-pipeline
+
+Contact
+* Alexander Malic @amalic
+* Vincent Emonet @vemonet


### PR DESCRIPTION
Add data2services folder with .htaccess and README.md

Used to resolve URI used in the Data2Services project (http://github.com/MaastrichtU-IDS/data2services-pipeline). It redirects https://w3id.org/data2services to http://graphdb.dumontierlab.com (a GraphDB triplestore)