### PR TITLE
updated htaccess of BPO

### DIFF
--- a/bot/.htaccess
+++ b/bot/.htaccess
@@ -1,20 +1,65 @@
-Options +FollowSymLinks
 RewriteEngine on
 
 # Turn off MultiViews
 Options -MultiViews
 
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
 AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
 
-# In case of accept header <text/turtle>
-RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
-RewriteRule ^$ https://w3c-lbd-cg.github.io/bot/bot.ttl [R=303,NE,L]
+
+### Rewrite rules for latest version
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://w3c-lbd-cg.github.io/bot [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle 
+RewriteRule ^$ https://w3c-lbd-cg.github.io/bot.ttl [R=303,L]
 
 # If suffix ttl, redirect to turtle version
-RewriteRule ^bot.ttl$ https://w3c-lbd-cg.github.io/bot/bot.ttl [R=302,NE,L]
+RewriteRule ^bot.ttl$ https://w3c-lbd-cg.github.io/bot.ttl [R=303,L]
 
 # If suffix html, redirect to html version
-RewriteRule ^bot.html$ https://w3c-lbd-cg.github.io/bot [R=302,NE,L]
+RewriteRule ^bot.html$ https://w3c-lbd-cg.github.io/bot [R=303,L]
 
-# Default response: html
-RewriteRule ^$ https://w3c-lbd-cg.github.io/bot [R=303,NE,L]
+
+### Rewrite rules for other serialisation (if they get converted)
+## Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+#RewriteCond %{HTTP_ACCEPT} application/ld\+json
+#RewriteRule ^$ https://w3c-lbd-cg.github.io/bot.jsonld [R=303,L]
+
+## Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+#RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+#RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+#RewriteRule ^$ https://w3c-lbd-cg.github.io/bot.rdf [R=303,L]
+
+## Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+#RewriteCond %{HTTP_ACCEPT} application/n-triples
+#RewriteRule ^$ https://w3c-lbd-cg.github.io/bot.nt [R=303,L]
+
+
+## If suffix rdf, redirect to rdf version
+#RewriteRule ^bot.rdf$ https://w3c-lbd-cg.github.io/bot.rdf [R=303,L]
+
+## If suffix jsonld, redirect to jsonld version
+#RewriteRule ^bot.jsonld$ https://w3c-lbd-cg.github.io/bot.jsonld [R=303,L]
+
+## If suffix nt, redirect to nt version
+#RewriteRule ^bot.nt$ https://w3c-lbd-cg.github.io/bot.nt [R=303,L]
+
+
+### Rewrite rules for any other version
+
+
+### Default response
+RewriteRule ^$ https://w3c-lbd-cg.github.io/bot [R=303,L]


### PR DESCRIPTION
updated htaccess according to https://w3id.org/mint/modelCatalog and https://w3id.org/omg to enable users to import BOT on the fly from Protégé (see issue https://github.com/perma-id/w3id.org/pull/1384)