### PR TITLE
SARO Ontology permanent namespace

### DIFF
--- a/saro/.htaccess
+++ b/saro/.htaccess
@@ -4,10 +4,10 @@ AddType text/turtle .ttl
 Header set Access-Control-Allow-Origin *
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^/?$ https://elisasibarani.github.io/SARO/ [R=302,L]
+RewriteRule ^/?$ https://elisasibarani.github.io/SARO/ [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.* 
-RewriteRule ^$  https://github.com/elisasibarani/SARO/blob/master/saro.rdfs [R=303,NE,L]
+RewriteRule ^$ https://elisasibarani.github.io/SARO/saro.rdfs [R=303,NE,L]
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.*
-RewriteRule ^$  https://github.com/elisasibarani/SARO/blob/master/saro.ttl [R=303,NE,L]
+RewriteRule ^$  https://elisasibarani.github.io/SARO/saro.ttl [R=303,NE,L]
 © 2019 GitHub, Inc.

--- a/saro/.htaccess
+++ b/saro/.htaccess
@@ -7,7 +7,7 @@ RewriteEngine on
 RewriteRule ^/?$ https://elisasibarani.github.io/SARO/ [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.* 
-RewriteRule ^$ https://elisasibarani.github.io/SARO/saro.rdfs [R=303,NE,L]
+RewriteRule ^$ https://elisasibarani.github.io/SARO/saro.rdf [R=303,NE,L]
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.*
 RewriteRule ^$  https://elisasibarani.github.io/SARO/saro.ttl [R=303,NE,L]
 © 2019 GitHub, Inc.

--- a/saro/.htaccess
+++ b/saro/.htaccess
@@ -4,7 +4,7 @@ AddType text/turtle .ttl
 Header set Access-Control-Allow-Origin *
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^/?$ https://github.com/elisasibarani/SARO/blob/master/saro.html [R=302,L]
+RewriteRule ^/?$ https://elisasibarani.github.io/SARO/ [R=302,L]
 
 RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.* 
 RewriteRule ^$  https://github.com/elisasibarani/SARO/blob/master/saro.rdfs [R=303,NE,L]

--- a/saro/.htaccess
+++ b/saro/.htaccess
@@ -1,0 +1,13 @@
+AddType application/rdf+xml .rdf
+AddType text/turtle .ttl
+
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^/?$ https://github.com/elisasibarani/SARO/blob/master/saro.html [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.* 
+RewriteRule ^$  https://github.com/elisasibarani/SARO/blob/master/saro.rdfs [R=303,NE,L]
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.*
+RewriteRule ^$  https://github.com/elisasibarani/SARO/blob/master/saro.ttl [R=303,NE,L]
+© 2019 GitHub, Inc.

--- a/saro/.htaccess
+++ b/saro/.htaccess
@@ -4,10 +4,10 @@ AddType text/turtle .ttl
 Header set Access-Control-Allow-Origin *
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^/?$ https://elisasibarani.github.io/SARO/ [R=303,L]
+RewriteRule ^$ https://elisasibarani.github.io/SARO/ [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.* 
 RewriteRule ^$ https://elisasibarani.github.io/SARO/saro.rdf [R=303,NE,L]
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.*
 RewriteRule ^$  https://elisasibarani.github.io/SARO/saro.ttl [R=303,NE,L]
-© 2019 GitHub, Inc.
+

--- a/saro/README.md
+++ b/saro/README.md
@@ -1,9 +1,13 @@
 Repository for redirecting to SARO ontology
 
 
-Original Specs: https://github.com/elisasibarani/SARO/blob/master/saro.html
+Original Specs: hhttps://elisasibarani.github.io/SARO/ 
 Description and Viz instance on VOCOL: https://vocol.iais.fraunhofer.de/saro/visualization
 
 Raw files:
-https://github.com/elisasibarani/SARO/blob/master/saro.rdfs
-https://github.com/elisasibarani/SARO/blob/master/saro.ttl
+https://elisasibarani.github.io/SARO/saro.rdf
+https://elisasibarani.github.io/SARO/saro.ttl
+
+Contact info: scerrisimon.academia@gmail.com
+
+

--- a/saro/README.md
+++ b/saro/README.md
@@ -1,0 +1,9 @@
+Repository for redirecting to SARO ontology
+
+
+Original Specs: https://github.com/elisasibarani/SARO/blob/master/saro.html
+Description and Viz instance on VOCOL: https://vocol.iais.fraunhofer.de/saro/visualization
+
+Raw files:
+https://github.com/elisasibarani/SARO/blob/master/saro.rdfs
+https://github.com/elisasibarani/SARO/blob/master/saro.ttl


### PR DESCRIPTION
The namespace of the ontology (available at the rewrite rule URI) will be changed to:

w3id.org/saro#
