### PR TITLE
Fix Maastricht University .htaccess redirection

### DIFF
--- a/um/.htaccess
+++ b/um/.htaccess
@@ -2,7 +2,7 @@ Header set Access-Control-Allow-Origin *
 Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^(.*)/cbcm/eu-cm-ontology(.*)$ https://maastrichtu-ids.github.io/cbcm-ontology$2 [R=302,L]
-RewriteRule ^(.*)/ids/shapes(.*)$ https://maastrichtu-ids.github.io/shapes-of-you/ [R=302,L]
-RewriteRule ^(.*)/ids/projects(.*)$ https://maastrichtu-ids.github.io/projects/ [R=302,L]
-RewriteRule ^(.*)$ https://www.maastrichtuniversity.nl [R=302,L]
+RewriteRule ^$ https://www.maastrichtuniversity.nl [R=302,L]
+RewriteRule ^cbcm/eu-cm-ontology(.*)$ https://maastrichtu-ids.github.io/cbcm-ontology$1 [R=302,L]
+RewriteRule ^ids/shapes(.*)$ https://maastrichtu-ids.github.io/shapes-of-you/ [R=302,L]
+RewriteRule ^ids/projects(.*)$ https://maastrichtu-ids.github.io/projects/ [R=302,L]


### PR DESCRIPTION
Fix Maastricht University .htaccess redirection to CBCM ontologies (was overwritten by the default redirect)