### PR TITLE
Added redirects to AtomGraph's open-source project ontologies

### DIFF
--- a/atomgraph/README.md
+++ b/atomgraph/README.md
@@ -1,0 +1,15 @@
+# AtomGraph namespace
+## Ontologies of AtomGraph's open-source projects
+
+Homepage:
+* [AtomGraph](https://atomgraph.com)
+
+Projects:
+* [LinkedDataHub](https://atomgraph.github.io/LinkedDataHub/)
+* [Processor](https://github.com/AtomGraph/Processor)
+* [Web-Client](https://github.com/AtomGraph/Web-Client)
+* [Core](https://github.com/AtomGraph/Core)
+
+Maintainers:
+* [Martynas Jusevičius](mailto:martynas@atomgraph.com)
+* [Džiugas Tornau](mailto:dziugas@atomgraph.com)

--- a/atomgraph/core/.htaccess
+++ b/atomgraph/core/.htaccess
@@ -1,0 +1,3 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ https://atomgraph.github.io/Core/ns.ttl [R=302,L]

--- a/atomgraph/linkeddatahub/.htaccess
+++ b/atomgraph/linkeddatahub/.htaccess
@@ -1,0 +1,4 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^domain$ https://atomgraph.github.io/LinkedDataHub/ns/apl.ttl [R=302,L]
+RewriteRule ^templates$ https://atomgraph.github.io/LinkedDataHub/ns/aplt.ttl [R=302,L]

--- a/atomgraph/linkeddatahub/admin/.htaccess
+++ b/atomgraph/linkeddatahub/admin/.htaccess
@@ -1,0 +1,3 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^templates$ https://atomgraph.github.io/LinkedDataHub/admin/ladmt.ttl [R=302,L]

--- a/atomgraph/linkeddatahub/admin/.htaccess
+++ b/atomgraph/linkeddatahub/admin/.htaccess
@@ -1,3 +1,3 @@
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^templates$ https://atomgraph.github.io/LinkedDataHub/admin/ladmt.ttl [R=302,L]
+RewriteRule ^templates$ https://atomgraph.github.io/LinkedDataHub/ns/admin/ladmt.ttl [R=302,L]

--- a/atomgraph/linkeddatahub/admin/acl/.htaccess
+++ b/atomgraph/linkeddatahub/admin/acl/.htaccess
@@ -1,0 +1,4 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^domain$ https://atomgraph.github.io/LinkedDataHub/ns/admin/acl/lacl.ttl [R=302,L]
+RewriteRule ^templates$ https://atomgraph.github.io/LinkedDataHub/ns/admin/acl/laclt.ttl [R=302,L]

--- a/atomgraph/linkeddatahub/admin/sitemap/.htaccess
+++ b/atomgraph/linkeddatahub/admin/sitemap/.htaccess
@@ -1,0 +1,4 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^domain$ https://atomgraph.github.io/LinkedDataHub/ns/admin/sitemap/lsm.ttl [R=302,L]
+RewriteRule ^templates$ https://atomgraph.github.io/LinkedDataHub/ns/admin/sitemap/lsmt.ttl [R=302,L]

--- a/atomgraph/linkeddatahub/apps/.htaccess
+++ b/atomgraph/linkeddatahub/apps/.htaccess
@@ -1,3 +1,3 @@
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^domain$ https://atomgraph.github.io/LinkedDataHub/apps/lapp.ttl [R=302,L]
+RewriteRule ^domain$ https://atomgraph.github.io/LinkedDataHub/ns/apps/lapp.ttl [R=302,L]

--- a/atomgraph/linkeddatahub/apps/.htaccess
+++ b/atomgraph/linkeddatahub/apps/.htaccess
@@ -1,0 +1,3 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^domain$ https://atomgraph.github.io/LinkedDataHub/apps/lapp.ttl [R=302,L]

--- a/atomgraph/web-client/.htaccess
+++ b/atomgraph/web-client/.htaccess
@@ -1,0 +1,3 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ https://atomgraph.github.io/Web-Client/ns.ttl [R=302,L]


### PR DESCRIPTION
Under the `/atomgraph` namespace