### PR TITLE
Fix urban-iot rewrite rules

### DIFF
--- a/urban-iot/.htaccess
+++ b/urban-iot/.htaccess
@@ -25,24 +25,24 @@ SetEnvIf Request_URI ^(.*)kos/(.*)$ FILE=kos
 # KOS files
 RewriteCond %{ENV:FILE} ^kos$
 RewriteCond %{ENV:SYNTAX} ^(rdf|ttl|json|nt)$
-RewriteRule ^(.*)kos/(.+)/([^/]+)/?$ %{ENV:ROOT_URL}$2/$3/$3.%{ENV:SYNTAX} [R=303,L]
+RewriteRule ^kos/(.+)/([^/]+)/?$ %{ENV:ROOT_URL}$1/$2/$2.%{ENV:SYNTAX} [R=303,L]
 
 # Versioned onto modules
 RewriteCond %{ENV:SYNTAX} ^(rdf|ttl|json|nt)$
-RewriteRule ^(.*)/(.+)/([0-9].[0-9].[0-9])/?$ %{ENV:ROOT_URL}$2/$3/$2.%{ENV:SYNTAX} [R=303,L]
+RewriteRule ^(.+)/([0-9].[0-9].[0-9])/?$ %{ENV:ROOT_URL}$1/$2/$1.%{ENV:SYNTAX} [R=303,L]
 
 # Latest onto modules
 RewriteCond %{ENV:SYNTAX} ^(rdf|ttl|json|nt)$
-RewriteRule ^(.*)/([^/]+)/?$ %{ENV:ROOT_URL}$2/latest/$2.%{ENV:SYNTAX} [R=303,L]
+RewriteRule ^([^/]+)/?$ %{ENV:ROOT_URL}$1/latest/$1.%{ENV:SYNTAX} [R=303,L]
 
 # KOS documentation
 RewriteCond %{ENV:FILE} ^kos$
 RewriteCond %{ENV:SYNTAX} ^html$
-RewriteRule ^(.*)kos/(.+)/([^/]+)/?$ https://comune-milano.github.io/ontologie-iot-urbani/docs/kos/$2/$3/index-en.html [R=303,L]
+RewriteRule ^kos/(.+)/([^/]+)/?$ https://comune-milano.github.io/ontologie-iot-urbani/docs/kos/$1/$2/index-en.html [R=303,L]
 
 # Onto documentation
 RewriteCond %{ENV:SYNTAX} ^html$
-RewriteRule ^(.*)/([^/]+)/?$ https://comune-milano.github.io/ontologie-iot-urbani/docs/$2/index-en.html [R=303,L]
+RewriteRule ^([^/]+)/?$ https://comune-milano.github.io/ontologie-iot-urbani/docs/$1/index-en.html [R=303,L]
 
 # Onto repo
 RewriteCond %{ENV:SYNTAX} ^html$


### PR DESCRIPTION
Fix rewrite rules for urban-iot modules.

Repo ref: https://github.com/Comune-Milano/ontologie-iot-urbani
cc @Comune-Milano

@dgarijo my apologies, now it should work. Updates PR previously merged https://github.com/perma-id/w3id.org/pull/1915.