### PR TITLE
Add traceability vocab

### DIFF
--- a/traceability/.htaccess
+++ b/traceability/.htaccess
@@ -1,0 +1,6 @@
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ https://w3c-ccg.github.io/traceability-vocab/ [R=302,L]
+RewriteRule ^v1$ https://w3c-ccg.github.io/traceability-vocab/contexts/traceability-v1.jsonld [R=302,L]

--- a/traceability/README.md
+++ b/traceability/README.md
@@ -1,0 +1,10 @@
+# Traceability Vocabulary
+
+- https://w3c-ccg.github.io/traceability-vocab
+- https://github.com/w3c-ccg/traceability-vocab
+
+## Maintainers
+
+- Orie Steele (@OR13)
+- Mike Prorock (@mprorock)
+- @mkhraisha


### PR DESCRIPTION
This PR adds support for the W3C CCG Traceability Vocabulary: https://w3c-ccg.github.io/traceability-vocab/

This work item is a collaboration among companies working with Decentralized Identifiers, Verifiable Credentials and JSON-LD as they relate to global supply chain traceability.