### PR TITLE
Fix URL redirect in data2services htaccess

### DIFF
--- a/data2services/.htaccess
+++ b/data2services/.htaccess
@@ -1,2 +1,2 @@
 RewriteEngine on
-RewriteRule ^(.*)$ http://graphdb.dumontierlab.com/resource?uri=http://w3id.org/data2services/$1  [R=302,L]
+RewriteRule ^(.*)$ http://graphdb.dumontierlab.com/resource?uri=https://w3id.org/data2services/$1  [R=302,L]


### PR DESCRIPTION
Redirect to https://w3id.org instead of http://w3id.org