### PR TITLE
added w3id config for the HCLSCG and its first community group report

### DIFF
--- a/hclscg/.htaccess
+++ b/hclscg/.htaccess
@@ -1,0 +1,5 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ https://www.w3.org/community/hclscg/ [R=302,L]
+RewriteRule ^pddi$ https://dbmi-icode-01.dbmi.pitt.edu/dikb-evidence/hcls-drug-drug-interaction/index.html [R=302,L]
+

--- a/hclscg/README.md
+++ b/hclscg/README.md
@@ -1,0 +1,11 @@
+HCLSCG
+===
+
+Homepage:
+* https://w3id.org/hclscg
+
+Community group report "A Minimum Representation of Potential Drug-Drug Interaction Knowledge and Evidence - Technical and User-centered Foundation":
+* https://w3id.org/hclscg/pddi
+
+Contacts: 
+* Richard D. Boyce <rdb20@pitt.edu>


### PR DESCRIPTION
I did my best to check the links locally but had trouble getting linkchecker to work. Hopefully, these resolve. The community group not link will move from my pitt server to to the W3C community group page once it the final version is published at which case, I will do another pull request. Thanks for your help.  