### PR TITLE
Updated .htaccess for GOM and FOG

### DIFF
--- a/fog/.htaccess
+++ b/fog/.htaccess
@@ -11,7 +11,7 @@ AddType application/rdf+xml .rdf
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://mathib.github.io/fog-ontology/ [R=302,NE,L]
+RewriteRule ^$ https://mathib.github.io/fog-ontology/ [R=303,NE,L]
 
 # In case of accept header <text/turtle>
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
@@ -19,22 +19,22 @@ RewriteRule ^$ https://mathib.github.io/fog-ontology/ontology.ttl [R=303,NE,L]
 
 # In case of accept header <application/rdf+xml>
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^$ https://mathib.github.io/fog-ontology/ontology.xml [R=302,NE,L]
+RewriteRule ^$ https://mathib.github.io/fog-ontology/ontology.xml [R=303,NE,L]
 
 # If suffix ttl, redirect to turtle version
-RewriteRule ^fog.ttl$ https://mathib.github.io/fog-ontology/ontology.ttl [R=302,NE,L]
+RewriteRule ^fog.ttl$ https://mathib.github.io/fog-ontology/ontology.ttl [R=303,NE,L]
 
 # If suffix html, redirect to html version
-RewriteRule ^fog.html$ https://mathib.github.io/fog-ontology/ [R=302,NE,L]
+RewriteRule ^fog.html$ https://mathib.github.io/fog-ontology/ [R=303,NE,L]
 
 # If suffix rdf, redirect to rdf version
-RewriteRule ^fog.rdf$ https://mathib.github.io/fog-ontology/ontology.xml [R=302,NE,L]
+RewriteRule ^fog.rdf$ https://mathib.github.io/fog-ontology/ontology.xml [R=303,NE,L]
 
 # If suffix jsonld, redirect to jsonld version
-RewriteRule ^fog.jsonld$ https://mathib.github.io/fog-ontology/ontology.json [R=302,NE,L]
+RewriteRule ^fog.jsonld$ https://mathib.github.io/fog-ontology/ontology.json [R=303,NE,L]
 
 # If suffix nt, redirect to nt version
-RewriteRule ^fog.nt$ https://mathib.github.io/fog-ontology/ontology.nt [R=302,NE,L]
+RewriteRule ^fog.nt$ https://mathib.github.io/fog-ontology/ontology.nt [R=303,NE,L]
 
 # Default response: html
 RewriteRule ^$ https://mathib.github.io/fog-ontology/ [R=303,NE,L]

--- a/gom/.htaccess
+++ b/gom/.htaccess
@@ -11,7 +11,7 @@ AddType application/rdf+xml .rdf
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://mathib.github.io/gom-ontology/ [R=302,NE,L]
+RewriteRule ^$ https://mathib.github.io/gom-ontology/ [R=303,NE,L]
 
 # In case of accept header <text/turtle>
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
@@ -19,22 +19,22 @@ RewriteRule ^$ https://mathib.github.io/gom-ontology/ontology.ttl [R=303,NE,L]
 
 # In case of accept header <application/rdf+xml>
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^$ https://mathib.github.io/gom-ontology/ontology.xml [R=302,NE,L]
+RewriteRule ^$ https://mathib.github.io/gom-ontology/ontology.xml [R=303,NE,L]
 
 # If suffix ttl, redirect to turtle version
-RewriteRule ^gom.ttl$ https://mathib.github.io/gom-ontology/ontology.ttl [R=302,NE,L]
+RewriteRule ^gom.ttl$ https://mathib.github.io/gom-ontology/ontology.ttl [R=303,NE,L]
 
 # If suffix html, redirect to html version
-RewriteRule ^gom.html$ https://mathib.github.io/gom-ontology/ [R=302,NE,L]
+RewriteRule ^gom.html$ https://mathib.github.io/gom-ontology/ [R=303,NE,L]
 
 # If suffix rdf, redirect to rdf version
-RewriteRule ^gom.rdf$ https://mathib.github.io/gom-ontology/ontology.xml [R=302,NE,L]
+RewriteRule ^gom.rdf$ https://mathib.github.io/gom-ontology/ontology.xml [R=303,NE,L]
 
 # If suffix jsonld, redirect to jsonld version
-RewriteRule ^gom.jsonld$ https://mathib.github.io/gom-ontology/ontology.json [R=302,NE,L]
+RewriteRule ^gom.jsonld$ https://mathib.github.io/gom-ontology/ontology.json [R=303,NE,L]
 
 # If suffix nt, redirect to nt version
-RewriteRule ^gom.nt$ https://mathib.github.io/gom-ontology/ontology.nt [R=302,NE,L]
+RewriteRule ^gom.nt$ https://mathib.github.io/gom-ontology/ontology.nt [R=303,NE,L]
 
 # Default response: html
 RewriteRule ^$ https://mathib.github.io/gom-ontology/ [R=303,NE,L]


### PR DESCRIPTION
Hi, I just updated the rules of two .htaccess files pointing to my repositories from 302 to 303 according to the recommendations in https://github.com/perma-id/w3id.org/pull/1514

Best regards,

Mathias