### PR TITLE
Added rule for test cases

### DIFF
--- a/arco/.htaccess
+++ b/arco/.htaccess
@@ -7,4 +7,5 @@ SetEnvIf Request_URI ^.*$ ROOT_URL=https://raw.githubusercontent.com/ICCD-MiBACT
 RewriteRule ^resource/(.+)$ http://wit.istc.cnr.it/lodview/resource/$1 [R=303,L]
 RewriteRule ^ontology/(.+)/(.+)$ http://wit.istc.cnr.it/lodview/$1 [R=303,L]
 RewriteRule ^ontology/(.+)$ %{ENV:ROOT_URL}$1/$1.owl [R=303,L]
+RewriteRule ^test/(.+)$ https://raw.githubusercontent.com/ICCD-MiBACT/ArCo/master/ArCo-release/test/$1 [R=303,L]
 RewriteRule ^(.+)$ http://wit.istc.cnr.it/lodview/$1 [R=303,L]


### PR DESCRIPTION
The redirect rule allows to access the test cases defined for
validating the ontology modules available within the ArCo ontology
network.