### PR TITLE
Adding permanent identifier for Damage Topology Ontology (dot)

### DIFF
--- a/dot/.htaccess
+++ b/dot/.htaccess
@@ -1,0 +1,40 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://alhakam.github.io/dot/ [R=302,NE,L]
+
+# In case of accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://alhakam.github.io/dot/ontology.ttl [R=303,NE,L]
+
+# In case of accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://alhakam.github.io/dot/ontology.xml [R=302,NE,L]
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^dot.ttl$ https://alhakam.github.io/dot/ontology.ttl [R=302,NE,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^dot.html$ https://alhakam.github.io/dot/ [R=302,NE,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^dot.rdf$ https://alhakam.github.io/dot/ontology.xml [R=302,NE,L]
+
+# If suffix jsonld, redirect to jsonld version
+RewriteRule ^dot.jsonld$ https://alhakam.github.io/dot/ontology.json [R=302,NE,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^dot.nt$ https://alhakam.github.io/dot/ontology.nt [R=302,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://alhakam.github.io/dot/ [R=303,NE,L]

--- a/dot/readme.md
+++ b/dot/readme.md
@@ -1,0 +1,12 @@
+## Damage Topology Ontology (DOT)
+
+Ontology
+
+* Doc      https://alhakam.github.io/dot/
+* Turtle   https://alhakam.github.io/dot/dot.ttl
+
+
+Contacts
+
+* Al-Hakam Hamdan <al-hakam.hamdan@tu-dresden.de>
+* Mathias Bonduel <mathias.bonduel@kuleuven.be>


### PR DESCRIPTION
Pull request for adding a permanent identifier for the Damage Topology Ontology (dot) to w3id.org. 

The Damage Topology Ontology (DOT) allows the definition of damage representations and their relations with other damages and affected construction components.