### PR TITLE
Add the trek namespace

### DIFF
--- a/trek/.htaccess
+++ b/trek/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine on
+RewriteRule ^(.*)$ https://trek.semanticscience.org/describe?uri=https://w3id.org/trek/$1  [R=302,L]

--- a/trek/.htaccess
+++ b/trek/.htaccess
@@ -1,2 +1,2 @@
 RewriteEngine on
-RewriteRule ^(.*)$ https://trek.semanticscience.org/describe?uri=https://w3id.org/trek/$1  [R=302,L]
+RewriteRule ^(.*)$ http://trek.semanticscience.org/describe?uri=https://w3id.org/trek/$1  [R=302,L]

--- a/trek/README.md
+++ b/trek/README.md
@@ -1,0 +1,14 @@
+TReK
+=======
+
+Translator Red Knowledge Graph, about concepts co-occurences in Clinical data reports 
+
+Homepage
+* https://trek.semanticscience.org
+
+Docs
+* http://d2s.semanticscience.org/
+
+Contact
+* Vincent Emonet @vemonet
+* Michel Dumontier @dumontier

--- a/trek/README.md
+++ b/trek/README.md
@@ -1,13 +1,13 @@
 TReK
 =======
 
-[Translator Red Knowledge](https://trek.semanticscience.org), a resource for [Columbia Open Health Data](http://cohd.smart-api.info/), concepts co-occurences in Clinical data reports, for the [NIH NCATS Translator program](https://ncats.nih.gov/translator). 
+[Translator Red Knowledge](http://trek.semanticscience.org), a resource for [Columbia Open Health Data](http://cohd.smart-api.info/), concepts co-occurences in Clinical data reports, for the [NIH NCATS Translator program](https://ncats.nih.gov/translator). 
 
 Homepage
-* https://trek.semanticscience.org
+* http://trek.semanticscience.org
 
 Docs
-* http://d2s.semanticscience.org/
+* https://d2s.semanticscience.org/
 
 Contact
 * Vincent Emonet @vemonet

--- a/trek/README.md
+++ b/trek/README.md
@@ -1,7 +1,7 @@
 TReK
 =======
 
-Translator Red Knowledge Graph, about concepts co-occurences in Clinical data reports 
+[Translator Red Knowledge](https://trek.semanticscience.org), a resource for [Columbia Open Health Data](http://cohd.smart-api.info/), concepts co-occurences in Clinical data reports, for the [NIH NCATS Translator program](https://ncats.nih.gov/translator). 
 
 Homepage
 * https://trek.semanticscience.org


### PR DESCRIPTION
Add the trek namespace. Used by a clinical data KG for the NIH NCATS Translator project

Redirect to https://trek.semanticscience.org