### PR TITLE
Updated the .htaccess to accomodate with the / namespace

### DIFF
--- a/obelisk/.htaccess
+++ b/obelisk/.htaccess
@@ -3,4 +3,4 @@ Options +FollowSymLinks
 RewriteEngine on
 
 
-RewriteRule ^$ https://zwifi.eu/voc/obelisk/ [R=302,L]
+RewriteRule ^.*$ https://zwifi.eu/voc/obelisk/ [R=302,L]


### PR DESCRIPTION
The obelisk vocabulary uses a / namespace (as opposed to a # namespace, which is not sent to the server), so it is necessary to accept extended paths.