### PR TITLE
Update .htaccess

### DIFF
--- a/demeter/.htaccess
+++ b/demeter/.htaccess
@@ -6,7 +6,7 @@ RewriteRule ^$ https://h2020-demeter.eu/ [R=302,L]
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^agri$ https://defs-dev.opengis.net/def/schema/demeter_aim [R=303,L]
 RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.* 
-RewriteRule ^agri$ https://raw.githubusercontent.com/rapw3k/DEMETER/master/models/demeterAgriProfile.ttl [R=303,L]
+RewriteRule ^agri$ https://raw.githubusercontent.com/rapw3k/DEMETER/master/models/demeterAgriProfile.rdf [R=303,L]
 #RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
 RewriteRule ^agri$ https://raw.githubusercontent.com/rapw3k/DEMETER/master/models/demeterAgriProfile.ttl [R=303,L]
 

--- a/glosis/.htaccess
+++ b/glosis/.htaccess
@@ -3,7 +3,7 @@ RewriteEngine on
 RewriteRule ^$ https://www.sieusoil.eu/ [R=302,L]
 
 # Ontologies
-RewriteRule ^model$ https://raw.githubusercontent.com/rapw3k/glosis/master/model/glosis.ttl [R=302,L]
+RewriteRule ^model$ https://raw.githubusercontent.com/rapw3k/glosis/master/model/glosis_main.ttl [R=302,L]
 RewriteRule ^model/iso28258/2013$ https://raw.githubusercontent.com/rapw3k/glosis/master/iso28258_v1.0.0.ttl [R=302,L]
 RewriteRule ^model/common$ https://raw.githubusercontent.com/rapw3k/glosis/master/glosis_common_v1.0.0.ttl [R=302,L]
 RewriteRule ^model/codelists$ https://raw.githubusercontent.com/rapw3k/glosis/master/glosis_cl_v1.0.0.ttl [R=302,L]


### PR DESCRIPTION
I logged the requests from Protege (Mac). It tries multiple times using two different requests, with the headers below. So, no turtle is even considered, and it seems text/html has higher weight than text/turtle. see issue: https://github.com/protegeproject/protege/issues/973 . In meantime, adding rdf+xml sending to ttl to try make it Protege to load.

accept: 'application/rdf+xml, application/xml; q=0.7, text/xml; q=0.6, text/plain; q=0.1, /; q=0.09', 'accept-encoding': 'xz,gzip,deflate', 'user-agent': 'Java/1.8.0_121'

accept: 'text/html, image/gif, image/jpeg, *; q=.2, /; q=.2',