### PR TITLE
Add um folder for Maastricht University ontologies

### DIFF
--- a/um/.htaccess
+++ b/um/.htaccess
@@ -2,5 +2,7 @@ Header set Access-Control-Allow-Origin *
 Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^(.*)/cbcm/eu-cm-ontology(.*)$ https://maastrichtu-ids.github.io/cbcm-ontology/ [R=302,L]
+RewriteRule ^(.*)/cbcm/eu-cm-ontology(.*)$ https://maastrichtu-ids.github.io/cbcm-ontology$2 [R=302,L]
+RewriteRule ^(.*)/ids/shapes(.*)$ https://maastrichtu-ids.github.io/shapes-of-you/ [R=302,L]
+RewriteRule ^(.*)/ids/projects(.*)$ https://maastrichtu-ids.github.io/projects/ [R=302,L]
 RewriteRule ^(.*)$ https://www.maastrichtuniversity.nl [R=302,L]

--- a/um/.htaccess
+++ b/um/.htaccess
@@ -1,0 +1,6 @@
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^(.*)/cbcm/eu-cm-ontology(.*)$ https://maastrichtu-ids.github.io/cbcm-ontology/ [R=302,L]
+RewriteRule ^(.*)$ https://www.maastrichtuniversity.nl [R=302,L]

--- a/um/README.md
+++ b/um/README.md
@@ -1,0 +1,12 @@
+# Maastricht University (UM)
+
+A namespace for ontologies published by [Maastricht University](https://maastrichtuniversity.nl/)
+
+* **CBCM Ontology** at https://w3id.org/um/cbcm/eu-cm-ontology
+  * An OWL ontology to define terms from EU company law that are relevant for cross-border mobility of EU companies. 
+
+## Maintainers
+
+- Vincent Emonet (@vemonet)
+- Kody Moodley (@kodymoodley)
+- Pedro V (@pedrohserrano)

--- a/um/README.md
+++ b/um/README.md
@@ -4,6 +4,9 @@ A namespace for ontologies published by [Maastricht University](https://maastric
 
 * **CBCM Ontology** at https://w3id.org/um/cbcm/eu-cm-ontology
   * An OWL ontology to define terms from EU company law that are relevant for cross-border mobility of EU companies. 
+* Knowledge graphs for the **Institute of Data Science**
+  * [SHACL Shapes registry](https://github.com/MaastrichtU-IDS/shapes-of-you) at https://w3id.org/um/ids/shapes
+  * [IDS Projects](https://github.com/MaastrichtU-IDS/projects) at https://w3id.org/um/ids/projects
 
 ## Maintainers
 


### PR DESCRIPTION
Add `um` folder for Maastricht University ontologies and knowledge graphs redirections (Cross border mobility legal ontology redirection added)

* [**CBCM ontology**](https://github.com/MaastrichtU-IDS/cbcm-ontology/) redirection added at https://w3id.org/um/cbcm/eu-cm-ontology
  * An OWL ontology to define terms from EU company law that are relevant for cross-border mobility of EU companies. 
* Knowledge graphs for the **Institute of Data Science**
  * [SHACL Shapes registry](https://github.com/MaastrichtU-IDS/shapes-of-you) at https://w3id.org/um/ids/shapes
  * [IDS Projects](https://github.com/MaastrichtU-IDS/projects) at https://w3id.org/um/ids/projects
* Default redirection to https://maastrichtuniversity.nl