### PR TITLE
fix broken redirect

### DIFF
--- a/idsa/.htaccess
+++ b/idsa/.htaccess
@@ -3,4 +3,4 @@ RewriteEngine on
 RewriteRule ^$ https://www.internationaldataspaces.org/ [R=302]
 RewriteRule ^(core|code)($|/(.*?$)) https://github.com/IndustrialDataSpace/InformationModel/releases/download/v1.0.0/IDS-InformationModel_v1.0.0.ttl [R=302]
 RewriteRule ^contexts/context.jsonld$ https://github.com/IndustrialDataSpace/InformationModel/releases/download/v1.0.0/context.json [R=302]
-RewriteRule ^contexts/context-dev.jsonld$ https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/context.json?at=refs%2Fheads%2Fmaster [R=302] 
+RewriteRule ^contexts/context-dev.jsonld$ https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/context.json?at=refs/heads/master [R=302] 


### PR DESCRIPTION
It seems like the context-dev.jsonld redirect link is processed in a way that breaks encoding. Replacing '%2F' with native slashes should fix it. Sorry for the inconvenience.