### PR TITLE
Correct for Beacon API URL

### DIFF
--- a/ga4gh/.htaccess
+++ b/ga4gh/.htaccess
@@ -16,5 +16,5 @@ RewriteRule ^minutes/rnaseq$ https://docs.google.com/document/d/1M75HhUcE-BJPxFw
 # Discovery Work Stream Links
 RewriteRule ^minutes/discovery-networks$ https://docs.google.com/document/d/13K4ce05Vvcz7VU3uZnOPUNhvgtu2u2yeCKVnIJKgQBU/edit?usp=sharing [R=302,L]
 RewriteRule ^minutes/discovery-search$ https://docs.google.com/document/d/1sG--PPVlVWb1-_ZN7cHta79uU9tU2y-17U11PYzvMu8/edit?usp=sharing [R=302,L]
-RewriteRule ^minutes/beacon-api$ https://docs.google.com/document/d/13Z8-DP6MfnkyW8aHJGfzaTG-NejbxkVBoZ9nqRhh3GE/edit#heading=h.lurwgc2rlzlh [R=302,L]
+RewriteRule ^minutes/beacon-api$ https://docs.google.com/document/d/13Z8-DP6MfnkyW8aHJGfzaTG-NejbxkVBoZ9nqRhh3GE/edit?usp=sharing [R=302,L]
 RewriteRule ^minutes/discovery$ https://docs.google.com/document/d/12okPW4xLPY0Dfz9eAzkot-5aoYIzRg0lyi5Aa7zp9is/edit?usp=sharing [R=302,L]


### PR DESCRIPTION
Previous link not translated to Google Doc link correctly