### PR TITLE
Added obelisk namespace

### DIFF
--- a/obelisk/.htaccess
+++ b/obelisk/.htaccess
@@ -1,0 +1,6 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+
+RewriteRule ^$ https://zwifi.eu/voc/obelisk/ [R=302,L]

--- a/obelisk/README.md
+++ b/obelisk/README.md
@@ -1,0 +1,10 @@
+# Obelisk vocabulary namespace
+
+## Presentation
+This namespace is used for a simple vocabulary describing obelisks. This vocabulary is used as an example for a tutorial on https://solidproject.org/, and its publication under a permanent IRI is consistent with the good practices identified in said tutorial.
+
+## Services
+- Obelisk vocabulary : https://w3id.org/obelisk/ns/ --> https://zwifi.eu/voc/obelisk/
+
+## Contacts
+- Nicolas Seydoux : nseydoux@inrupt.com


### PR DESCRIPTION
This namespace is used for a simple vocabulary describing obelisks. This vocabulary is used as an example for a tutorial on https://solidproject.org/, and its publication under a permanent IRI is consistent with the good practices identified in said tutorial.