### PR TITLE
Update dr information

### DIFF
--- a/ecsel-dr-sn-SSP/README.md
+++ b/ecsel-dr-sn-SSP/README.md
@@ -1,0 +1,9 @@
+Repository for a Sensor and Semiconductor Product Ontology:
+
+https://vocol.iais.fraunhofer.de/ecsel-dr-sn-SSP/
+
+Owner of this ontology:
+
+https://github.com/fsteinemann
+
+Email: fabian.steinemann@infineon.com

--- a/ecsel-dr/README.md
+++ b/ecsel-dr/README.md
@@ -1,9 +1,9 @@
-Repository for an digital twin ontology:
+Repository for a digital twin ontology:
 
-https://vocol.iais.fraunhofer.de/ecsel-dr/
+http://ontology.tib.eu/dr/
 
 Owner of this ontology:
 
-https://github.com/fsteinemann
+https://github.com/ifx-dr
 
-Email: fabian.steinemann@infineon.com
+Email: Nour.Ramzy@infineon.com


### PR DESCRIPTION
Our ontology, the Digital Reference moved from the Fraunhofer server https://vocol.iais.fraunhofer.de/ecsel-dr/ to a new server hosted by TIB http://ontology.tib.eu/dr/.
The following changes were therefore made:

- Update the rewrite rule to point to the new location in the .htaccess file
- Update the readme to include the new location
- Updated the responsible person and github as the old responsible left the company
