### PR TITLE
Update redirects of ontologies in the Evolopro project

### DIFF
--- a/fraunhofer/Readme.md
+++ b/fraunhofer/Readme.md
@@ -5,4 +5,3 @@ https://www.fraunhofer.de/
 
 Contacts
 * Christoph Lange-Bever <christoph.lange-bever@fit.fraunhofer.de> (GitHub: clange)
-* Felix Konstantin Maurer <felix.konstantin.maurer@ipt.fraunhofer.de> (GitHub: mrf-ipt)

--- a/fraunhofer/lighthouse-projects/evolopro/.htaccess
+++ b/fraunhofer/lighthouse-projects/evolopro/.htaccess
@@ -4,6 +4,6 @@ AddType text/turtle .ttl
 
 RewriteEngine On
 
-RewriteRule ^cirp.ttl$ https://mrf-ipt.github.io/cirp.ttl [R=303,L]
-RewriteRule ^helical-end-mills.ttl$ https://mrf-ipt.github.io/helical-end-mills.ttl [R=303,L]
-RewriteRule ^dpart.ttl$ https://mrf-ipt.github.io/dpart.ttl [R=303,L]
+RewriteRule ^cirp.ttl$ https://evolopro.pages.fraunhofer.de/milling-schema/cirp.ttl [R=303,L]
+RewriteRule ^helical-end-mills.ttl$ https://evolopro.pages.fraunhofer.de/milling-schema/helical-end-mills.ttl [R=303,L]
+RewriteRule ^dpart.ttl$ https://evolopro.pages.fraunhofer.de/milling-schema/dpart.ttl [R=303,L]

--- a/fraunhofer/lighthouse-projects/evolopro/Readme.md
+++ b/fraunhofer/lighthouse-projects/evolopro/Readme.md
@@ -1,4 +1,4 @@
 # Ontologies for the EVOLOPRO lighthouse project
 
 Contacts
-* Felix Konstantin Maurer <felix.konstantin.maurer@ipt.fraunhofer.de>
+* Sven Schiller <sven.schiller@ipt.fraunhofer.de>


### PR DESCRIPTION
Hi,
I will unfortunately leave the Fraunhofer organization at the end of September. Therefore, I will also delete my Fraunhofer-specific GitHub account.
I improved our CI pipeline to directly publish the ontology files to GitLab pages, so that I can change the redirect from GitHub pages to GitLab pages.
Furthermore, I replaced my contact information with that of my colleague who will continue this work.