### PR TITLE
make default ttl

### DIFF
--- a/demeter/.htaccess
+++ b/demeter/.htaccess
@@ -3,9 +3,11 @@ RewriteEngine on
 RewriteRule ^$ https://h2020-demeter.eu/ [R=302,L]
 
 # main entry in OGC
-RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
-RewriteRule ^agri$ https://raw.githubusercontent.com/rapw3k/DEMETER/master/models/demeterAgriProfile.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^agri$ https://defs-dev.opengis.net/def/schema/demeter_aim [R=303,L]
+#RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^agri$ https://raw.githubusercontent.com/rapw3k/DEMETER/master/models/demeterAgriProfile.ttl [R=303,L]
+
 
 # Ontologies
 RewriteRule ^agri/agriFeature$ https://raw.githubusercontent.com/rapw3k/DEMETER/master/models/agriFeature.ttl [R=302,L]


### PR DESCRIPTION
cannot open in protege if default is the html page, seems like protege is not sending in request the accept header I found in https://github.com/protegeproject/protege/issues/849#issuecomment-461502769 

application/ld+json; q=1.0, application/x-trig; q=1.0, application/owl+xml; q=1.0, application/rdf+xml; q=1.0, application/x-binary-rdf; q=1.0, text/owl-manchester; q=1.0, text/turtle; q=1.0, application/trix; q=1.0, application/xhtml+xml; q=1.0, text/owl-functional; q=1.0, application/rdf+json; q=1.0, text/n3; q=1.0, text/plain; q=1.0, text/x-nquads; q=1.0, application/xml; q=0.5, application/x-turtle; q=0.5, application/html; q=0.5, text/xml; q=0.5, text/rdf+n3; q=0.5, text/html; q=0.3, */*; q=0.09