### PR TITLE
Update ic-Docbook and PUBS

### DIFF
--- a/ic/standards/.htaccess
+++ b/ic/standards/.htaccess
@@ -337,8 +337,8 @@ RewriteRule ^file/FAC/2019-MAR/?$  https://inteldocs.intelink.gov/inteldocs/page
 
 # Suffix: /ic/standards/ic-docbook
 # Type: 302
-# Target: https://intelshare.intelink.gov/sites/odni/cio/ea/library/Data%20Specifications/Forms/default.aspx
-RewriteRule ^IC-DOCBOOK/?$  https://intelshare.intelink.gov/sites/odni/cio/ea/library/Data\%20Specifications/Forms/default.aspx [NE,NC,R=302,L]
+# Target: https://intelshare.intelink.gov/sites/odni/cio/ea/library/Data%20Specifications/ic-docbook/default.aspx
+RewriteRule ^IC-DOCBOOK/?$  https://intelshare.intelink.gov/sites/odni/cio/ea/library/Data\%20Specifications/ic-docbook/default.aspx [NE,NC,R=302,L]
 
 # Suffix: /ic/standards/ic-docbook
 # Type: 302
@@ -819,8 +819,18 @@ RewriteRule ^repo/PUBS/2018-APR/?$  https://subversion.di2e.net/repos/ICSPACKAGE
 
 # Suffix: /ic/standards/PUBS
 # Type: 302
+# Target: https://subversion.di2e.net/repos/ICSPACKAGES/trunk/2019-SEP/02_Convenience_Packages_Not_Revving/PUBS
+RewriteRule ^repo/PUBS/2018-APR-2019-SEP-Convenience/?$  https://subversion.di2e.net/repos/ICSPACKAGES/trunk/2019-SEP/02_Convenience_Packages_Not_Revving/PUBS [NE,NC,R=302,L]
+
+# Suffix: /ic/standards/PUBS
+# Type: 302
 # Target: https://inteldocs.intelink.gov/inteldocs/page/repository#filter=path%7C/Group%2520Folders/E/Enterprise%2520Specifications/Final%2520Release/2018-APR/PUBS
 RewriteRule ^file/PUBS/2018-APR/?$  https://inteldocs.intelink.gov/inteldocs/page/repository#filter=path\%7C/Group\%2520Folders/E/Enterprise\%2520Specifications/Final\%2520Release/2018-APR/PUBS [NE,NC,R=302,L]
+
+# Suffix: /ic/standards/PUBS
+# Type: 302
+# Target: https://inteldocs.intelink.gov/inteldocs/page/repository#filter=path%7C/Group%2520Folders/E/Enterprise%2520Specifications/Final%2520Release/2019-SEP/02_Convenience_Packages_Not_Revving/PUBS
+RewriteRule ^file/PUBS/2018-APR-2019-SEP-Convenience/?$  https://inteldocs.intelink.gov/inteldocs/page/repository#filter=path\%7C/Group\%2520Folders/E/Enterprise\%2520Specifications/Final\%2520Release/2019-SEP/02_Convenience_Packages_Not_Revving/PUBS [NE,NC,R=302,L]
 
 # Suffix: /ic/standards/Public
 # Type: 302


### PR DESCRIPTION
Fix the IC-Docbook URL and add convenience package urls for PUPS 2019-SEP.