### PR TITLE
Change redirect in d2s/.htaccess

### DIFF
--- a/d2s/.htaccess
+++ b/d2s/.htaccess
@@ -1,2 +1,2 @@
 RewriteEngine on
-RewriteRule ^(.*)$ http://graphdb.dumontierlab.com/resource?uri=https://w3id.org/d2s/$1  [R=302,L]
+RewriteRule ^(.*)$ http://trek.semanticscience.org/describe?uri=https://w3id.org/d2s/$1  [R=302,L]

--- a/d2s/README.md
+++ b/d2s/README.md
@@ -1,8 +1,11 @@
 D2S
 =======
 
+[trek.semanticscience.org](http://trek.semanticscience.org), a web UI to resolve resources and browse any SPARQL endpoint. Mainly used for data generated using the [Data2Services framework](https://d2s.semanticscience.org).
+
+
 Homepage
-* http://graphdb.dumontierlab.com/
+* http://trek.semanticscience.org
 
 Docs
 * http://d2s.semanticscience.org/


### PR DESCRIPTION
Change the redirect in d2s/.htaccess to point to http://trek.semanticscience.org. A web UI to browse SPARQL endpoints for the Data2Services project

And edit README to add short description of the namespace