### PR TITLE
/profileresourcerole/ README & redirects

### DIFF
--- a/profileresourcerole/.htaccess
+++ b/profileresourcerole/.htaccess
@@ -1,0 +1,8 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+RewriteCond %{QUERY_STRING} ^_format=text/turtle$ [OR]
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule (.*) https://kurrawong.net/profileresourcerole/$1?_mediatype=text/turtle [R=302,L]
+RewriteRule (.*).ttl$ https://kurrawong.net/profileresourcerole/$1?_mediatype=text/turtle [R=302,L]
+RewriteRule (.*) https://kurrawong.net/profileresourcerole/$1 [R=302,L]

--- a/profileresourcerole/README.md
+++ b/profileresourcerole/README.md
@@ -1,0 +1,43 @@
+# Profile
+This `/profileresourcerole/` path segment within `w3id.org` is used for creating persistent URIs for instances of the `ResourceRole` class which is defined within the [W3C's Profiles Vocabulary](https://w3c.github.io/dxwg/prof/).
+
+A *profile* is:
+
+> A specification that constrains, extends, combines, or provides guidance or explanation about the usage of other data specifications.
+
+> This definition includes what are sometimes called "application profiles", "metadata application profiles", or "metadata profiles".
+- *defintion from the [W3C's Profiles Vocabulary](https://w3c.github.io/dxwg/prof/)*
+
+A `Profile Resource` is:
+
+> A resource that defines an aspect - a particular part or feature - of a Profile
+- *class definition of [prof:ResourceDescriptor](https://w3c.github.io/dxwg/prof/#Class:ResourceDescriptor)*
+
+A ` Resource Role` is:
+
+> The role that an Resource plays
+- *class definition of [prof:ResourceRole](https://w3c.github.io/dxwg/prof/#Class:ResourceRole)*
+
+### Existing Roles
+Within the [W3C's Profiles Vocabulary](https://w3c.github.io/dxwg/prof/) specification, there is already a "starter" list of `Resource Roles`:
+
+* [Constraints](https://w3c.github.io/dxwg/prof/#Role:constraints)
+* [Example](https://w3c.github.io/dxwg/prof/#Role:example)
+* [Guidance](https://w3c.github.io/dxwg/prof/#Role:guidance)
+* [Mapping](https://w3c.github.io/dxwg/prof/#Role:mapping)
+* [Schema](https://w3c.github.io/dxwg/prof/#Role:schema)
+* [Specification](https://w3c.github.io/dxwg/prof/#Role:specification)
+* [Validation](https://w3c.github.io/dxwg/prof/#Role:validation)
+* [Vocabulary](https://w3c.github.io/dxwg/prof/#Role:vocabulary)
+
+## Expected Use
+Anyone wanting to create a new `Resource Role` not already in the list above can apply to have a URI created of the form `https://w3id.org/profileresourcerole/<ROLE-NAME>`. Just email the contacts below.
+
+
+### Contacts
+**Nicholas Car**  
+*Data Systems Architect*  
+SURROUND Australia Pty Ltd  
+<nicholas.car@surroundaustralia.com>  
+<http://surroundaustralia.com>  
+<https://orcid.org/0000-0002-8742-7730>  


### PR DESCRIPTION
A URI for SKOS vocabulary Concepts for the roles that items within Profiles play with both `Resource Role` and `Profile` being defined within the [Profiles Vocabulary](https://w3c.github.io/dxwg/prof/).