### PR TITLE
Adding a w3id pid to the dcso ontology

### DIFF
--- a/dcso/.htaccess
+++ b/dcso/.htaccess
@@ -17,7 +17,7 @@ RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
-RewriteRule ^aco$ https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard/blob/master/ontologies/dcso/dcso.owl [R=303,NE,L]
+RewriteRule ^$ https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard/blob/master/ontologies/dcso/dcso.owl [R=303,NE,L]
 
 #default response: owl
-RewriteRule ^aco$ https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard/blob/master/ontologies/dcso/dcso.owl [R=303,NE,L]
+RewriteRule ^$ https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard/blob/master/ontologies/dcso/dcso.owl [R=303,NE,L]

--- a/dcso/.htaccess
+++ b/dcso/.htaccess
@@ -1,0 +1,23 @@
+Options +FollowSymLinks
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .owl
+
+
+RewriteEngine on
+
+#Rewrite rules for aco
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*|\*/\*)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteRule ^aco$ https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard/blob/master/ontologies/dcso/dcso.owl [R=303,NE,L]
+
+#default response: owl
+RewriteRule ^aco$ https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard/blob/master/ontologies/dcso/dcso.owl [R=303,NE,L]

--- a/dcso/.htaccess
+++ b/dcso/.htaccess
@@ -17,7 +17,7 @@ RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
-RewriteRule ^$ https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard/blob/master/ontologies/dcso/dcso.owl [R=303,NE,L]
+RewriteRule ^$ https://raw.githubusercontent.com/RDA-DMP-Common/RDA-DMP-Common-Standard/master/ontologies/dcso/dcso.owl [R=303,NE,L]
 
 #default response: owl
-RewriteRule ^$ https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard/blob/master/ontologies/dcso/dcso.owl [R=303,NE,L]
+RewriteRule ^$ https://raw.githubusercontent.com/RDA-DMP-Common/RDA-DMP-Common-Standard/master/ontologies/dcso/dcso.owl [R=303,NE,L]

--- a/dcso/readme.md
+++ b/dcso/readme.md
@@ -1,0 +1,36 @@
+# DMP Common Standard Ontology (DCSO)
+
+This ontology aims to represent the DMP Common Standard model, through the usage of semantic web technology. It represents the DMP Common Standard model using the [Web Ontology Language (OWL)](https://www.w3.org/OWL/).
+
+This is still a work in progress. The idea behind having the DMP Common Standard model represented in OWL, is to explore the potential behing a machine-readable version of the model.
+
+<!--The following is a diagram of the DCSO: -->
+
+<!--![DCSO Diagram](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard/blob/master/ontologies/diagrams/dcso30.png) -->
+
+## Exploring the ontology
+
+There are many tools that allow for the viewing of OWL ontologies. We recomend that you use [Protégé](https://protege.stanford.edu/), to open and view the ontology file.
+
+## Versioning
+
+We use [SemVer](http://semver.org/) for versioning.
+
+Versions available:
+
+* v1.0.0 [2019.05.09] - Initial release, modelling the [DMP Common Standard model 2019.03.25](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard/blob/master/docs/diagrams/RDA-DMP-Common-Model-Diagram-190325.pdf).
+* v1.1.1 [2019.09.12] - Fixed some consistency issues. Added cross references to the foaf, dcat and dct data properties.
+* v1.1.2 [2019.09.19] - Added the hostID object property, that now allows Host entities to be identified through TypeIdentifier entities.
+* v2.0.0 [2020.04.22] - Compliant with the published version of the RDA's DMP Common Standard. Namespaces fixed to allow for URL opening.
+* v2.0.1 [2020.05.01] - Corrected the lack of certain datatype entity associations.
+* v2.0.2 [2020.05.07] - Corrected the hasFunder_id object property, and changed the namespace to be compliant with the w3id.
+
+## Authors
+
+* **[João Cardoso](https://github.com/JoaoMFCardoso)**
+
+## Acknowledgments
+
+* Daniel Faria 
+* Tomasz Miksa
+* Diogo Proença


### PR DESCRIPTION
Hi.

I'm a relative newbie to this. I was told to resort to the w3id to get a persistent identifier for the ontology that I've been working on.

I've changed the namespace in the ontology to https://w3id.org/dcso#

I've tried to do my best to create a .htaccess file that points to the github location of the latest .owl file.

I've also added the version of the ontology as an annotation to the .owl file.

Any help spoting potential errors is much appreciated. As well as an approval of the pull request :)

Best,
JC