### PR TITLE
New htaccess for Progetto Irnerio (Irnerio Project)

### DIFF
--- a/irnerio/.htaccess
+++ b/irnerio/.htaccess
@@ -1,0 +1,22 @@
+# Name of the project: Progetto Irnerio
+#
+# Description: The core part of this project consists of digitizing and classifying the vast collection 
+# of legal and theological-philosophical codices making up the rare-books collection of the Reale Collegio 
+# di Spagna in Bologna: with this digital catalogue, built under the guidance of Professors Domenico 
+# Maffei and Andrea Padovani, not only can the fragile codices be readily accessed and studied, but their 
+# preservation for future use is guaranteed, too. The project - named for the primus illuminator of 
+# legal science studies in Bologna, the Italian jurist Irnerius - have been possible by the Collegio di Spagna that 
+# made its rare-books collection available. Funding for the project comes from the Fondazione Cassa di Risparmio 
+# in Bologna, and also from the Italian Ministry of Higher Education and Scientific Research. The digital images 
+# have been reproduced under the editorship of the publishing house CLUEB. 
+#
+# Contacts:
+# - Monica Palmirani <monica.palmirani@unibo.it>
+# - Silvio Peroni <silvio.peroni@unibo.it>
+
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+# Default behaviour
+RewriteRule ^/?$ http://irnerio.cirsfid.unibo.it/ [R=303,L]

--- a/irnerio/README.md
+++ b/irnerio/README.md
@@ -1,0 +1,7 @@
+**Name of the project:** Progetto Irnerio
+
+**Description:** The core part of this project consists of digitizing and classifying the vast collection of legal and theological-philosophical codices making up the rare-books collection of the Reale Collegio di Spagna in Bologna: with this digital catalogue, built under the guidance of Professors Domenico Maffei and Andrea Padovani, not only can the fragile codices be readily accessed and studied, but their preservation for future use is guaranteed, too. The project - named for the primus illuminator of legal science studies in Bologna, the Italian jurist Irnerius - have been possible by the Collegio di Spagna that made its rare-books collection available. Funding for the project comes from the Fondazione Cassa di Risparmio in Bologna, and also from the Italian Ministry of Higher Education and Scientific Research. The digital images have been reproduced under the editorship of the publishing house CLUEB. 
+
+**Contacts:**
+* Monica Palmirani <monica.palmirani@unibo.it> - GitHub: https://github.com/palmirani
+* Silvio Peroni <silvio.peroni@unibo.it> - GitHub: https://github.com/essepuntato


### PR DESCRIPTION
**Name of the project:** Progetto Irnerio

**Description:** The core part of this project consists of digitizing and classifying the vast collection of legal and theological-philosophical codices making up the rare-books collection of the Reale Collegio di Spagna in Bologna: with this digital catalogue, built under the guidance of Professors Domenico Maffei and Andrea Padovani, not only can the fragile codices be readily accessed and studied, but their preservation for future use is guaranteed, too. The project - named for the primus illuminator of legal science studies in Bologna, the Italian jurist Irnerius - have been possible by the Collegio di Spagna that made its rare-books collection available. Funding for the project comes from the Fondazione Cassa di Risparmio in Bologna, and also from the Italian Ministry of Higher Education and Scientific Research. The digital images have been reproduced under the editorship of the publishing house CLUEB. 

**Contacts:**
* Monica Palmirani <monica.palmirani@unibo.it>
* Silvio Peroni <silvio.peroni@unibo.it>