### PR TITLE
redirects for GOM ontology

### DIFF
--- a/gom/.htaccess
+++ b/gom/.htaccess
@@ -1,0 +1,40 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://mathib.github.io/gom-ontology/ [R=302,NE,L]
+
+# In case of accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://mathib.github.io/gom-ontology/ontology.ttl [R=303,NE,L]
+
+# In case of accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://mathib.github.io/gom-ontology/ontology.xml [R=302,NE,L]
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^gom.ttl$ https://mathib.github.io/gom-ontology/ontology.ttl [R=302,NE,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^gom.html$ https://mathib.github.io/gom-ontology/ [R=302,NE,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^gom.rdf$ https://mathib.github.io/gom-ontology/ontology.xml [R=302,NE,L]
+
+# If suffix jsonld, redirect to jsonld version
+RewriteRule ^gom.jsonld$ https://mathib.github.io/gom-ontology/ontology.json [R=302,NE,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^gom.nt$ https://mathib.github.io/gom-ontology/ontology.nt [R=302,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://mathib.github.io/gom-ontology/ [R=303,NE,L]

--- a/gom/readme.md
+++ b/gom/readme.md
@@ -1,0 +1,15 @@
+## Geometry Metadata Ontology (GOM)
+
+Ontology
+
+* Docs https://mathib.github.io/gom-ontology/
+* Turtle https://mathib.github.io/gom-ontology/ontology.ttl
+
+Extends
+
+* OMG http://w3id.org/omg#
+
+Contact
+
+* Mathias Bonduel mathias.bonduel@kuleuven.be
+* Anna Wagner wagner@iib.tu-darmstadt.de


### PR DESCRIPTION
Hi!

This redirect contains a proposal for the registration of https://w3id.org/gom for the GOM or Geometry Metadata Ontology. Additional references can be found in the readme.

Best regards,

Mathias Bonduel