### PR TITLE
Namespace change.

### DIFF
--- a/arco/.htaccess
+++ b/arco/.htaccess
@@ -5,5 +5,6 @@ RewriteEngine on
 SetEnvIf Request_URI ^.*$ ROOT_URL=https://raw.githubusercontent.com/ICCD-MiBACT/ArCo/master/ArCo-release/ontologie/
 
 RewriteRule ^resource/(.+)$ http://wit.istc.cnr.it/lodview/resource/$1 [R=303,L]
-RewriteRule ^(.+)/(.+)\.owl$ %{ENV:ROOT_URL}$1/$1.owl [R=303,L]
+RewriteRule ^ontology/(.+)/(.+)$ http://wit.istc.cnr.it/lodview/$1 [R=303,L]
+RewriteRule ^ontology/(.+)$ %{ENV:ROOT_URL}$1/$1.owl [R=303,L]
 RewriteRule ^(.+)$ http://wit.istc.cnr.it/lodview/$1 [R=303,L]


### PR DESCRIPTION
The modified rules reflect the change occurred to the namespace used
for identifying the ontologies of the ArCo project.