### PR TITLE
Add urban-iot ontologies

### DIFF
--- a/urban-iot/.htaccess
+++ b/urban-iot/.htaccess
@@ -1,0 +1,40 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+SetEnvIf Accept ^.*application/rdf\+xml.* SYNTAX=xml
+SetEnvIf Accept ^.*text/turtle.* SYNTAX=ttl
+SetEnvIf Accept ^.*application/json-ld.* SYNTAX=json
+SetEnvIf Accept ^.*application/n-triples.* SYNTAX=nt
+SetEnvIf Accept ^.*text/html.* SYNTAX=html
+SetEnvIf Request_URI ^.*$ ROOT_URL=https://raw.githubusercontent.com/Comune-Milano/ontologie-iot-urbani/master/onto/
+SetEnvIf Request_URI ^(.*)kos/(.*)$ ROOT_URL=https://raw.githubusercontent.com/Comune-Milano/ontologie-iot-urbani/master/kos/
+SetEnvIf Request_URI ^(.*)kos/(.*)$ FILE=kos
+
+
+RewriteCond %{ENV:FILE} ^kos$
+RewriteCond %{ENV:SYNTAX} ^(xml|ttl|json|nt)$
+RewriteRule ^(.*)kos/(.*)/(.*)$ %{ENV:ROOT_URL}$2/$3/$3.%{ENV:SYNTAX} [R=303,L]
+
+RewriteCond %{ENV:SYNTAX} ^(xml|ttl|json|nt)$
+RewriteRule ^(.*)/(.*)/([0-9].[0-9].[0-9])$ %{ENV:ROOT_URL}$2/$3/$2.%{ENV:SYNTAX} [R=303,L]
+RewriteCond %{ENV:SYNTAX} ^(xml|ttl|json|nt)$
+RewriteRule ^(.*)/(.*)$ %{ENV:ROOT_URL}$2/latest/$2.%{ENV:SYNTAX} [R=303,L]
+
+RewriteCond %{ENV:FILE} ^kos$
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^(.*)kos/(.*)/(.*)(/?)$ https://comune-milano.github.io/ontologie-iot-urbani/docs/kos/$2/$3/index-en.html [R=303,L]
+RewriteCond %{ENV:FILE} ^kos$
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^(.*)kos/(.*)/(.*)/$ https://comune-milano.github.io/ontologie-iot-urbani/docs/kos/$2/$3/index-en.html [R=303,L]
+
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^(.*)/(.*)$ https://comune-milano.github.io/ontologie-iot-urbani/docs/$2/index-en.html [R=303,L]
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^(.*)/(.*)/$ https://comune-milano.github.io/ontologie-iot-urbani/docs/$2/index-en.html [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^$ https://comune-milano.github.io/ontologie-iot-urbani/docs/406.html [R=406,L]
+# Default response
+# ---------------------------
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^$ https://comune-milano.github.io/ontologie-iot-urbani/docs/core/index-en.html [R=303,L]

--- a/urban-iot/README.md
+++ b/urban-iot/README.md
@@ -1,0 +1,16 @@
+urban-iot
+===
+
+Urban IoT Ontologies designed to support the integration and pubblication of data from different service providers operating IoT devices in an urban area. The ontologies were developed for the Municipality of Milano (Italy), but they are generic and can be applied to any other city. 
+
+The first two ontologies focus on Sharing Mobility (Car, Bike, Moto, Micro-Mobility Sharing) and Charging Stations for Electric Mobility.
+
+The first version of the Urban IoT suite of ontologies is composed by:
+- *Core* Module: [https://w3id.org/urban-iot/core](https://w3id.org/urban-iot/core) (preferred prefix _uiot:_)
+- *Sharing Mobility* Module: [https://w3id.org/urban-iot/sharing](https://w3id.org/urban-iot/sharing) (preferred prefix _uiots:_)
+- *Electric Mobility* Module: [https://w3id.org/urban-iot/electric](https://w3id.org/urban-iot/electric) (preferred prefix _uiote:_)
+
+Ontologies are complemented by a set of thesauri (SKOS vocabularies) using the same namespace and referenced in the different modules.
+
+Contacts: 
+* Unità open data Comune di Milano: opendatamilano@comune.milano.it


### PR DESCRIPTION
Urban IoT Ontologies designed to support the integration and pubblication of data from different service providers operating IoT devices in an urban area. The ontologies were developed for the Municipality of Milano (Italy), but they are generic and can be applied to any other city.