### PR TITLE
update to point to ProfCat

### DIFF
--- a/profile/.htaccess
+++ b/profile/.htaccess
@@ -1,8 +1,23 @@
 Options +FollowSymLinks
 RewriteEngine on
 
+RewriteRule ^$ https://profcat.conneg.info/resource/ [R=302,L]
+RewriteRule catalogue.ttl https://profcat.conneg.info/object?uri=https://w3id.org/profile?_mediatype=text/turtle [R=302,L,NE]
+
 RewriteCond %{QUERY_STRING} ^_format=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule (.*) https://kurrawong.net/profile/$1?_mediatype=text/turtle [R=302,L]
-RewriteRule (.*).ttl$ https://kurrawong.net/profile/$1?_mediatype=text/turtle [R=302,L]
-RewriteRule (.*) https://kurrawong.net/profile/$1 [R=302,L]
+RewriteRule (.*) https://profcat.conneg.info/object?uri=https://w3id.org/profile/$1$1?_mediatype=text/turtle [R=302,L]
+RewriteRule (.*).ttl$ https://profcat.conneg.info/object?uri=https://w3id.org/profile/$1?_mediatype=text/turtle [R=302,L,NE]
+RewriteRule (.*) https://profcat.conneg.info/object?uri=https://w3id.org/profile/$1 [R=302,L,QSA]
+
+
+# Example URIs handled
+#
+# https://w3id.org/profile
+# https://w3id.org/profile/catalogue.ttl
+# https://w3id.org/profile/
+#
+# https://w3id.org/profile/dcatnull
+# https://w3id.org/profile/ontdoc
+# https://w3id.org/profile/vocpub
+# etc...

--- a/profile/README.md
+++ b/profile/README.md
@@ -8,9 +8,24 @@ A *profile* is:
 > This definition includes what are sometimes called "application profiles", "metadata application profiles", or "metadata profiles".
 - *defintion from the [W3C's Profiles Vocabulary](https://w3c.github.io/dxwg/prof/)*
 
-Resolving this URI at it's 'slash' location, i.e. <https://w3id.org/profile/> will list all the *profiles* registered within this namespace.
 
-## Expected Use
+## Catalogue
+Individual profile URI may be created (`https://w3id.org/profile/XXX`) and pointed anywhere - wherever the profile content is hosted - however expected use is for profiles to be allocated URIs and metadata for them listed in a profiles catalogue. See the catalogue entry point:
+
+* <https://w3id.org/profile/catalogue>
+
+So, to request a URI for a profile and to add to the Profiles Catalogue, please submit profile metadata, in the form of [DCAT2](https://www.w3.org/TR/vocab-dcat/) metadata entries, as RDF files to the catalogue's content repository:
+
+* <https://github.com/surroundaustralia/catprez-overlay-profcat>
+
+See the existing example in the repository for guidance.
+
+
+## Just URIs
+If you really, really just want a URI for a profile but don't want it listed in the Profile Catalogue, please just ask via the contact details below.
+
+
+## Motivation
 This persistent URI namespace has been created to support users of both the [W3C's Profiles Vocabulary](https://w3c.github.io/dxwg/prof/) and also the [W3C's Content Negotiation by Profile](https://w3c.github.io/dxwg/conneg-by-ap/) and the related [IETF's Indicating and Negotiating Profiles in HTTP](https://profilenegotiation.github.io/I-D-Profile-Negotiation/I-D-Profile-Negotiation), all of which require URIs for profiles.
 
 


### PR DESCRIPTION
An update for the PID URI https://w3id.org/profile/* due to a new back-end system change.