### PR TITLE
new redirect for execution technique ontology

### DIFF
--- a/executionTechnique/.htaccess
+++ b/executionTechnique/.htaccess
@@ -1,0 +1,3 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^ontology$ https://raw.githubusercontent.com/EAGLE-BPN/epidocupconversion/master/ExecutionTechniqueOntology.owl [R=302,L]

--- a/executionTechnique/readme.md
+++ b/executionTechnique/readme.md
@@ -1,0 +1,6 @@
+# Execution Technique Ontology
+
+https://w3id.org/executionTechnique/ontology is the namespace for the ontology based on Evangelisti, S. 2017. ‘Scrittura Epigrafica, alcune Riflessioni’, in S. Antolini, S. M. Marengo, and G. Paci, eds, Colonie e Municipi nell’Era digitale: Documentazione Epigrafica per La Conoscenza delle Città antiche, Atti del Convegno di studi (Macerata, 10–12 Dicembre 2015), 14, Ichnia (Tivoli: Edizioni Tored, 2017), 163–178.
+for the modeling of the information relative to the execution techniques of inscriptions.
+
+The Ontology is under development at https://github.com/EAGLE-BPN/epidocupconversion under the auspices of the International Association of Digital Epigraphy (https://www.eagle-network.eu/) and is used in the EAGLE Vocabulary for Execution Technique (https://www.eagle-network.eu/voc/writing.html).


### PR DESCRIPTION
This is a redirect for a w3id url we would like to use for our execution technique ontology, which is part of the efforts towards a general modelling of epigraphic documents. 