### PR TITLE
Redirect for any accept header

### DIFF
--- a/fraunhofer/lighthouse-projects/evolopro/.htaccess
+++ b/fraunhofer/lighthouse-projects/evolopro/.htaccess
@@ -4,7 +4,6 @@ AddType text/turtle .ttl
 
 RewriteEngine On
 
-RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
 RewriteRule ^cirp.ttl$ https://mrf-ipt.github.io/cirp.ttl [R=303,L]
 RewriteRule ^helical-end-mills.ttl$ https://mrf-ipt.github.io/helical-end-mills.ttl [R=303,L]
 RewriteRule ^dpart.ttl$ https://mrf-ipt.github.io/dpart.ttl [R=303,L]


### PR DESCRIPTION
I didn't think it through when I based my `.htaccess` on other examples. I would always like to redirect the request, not just when the client sends the correct `Accept` header.