### PR TITLE
Update .htaccess

### DIFF
--- a/ozcar-theia/.htaccess
+++ b/ozcar-theia/.htaccess
@@ -18,19 +18,19 @@ RewriteCond %{HTTP_ACCEPT} !text/turtle
 RewriteCond %{HTTP_ACCEPT} !application/json
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
-RewriteRule ^(.+) http://in-situ.theia-land.fr/vocabularies/Skosmos/theia_ozcar_thesaurus/page/?uri=https\%3A\%2F\%2Fw3id.org\%2F$0  [R=303,NE,L]
+RewriteRule ^(.+) http://in-situ.theia-land.fr/vocabularies/Skosmos/theia_ozcar_thesaurus/page/?uri=https\%3A\%2F\%2Fw3id.org\%2Fozcar-theia\%2F$0  [R=303,NE,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^(.+) http://in-situ.theia-land.fr/vocabularies/Skosmos/rest/v1/theia_ozcar_thesaurus/data?uri=https\%3A\%2F\%2Fw3id.org\%2F$0&format=application/rdf\%2Bxml  [R=303,NE,L]
+RewriteRule ^(.+) http://in-situ.theia-land.fr/vocabularies/Skosmos/rest/v1/theia_ozcar_thesaurus/data?uri=https\%3A\%2F\%2Fw3id.org\%2Fozcar-theia\%2F$0&format=application/rdf\%2Bxml  [R=303,NE,L]
 
 # Rewrite rule to serve TURTLE content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^(.+) http://in-situ.theia-land.fr/vocabularies/Skosmos/rest/v1/theia_ozcar_thesaurus/data?uri=https\%3A\%2F\%2Fw3id.org\%2F$0&format=text/turtle  [R=303,NE,L]
+RewriteRule ^(.+) http://in-situ.theia-land.fr/vocabularies/Skosmos/rest/v1/theia_ozcar_thesaurus/data?uri=https\%3A\%2F\%2Fw3id.org\%2Fozcar-theia\%2F$0&format=text/turtle  [R=303,NE,L]
 
 # Rewrite rule to serve json content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/json 
-RewriteRule ^(.+) http://in-situ.theia-land.fr/vocabularies/Skosmos/rest/v1/theia_ozcar_thesaurus/data?uri=https\%3A\%2F\%2Fw3id.org\%2F$0&format=application/json  [R=303,NE,L]
+RewriteRule ^(.+) http://in-situ.theia-land.fr/vocabularies/Skosmos/rest/v1/theia_ozcar_thesaurus/data?uri=https\%3A\%2F\%2Fw3id.org\%2Fozcar-theia\%2F$0&format=application/json  [R=303,NE,L]
 
 #default response
-RewriteRule ^(.+) http://in-situ.theia-land.fr/vocabularies/Skosmos/rest/v1/theia_ozcar_thesaurus/data?uri=https\%3A\%2F\%2Fw3id.org\%2F$0&format=application/rdf\%2Bxml [R=303,NE,L]
+RewriteRule ^(.+) http://in-situ.theia-land.fr/vocabularies/Skosmos/rest/v1/theia_ozcar_thesaurus/data?uri=https\%3A\%2F\%2Fw3id.org\%2Fozcar-theia\%2F$0&format=application/rdf\%2Bxml [R=303,NE,L]


### PR DESCRIPTION
Add missing "ozcar-theia\%2F" in the uri parameter.
Currently https://w3id.org/ozcar-theia/variables/airPressure is redirected to http://in-situ.theia-land.fr/vocabularies/Skosmos/theia_ozcar_thesaurus/en/page/?uri=https%3A%2F%2Fw3id.org%2Fvariables/airPressure which is not a valid

A valid redirection would be https://w3id.org/ozcar-theia/variables/airPressure is redirected to http://in-situ.theia-land.fr/vocabularies/Skosmos/theia_ozcar_thesaurus/en/page/?uri=https%3A%2F%2Fw3id.org%2Fozcar-theia%2Fvariables/airPressure