### PR TITLE
Add redirect for security/v3

### DIFF
--- a/security/.htaccess
+++ b/security/.htaccess
@@ -5,4 +5,4 @@ RewriteEngine on
 RewriteRule ^$ https://w3c-ccg.github.io/security-vocab/ [R=302,L]
 RewriteRule ^v1$ https://w3c-ccg.github.io/security-vocab/contexts/security-v1.jsonld [R=302,L]
 RewriteRule ^v2$ https://w3c-ccg.github.io/security-vocab/contexts/security-v2.jsonld [R=302,L]
-RewriteRule ^v3$ https://w3c-ccg.github.io/security-vocab/contexts/security-v3-unstable.jsonld [R=302,L]
+RewriteRule ^v3-unstable$ https://w3c-ccg.github.io/security-vocab/contexts/security-v3-unstable.jsonld [R=302,L]

--- a/security/.htaccess
+++ b/security/.htaccess
@@ -5,3 +5,4 @@ RewriteEngine on
 RewriteRule ^$ https://w3c-ccg.github.io/security-vocab/ [R=302,L]
 RewriteRule ^v1$ https://w3c-ccg.github.io/security-vocab/contexts/security-v1.jsonld [R=302,L]
 RewriteRule ^v2$ https://w3c-ccg.github.io/security-vocab/contexts/security-v2.jsonld [R=302,L]
+RewriteRule ^v3$ https://w3c-ccg.github.io/security-vocab/contexts/security-v3-unstable.jsonld [R=302,L]


### PR DESCRIPTION
@dlongley @tplooker @davidlehn @msporny This will allow us to start using security/v3 with "default" document loaders.

It will also help with automated linting / documentation tooling for properties that are not not in sec-v2.