### PR TITLE
Digitalconstruction: redirects to new ontology modules

### DIFF
--- a/digitalconstruction/Activities/.htaccess
+++ b/digitalconstruction/Activities/.htaccess
@@ -1,0 +1,37 @@
+Options +FollowSymLinks
+RewriteEngine on
+Options -MultiViews
+AddType text/turtle .ttl
+
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, nt, html)
+RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/Activities/ontology.ttl [R=302,NE,L]
+RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/Activities/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/Activities/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.json$ https://digitalconstruction.github.io/Activities/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/Activities/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.nt$ https://digitalconstruction.github.io/Activities/ontology.nt [R=302,NE,L]
+RewriteRule ^ontology.html$ https://digitalconstruction.github.io/Activities [R=302,NE,L]
+
+# If accept <text/turtle>, redirect to .ttl
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://digitalconstruction.github.io/Activities/ontology.ttl [R=303,NE,L]
+
+# If accept <application/n-triples>, redirect to .nt
+RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.* 
+RewriteRule ^$ https://digitalconstruction.github.io/Activities/ontology.nt [R=303,NE,L]
+
+# If accept <application/json> or <application/ld+json>, redirect to .json 
+RewriteCond %{HTTP_ACCEPT} ^.application/json.* [OR]
+RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
+RewriteRule ^$ https://digitalconstruction.github.io/Activities/ontology.json [R=303,NE,L]
+
+# If accept <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*  [OR]
+RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
+RewriteRule ^$ https://digitalconstruction.github.io/Activities/ontology.xml [R=303,NE,L]
+
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.
+RewriteRule ^$ https://digitalconstruction.github.io/Activities [R=303,L]

--- a/digitalconstruction/EnergyEfficiency/.htaccess
+++ b/digitalconstruction/EnergyEfficiency/.htaccess
@@ -1,0 +1,37 @@
+Options +FollowSymLinks
+RewriteEngine on
+Options -MultiViews
+AddType text/turtle .ttl
+
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, nt, html)
+RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/EnergyEfficiency/ontology.ttl [R=302,NE,L]
+RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/EnergyEfficiency/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/EnergyEfficiency/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.json$ https://digitalconstruction.github.io/EnergyEfficiency/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/EnergyEfficiency/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.nt$ https://digitalconstruction.github.io/EnergyEfficiency/ontology.nt [R=302,NE,L]
+RewriteRule ^ontology.html$ https://digitalconstruction.github.io/EnergyEfficiency [R=302,NE,L]
+
+# If accept <text/turtle>, redirect to .ttl
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://digitalconstruction.github.io/EnergyEfficiency/ontology.ttl [R=303,NE,L]
+
+# If accept <application/n-triples>, redirect to .nt
+RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.* 
+RewriteRule ^$ https://digitalconstruction.github.io/EnergyEfficiency/ontology.nt [R=303,NE,L]
+
+# If accept <application/json> or <application/ld+json>, redirect to .json 
+RewriteCond %{HTTP_ACCEPT} ^.application/json.* [OR]
+RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
+RewriteRule ^$ https://digitalconstruction.github.io/EnergyEfficiency/ontology.json [R=303,NE,L]
+
+# If accept <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*  [OR]
+RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
+RewriteRule ^$ https://digitalconstruction.github.io/EnergyEfficiency/ontology.xml [R=303,NE,L]
+
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.
+RewriteRule ^$ https://digitalconstruction.github.io/EnergyEfficiency [R=303,L]

--- a/digitalconstruction/Lifecycle/.htaccess
+++ b/digitalconstruction/Lifecycle/.htaccess
@@ -1,0 +1,37 @@
+Options +FollowSymLinks
+RewriteEngine on
+Options -MultiViews
+AddType text/turtle .ttl
+
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, nt, html)
+RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/Lifecycle/ontology.ttl [R=302,NE,L]
+RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/Lifecycle/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/Lifecycle/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.json$ https://digitalconstruction.github.io/Lifecycle/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/Lifecycle/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.nt$ https://digitalconstruction.github.io/Lifecycle/ontology.nt [R=302,NE,L]
+RewriteRule ^ontology.html$ https://digitalconstruction.github.io/Lifecycle [R=302,NE,L]
+
+# If accept <text/turtle>, redirect to .ttl
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://digitalconstruction.github.io/Lifecycle/ontology.ttl [R=303,NE,L]
+
+# If accept <application/n-triples>, redirect to .nt
+RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.* 
+RewriteRule ^$ https://digitalconstruction.github.io/Lifecycle/ontology.nt [R=303,NE,L]
+
+# If accept <application/json> or <application/ld+json>, redirect to .json 
+RewriteCond %{HTTP_ACCEPT} ^.application/json.* [OR]
+RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
+RewriteRule ^$ https://digitalconstruction.github.io/Lifecycle/ontology.json [R=303,NE,L]
+
+# If accept <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*  [OR]
+RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
+RewriteRule ^$ https://digitalconstruction.github.io/Lifecycle/ontology.xml [R=303,NE,L]
+
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.
+RewriteRule ^$ https://digitalconstruction.github.io/Lifecycle [R=303,L]

--- a/digitalconstruction/Variables/.htaccess
+++ b/digitalconstruction/Variables/.htaccess
@@ -1,0 +1,37 @@
+Options +FollowSymLinks
+RewriteEngine on
+Options -MultiViews
+AddType text/turtle .ttl
+
+# Redirect based on file suffix (ttl, xml, owl, json, jsonld, nt, html)
+RewriteRule ^ontology.ttl$ https://digitalconstruction.github.io/Variables/ontology.ttl [R=302,NE,L]
+RewriteRule ^ontology.xml$ https://digitalconstruction.github.io/Variables/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.owl$ https://digitalconstruction.github.io/Variables/ontology.xml [R=302,NE,L]
+RewriteRule ^ontology.json$ https://digitalconstruction.github.io/Variables/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.jsonld$ https://digitalconstruction.github.io/Variables/ontology.json [R=302,NE,L]
+RewriteRule ^ontology.nt$ https://digitalconstruction.github.io/Variables/ontology.nt [R=302,NE,L]
+RewriteRule ^ontology.html$ https://digitalconstruction.github.io/Variables [R=302,NE,L]
+
+# If accept <text/turtle>, redirect to .ttl
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://digitalconstruction.github.io/Variables/ontology.ttl [R=303,NE,L]
+
+# If accept <application/n-triples>, redirect to .nt
+RewriteCond %{HTTP_ACCEPT} ^.application/n-triples.* 
+RewriteRule ^$ https://digitalconstruction.github.io/Variables/ontology.nt [R=303,NE,L]
+
+# If accept <application/json> or <application/ld+json>, redirect to .json 
+RewriteCond %{HTTP_ACCEPT} ^.application/json.* [OR]
+RewriteCond %{HTTP_ACCEPT} ^.application/ld\+json.*
+RewriteRule ^$ https://digitalconstruction.github.io/Variables/ontology.json [R=303,NE,L]
+
+# If accept <application/rdf+xml> or <application/owl+xml>, redirect to .xml 
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*  [OR]
+RewriteCond %{HTTP_ACCEPT} ^.*application/owl\+xml.*
+RewriteRule ^$ https://digitalconstruction.github.io/Variables/ontology.xml [R=303,NE,L]
+
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.
+RewriteRule ^$ https://digitalconstruction.github.io/Variables [R=303,L]


### PR DESCRIPTION
As a result of refactoring and refinements on digital construction ontologies, we would need to create redirects to modules Activities, EnergyEfficiency, Lifecycle, and Variables. 

- Seppo