### PR TITLE
Creation of htaccess for SPICE H2020

### DIFF
--- a/spice/.htaccess
+++ b/spice/.htaccess
@@ -1,0 +1,36 @@
+# Name of the project: SPICE H2020 (https://cordis.europa.eu/project/id/870811)
+#
+# Description: The overall aim of the project is to foster diverse participation 
+# in the heritage domain through a process of ""citizen curation"". Citizens will 
+# be supported to: develop their own personal interpretations of cultural objects; 
+# work together to present their collective view of life through culture and heritage; 
+# and gain an appreciation of alternative cultural viewpoints.
+# Methods will be codesigned that can be used by citizen groups to produce personal 
+# interpretations of cultural objects and analyse and compare them against the 
+# interpretations of others. Tools will be developed for modelling users and groups 
+# and recommending content in a way that assists citizen groups in building a 
+# representation of themselves and appreciating variety within groups and similarity across 
+# groups to enhance social cohesion. A Linked Data infrastructure will support citizen 
+# curation using social media platforms in a way that gives heritage institutions control 
+# over rights protected digital assets and access to citizens responses to their collections. 
+# User experiences will be designed that enable inclusive participation in citizen curation 
+# activities across cultures and abilities. A series of citizen curation case studies with 
+# a diverse set of museums and citizen groups will demonstrate how the approach can promote 
+# inclusive participation and social cohesion in a variety of contexts.
+# The project brings together 13 partners from 7 countries. The consortium comprises: 
+# three SMEs from the visitor guide (GVAM), mobile game (PadaOne) and data mining 
+# (CELI) sectors; four heritage institutions (Design Museum Helsinki, Irish Museum 
+# of Modern Art, Gallery of Modern Art Turin, Hecht Museum); and seven research 
+# centres (Bologna, Aalto, Aalborg, OU, UCM, Turin, Haifa) with expertise in codesign, 
+# museology, HCI, Linked Data, narratology, ontologies, visualisation and user modelling.
+#
+# Contacts:
+# - Silvio Peroni <silvio.peroni@unibo.it>
+# - Aldo Gangemi <aldo.gangemi@unibo.it>
+
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+# Default behaviour
+RewriteRule ^.*$ https://cordis.europa.eu/project/id/870811 [R=303,L]


### PR DESCRIPTION
The htaccess file to handling all the IRIs of the terms included in the ontologies developed during the SPICE H2020 project (https://cordis.europa.eu/project/id/870811), started 1 May 2020.