### PR TITLE
Add namespace for Fraunhofer

### DIFF
--- a/fraunhofer/Readme.md
+++ b/fraunhofer/Readme.md
@@ -1,0 +1,4 @@
+# Fraunhofer namespace
+This namespace is for ontologies developed at Fraunhofer institutes.
+
+https://www.fraunhofer.de/

--- a/fraunhofer/Readme.md
+++ b/fraunhofer/Readme.md
@@ -2,3 +2,7 @@
 This namespace is for ontologies developed at Fraunhofer institutes.
 
 https://www.fraunhofer.de/
+
+Contacts
+* Christoph Lange-Bever <christoph.lange-bever@fit.fraunhofer.de> (GitHub: clange)
+* Felix Konstantin Maurer <felix.konstantin.maurer@ipt.fraunhofer.de> (GitHub: mrf-ipt)

--- a/fraunhofer/lighthouse-projects/evolopro/.htaccess
+++ b/fraunhofer/lighthouse-projects/evolopro/.htaccess
@@ -1,0 +1,10 @@
+Header set Access-Control-Allow-Origin *
+
+AddType text/turtle .ttl
+
+RewriteEngine On
+
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^cirp.ttl$ https://mrf-ipt.github.io/cirp.ttl [R=303,L]
+RewriteRule ^helical-end-mills.ttl$ https://mrf-ipt.github.io/helical-end-mills.ttl [R=303,L]
+RewriteRule ^dpart.ttl$ https://mrf-ipt.github.io/dpart.ttl [R=303,L]

--- a/fraunhofer/lighthouse-projects/evolopro/Readme.md
+++ b/fraunhofer/lighthouse-projects/evolopro/Readme.md
@@ -1,0 +1,4 @@
+# Ontologies for the EVOLOPRO lighthouse project
+
+Contacts
+* Felix Konstantin Maurer <felix.konstantin.maurer@ipt.fraunhofer.de>


### PR DESCRIPTION
I would like to add a namespace for ontologies of Fraunhofer institutes.
A first use for this namespace are our ontologies for the lighthouse project EVOLOPRO.