### PR TITLE
Handling of all the LODE calls via w3id.org URL

### DIFF
--- a/lode/.htaccess
+++ b/lode/.htaccess
@@ -5,4 +5,64 @@ Header set Access-Control-Allow-Origin *
 Options +FollowSymLinks
 RewriteEngine on
 
-RewriteRule ^(.*)$ https://essepuntato.github.io/lode/$1 [R=303,L]
+RewriteCond %{REQUEST_URI} reasoner/
+RewriteCond %{REQUEST_URI} closure/
+RewriteCond %{REQUEST_URI} (lang=[^/]+)/
+RewriteRule ^.+(https?)://?(.+)$ http://150.146.207.114/lode/extract?%1&closure=true&reasoner=true&url=$1://$2 [QSA,L,R=303]
+
+RewriteCond %{REQUEST_URI} reasoner/
+RewriteCond %{REQUEST_URI} imported/
+RewriteCond %{REQUEST_URI} (lang=[^/]+)/
+RewriteRule ^.+(https?)://?(.+)$ http://150.146.207.114/lode/extract?%1&imported=true&reasoner=true&url=$1://$2 [QSA,L,R=303]
+
+RewriteCond %{REQUEST_URI} reasoner/
+RewriteCond %{REQUEST_URI} owlapi/
+RewriteCond %{REQUEST_URI} (lang=[^/]+)/
+RewriteRule ^.+(https?)://?(.+)$ http://150.146.207.114/lode/extract?%1&owlapi=true&reasoner=true&url=$1://$2 [QSA,L,R=303]
+
+RewriteCond %{REQUEST_URI} reasoner/
+RewriteCond %{REQUEST_URI} closure/
+RewriteRule ^.+(https?)://?(.+)$ http://150.146.207.114/lode/extract?closure=true&reasoner=true&url=$1://$2 [QSA,L,R=303]
+
+RewriteCond %{REQUEST_URI} reasoner/
+RewriteCond %{REQUEST_URI} imported/
+RewriteRule ^.+(https?)://?(.+)$ http://150.146.207.114/lode/extract?imported=true&reasoner=true&url=$1://$2 [QSA,L,R=303]
+
+RewriteCond %{REQUEST_URI} reasoner/
+RewriteCond %{REQUEST_URI} owlapi/
+RewriteRule ^.+(https?)://?(.+)$ http://150.146.207.114/lode/extract?owlapi=true&reasoner=true&url=$1://$2 [QSA,L,R=303]
+
+RewriteCond %{REQUEST_URI} reasoner/
+RewriteCond %{REQUEST_URI} (lang=[^/]+)/
+RewriteRule ^.+(https?)://?(.+)$ http://150.146.207.114/lode/extract?%1&reasoner=true&url=$1://$2 [QSA,L,R=303]
+
+RewriteCond %{REQUEST_URI} closure/
+RewriteCond %{REQUEST_URI} (lang=[^/]+)/
+RewriteRule ^.+(https?)://?(.+)$ http://150.146.207.114/lode/extract?%1&closure=true&url=$1://$2 [QSA,L,R=303]
+
+RewriteCond %{REQUEST_URI} imported/
+RewriteCond %{REQUEST_URI} (lang=[^/]+)/
+RewriteRule ^.+(https?)://?(.+)$ http://150.146.207.114/lode/extract?%1&imported=true&url=$1://$2 [QSA,L,R=303]
+
+RewriteCond %{REQUEST_URI} owlapi/
+RewriteCond %{REQUEST_URI} (lang=[^/]+)/
+RewriteRule ^.+(https?)://?(.+)$ http://150.146.207.114/lode/extract?%1&owlapi=true&url=$1://$2 [QSA,L,R=303]
+
+RewriteCond %{REQUEST_URI} reasoner/
+RewriteRule ^.+(https?)://?(.+)$ http://150.146.207.114/lode/extract?reasoner=true&url=$1://$2 [QSA,L,R=303]
+
+RewriteCond %{REQUEST_URI} closure/
+RewriteRule ^.+(https?)://?(.+)$ http://150.146.207.114/lode/extract?closure=true&url=$1://$2 [QSA,L,R=303]
+
+RewriteCond %{REQUEST_URI} imported/
+RewriteRule ^.+(https?)://?(.+)$ http://150.146.207.114/lode/extract?imported=true&url=$1://$2 [QSA,L,R=303]
+
+RewriteCond %{REQUEST_URI} owlapi/
+RewriteRule ^.+(https?)://?(.+)$ http://150.146.207.114/lode/extract?owlapi=true&url=$1://$2 [NE,QSA,L,R=303]
+
+RewriteCond %{REQUEST_URI} (lang=[^/]+)/
+RewriteRule ^.+(https?)://?(.+)$ http://150.146.207.114/lode/extract?%1&url=$1://$2 [QSA,L,R=303]
+
+RewriteRule ^(https?)://?(.+)$  http://150.146.207.114/lode/extract?url=$1://$2 [NE,QSA,L,R=303]
+
+RewriteRule ^.*$ http://essepuntato.it/lode [L,R=303]


### PR DESCRIPTION
Hi @davidlehn 

As discussed in https://github.com/perma-id/w3id.org/pull/1460, I've tested new rules again in a proper Apache testing space (i.e. http://earmark.sourceforge.net), and now it seems that everything works correctly. For instance, if you try

http://earmark.sourceforge.net/lang=it/imported/http://purl.org/spar/fabio

it will redirect to the correct service and generate the right HTML page. Thus, merging this request in w3id.org should work fine as well - once merged try

https://w3id.org/lode/lang=it/imported/http://purl.org/spar/fabio

that should behave like the previous call.