### PR TITLE
Add three additional redirections to w3id.org/hdgi

### DIFF
--- a/hdgi/.htaccess
+++ b/hdgi/.htaccess
@@ -44,13 +44,16 @@ RewriteCond %{HTTP_ACCEPT} .+
 RewriteRule ^$ https://madhawap.github.io/human-device-gesture-interaction-ontology/v0.1/406.html [R=406,L]
 
 # Redirect https://w3id.org/hdgi/v0.1 to https://w3id.org/hdgi
-Redirect /hdgi/v0.1 https://w3id.org/hdgi
+# Redirect /hdgi/v0.1 https://w3id.org/hdgi
+RewriteRule ^v0.1$ https://w3id.org/hdgi
 
 # Redirect https://w3id.org/hdgi/mappings-api to https://github.com/madhawap/human-device-gesture-interaction-ontology/tree/master/api
-Redirect /hdgi/mappings-api https://github.com/madhawap/human-device-gesture-interaction-ontology/tree/master/api
+# Redirect /hdgi/mappings-api https://github.com/madhawap/human-device-gesture-interaction-ontology/tree/master/api
+RewriteRule ^mappings-api$ https://github.com/madhawap/human-device-gesture-interaction-ontology/tree/master/api
 
 # Redirect https://w3id.org/hdgi/mappings-docs to https://github.com/madhawap/human-device-interaction-ontology/blob/master/README.md
-Redirect /hdgi/mappings-docs https://github.com/madhawap/human-device-gesture-interaction-ontology/blob/master/README.md
+# Redirect /hdgi/mappings-docs https://github.com/madhawap/human-device-gesture-interaction-ontology/blob/master/README.md
+RewriteRule ^mappings-docs$ https://github.com/madhawap/human-device-gesture-interaction-ontology/blob/master/README.md
 
 # Default response
 # ---------------------------

--- a/hdgi/.htaccess
+++ b/hdgi/.htaccess
@@ -43,6 +43,15 @@ RewriteRule ^$ https://madhawap.github.io/human-device-gesture-interaction-ontol
 RewriteCond %{HTTP_ACCEPT} .+
 RewriteRule ^$ https://madhawap.github.io/human-device-gesture-interaction-ontology/v0.1/406.html [R=406,L]
 
+# Redirect https://w3id.org/hdgi/v0.1 to https://w3id.org/hdgi
+Redirect /hdgi/v0.1 https://w3id.org/hdgi
+
+# Redirect https://w3id.org/hdgi/mappings-api to https://github.com/madhawap/human-device-gesture-interaction-ontology/tree/master/api
+Redirect /hdgi/mappings-api https://github.com/madhawap/human-device-gesture-interaction-ontology/tree/master/api
+
+# Redirect https://w3id.org/hdgi/mappings-docs to https://github.com/madhawap/human-device-interaction-ontology/blob/master/README.md
+Redirect /hdgi/mappings-docs https://github.com/madhawap/human-device-interaction-ontology/blob/master/README.md
+
 # Default response
 # ---------------------------
 RewriteRule ^$ https://madhawap.github.io/human-device-gesture-interaction-ontology/v0.1/index-en.html [R=303,L]

--- a/hdgi/.htaccess
+++ b/hdgi/.htaccess
@@ -50,7 +50,7 @@ Redirect /hdgi/v0.1 https://w3id.org/hdgi
 Redirect /hdgi/mappings-api https://github.com/madhawap/human-device-gesture-interaction-ontology/tree/master/api
 
 # Redirect https://w3id.org/hdgi/mappings-docs to https://github.com/madhawap/human-device-interaction-ontology/blob/master/README.md
-Redirect /hdgi/mappings-docs https://github.com/madhawap/human-device-interaction-ontology/blob/master/README.md
+Redirect /hdgi/mappings-docs https://github.com/madhawap/human-device-gesture-interaction-ontology/blob/master/README.md
 
 # Default response
 # ---------------------------


### PR DESCRIPTION
This will add the following URL redirections to https://w3id.org/hdgi
1. https://w3id.org/hdgi/v0.1 ->  https://w3id.org/hdgi
2. https://w3id.org/hdgi/mappings-apis -> GitHub repo
3. https://w3id.org/hdgi/mappings-docs -> GitHub repo