### PR TITLE
Feature/moved idsa repo

### DIFF
--- a/idsa/.htaccess
+++ b/idsa/.htaccess
@@ -18,40 +18,40 @@ RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/\* 
-RewriteRule ^(core|code)/?$ https://industrialdataspace.github.io/InformationModel/ [R=303]
+RewriteRule ^(core|code)/?$ https://international-data-spaces-association.github.io/InformationModel/ [R=303]
 
 # TURTLE
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
-RewriteRule ^(core|code)(/|#)* https://industrialdataspace.github.io/InformationModel/docs/serializations/ontology.ttl [R=303]
-RewriteRule ^(core|code).ttl https://industrialdataspace.github.io/InformationModel/docs/serializations/ontology.ttl [R=303]
+RewriteRule ^(core|code)(/|#)* https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.ttl [R=303]
+RewriteRule ^(core|code).ttl https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.ttl [R=303]
 
 # RDF/XML
 RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*  [OR]
 RewriteCond %{HTTP_ACCEPT} ^.*application/xml.* [OR]
 RewriteCond %{HTTP_ACCEPT} ^.*text/xml.*
-RewriteRule ^(core|code)(/|#)*(.*) https://industrialdataspace.github.io/InformationModel/docs/serializations/ontology.xml  [R=303]
-RewriteRule ^(core|code).rdf https://industrialdataspace.github.io/InformationModel/docs/serializations/ontology.xml [R=303]
-RewriteRule ^(core|code).xml https://industrialdataspace.github.io/InformationModel/docs/serializations/ontology.xml [R=303]
+RewriteRule ^(core|code)(/|#)*(.*) https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.xml  [R=303]
+RewriteRule ^(core|code).rdf https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.xml [R=303]
+RewriteRule ^(core|code).xml https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.xml [R=303]
 
 # JSON-LD
 RewriteCond %{HTTP_ACCEPT} ^.*application/ld\+json.* [OR]
 RewriteCond %{HTTP_ACCEPT} ^.*application/json.*
-RewriteRule ^(core|code)(/|#)*(.*) https://industrialdataspace.github.io/InformationModel/docs/serializations/ontology.json [R=303]
-RewriteRule ^(core|code).json https://industrialdataspace.github.io/InformationModel/docs/serializations/ontology.json [R=303]
-RewriteRule ^(core|code).jsonld https://industrialdataspace.github.io/InformationModel/docs/serializations/ontology.json [R=303]
+RewriteRule ^(core|code)(/|#)*(.*) https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.json [R=303]
+RewriteRule ^(core|code).json https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.json [R=303]
+RewriteRule ^(core|code).jsonld https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.json [R=303]
 
 # N-TRIPLES
 RewriteCond %{HTTP_ACCEPT} ^.*application/n-triples.*
-RewriteRule ^(core|code)(/|#)* https://industrialdataspace.github.io/InformationModel/docs/serializations/ontology.nt [R=303]
-RewriteRule ^(core|code).nt https://industrialdataspace.github.io/InformationModel/docs/serializations/ontology.nt [R=303]
+RewriteRule ^(core|code)(/|#)* https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.nt [R=303]
+RewriteRule ^(core|code).nt https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.nt [R=303]
 
 # context.json(ld)
-RewriteRule ^contexts/context.json$ https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/2.0.1/context.jsonld [R=303]
-RewriteRule ^contexts/context.jsonld$ https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/2.0.1/context.jsonld [R=303]
-RewriteRule ^contexts/context-dev.json$ https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/2.0.1/context.jsonld [R=303] 
-RewriteRule ^contexts/context-dev.jsonld$ https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/2.0.1/context.jsonld [R=303] 
+RewriteRule ^contexts/context.json$ https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/3.0.0/context.jsonld [R=303]
+RewriteRule ^contexts/context.jsonld$ https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/3.0.0/context.jsonld [R=303]
+RewriteRule ^contexts/context-dev.json$ https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/3.1.0/context.jsonld [R=303] 
+RewriteRule ^contexts/context-dev.jsonld$ https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/3.1.0/context.jsonld [R=303] 
 RewriteRule ^contexts/([0-9][.][0-9][.][0-9])/context.json$ https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/$1/context.jsonld [R=303]
 RewriteRule ^contexts/([0-9][.][0-9][.][0-9])/context.jsonld$ https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/$1/context.jsonld [R=303]
 
 # 
-RewriteRule ^(core|code)/(.+) https://industrialdataspace.github.io/InformationModel/docs/index.html#/$2 [R=303,NE]
+RewriteRule ^(core|code)/(.+) https://international-data-spaces-association.github.io/InformationModel/docs/index.html#/$2 [R=303,NE]

--- a/idsa/.htaccess
+++ b/idsa/.htaccess
@@ -55,7 +55,7 @@ RewriteRule ^contexts/([0-9][.][0-9][.][0-9])/context.jsonld$ https://jira.iais.
 
 # 
 RewriteRule ^(core|code)/(.+) https://international-data-spaces-association.github.io/InformationModel/docs/index.html#/$2 [R=303,NE]
-RewriteRule ^shacl/(.+) https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/develop/testing/$2 [R=303,NE]
+RewriteRule ^shacl/(.+) https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/develop/testing/$1 [R=303,NE]
 
 # IDS Messages Table
 RewriteRule ^(ids-messages)?$ http://htmlpreview.github.io/?https://github.com/International-Data-Spaces-Association/InformationModel/blob/feature/message_taxonomy_description/model/communication/Message_Description.htm [R=303]

--- a/idsa/.htaccess
+++ b/idsa/.htaccess
@@ -55,3 +55,6 @@ RewriteRule ^contexts/([0-9][.][0-9][.][0-9])/context.jsonld$ https://jira.iais.
 
 # 
 RewriteRule ^(core|code)/(.+) https://international-data-spaces-association.github.io/InformationModel/docs/index.html#/$2 [R=303,NE]
+
+# IDS Messages Table
+RewriteRule ^(ids-messages)?$ http://htmlpreview.github.io/?https://github.com/International-Data-Spaces-Association/InformationModel/blob/feature/message_taxonomy_description/model/communication/Message_Description.htm [R=303]

--- a/idsa/README.md
+++ b/idsa/README.md
@@ -15,6 +15,7 @@ Redirections:
 * https://w3id.org/idsa/contexts/[a.b.c]/context.[jsonld|json] --> https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/[a.b.c]/context.jsonld
 * https://w3id.org/idsa/contexts/context-dev.[jsonld|json] --> https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/3.1.0/context.jsonld
 * https://w3id.org/idsa/ids-messages --> http://htmlpreview.github.io/?https://github.com/International-Data-Spaces-Association/InformationModel/blob/feature/message_taxonomy_description/model/communication/Message_Description.htm
+* https://w3id.org/idsa/shacl/* --> https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/develop/testing/*
 
 Support:
 * [Information Model GitHub Repository](https://github.com/International-Data-Spaces-Association/InformationModel)

--- a/idsa/README.md
+++ b/idsa/README.md
@@ -14,6 +14,7 @@ Redirections:
 * https://w3id.org/idsa/contexts/context.[jsonld|json] --> https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/3.0.0/context.jsonld
 * https://w3id.org/idsa/contexts/[a.b.c]/context.[jsonld|json] --> https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/[a.b.c]/context.jsonld
 * https://w3id.org/idsa/contexts/context-dev.[jsonld|json] --> https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/3.1.0/context.jsonld
+* https://w3id.org/idsa/ids-messages --> http://htmlpreview.github.io/?https://github.com/International-Data-Spaces-Association/InformationModel/blob/feature/message_taxonomy_description/model/communication/Message_Description.htm
 
 Support:
 * [Information Model GitHub Repository](https://github.com/International-Data-Spaces-Association/InformationModel)

--- a/idsa/README.md
+++ b/idsa/README.md
@@ -6,18 +6,18 @@ Homepage:
 
 Redirections:
 * https://w3id.org/idsa --> https://www.internationaldataspaces.org/ 
-* https://w3id.org/idsa/core, https://w3id.org/idsa/code --> https://industrialdataspace.github.io/InformationModel/
-* https://w3id.org/idsa/core, https://w3id.org/idsa/code with "Accept: text/turtle" --> https://industrialdataspace.github.io/InformationModel/docs/serializations/ontology.ttl
-* https://w3id.org/idsa/core.ttl, https://w3id.org/idsa/code.ttl --> https://industrialdataspace.github.io/InformationModel/docs/serializations/ontology.ttl
-* https://w3id.org/idsa/core[.rdf|.xml|.json|.nt], https://w3id.org/idsa/code[.rdf|.xml|.json|.nt] --> https://industrialdataspace.github.io/InformationModel/docs/serializations/ontology[.rdf|.xml|.json|.nt]
-* https://w3id.org/idsa/core, https://w3id.org/idsa/code with "Accept: application/[rdf+xml|xml|json|ld+json|n-triples]" or "Accept: text/xml" --> https://industrialdataspace.github.io/InformationModel/docs/serializations/ontology[.rdf|.xml|.json|.nt]
-* https://w3id.org/idsa/contexts/context.[jsonld|json] --> https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/2.0.1/context.jsonld
+* https://w3id.org/idsa/core, https://w3id.org/idsa/code --> https://International-Data-Spaces-Association.github.io/InformationModel/
+* https://w3id.org/idsa/core, https://w3id.org/idsa/code with "Accept: text/turtle" --> https://International-Data-Spaces-Association.github.io/InformationModel/docs/serializations/ontology.ttl
+* https://w3id.org/idsa/core.ttl, https://w3id.org/idsa/code.ttl --> https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.ttl
+* https://w3id.org/idsa/core[.rdf|.xml|.json|.nt], https://w3id.org/idsa/code[.rdf|.xml|.json|.nt] --> https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology[.rdf|.xml|.json|.nt]
+* https://w3id.org/idsa/core, https://w3id.org/idsa/code with "Accept: application/[rdf+xml|xml|json|ld+json|n-triples]" or "Accept: text/xml" --> https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology[.rdf|.xml|.json|.nt]
+* https://w3id.org/idsa/contexts/context.[jsonld|json] --> https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/3.0.0/context.jsonld
 * https://w3id.org/idsa/contexts/[a.b.c]/context.[jsonld|json] --> https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/[a.b.c]/context.jsonld
-* https://w3id.org/idsa/contexts/context-dev.[jsonld|json] --> https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/2.1.0/context.jsonld
+* https://w3id.org/idsa/contexts/context-dev.[jsonld|json] --> https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/3.1.0/context.jsonld
 
 Support:
-* [Information Model GitHub Repository](https://github.com/IndustrialDataSpace/InformationModel)
+* [Information Model GitHub Repository](https://github.com/International-Data-Spaces-Association/InformationModel)
 
 Contacts: 
-* Christoph LANGE <christoph.lange-bever@fit.fraunhofer.de>
-* Sebastian Bader <sebastian.bader@iais.fraunhofer.de>
+* [Christoph Lange](https://github.com/clange/) <christoph.lange-bever@fit.fraunhofer.de>
+* [Sebastian Bader](https://github.com/sebbader) <sebastian.bader@iais.fraunhofer.de>


### PR DESCRIPTION
IDSA home repository has moved from https://github.com/IndustrialDataSpace/InformationModel/ to https://github.com/International-Data-Spaces-Association/InformationModel/

Update of JSON-LD context URL to 3.0.0 (3.1.0 respectively for dev-context)

Adding /idsa/shacl to the new SHACL Shapes at https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/develop/testing/*
