### PR TITLE
Update DID v1 context file location

### DIFF
--- a/did/.htaccess
+++ b/did/.htaccess
@@ -2,5 +2,5 @@ Header set Access-Control-Allow-Origin *
 Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^$ https://w3c-ccg.github.io/did-spec/ [R=302,L]
-RewriteRule ^v(.+)$ https://w3c-ccg.github.io/did-spec/contexts/did-v$1.jsonld [R=302,L]
+RewriteRule ^$ https://www.w3.org/ns/did/ [R=302,L]
+RewriteRule ^v(.+)$ https://www.w3.org/ns/did/v$1 [R=302,L]


### PR DESCRIPTION
The CCG's context file is missing things like `RsaVerificationKey2018` (probably due to changes happening now that DID is a WG). So, this should get the w3id.org URL pointing to the correct DID v1 context file (afaik).

Thanks!
🎩 