### PR TITLE
Fix w3id.org/security context links

### DIFF
--- a/security/.htaccess
+++ b/security/.htaccess
@@ -2,6 +2,6 @@ Header set Access-Control-Allow-Origin *
 Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^$ https://web-payments.org/vocabs/security [R=302,L]
-RewriteRule ^v1$ https://web-payments.org/contexts/security-v1.jsonld [R=302,L]
-RewriteRule ^v2$ https://web-payments.org/contexts/security-v2.jsonld [R=302,L]
+RewriteRule ^$ https://w3c-ccg.github.io/security-vocab/ [R=302,L]
+RewriteRule ^v1$ https://w3c-ccg.github.io/security-vocab/contexts/security-v1.jsonld [R=302,L]
+RewriteRule ^v2$ https://w3c-ccg.github.io/security-vocab/contexts/security-v2.jsonld [R=302,L]


### PR DESCRIPTION
Stop redirecting to web-payments and use: https://w3c-ccg.github.io/security-vocab/ to define security vocabulary