### PR TITLE
RealEstateCore: added graph API 2.3

### DIFF
--- a/rec/.htaccess
+++ b/rec/.htaccess
@@ -2,8 +2,9 @@ Options +FollowSymLinks
 
 RewriteEngine on
 
-# 2.3 Streaming API
+# 2.3 API:s
 RewriteRule ^api/2.3/streaming/$ https://github.com/Vasakronan/Idun-Examples/tree/master/Idun-Streaming-Api/Consumer/netcore/Idun.StreamingApi.Examples/Idun.StreamingApi.Examples [R=303,NE,L]
+RewriteRule ^api/2.3/graph/$ https://doc.realestatecore.io/api/2.3/ [R=303,NE,L]
 
 # Legacy versions (2.x) are redirected to .xml files
 RewriteRule ^(\w+)/(2.[\d.]+)/(\w*)$ https://raw.githubusercontent.com/RealEstateCore/rec/v$2/$1.xml#$3 [R=303,NE,L]


### PR DESCRIPTION
Note -- this is not an actual live API (that would be stupid and probably wasteful), just a redirect to API documentation.