### PR TITLE
add rdf+xml request rule

### DIFF
--- a/demeter/.htaccess
+++ b/demeter/.htaccess
@@ -5,6 +5,8 @@ RewriteRule ^$ https://h2020-demeter.eu/ [R=302,L]
 # main entry in OGC
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^agri$ https://defs-dev.opengis.net/def/schema/demeter_aim [R=303,L]
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.* 
+RewriteRule ^agri$ https://raw.githubusercontent.com/rapw3k/DEMETER/master/models/demeterAgriProfile.ttl [R=303,L]
 #RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
 RewriteRule ^agri$ https://raw.githubusercontent.com/rapw3k/DEMETER/master/models/demeterAgriProfile.ttl [R=303,L]
 


### PR DESCRIPTION
I logged the requests from Protege (Mac). It tries multiple times using two different requests, with the headers below. So, no turtle is even considered, and it seems text/html has higher weight than text/turtle. see issue: https://github.com/protegeproject/protege/issues/973 . In meantime, adding rdf+xml sending to ttl to try make it Protege to load.

accept: 'application/rdf+xml, application/xml; q=0.7, text/xml; q=0.6, text/plain; q=0.1, /; q=0.09', 'accept-encoding': 'xz,gzip,deflate', 'user-agent': 'Java/1.8.0_121'

accept: 'text/html, image/gif, image/jpeg, *; q=.2, /; q=.2',