### PR TITLE
Add redirection for Materials Design Ontology

### DIFF
--- a/mdo/.htaccess
+++ b/mdo/.htaccess
@@ -1,0 +1,48 @@
+Options +FollowSymLinks
+
+
+# Rewrite engine setup
+RewriteEngine on
+
+
+# Homepage
+RewriteRule ^$ https://github.com/huanyu-li/Materials-Design-Ontology [R=308,L]
+
+
+
+
+# Redirect modules to latest version (currently 1.0)
+RewriteRule ^(\w+)/(\w*)$ https://w3id.org/mdo/$1/1.0/$2 [R=303,NE,L]
+
+
+
+# Default redirect for unmatched patterns to MDO website
+RewriteRule ^.* https://github.com/huanyu-li/Materials-Design-Ontology [R=303,NE,L]
+
+# Redirect versioned request for any text-oriented MIME type to the documentation
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*|\*/\*)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(\w+)/([\w.-]+)/(\w*)$ https://huanyu-li.github.io/$1/$2/index-en.html [R=303,NE,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(\w+)/([\w.-]+)/(\w*)$ https://huanyu-li.github.io/$1/$2/ontology.nt [R=303,NE,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(\w+)/([\w.-]+)/(\w*)$ https://huanyu-li.github.io/$1/$2/ontology.json [R=303,NE,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(\w+)/([\w.-]+)/(\w*)$ https://huanyu-li.github.io/$1/$2/ontology.xml [R=303,NE,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^(\w+)/([\w.-]+)/(\w*)$ https://huanyu-li.github.io/$1/$2/ontology.ttl [R=303,NE,L]

--- a/mdo/.htaccess
+++ b/mdo/.htaccess
@@ -13,26 +13,26 @@ RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(\w+)/([0-9]\.[0-9](?:\.[0-9])?)/?$ https://huanyu-li.github.io/$1/$2/index-en.html [R=303,NE,L]
+RewriteRule ^(\w+)/([0-9]\.[0-9](?:\.[0-9])?)/?$ https://huanyu-li.github.io/mdo/$1/$2/index.html [R=303,NE,L]
 
 # Rewrite rule to serve N-Triples content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^(\w+)/([0-9]\.[0-9](?:\.[0-9])?)/?$ https://huanyu-li.github.io/$1/$2/ontology.nt [R=303,NE,L]
+RewriteRule ^(\w+)/([0-9]\.[0-9](?:\.[0-9])?)/?$ https://huanyu-li.github.io/mdo/$1/$2/ontology.nt [R=303,NE,L]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^(\w+)/([0-9]\.[0-9](?:\.[0-9])?)/?$ https://huanyu-li.github.io/$1/$2/ontology.json [R=303,NE,L]
+RewriteRule ^(\w+)/([0-9]\.[0-9](?:\.[0-9])?)/?$ https://huanyu-li.github.io/mdo/$1/$2/ontology.json [R=303,NE,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^(\w+)/([0-9]\.[0-9](?:\.[0-9])?)/?$ https://huanyu-li.github.io/$1/$2/ontology.xml [R=303,NE,L]
+RewriteRule ^(\w+)/([0-9]\.[0-9](?:\.[0-9])?)/?$ https://huanyu-li.github.io/mdo/$1/$2/ontology.xml [R=303,NE,L]
 
 # Rewrite rule to serve TTL content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle
-RewriteRule ^(\w+)/([0-9]\.[0-9](?:\.[0-9])?)/?$ https://huanyu-li.github.io/$1/$2/ontology.ttl [R=303,NE,L]
+RewriteRule ^(\w+)/([0-9]\.[0-9](?:\.[0-9])?)/?$ https://huanyu-li.github.io/mdo/$1/$2/ontology.ttl [R=303,NE,L]
 
 # Default redirect for unmatched patterns to MDO website
 RewriteRule ^.* https://github.com/huanyu-li/Materials-Design-Ontology [R=303,NE,L]

--- a/mdo/.htaccess
+++ b/mdo/.htaccess
@@ -1,23 +1,10 @@
 Options +FollowSymLinks
 
-
 # Rewrite engine setup
 RewriteEngine on
 
-
 # Homepage
 RewriteRule ^$ https://github.com/huanyu-li/Materials-Design-Ontology [R=308,L]
-
-
-
-
-# Redirect modules to latest version (currently 1.0)
-RewriteRule ^(\w+)/(\w*)$ https://w3id.org/mdo/$1/1.0/$2 [R=303,NE,L]
-
-
-
-# Default redirect for unmatched patterns to MDO website
-RewriteRule ^.* https://github.com/huanyu-li/Materials-Design-Ontology [R=303,NE,L]
 
 # Redirect versioned request for any text-oriented MIME type to the documentation
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*|\*/\*)
@@ -26,23 +13,26 @@ RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(\w+)/([\w.-]+)/(\w*)$ https://huanyu-li.github.io/$1/$2/index-en.html [R=303,NE,L]
+RewriteRule ^(\w+)/([0-9]\.[0-9](?:\.[0-9])?)/?$ https://huanyu-li.github.io/$1/$2/index-en.html [R=303,NE,L]
 
 # Rewrite rule to serve N-Triples content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^(\w+)/([\w.-]+)/(\w*)$ https://huanyu-li.github.io/$1/$2/ontology.nt [R=303,NE,L]
+RewriteRule ^(\w+)/([0-9]\.[0-9](?:\.[0-9])?)/?$ https://huanyu-li.github.io/$1/$2/ontology.nt [R=303,NE,L]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^(\w+)/([\w.-]+)/(\w*)$ https://huanyu-li.github.io/$1/$2/ontology.json [R=303,NE,L]
+RewriteRule ^(\w+)/([0-9]\.[0-9](?:\.[0-9])?)/?$ https://huanyu-li.github.io/$1/$2/ontology.json [R=303,NE,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^(\w+)/([\w.-]+)/(\w*)$ https://huanyu-li.github.io/$1/$2/ontology.xml [R=303,NE,L]
+RewriteRule ^(\w+)/([0-9]\.[0-9](?:\.[0-9])?)/?$ https://huanyu-li.github.io/$1/$2/ontology.xml [R=303,NE,L]
 
 # Rewrite rule to serve TTL content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle
-RewriteRule ^(\w+)/([\w.-]+)/(\w*)$ https://huanyu-li.github.io/$1/$2/ontology.ttl [R=303,NE,L]
+RewriteRule ^(\w+)/([0-9]\.[0-9](?:\.[0-9])?)/?$ https://huanyu-li.github.io/$1/$2/ontology.ttl [R=303,NE,L]
+
+# Default redirect for unmatched patterns to MDO website
+RewriteRule ^.* https://github.com/huanyu-li/Materials-Design-Ontology [R=303,NE,L]

--- a/mdo/readme.md
+++ b/mdo/readme.md
@@ -1,0 +1,20 @@
+# MDO: Materials Design Ontology
+
+This ontology models the concepts, relationships for the materials design domain. The general aim for this ontology is to represent the domain knowledge for material design with the purpose to increase the interoperability of materials databases.
+
+# Homepage
+
+Redirection for project repository: https://w3id.org/mdo -> https://github.com/huanyu-li/Materials-Design-Ontology
+Redirection for full ontology's specification: https://w3id.org/mdo/full/1.0 -> https://huanyu-li.github.io/full/1.0/index-en.html
+Redirection for core module's specification: https://w3id.org/mdo/core/1.0 -> https://huanyu-li.github.io/core/1.0/index-en.html
+Redirection for structure module's specification: https://w3id.org/mdo/structure/1.0 -> https://huanyu-li.github.io/structure/1.0/index-en.html
+Redirection for calculation module's specification: https://w3id.org/mdo/calculation/1.0 -> https://huanyu-li.github.io/calculation/1.0/index-en.html
+Redirection for provenance module's specification: https://w3id.org/mdo/provenance/1.0 -> https://huanyu-li.github.io/provenance/1.0/index-en.html
+
+# Contact
+
+* Author: Huanyu Li huanyu.li@liu.se / huanyu.li9206@gmail.com
+* Author: Rickard Armiento rickard.armiento@liu.se
+* Author: Patrick Lambrix patrick.lambrix@liu.se
+
+[//]: <> (This is also a comment.)

--- a/mdo/readme.md
+++ b/mdo/readme.md
@@ -5,10 +5,15 @@ This ontology models the concepts, relationships for the materials design domain
 # Homepage
 
 Redirection for project repository: https://w3id.org/mdo -> https://github.com/huanyu-li/Materials-Design-Ontology
+
 Redirection for full ontology's specification: https://w3id.org/mdo/full/1.0 -> https://huanyu-li.github.io/full/1.0/index-en.html
+
 Redirection for core module's specification: https://w3id.org/mdo/core/1.0 -> https://huanyu-li.github.io/core/1.0/index-en.html
+
 Redirection for structure module's specification: https://w3id.org/mdo/structure/1.0 -> https://huanyu-li.github.io/structure/1.0/index-en.html
+
 Redirection for calculation module's specification: https://w3id.org/mdo/calculation/1.0 -> https://huanyu-li.github.io/calculation/1.0/index-en.html
+
 Redirection for provenance module's specification: https://w3id.org/mdo/provenance/1.0 -> https://huanyu-li.github.io/provenance/1.0/index-en.html
 
 # Contact

--- a/mdo/readme.md
+++ b/mdo/readme.md
@@ -6,17 +6,17 @@ This ontology models the concepts, relationships for the materials design domain
 
 Redirection for project repository: https://w3id.org/mdo -> https://github.com/huanyu-li/Materials-Design-Ontology
 
-Redirection for latest specification: https://w3id.org/mdo/1.0 -> https://huanyu-li.github.io/mdo/full/1.0/index-en.html
+Redirection for latest specification: https://w3id.org/mdo/1.0 -> https://huanyu-li.github.io/mdo/full/1.0/index.html
 
-Redirection for full ontology's specification: https://w3id.org/mdo/full/1.0 -> https://huanyu-li.github.io/mdo/full/1.0/index-en.html
+Redirection for full ontology's specification: https://w3id.org/mdo/full/1.0 -> https://huanyu-li.github.io/mdo/full/1.0/index.html
 
-Redirection for core module's specification: https://w3id.org/mdo/core/1.0 -> https://huanyu-li.github.io/mdo/core/1.0/index-en.html
+Redirection for core module's specification: https://w3id.org/mdo/core/1.0 -> https://huanyu-li.github.io/mdo/core/1.0/index.html
 
-Redirection for structure module's specification: https://w3id.org/mdo/structure/1.0 -> https://huanyu-li.github.io/mdo/structure/1.0/index-en.html
+Redirection for structure module's specification: https://w3id.org/mdo/structure/1.0 -> https://huanyu-li.github.io/mdo/structure/1.0/index.html
 
-Redirection for calculation module's specification: https://w3id.org/mdo/calculation/1.0 -> https://huanyu-li.github.io/mdo/calculation/1.0/index-en.html
+Redirection for calculation module's specification: https://w3id.org/mdo/calculation/1.0 -> https://huanyu-li.github.io/mdo/calculation/1.0/index.html
 
-Redirection for provenance module's specification: https://w3id.org/mdo/provenance/1.0 -> https://huanyu-li.github.io/mdo/provenance/1.0/index-en.html
+Redirection for provenance module's specification: https://w3id.org/mdo/provenance/1.0 -> https://huanyu-li.github.io/mdo/provenance/1.0/index.html
 
 # Contact
 

--- a/mdo/readme.md
+++ b/mdo/readme.md
@@ -6,15 +6,17 @@ This ontology models the concepts, relationships for the materials design domain
 
 Redirection for project repository: https://w3id.org/mdo -> https://github.com/huanyu-li/Materials-Design-Ontology
 
-Redirection for full ontology's specification: https://w3id.org/mdo/full/1.0 -> https://huanyu-li.github.io/full/1.0/index-en.html
+Redirection for latest specification: https://w3id.org/mdo/1.0 -> https://huanyu-li.github.io/mdo/full/1.0/index-en.html
 
-Redirection for core module's specification: https://w3id.org/mdo/core/1.0 -> https://huanyu-li.github.io/core/1.0/index-en.html
+Redirection for full ontology's specification: https://w3id.org/mdo/full/1.0 -> https://huanyu-li.github.io/mdo/full/1.0/index-en.html
 
-Redirection for structure module's specification: https://w3id.org/mdo/structure/1.0 -> https://huanyu-li.github.io/structure/1.0/index-en.html
+Redirection for core module's specification: https://w3id.org/mdo/core/1.0 -> https://huanyu-li.github.io/mdo/core/1.0/index-en.html
 
-Redirection for calculation module's specification: https://w3id.org/mdo/calculation/1.0 -> https://huanyu-li.github.io/calculation/1.0/index-en.html
+Redirection for structure module's specification: https://w3id.org/mdo/structure/1.0 -> https://huanyu-li.github.io/mdo/structure/1.0/index-en.html
 
-Redirection for provenance module's specification: https://w3id.org/mdo/provenance/1.0 -> https://huanyu-li.github.io/provenance/1.0/index-en.html
+Redirection for calculation module's specification: https://w3id.org/mdo/calculation/1.0 -> https://huanyu-li.github.io/mdo/calculation/1.0/index-en.html
+
+Redirection for provenance module's specification: https://w3id.org/mdo/provenance/1.0 -> https://huanyu-li.github.io/mdo/provenance/1.0/index-en.html
 
 # Contact
 


### PR DESCRIPTION
This is for redirecting w3id urls to Materials Design Ontology.