### PR TITLE
Attempt to fix AtomGraph's 404 links

### DIFF
--- a/atomgraph/linkeddatahub/.htaccess
+++ b/atomgraph/linkeddatahub/.htaccess
@@ -2,3 +2,8 @@ Options +FollowSymLinks
 RewriteEngine on
 RewriteRule ^domain$ https://atomgraph.github.io/LinkedDataHub/ns/apl.ttl [R=302,L]
 RewriteRule ^templates$ https://atomgraph.github.io/LinkedDataHub/ns/aplt.ttl [R=302,L]
+RewriteRule ^admin/acl/domain$ https://atomgraph.github.io/LinkedDataHub/ns/admin/acl/lacl.ttl [R=302,L]
+RewriteRule ^admin/acl/templates$ https://atomgraph.github.io/LinkedDataHub/ns/admin/acl/laclt.ttl [R=302,L]
+RewriteRule ^admin/sitemap/domain$ https://atomgraph.github.io/LinkedDataHub/ns/admin/sitemap/lsm.ttl [R=302,L]
+RewriteRule ^admin/sitemap/templates$ https://atomgraph.github.io/LinkedDataHub/ns/admin/sitemap/lsmt.ttl [R=302,L]
+RewriteRule ^apps/domain$ https://atomgraph.github.io/LinkedDataHub/ns/apps/lapp.ttl [R=302,L]

--- a/atomgraph/linkeddatahub/admin/.htaccess
+++ b/atomgraph/linkeddatahub/admin/.htaccess
@@ -1,3 +1,0 @@
-Options +FollowSymLinks
-RewriteEngine on
-RewriteRule ^templates$ https://atomgraph.github.io/LinkedDataHub/ns/admin/ladmt.ttl [R=302,L]

--- a/atomgraph/linkeddatahub/admin/acl/.htaccess
+++ b/atomgraph/linkeddatahub/admin/acl/.htaccess
@@ -1,4 +1,0 @@
-Options +FollowSymLinks
-RewriteEngine on
-RewriteRule ^domain$ https://atomgraph.github.io/LinkedDataHub/ns/admin/acl/lacl.ttl [R=302,L]
-RewriteRule ^templates$ https://atomgraph.github.io/LinkedDataHub/ns/admin/acl/laclt.ttl [R=302,L]

--- a/atomgraph/linkeddatahub/admin/sitemap/.htaccess
+++ b/atomgraph/linkeddatahub/admin/sitemap/.htaccess
@@ -1,4 +1,0 @@
-Options +FollowSymLinks
-RewriteEngine on
-RewriteRule ^domain$ https://atomgraph.github.io/LinkedDataHub/ns/admin/sitemap/lsm.ttl [R=302,L]
-RewriteRule ^templates$ https://atomgraph.github.io/LinkedDataHub/ns/admin/sitemap/lsmt.ttl [R=302,L]

--- a/atomgraph/linkeddatahub/apps/.htaccess
+++ b/atomgraph/linkeddatahub/apps/.htaccess
@@ -1,3 +1,0 @@
-Options +FollowSymLinks
-RewriteEngine on
-RewriteRule ^domain$ https://atomgraph.github.io/LinkedDataHub/ns/apps/lapp.ttl [R=302,L]


### PR DESCRIPTION
Our last PR passed tests but resulted in some 404 links: https://github.com/perma-id/w3id.org/pull/1628

We have now removed the sub-folders and collected those redirects into `linkeddatahub/.htaccess`.