### PR TITLE
Added CRI association namespace

### DIFF
--- a/cri/.htaccess
+++ b/cri/.htaccess
@@ -1,0 +1,8 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+
+RewriteRule ^.*/cri/?$ https://cri-association.fr/ [R=302,L]
+
+RewriteRule ^.*/cri/ns/obema$ https://zwifi.eu/voc/obema/ [R=302,L]

--- a/cri/.htaccess
+++ b/cri/.htaccess
@@ -3,6 +3,6 @@ Options +FollowSymLinks
 RewriteEngine on
 
 
-RewriteRule ^.*/cri/?$ https://cri-association.fr/ [R=302,L]
+RewriteRule ^$ https://cri-association.fr/ [R=302,L]
 
-RewriteRule ^.*/cri/ns/obema$ https://zwifi.eu/voc/obema/ [R=302,L]
+RewriteRule ^/ns/obema$ https://zwifi.eu/voc/obema/ [R=302,L]

--- a/cri/README.md
+++ b/cri/README.md
@@ -1,0 +1,13 @@
+# CRI association namespace
+
+## Presentation
+This is the redirection to the CRI (https://cri-association.fr/) namespace. CRI is an independant research collective willing to produce open science and data in many fields, including but not limited to computer science, citizenship and social sciences.
+
+Some of the members being semantic Web experts, the existence of a namespace will enable the durable publication of ontologies.
+
+## Services
+- CRI homepage : https://w3id.org/cri --> https://cri-association.fr/
+- OBeMa vocabulary : https://w3id.org/cri/ns/obema/ --> https://zwifi.eu/voc/obema/
+
+## Contacts
+- Nicolas Seydoux : contact@zwifi.eu


### PR DESCRIPTION
CRI is an independant research association, and part of its activity will resort to the publication of vocabularies, hence the need of a permanent namespace.