### PR TITLE
Added the transmodel ontology base URI as a placeholder

### DIFF
--- a/transmodel/.htaccess
+++ b/transmodel/.htaccess
@@ -1,0 +1,5 @@
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^.*$ https://openplanner.team/specs/transmodel [R=303,L]

--- a/transmodel/README.md
+++ b/transmodel/README.md
@@ -1,0 +1,15 @@
+The Transmodel Linked Data namespace
+===
+
+The CEN standard’s project website at: http://www.transmodel-cen.eu/
+
+This is a result of CEN TC278WG3 meeting at 2019-06-19
+
+The terms are currently available at this base URI:
+
+ * https://w3id.org/transmodel/terms#
+ * Preferred prefix: `transmodel:`
+ 
+Contact:
+ 
+ * Pieter Colpaert <pieter.colpaert@ugent.be>


### PR DESCRIPTION
This Pull Request is a result of CEN TC278WG3 meeting at 2019-06-19. This group decided to make an official base URI for the Transmodel ontology at W3ID. I was given the task to create the URI.