### PR TITLE
Add redirects from deprecated to new KIM namespace

### DIFF
--- a/dini-ag-kim/.htaccess
+++ b/dini-ag-kim/.htaccess
@@ -1,0 +1,7 @@
+RewriteEngine on
+RewriteRule ^hs-oer-lom-profil/latest/ https://w3id.org/kim/hs-oer-lom-profil/latest/ [R=302,L]
+RewriteRule ^hs-oer-lom-profil/20200116/ https://w3id.org/kim/hs-oer-lom-profil/20200116/ [R=302,L]
+RewriteRule ^hs-oer-lom-profil/draft/ https://w3id.org/kim/hs-oer-lom-profil/draft/ [R=302,L]
+RewriteRule ^oer-service-card/latest/ https://w3id.org/kim/hs-oer-lom-profil/latest/ [R=302,L]
+RewriteRule ^oer-service-card/20200116/ https://w3id.org/kim/hs-oer-lom-profil/20200116/ [R=302,L]
+RewriteRule ^oer-service-card/draft/ https://w3id.org/kim/hs-oer-lom-profil/draft/ [R=302,L]

--- a/dini-ag-kim/.htaccess
+++ b/dini-ag-kim/.htaccess
@@ -2,6 +2,7 @@ RewriteEngine on
 RewriteRule ^hs-oer-lom-profil/latest/ https://w3id.org/kim/hs-oer-lom-profil/latest/ [R=302,L]
 RewriteRule ^hs-oer-lom-profil/20200116/ https://w3id.org/kim/hs-oer-lom-profil/20200116/ [R=302,L]
 RewriteRule ^hs-oer-lom-profil/draft/ https://w3id.org/kim/hs-oer-lom-profil/draft/ [R=302,L]
+RewriteRule ^hs-oer-lom-profil/20200116/schemas/hs-oer-lom.xsd https://w3id.org/kim/hs-oer-lom-profil/20200116/schemas/hs-oer-lom.xsd [R=302,L]
 RewriteRule ^oer-service-card/latest/ https://w3id.org/kim/hs-oer-lom-profil/latest/ [R=302,L]
 RewriteRule ^oer-service-card/20200116/ https://w3id.org/kim/hs-oer-lom-profil/20200116/ [R=302,L]
 RewriteRule ^oer-service-card/draft/ https://w3id.org/kim/hs-oer-lom-profil/draft/ [R=302,L]

--- a/dini-ag-kim/README.md
+++ b/dini-ag-kim/README.md
@@ -1,0 +1,3 @@
+This is a deprecated namespace for perma URIs of the Kompentenzzentrum Interoperable Metadaten (Interoperable Metadata Competence Center, KIM). See `/kim` for the current URI configurations.
+
+* Contact: [Adrian Pohl](http://lobid.org/team/ap#!)


### PR DESCRIPTION
As the old URIs were actually in use in some docs, I am adding redirects from the deprecated to the new namespace.