### PR TITLE
Digital Construction Ontologies - Reorganization

### DIFF
--- a/digitalconstruction/.htaccess
+++ b/digitalconstruction/.htaccess
@@ -1,1 +1,1 @@
-Redirect 301 index.html https://digitalconstruction.github.io/index.html
+Redirect /index.html https://digitalconstruction.github.io/index.html

--- a/digitalconstruction/.htaccess
+++ b/digitalconstruction/.htaccess
@@ -1,1 +1,3 @@
-Redirect /index.html https://digitalconstruction.github.io/index.html
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ https://digitalconstruction.github.io/index.html [R=302,L]

--- a/digitalconstruction/.htaccess
+++ b/digitalconstruction/.htaccess
@@ -1,0 +1,1 @@
+Redirect 301 index.html https://digitalconstruction.github.io/index.html

--- a/digitalconstruction/Agents/.htaccess
+++ b/digitalconstruction/Agents/.htaccess
@@ -21,15 +21,18 @@ RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.*
 RewriteRule ^$ https://digitalconstruction.github.io/Agents/ontology.nt [R=303,NE,L]
 
 # If accept <application/json> or <application/ld+json>, redirect to .json 
-RewriteCond %{HTTP_ACCEPT} ^.application/json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/json.* [OR]
 RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
 RewriteRule ^$ https://digitalconstruction.github.io/Agents/ontology.json [R=303,NE,L]
 
 # If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
-RewriteCond %{HTTP_ACCEPT} ^.*application/xml.*
-RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/xml.* [OR]
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*  [OR]
 RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
 RewriteRule ^$ https://digitalconstruction.github.io/Agents/ontology.xml [R=303,NE,L]
 
-# Default response: html
-RewriteRule ^$ https://digitalconstruction.github.io/Agents [R=303,NE,L]
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.
+RewriteRule ^$ https://digitalconstruction.github.io/Agents [R=303,L]

--- a/digitalconstruction/Agents/.htaccess
+++ b/digitalconstruction/Agents/.htaccess
@@ -1,0 +1,27 @@
+Options +FollowSymLinks
+RewriteEngine on
+Options -MultiViews
+AddType text/turtle .ttl
+
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, html)
+RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/Agents/ontology.ttl [R=302,NE,L]
+RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/Agents/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/Agents/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.json$ https://digitalconstruction.github.io/Agents/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/Agents/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.html$ https://digitalconstruction.github.io/Agents [R=302,NE,L]
+
+# If accept <text/turtle>, redirect to .ttl
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://digitalconstruction.github.io/Agents/ontology.ttl [R=303,NE,L]
+
+# If accept <application/json> or <application/ld+json>, redirect to .json 
+RewriteCond %{HTTP_ACCEPT} ^.*json.*
+RewriteRule ^$ https://digitalconstruction.github.io/Agents/ontology.json [R=303,NE,L]
+
+# If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
+RewriteCond %{HTTP_ACCEPT} ^.*xml.*
+RewriteRule ^$ https://digitalconstruction.github.io/Agents/ontology.xml [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://digitalconstruction.github.io/Agents [R=303,NE,L]

--- a/digitalconstruction/Agents/.htaccess
+++ b/digitalconstruction/Agents/.htaccess
@@ -3,24 +3,32 @@ RewriteEngine on
 Options -MultiViews
 AddType text/turtle .ttl
 
-# Redirect based on file suffix (ttl, xml, owl, json, jsonld, html)
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, nt, html)
 RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/Agents/ontology.ttl [R=302,NE,L]
 RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/Agents/ontology.xml [R=302,NE,L]
 RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/Agents/ontology.xml [R=302,NE,L]
 RewriteRule ^ontology.json$ https://digitalconstruction.github.io/Agents/ontology.json [R=302,NE,L]
 RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/Agents/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.nt$ https://digitalconstruction.github.io/Agents/ontology.nt [R=302,NE,L]
 RewriteRule ^ontology.html$ https://digitalconstruction.github.io/Agents [R=302,NE,L]
 
 # If accept <text/turtle>, redirect to .ttl
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
 RewriteRule ^$ https://digitalconstruction.github.io/Agents/ontology.ttl [R=303,NE,L]
 
+# If accept <application/n-triples>, redirect to .nt
+RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.* 
+RewriteRule ^$ https://digitalconstruction.github.io/Agents/ontology.nt [R=303,NE,L]
+
 # If accept <application/json> or <application/ld+json>, redirect to .json 
-RewriteCond %{HTTP_ACCEPT} ^.*json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
 RewriteRule ^$ https://digitalconstruction.github.io/Agents/ontology.json [R=303,NE,L]
 
 # If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
-RewriteCond %{HTTP_ACCEPT} ^.*xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
 RewriteRule ^$ https://digitalconstruction.github.io/Agents/ontology.xml [R=303,NE,L]
 
 # Default response: html

--- a/digitalconstruction/BuildingAcoustics/.htaccess
+++ b/digitalconstruction/BuildingAcoustics/.htaccess
@@ -21,15 +21,18 @@ RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.*
 RewriteRule ^$ https://digitalconstruction.github.io/BuildingAcoustics/ontology.nt [R=303,NE,L]
 
 # If accept <application/json> or <application/ld+json>, redirect to .json 
-RewriteCond %{HTTP_ACCEPT} ^.application/json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/json.* [OR]
 RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
 RewriteRule ^$ https://digitalconstruction.github.io/BuildingAcoustics/ontology.json [R=303,NE,L]
 
 # If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
-RewriteCond %{HTTP_ACCEPT} ^.*application/xml.*
-RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/xml.* [OR]
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*  [OR]
 RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
 RewriteRule ^$ https://digitalconstruction.github.io/BuildingAcoustics/ontology.xml [R=303,NE,L]
 
-# Default response: html
-RewriteRule ^$ https://digitalconstruction.github.io/BuildingAcoustics [R=303,NE,L]
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.
+RewriteRule ^$ https://digitalconstruction.github.io/BuildingAcoustics [R=303,L]

--- a/digitalconstruction/BuildingAcoustics/.htaccess
+++ b/digitalconstruction/BuildingAcoustics/.htaccess
@@ -3,24 +3,32 @@ RewriteEngine on
 Options -MultiViews
 AddType text/turtle .ttl
 
-# Redirect based on file suffix (ttl, xml, owl, json, jsonld, html)
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, nt, html)
 RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/BuildingAcoustics/ontology.ttl [R=302,NE,L]
 RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/BuildingAcoustics/ontology.xml [R=302,NE,L]
 RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/BuildingAcoustics/ontology.xml [R=302,NE,L]
 RewriteRule ^ontology.json$ https://digitalconstruction.github.io/BuildingAcoustics/ontology.json [R=302,NE,L]
 RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/BuildingAcoustics/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.nt$ https://digitalconstruction.github.io/BuildingAcoustics/ontology.nt [R=302,NE,L]
 RewriteRule ^ontology.html$ https://digitalconstruction.github.io/BuildingAcoustics [R=302,NE,L]
 
 # If accept <text/turtle>, redirect to .ttl
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
 RewriteRule ^$ https://digitalconstruction.github.io/BuildingAcoustics/ontology.ttl [R=303,NE,L]
 
+# If accept <application/n-triples>, redirect to .nt
+RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.* 
+RewriteRule ^$ https://digitalconstruction.github.io/BuildingAcoustics/ontology.nt [R=303,NE,L]
+
 # If accept <application/json> or <application/ld+json>, redirect to .json 
-RewriteCond %{HTTP_ACCEPT} ^.*json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
 RewriteRule ^$ https://digitalconstruction.github.io/BuildingAcoustics/ontology.json [R=303,NE,L]
 
 # If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
-RewriteCond %{HTTP_ACCEPT} ^.*xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
 RewriteRule ^$ https://digitalconstruction.github.io/BuildingAcoustics/ontology.xml [R=303,NE,L]
 
 # Default response: html

--- a/digitalconstruction/BuildingAcoustics/.htaccess
+++ b/digitalconstruction/BuildingAcoustics/.htaccess
@@ -1,0 +1,27 @@
+Options +FollowSymLinks
+RewriteEngine on
+Options -MultiViews
+AddType text/turtle .ttl
+
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, html)
+RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/BuildingAcoustics/ontology.ttl [R=302,NE,L]
+RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/BuildingAcoustics/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/BuildingAcoustics/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.json$ https://digitalconstruction.github.io/BuildingAcoustics/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/BuildingAcoustics/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.html$ https://digitalconstruction.github.io/BuildingAcoustics [R=302,NE,L]
+
+# If accept <text/turtle>, redirect to .ttl
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://digitalconstruction.github.io/BuildingAcoustics/ontology.ttl [R=303,NE,L]
+
+# If accept <application/json> or <application/ld+json>, redirect to .json 
+RewriteCond %{HTTP_ACCEPT} ^.*json.*
+RewriteRule ^$ https://digitalconstruction.github.io/BuildingAcoustics/ontology.json [R=303,NE,L]
+
+# If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
+RewriteCond %{HTTP_ACCEPT} ^.*xml.*
+RewriteRule ^$ https://digitalconstruction.github.io/BuildingAcoustics/ontology.xml [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://digitalconstruction.github.io/BuildingAcoustics [R=303,NE,L]

--- a/digitalconstruction/BuildingMaterials/.htaccess
+++ b/digitalconstruction/BuildingMaterials/.htaccess
@@ -21,15 +21,18 @@ RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.*
 RewriteRule ^$ https://digitalconstruction.github.io/BuildingMaterials/ontology.nt [R=303,NE,L]
 
 # If accept <application/json> or <application/ld+json>, redirect to .json 
-RewriteCond %{HTTP_ACCEPT} ^.application/json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/json.* [OR]
 RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
 RewriteRule ^$ https://digitalconstruction.github.io/BuildingMaterials/ontology.json [R=303,NE,L]
 
 # If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
-RewriteCond %{HTTP_ACCEPT} ^.*application/xml.*
-RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/xml.* [OR]
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*  [OR]
 RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
 RewriteRule ^$ https://digitalconstruction.github.io/BuildingMaterials/ontology.xml [R=303,NE,L]
 
-# Default response: html
-RewriteRule ^$ https://digitalconstruction.github.io/BuildingMaterials [R=303,NE,L]
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.
+RewriteRule ^$ https://digitalconstruction.github.io/BuildingMaterials [R=303,L]

--- a/digitalconstruction/BuildingMaterials/.htaccess
+++ b/digitalconstruction/BuildingMaterials/.htaccess
@@ -3,24 +3,32 @@ RewriteEngine on
 Options -MultiViews
 AddType text/turtle .ttl
 
-# Redirect based on file suffix (ttl, xml, owl, json, jsonld, html)
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, nt, html)
 RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/BuildingMaterials/ontology.ttl [R=302,NE,L]
 RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/BuildingMaterials/ontology.xml [R=302,NE,L]
 RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/BuildingMaterials/ontology.xml [R=302,NE,L]
 RewriteRule ^ontology.json$ https://digitalconstruction.github.io/BuildingMaterials/ontology.json [R=302,NE,L]
 RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/BuildingMaterials/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.nt$ https://digitalconstruction.github.io/BuildingMaterials/ontology.nt [R=302,NE,L]
 RewriteRule ^ontology.html$ https://digitalconstruction.github.io/BuildingMaterials [R=302,NE,L]
 
 # If accept <text/turtle>, redirect to .ttl
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
 RewriteRule ^$ https://digitalconstruction.github.io/BuildingMaterials/ontology.ttl [R=303,NE,L]
 
+# If accept <application/n-triples>, redirect to .nt
+RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.* 
+RewriteRule ^$ https://digitalconstruction.github.io/BuildingMaterials/ontology.nt [R=303,NE,L]
+
 # If accept <application/json> or <application/ld+json>, redirect to .json 
-RewriteCond %{HTTP_ACCEPT} ^.*json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
 RewriteRule ^$ https://digitalconstruction.github.io/BuildingMaterials/ontology.json [R=303,NE,L]
 
 # If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
-RewriteCond %{HTTP_ACCEPT} ^.*xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
 RewriteRule ^$ https://digitalconstruction.github.io/BuildingMaterials/ontology.xml [R=303,NE,L]
 
 # Default response: html

--- a/digitalconstruction/BuildingMaterials/.htaccess
+++ b/digitalconstruction/BuildingMaterials/.htaccess
@@ -1,0 +1,27 @@
+Options +FollowSymLinks
+RewriteEngine on
+Options -MultiViews
+AddType text/turtle .ttl
+
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, html)
+RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/BuildingMaterials/ontology.ttl [R=302,NE,L]
+RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/BuildingMaterials/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/BuildingMaterials/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.json$ https://digitalconstruction.github.io/BuildingMaterials/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/BuildingMaterials/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.html$ https://digitalconstruction.github.io/BuildingMaterials [R=302,NE,L]
+
+# If accept <text/turtle>, redirect to .ttl
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://digitalconstruction.github.io/BuildingMaterials/ontology.ttl [R=303,NE,L]
+
+# If accept <application/json> or <application/ld+json>, redirect to .json 
+RewriteCond %{HTTP_ACCEPT} ^.*json.*
+RewriteRule ^$ https://digitalconstruction.github.io/BuildingMaterials/ontology.json [R=303,NE,L]
+
+# If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
+RewriteCond %{HTTP_ACCEPT} ^.*xml.*
+RewriteRule ^$ https://digitalconstruction.github.io/BuildingMaterials/ontology.xml [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://digitalconstruction.github.io/BuildingMaterials [R=303,NE,L]

--- a/digitalconstruction/Contexts/.htaccess
+++ b/digitalconstruction/Contexts/.htaccess
@@ -1,0 +1,27 @@
+Options +FollowSymLinks
+RewriteEngine on
+Options -MultiViews
+AddType text/turtle .ttl
+
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, html)
+RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/Contexts/ontology.ttl [R=302,NE,L]
+RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/Contexts/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/Contexts/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.json$ https://digitalconstruction.github.io/Contexts/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/Contexts/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.html$ https://digitalconstruction.github.io/Contexts [R=302,NE,L]
+
+# If accept <text/turtle>, redirect to .ttl
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://digitalconstruction.github.io/Contexts/ontology.ttl [R=303,NE,L]
+
+# If accept <application/json> or <application/ld+json>, redirect to .json 
+RewriteCond %{HTTP_ACCEPT} ^.*json.*
+RewriteRule ^$ https://digitalconstruction.github.io/Contexts/ontology.json [R=303,NE,L]
+
+# If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
+RewriteCond %{HTTP_ACCEPT} ^.*xml.*
+RewriteRule ^$ https://digitalconstruction.github.io/Contexts/ontology.xml [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://digitalconstruction.github.io/Contexts [R=303,NE,L]

--- a/digitalconstruction/Contexts/.htaccess
+++ b/digitalconstruction/Contexts/.htaccess
@@ -21,15 +21,18 @@ RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.*
 RewriteRule ^$ https://digitalconstruction.github.io/Contexts/ontology.nt [R=303,NE,L]
 
 # If accept <application/json> or <application/ld+json>, redirect to .json 
-RewriteCond %{HTTP_ACCEPT} ^.application/json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/json.* [OR]
 RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
 RewriteRule ^$ https://digitalconstruction.github.io/Contexts/ontology.json [R=303,NE,L]
 
 # If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
-RewriteCond %{HTTP_ACCEPT} ^.*application/xml.*
-RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/xml.* [OR]
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*  [OR]
 RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
 RewriteRule ^$ https://digitalconstruction.github.io/Contexts/ontology.xml [R=303,NE,L]
 
-# Default response: html
-RewriteRule ^$ https://digitalconstruction.github.io/Contexts [R=303,NE,L]
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.
+RewriteRule ^$ https://digitalconstruction.github.io/Contexts [R=303,L]

--- a/digitalconstruction/Contexts/.htaccess
+++ b/digitalconstruction/Contexts/.htaccess
@@ -3,24 +3,32 @@ RewriteEngine on
 Options -MultiViews
 AddType text/turtle .ttl
 
-# Redirect based on file suffix (ttl, xml, owl, json, jsonld, html)
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, nt, html)
 RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/Contexts/ontology.ttl [R=302,NE,L]
 RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/Contexts/ontology.xml [R=302,NE,L]
 RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/Contexts/ontology.xml [R=302,NE,L]
 RewriteRule ^ontology.json$ https://digitalconstruction.github.io/Contexts/ontology.json [R=302,NE,L]
 RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/Contexts/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.nt$ https://digitalconstruction.github.io/Contexts/ontology.nt [R=302,NE,L]
 RewriteRule ^ontology.html$ https://digitalconstruction.github.io/Contexts [R=302,NE,L]
 
 # If accept <text/turtle>, redirect to .ttl
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
 RewriteRule ^$ https://digitalconstruction.github.io/Contexts/ontology.ttl [R=303,NE,L]
 
+# If accept <application/n-triples>, redirect to .nt
+RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.* 
+RewriteRule ^$ https://digitalconstruction.github.io/Contexts/ontology.nt [R=303,NE,L]
+
 # If accept <application/json> or <application/ld+json>, redirect to .json 
-RewriteCond %{HTTP_ACCEPT} ^.*json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
 RewriteRule ^$ https://digitalconstruction.github.io/Contexts/ontology.json [R=303,NE,L]
 
 # If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
-RewriteCond %{HTTP_ACCEPT} ^.*xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
 RewriteRule ^$ https://digitalconstruction.github.io/Contexts/ontology.xml [R=303,NE,L]
 
 # Default response: html

--- a/digitalconstruction/EnergySystems/.htaccess
+++ b/digitalconstruction/EnergySystems/.htaccess
@@ -3,24 +3,32 @@ RewriteEngine on
 Options -MultiViews
 AddType text/turtle .ttl
 
-# Redirect based on file suffix (ttl, xml, owl, json, jsonld, html)
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, nt, html)
 RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/EnergySystems/ontology.ttl [R=302,NE,L]
 RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/EnergySystems/ontology.xml [R=302,NE,L]
 RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/EnergySystems/ontology.xml [R=302,NE,L]
 RewriteRule ^ontology.json$ https://digitalconstruction.github.io/EnergySystems/ontology.json [R=302,NE,L]
 RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/EnergySystems/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.nt$ https://digitalconstruction.github.io/EnergySystems/ontology.nt [R=302,NE,L]
 RewriteRule ^ontology.html$ https://digitalconstruction.github.io/EnergySystems [R=302,NE,L]
 
 # If accept <text/turtle>, redirect to .ttl
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
 RewriteRule ^$ https://digitalconstruction.github.io/EnergySystems/ontology.ttl [R=303,NE,L]
 
+# If accept <application/n-triples>, redirect to .nt
+RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.* 
+RewriteRule ^$ https://digitalconstruction.github.io/EnergySystems/ontology.nt [R=303,NE,L]
+
 # If accept <application/json> or <application/ld+json>, redirect to .json 
-RewriteCond %{HTTP_ACCEPT} ^.*json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
 RewriteRule ^$ https://digitalconstruction.github.io/EnergySystems/ontology.json [R=303,NE,L]
 
 # If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
-RewriteCond %{HTTP_ACCEPT} ^.*xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
 RewriteRule ^$ https://digitalconstruction.github.io/EnergySystems/ontology.xml [R=303,NE,L]
 
 # Default response: html

--- a/digitalconstruction/EnergySystems/.htaccess
+++ b/digitalconstruction/EnergySystems/.htaccess
@@ -21,15 +21,18 @@ RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.*
 RewriteRule ^$ https://digitalconstruction.github.io/EnergySystems/ontology.nt [R=303,NE,L]
 
 # If accept <application/json> or <application/ld+json>, redirect to .json 
-RewriteCond %{HTTP_ACCEPT} ^.application/json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/json.* [OR]
 RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
 RewriteRule ^$ https://digitalconstruction.github.io/EnergySystems/ontology.json [R=303,NE,L]
 
 # If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
-RewriteCond %{HTTP_ACCEPT} ^.*application/xml.*
-RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/xml.* [OR]
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*  [OR]
 RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
 RewriteRule ^$ https://digitalconstruction.github.io/EnergySystems/ontology.xml [R=303,NE,L]
 
-# Default response: html
-RewriteRule ^$ https://digitalconstruction.github.io/EnergySystems [R=303,NE,L]
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.
+RewriteRule ^$ https://digitalconstruction.github.io/EnergySystems [R=303,L]

--- a/digitalconstruction/EnergySystems/.htaccess
+++ b/digitalconstruction/EnergySystems/.htaccess
@@ -1,0 +1,27 @@
+Options +FollowSymLinks
+RewriteEngine on
+Options -MultiViews
+AddType text/turtle .ttl
+
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, html)
+RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/EnergySystems/ontology.ttl [R=302,NE,L]
+RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/EnergySystems/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/EnergySystems/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.json$ https://digitalconstruction.github.io/EnergySystems/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/EnergySystems/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.html$ https://digitalconstruction.github.io/EnergySystems [R=302,NE,L]
+
+# If accept <text/turtle>, redirect to .ttl
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://digitalconstruction.github.io/EnergySystems/ontology.ttl [R=303,NE,L]
+
+# If accept <application/json> or <application/ld+json>, redirect to .json 
+RewriteCond %{HTTP_ACCEPT} ^.*json.*
+RewriteRule ^$ https://digitalconstruction.github.io/EnergySystems/ontology.json [R=303,NE,L]
+
+# If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
+RewriteCond %{HTTP_ACCEPT} ^.*xml.*
+RewriteRule ^$ https://digitalconstruction.github.io/EnergySystems/ontology.xml [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://digitalconstruction.github.io/EnergySystems [R=303,NE,L]

--- a/digitalconstruction/Entities/.htaccess
+++ b/digitalconstruction/Entities/.htaccess
@@ -1,0 +1,27 @@
+Options +FollowSymLinks
+RewriteEngine on
+Options -MultiViews
+AddType text/turtle .ttl
+
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, html)
+RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/Entities/ontology.ttl [R=302,NE,L]
+RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/Entities/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/Entities/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.json$ https://digitalconstruction.github.io/Entities/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/Entities/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.html$ https://digitalconstruction.github.io/Entities [R=302,NE,L]
+
+# If accept <text/turtle>, redirect to .ttl
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://digitalconstruction.github.io/Entities/ontology.ttl [R=303,NE,L]
+
+# If accept <application/json> or <application/ld+json>, redirect to .json 
+RewriteCond %{HTTP_ACCEPT} ^.*json.*
+RewriteRule ^$ https://digitalconstruction.github.io/Entities/ontology.json [R=303,NE,L]
+
+# If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
+RewriteCond %{HTTP_ACCEPT} ^.*xml.*
+RewriteRule ^$ https://digitalconstruction.github.io/Entities/ontology.xml [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://digitalconstruction.github.io/Entities [R=303,NE,L]

--- a/digitalconstruction/Entities/.htaccess
+++ b/digitalconstruction/Entities/.htaccess
@@ -21,15 +21,18 @@ RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.*
 RewriteRule ^$ https://digitalconstruction.github.io/Entities/ontology.nt [R=303,NE,L]
 
 # If accept <application/json> or <application/ld+json>, redirect to .json 
-RewriteCond %{HTTP_ACCEPT} ^.application/json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/json.* [OR]
 RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
 RewriteRule ^$ https://digitalconstruction.github.io/Entities/ontology.json [R=303,NE,L]
 
 # If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
-RewriteCond %{HTTP_ACCEPT} ^.*application/xml.*
-RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/xml.* [OR]
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*  [OR]
 RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
 RewriteRule ^$ https://digitalconstruction.github.io/Entities/ontology.xml [R=303,NE,L]
 
-# Default response: html
-RewriteRule ^$ https://digitalconstruction.github.io/Entities [R=303,NE,L]
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.
+RewriteRule ^$ https://digitalconstruction.github.io/Entities [R=303,L]

--- a/digitalconstruction/Entities/.htaccess
+++ b/digitalconstruction/Entities/.htaccess
@@ -3,24 +3,32 @@ RewriteEngine on
 Options -MultiViews
 AddType text/turtle .ttl
 
-# Redirect based on file suffix (ttl, xml, owl, json, jsonld, html)
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, nt, html)
 RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/Entities/ontology.ttl [R=302,NE,L]
 RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/Entities/ontology.xml [R=302,NE,L]
 RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/Entities/ontology.xml [R=302,NE,L]
 RewriteRule ^ontology.json$ https://digitalconstruction.github.io/Entities/ontology.json [R=302,NE,L]
 RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/Entities/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.nt$ https://digitalconstruction.github.io/Entities/ontology.nt [R=302,NE,L]
 RewriteRule ^ontology.html$ https://digitalconstruction.github.io/Entities [R=302,NE,L]
 
 # If accept <text/turtle>, redirect to .ttl
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
 RewriteRule ^$ https://digitalconstruction.github.io/Entities/ontology.ttl [R=303,NE,L]
 
+# If accept <application/n-triples>, redirect to .nt
+RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.* 
+RewriteRule ^$ https://digitalconstruction.github.io/Entities/ontology.nt [R=303,NE,L]
+
 # If accept <application/json> or <application/ld+json>, redirect to .json 
-RewriteCond %{HTTP_ACCEPT} ^.*json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
 RewriteRule ^$ https://digitalconstruction.github.io/Entities/ontology.json [R=303,NE,L]
 
 # If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
-RewriteCond %{HTTP_ACCEPT} ^.*xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
 RewriteRule ^$ https://digitalconstruction.github.io/Entities/ontology.xml [R=303,NE,L]
 
 # Default response: html

--- a/digitalconstruction/IndoorAirQuality/.htaccess
+++ b/digitalconstruction/IndoorAirQuality/.htaccess
@@ -1,0 +1,27 @@
+Options +FollowSymLinks
+RewriteEngine on
+Options -MultiViews
+AddType text/turtle .ttl
+
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, html)
+RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/IndoorAirQuality/ontology.ttl [R=302,NE,L]
+RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/IndoorAirQuality/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/IndoorAirQuality/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.json$ https://digitalconstruction.github.io/IndoorAirQuality/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/IndoorAirQuality/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.html$ https://digitalconstruction.github.io/IndoorAirQuality [R=302,NE,L]
+
+# If accept <text/turtle>, redirect to .ttl
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://digitalconstruction.github.io/IndoorAirQuality/ontology.ttl [R=303,NE,L]
+
+# If accept <application/json> or <application/ld+json>, redirect to .json 
+RewriteCond %{HTTP_ACCEPT} ^.*json.*
+RewriteRule ^$ https://digitalconstruction.github.io/IndoorAirQuality/ontology.json [R=303,NE,L]
+
+# If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
+RewriteCond %{HTTP_ACCEPT} ^.*xml.*
+RewriteRule ^$ https://digitalconstruction.github.io/IndoorAirQuality/ontology.xml [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://digitalconstruction.github.io/IndoorAirQuality [R=303,NE,L]

--- a/digitalconstruction/IndoorAirQuality/.htaccess
+++ b/digitalconstruction/IndoorAirQuality/.htaccess
@@ -21,15 +21,18 @@ RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.*
 RewriteRule ^$ https://digitalconstruction.github.io/IndoorAirQuality/ontology.nt [R=303,NE,L]
 
 # If accept <application/json> or <application/ld+json>, redirect to .json 
-RewriteCond %{HTTP_ACCEPT} ^.application/json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/json.* [OR]
 RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
 RewriteRule ^$ https://digitalconstruction.github.io/IndoorAirQuality/ontology.json [R=303,NE,L]
 
 # If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
-RewriteCond %{HTTP_ACCEPT} ^.*application/xml.*
-RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/xml.* [OR]
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*  [OR]
 RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
 RewriteRule ^$ https://digitalconstruction.github.io/IndoorAirQuality/ontology.xml [R=303,NE,L]
 
-# Default response: html
-RewriteRule ^$ https://digitalconstruction.github.io/IndoorAirQuality [R=303,NE,L]
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.
+RewriteRule ^$ https://digitalconstruction.github.io/IndoorAirQuality [R=303,L]

--- a/digitalconstruction/IndoorAirQuality/.htaccess
+++ b/digitalconstruction/IndoorAirQuality/.htaccess
@@ -3,24 +3,32 @@ RewriteEngine on
 Options -MultiViews
 AddType text/turtle .ttl
 
-# Redirect based on file suffix (ttl, xml, owl, json, jsonld, html)
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, nt, html)
 RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/IndoorAirQuality/ontology.ttl [R=302,NE,L]
 RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/IndoorAirQuality/ontology.xml [R=302,NE,L]
 RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/IndoorAirQuality/ontology.xml [R=302,NE,L]
 RewriteRule ^ontology.json$ https://digitalconstruction.github.io/IndoorAirQuality/ontology.json [R=302,NE,L]
 RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/IndoorAirQuality/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.nt$ https://digitalconstruction.github.io/IndoorAirQuality/ontology.nt [R=302,NE,L]
 RewriteRule ^ontology.html$ https://digitalconstruction.github.io/IndoorAirQuality [R=302,NE,L]
 
 # If accept <text/turtle>, redirect to .ttl
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
 RewriteRule ^$ https://digitalconstruction.github.io/IndoorAirQuality/ontology.ttl [R=303,NE,L]
 
+# If accept <application/n-triples>, redirect to .nt
+RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.* 
+RewriteRule ^$ https://digitalconstruction.github.io/IndoorAirQuality/ontology.nt [R=303,NE,L]
+
 # If accept <application/json> or <application/ld+json>, redirect to .json 
-RewriteCond %{HTTP_ACCEPT} ^.*json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
 RewriteRule ^$ https://digitalconstruction.github.io/IndoorAirQuality/ontology.json [R=303,NE,L]
 
 # If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
-RewriteCond %{HTTP_ACCEPT} ^.*xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
 RewriteRule ^$ https://digitalconstruction.github.io/IndoorAirQuality/ontology.xml [R=303,NE,L]
 
 # Default response: html

--- a/digitalconstruction/Information/.htaccess
+++ b/digitalconstruction/Information/.htaccess
@@ -1,0 +1,27 @@
+Options +FollowSymLinks
+RewriteEngine on
+Options -MultiViews
+AddType text/turtle .ttl
+
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, html)
+RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/Information/ontology.ttl [R=302,NE,L]
+RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/Information/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/Information/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.json$ https://digitalconstruction.github.io/Information/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/Information/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.html$ https://digitalconstruction.github.io/Information [R=302,NE,L]
+
+# If accept <text/turtle>, redirect to .ttl
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://digitalconstruction.github.io/Information/ontology.ttl [R=303,NE,L]
+
+# If accept <application/json> or <application/ld+json>, redirect to .json 
+RewriteCond %{HTTP_ACCEPT} ^.*json.*
+RewriteRule ^$ https://digitalconstruction.github.io/Information/ontology.json [R=303,NE,L]
+
+# If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
+RewriteCond %{HTTP_ACCEPT} ^.*xml.*
+RewriteRule ^$ https://digitalconstruction.github.io/Information/ontology.xml [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://digitalconstruction.github.io/Information [R=303,NE,L]

--- a/digitalconstruction/Information/.htaccess
+++ b/digitalconstruction/Information/.htaccess
@@ -21,15 +21,18 @@ RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.*
 RewriteRule ^$ https://digitalconstruction.github.io/Information/ontology.nt [R=303,NE,L]
 
 # If accept <application/json> or <application/ld+json>, redirect to .json 
-RewriteCond %{HTTP_ACCEPT} ^.application/json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/json.* [OR]
 RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
 RewriteRule ^$ https://digitalconstruction.github.io/Information/ontology.json [R=303,NE,L]
 
 # If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
-RewriteCond %{HTTP_ACCEPT} ^.*application/xml.*
-RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/xml.* [OR]
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*  [OR]
 RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
 RewriteRule ^$ https://digitalconstruction.github.io/Information/ontology.xml [R=303,NE,L]
 
-# Default response: html
-RewriteRule ^$ https://digitalconstruction.github.io/Information [R=303,NE,L]
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.
+RewriteRule ^$ https://digitalconstruction.github.io/Information [R=303,L]

--- a/digitalconstruction/Information/.htaccess
+++ b/digitalconstruction/Information/.htaccess
@@ -3,24 +3,32 @@ RewriteEngine on
 Options -MultiViews
 AddType text/turtle .ttl
 
-# Redirect based on file suffix (ttl, xml, owl, json, jsonld, html)
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, nt, html)
 RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/Information/ontology.ttl [R=302,NE,L]
 RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/Information/ontology.xml [R=302,NE,L]
 RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/Information/ontology.xml [R=302,NE,L]
 RewriteRule ^ontology.json$ https://digitalconstruction.github.io/Information/ontology.json [R=302,NE,L]
 RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/Information/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.nt$ https://digitalconstruction.github.io/Information/ontology.nt [R=302,NE,L]
 RewriteRule ^ontology.html$ https://digitalconstruction.github.io/Information [R=302,NE,L]
 
 # If accept <text/turtle>, redirect to .ttl
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
 RewriteRule ^$ https://digitalconstruction.github.io/Information/ontology.ttl [R=303,NE,L]
 
+# If accept <application/n-triples>, redirect to .nt
+RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.* 
+RewriteRule ^$ https://digitalconstruction.github.io/Information/ontology.nt [R=303,NE,L]
+
 # If accept <application/json> or <application/ld+json>, redirect to .json 
-RewriteCond %{HTTP_ACCEPT} ^.*json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
 RewriteRule ^$ https://digitalconstruction.github.io/Information/ontology.json [R=303,NE,L]
 
 # If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
-RewriteCond %{HTTP_ACCEPT} ^.*xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
 RewriteRule ^$ https://digitalconstruction.github.io/Information/ontology.xml [R=303,NE,L]
 
 # Default response: html

--- a/digitalconstruction/OccupantBehavior/.htaccess
+++ b/digitalconstruction/OccupantBehavior/.htaccess
@@ -1,0 +1,27 @@
+Options +FollowSymLinks
+RewriteEngine on
+Options -MultiViews
+AddType text/turtle .ttl
+
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, html)
+RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/OccupantBehavior/ontology.ttl [R=302,NE,L]
+RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/OccupantBehavior/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/OccupantBehavior/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.json$ https://digitalconstruction.github.io/OccupantBehavior/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/OccupantBehavior/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.html$ https://digitalconstruction.github.io/OccupantBehavior [R=302,NE,L]
+
+# If accept <text/turtle>, redirect to .ttl
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://digitalconstruction.github.io/OccupantBehavior/ontology.ttl [R=303,NE,L]
+
+# If accept <application/json> or <application/ld+json>, redirect to .json 
+RewriteCond %{HTTP_ACCEPT} ^.*json.*
+RewriteRule ^$ https://digitalconstruction.github.io/OccupantBehavior/ontology.json [R=303,NE,L]
+
+# If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
+RewriteCond %{HTTP_ACCEPT} ^.*xml.*
+RewriteRule ^$ https://digitalconstruction.github.io/OccupantBehavior/ontology.xml [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://digitalconstruction.github.io/OccupantBehavior [R=303,NE,L]

--- a/digitalconstruction/OccupantBehavior/.htaccess
+++ b/digitalconstruction/OccupantBehavior/.htaccess
@@ -21,15 +21,18 @@ RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.*
 RewriteRule ^$ https://digitalconstruction.github.io/OccupantBehavior/ontology.nt [R=303,NE,L]
 
 # If accept <application/json> or <application/ld+json>, redirect to .json 
-RewriteCond %{HTTP_ACCEPT} ^.application/json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/json.* [OR]
 RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
 RewriteRule ^$ https://digitalconstruction.github.io/OccupantBehavior/ontology.json [R=303,NE,L]
 
 # If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
-RewriteCond %{HTTP_ACCEPT} ^.*application/xml.*
-RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/xml.* [OR]
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*  [OR]
 RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
 RewriteRule ^$ https://digitalconstruction.github.io/OccupantBehavior/ontology.xml [R=303,NE,L]
 
-# Default response: html
-RewriteRule ^$ https://digitalconstruction.github.io/OccupantBehavior [R=303,NE,L]
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.
+RewriteRule ^$ https://digitalconstruction.github.io/OccupantBehavior [R=303,L]

--- a/digitalconstruction/OccupantBehavior/.htaccess
+++ b/digitalconstruction/OccupantBehavior/.htaccess
@@ -3,24 +3,32 @@ RewriteEngine on
 Options -MultiViews
 AddType text/turtle .ttl
 
-# Redirect based on file suffix (ttl, xml, owl, json, jsonld, html)
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, nt, html)
 RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/OccupantBehavior/ontology.ttl [R=302,NE,L]
 RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/OccupantBehavior/ontology.xml [R=302,NE,L]
 RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/OccupantBehavior/ontology.xml [R=302,NE,L]
 RewriteRule ^ontology.json$ https://digitalconstruction.github.io/OccupantBehavior/ontology.json [R=302,NE,L]
 RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/OccupantBehavior/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.nt$ https://digitalconstruction.github.io/OccupantBehavior/ontology.nt [R=302,NE,L]
 RewriteRule ^ontology.html$ https://digitalconstruction.github.io/OccupantBehavior [R=302,NE,L]
 
 # If accept <text/turtle>, redirect to .ttl
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
 RewriteRule ^$ https://digitalconstruction.github.io/OccupantBehavior/ontology.ttl [R=303,NE,L]
 
+# If accept <application/n-triples>, redirect to .nt
+RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.* 
+RewriteRule ^$ https://digitalconstruction.github.io/OccupantBehavior/ontology.nt [R=303,NE,L]
+
 # If accept <application/json> or <application/ld+json>, redirect to .json 
-RewriteCond %{HTTP_ACCEPT} ^.*json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
 RewriteRule ^$ https://digitalconstruction.github.io/OccupantBehavior/ontology.json [R=303,NE,L]
 
 # If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
-RewriteCond %{HTTP_ACCEPT} ^.*xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
 RewriteRule ^$ https://digitalconstruction.github.io/OccupantBehavior/ontology.xml [R=303,NE,L]
 
 # Default response: html

--- a/digitalconstruction/Processes/.htaccess
+++ b/digitalconstruction/Processes/.htaccess
@@ -3,24 +3,32 @@ RewriteEngine on
 Options -MultiViews
 AddType text/turtle .ttl
 
-# Redirect based on file suffix (ttl, xml, owl, json, jsonld, html)
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, nt, html)
 RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/Processes/ontology.ttl [R=302,NE,L]
 RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/Processes/ontology.xml [R=302,NE,L]
 RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/Processes/ontology.xml [R=302,NE,L]
 RewriteRule ^ontology.json$ https://digitalconstruction.github.io/Processes/ontology.json [R=302,NE,L]
 RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/Processes/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.nt$ https://digitalconstruction.github.io/Processes/ontology.nt [R=302,NE,L]
 RewriteRule ^ontology.html$ https://digitalconstruction.github.io/Processes [R=302,NE,L]
 
 # If accept <text/turtle>, redirect to .ttl
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
 RewriteRule ^$ https://digitalconstruction.github.io/Processes/ontology.ttl [R=303,NE,L]
 
+# If accept <application/n-triples>, redirect to .nt
+RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.* 
+RewriteRule ^$ https://digitalconstruction.github.io/Processes/ontology.nt [R=303,NE,L]
+
 # If accept <application/json> or <application/ld+json>, redirect to .json 
-RewriteCond %{HTTP_ACCEPT} ^.*json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
 RewriteRule ^$ https://digitalconstruction.github.io/Processes/ontology.json [R=303,NE,L]
 
 # If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
-RewriteCond %{HTTP_ACCEPT} ^.*xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
 RewriteRule ^$ https://digitalconstruction.github.io/Processes/ontology.xml [R=303,NE,L]
 
 # Default response: html

--- a/digitalconstruction/Processes/.htaccess
+++ b/digitalconstruction/Processes/.htaccess
@@ -1,0 +1,27 @@
+Options +FollowSymLinks
+RewriteEngine on
+Options -MultiViews
+AddType text/turtle .ttl
+
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, html)
+RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/Processes/ontology.ttl [R=302,NE,L]
+RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/Processes/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/Processes/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.json$ https://digitalconstruction.github.io/Processes/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/Processes/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.html$ https://digitalconstruction.github.io/Processes [R=302,NE,L]
+
+# If accept <text/turtle>, redirect to .ttl
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://digitalconstruction.github.io/Processes/ontology.ttl [R=303,NE,L]
+
+# If accept <application/json> or <application/ld+json>, redirect to .json 
+RewriteCond %{HTTP_ACCEPT} ^.*json.*
+RewriteRule ^$ https://digitalconstruction.github.io/Processes/ontology.json [R=303,NE,L]
+
+# If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
+RewriteCond %{HTTP_ACCEPT} ^.*xml.*
+RewriteRule ^$ https://digitalconstruction.github.io/Processes/ontology.xml [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://digitalconstruction.github.io/Processes [R=303,NE,L]

--- a/digitalconstruction/Processes/.htaccess
+++ b/digitalconstruction/Processes/.htaccess
@@ -21,15 +21,18 @@ RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.*
 RewriteRule ^$ https://digitalconstruction.github.io/Processes/ontology.nt [R=303,NE,L]
 
 # If accept <application/json> or <application/ld+json>, redirect to .json 
-RewriteCond %{HTTP_ACCEPT} ^.application/json.*
+RewriteCond %{HTTP_ACCEPT} ^.application/json.* [OR]
 RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
 RewriteRule ^$ https://digitalconstruction.github.io/Processes/ontology.json [R=303,NE,L]
 
 # If accept <application/xml>, <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
-RewriteCond %{HTTP_ACCEPT} ^.*application/xml.*
-RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/xml.* [OR]
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*  [OR]
 RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
 RewriteRule ^$ https://digitalconstruction.github.io/Processes/ontology.xml [R=303,NE,L]
 
-# Default response: html
-RewriteRule ^$ https://digitalconstruction.github.io/Processes [R=303,NE,L]
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.
+RewriteRule ^$ https://digitalconstruction.github.io/Processes [R=303,L]

--- a/digitalconstruction/README.md
+++ b/digitalconstruction/README.md
@@ -1,21 +1,20 @@
 Digital Construction
 ===
 
-Digital construction ontologies created in the DiCtion project.  DiCtion aims at the creation of shared situational awareness of construction projects. There are needs to represent information about the building objects (as well as information objects related to it), construction planning and workflows, construction organization, and monitoring data.
+An ontology suite for digital construction. The purpose is to provide the representation mechanisms for construction and
+renovation projects that use digital technologies such as BIM modeling, construction management systems, sensor-based
+monitoring, scanning and photogrammetry, mobile devices on site, and so on.  The efficient utilization of digital
+technologies requires that ability to link the objects of design, measurement and control with activities in
+projects.
 
-The ontologies have been specified by Aalto University, VTT and VisuaLynk Ltd (Finland).
+Contributing projects:
+* Diction - The creation of shared situational awareness of construction projects.
+* BIM4EEB - BIM-based toolkit for efficient renovation of residential buildings.
 
 Homepage:
 * https://w3id.org/digitalconstruction
 
-Vocabularies:
-* https://w3id.org/digitalconstruction/objects - Building objects, their groupings and related information objects
-* https://w3id.org/digitalconstruction/planning - Construction planning and workflows 
-* https://w3id.org/digitalconstruction/monitoring - Gathering of data about construction
-* https://w3id.org/digitalconstruction/organization - Actors and contracts 
-
-
 Contacts: 
-* Seppo Törmä <seppo.torma@visualynk.com>
-* Yuan Zheng <yuan.zheng@aalto.fi>
+* Seppo Törmä (<seppo.torma@visualynk.com>)
+* Yuan Zheng (<yuan.zheng@aalto.fi>)
 


### PR DESCRIPTION
Hi, 

We are preparing a large ontology suite for digital construction, both for new construction and renovation projects. Since there are going to be a lot of internal imports between ontologies and our development is decentralized, it would be easier if we could import ontologies from permanent addresses at w3id.org/digitalconstruction.  

Currently there are only couple of ontologies published in the redirected addresses at digitalconstruction.github.io (Entities and Agents). Three others will be before the next week (Information, Processes and Contexts) and the rest five ontologies by mid January. All ontologies have been designed and initially formalized in OWL.

We are currently also discussing future research efforts that would utilize these ontologies. 

Best regards,
Seppo Törmä