### PR TITLE
Re: Direction service for ontologies designed for hazard assessment

### DIFF
--- a/gicentre/.htaccess
+++ b/gicentre/.htaccess
@@ -1,0 +1,11 @@
+Options +FollowSymLinks
+# Turn off MultiViews
+Options -MultiViews
+
+RewriteEngine on
+
+# Match anything that does not contain '.', assume to be request to OWL file.
+RewriteRule ^([^.]+)$ http://mazimweal.github.io/onto/$1.owl [R=303,L]
+
+# Match anything that ends with .owl
+RewriteRule ^(.+)\.owl$ http://mazimweal.github.io/onto/$1.owl [R=303,L]

--- a/gicentre/readme.md
+++ b/gicentre/readme.md
@@ -1,10 +1,10 @@
 Repository for redirecting to disaster ontologies and ontology patterns created by the GICentre members .
 ===================
 
-EventCore:
+Event:
 http://w3id.org/gicentre/onto/event ==> http://mazimweal.github.io/onto/event.owl
 
-SpatioTemporalExtent:
+QualityCausation:
 http://w3id.org/gicentre/onto/qualitycausation ==> http://mazimweal.github.io/onto/qualitycausation.owl
 
 

--- a/gicentre/readme.md
+++ b/gicentre/readme.md
@@ -1,0 +1,11 @@
+Repository for redirecting to disaster ontologies and ontology patterns created by the GICentre members .
+===================
+
+EventCore:
+http://w3id.org/gicentre/onto/event ==> http://mazimweal.github.io/onto/event.owl
+
+SpatioTemporalExtent:
+http://w3id.org/gicentre/onto/qualitycausation ==> http://mazimweal.github.io/onto/qualitycausation.owl
+
+
+Maintainer: https://github.com/mazimweal


### PR DESCRIPTION
Am working on disaster ontologies and ontology patterns created by the GICentre members .this service will allow repository redirecting. will be glad if you can help 