### PR TITLE
added con-tax ontology and related taxonomies

### DIFF
--- a/con-tax/.htaccess
+++ b/con-tax/.htaccess
@@ -1,0 +1,40 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://mathib.github.io/ConTax-ontology/ [R=303,NE,L]
+
+# In case of accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://mathib.github.io/ConTax-ontology/ontology.ttl [R=303,NE,L]
+
+# In case of accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://mathib.github.io/ConTax-ontology/ontology.xml [R=303,NE,L]
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^contax.ttl$ https://mathib.github.io/ConTax-ontology/ontology.ttl [R=303,NE,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^contax.html$ https://mathib.github.io/ConTax-ontology/ [R=303,NE,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^contax.rdf$ https://mathib.github.io/ConTax-ontology/ontology.xml [R=303,NE,L]
+
+# If suffix jsonld, redirect to jsonld version
+RewriteRule ^contax.jsonld$ https://mathib.github.io/ConTax-ontology/ontology.json [R=303,NE,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^contax.nt$ https://mathib.github.io/ConTax-ontology/ontology.nt [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://mathib.github.io/ConTax-ontology/ [R=303,NE,L]

--- a/con-tax/components/aat-arch/.htaccess
+++ b/con-tax/components/aat-arch/.htaccess
@@ -1,0 +1,40 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://mathib.github.io/aat-arch-taxonomy/ [R=303,NE,L]
+
+# In case of accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://mathib.github.io/aat-arch-taxonomy/ontology.ttl [R=303,NE,L]
+
+# In case of accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://mathib.github.io/aat-arch-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^aat-arch.ttl$ https://mathib.github.io/aat-arch-taxonomy/ontology.ttl [R=303,NE,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^aat-arch.html$ https://mathib.github.io/aat-arch-taxonomy/ [R=303,NE,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^aat-arch.rdf$ https://mathib.github.io/aat-arch-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix jsonld, redirect to jsonld version
+RewriteRule ^aat-arch.jsonld$ https://mathib.github.io/aat-arch-taxonomy/ontology.json [R=303,NE,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^aat-arch.nt$ https://mathib.github.io/aat-arch-taxonomy/ontology.nt [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://mathib.github.io/aat-arch-taxonomy/ [R=303,NE,L]

--- a/con-tax/components/aat-furn/.htaccess
+++ b/con-tax/components/aat-furn/.htaccess
@@ -1,0 +1,40 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://mathib.github.io/aat-furn-taxonomy/ [R=303,NE,L]
+
+# In case of accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://mathib.github.io/aat-furn-taxonomy/ontology.ttl [R=303,NE,L]
+
+# In case of accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://mathib.github.io/aat-furn-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^aat-furn.ttl$ https://mathib.github.io/aat-furn-taxonomy/ontology.ttl [R=303,NE,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^aat-furn.html$ https://mathib.github.io/aat-furn-taxonomy/ [R=303,NE,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^aat-furn.rdf$ https://mathib.github.io/aat-furn-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix jsonld, redirect to jsonld version
+RewriteRule ^aat-furn.jsonld$ https://mathib.github.io/aat-furn-taxonomy/ontology.json [R=303,NE,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^aat-furn.nt$ https://mathib.github.io/aat-furn-taxonomy/ontology.nt [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://mathib.github.io/aat-furn-taxonomy/ [R=303,NE,L]

--- a/con-tax/components/aat-mep/.htaccess
+++ b/con-tax/components/aat-mep/.htaccess
@@ -1,0 +1,40 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://mathib.github.io/aat-mep-taxonomy/ [R=303,NE,L]
+
+# In case of accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://mathib.github.io/aat-mep-taxonomy/ontology.ttl [R=303,NE,L]
+
+# In case of accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://mathib.github.io/aat-mep-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^aat-mep.ttl$ https://mathib.github.io/aat-mep-taxonomy/ontology.ttl [R=303,NE,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^aat-mep.html$ https://mathib.github.io/aat-mep-taxonomy/ [R=303,NE,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^aat-mep.rdf$ https://mathib.github.io/aat-mep-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix jsonld, redirect to jsonld version
+RewriteRule ^aat-mep.jsonld$ https://mathib.github.io/aat-mep-taxonomy/ontology.json [R=303,NE,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^aat-mep.nt$ https://mathib.github.io/aat-mep-taxonomy/ontology.nt [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://mathib.github.io/aat-mep-taxonomy/ [R=303,NE,L]

--- a/con-tax/damages/mwv/.htaccess
+++ b/con-tax/damages/mwv/.htaccess
@@ -1,0 +1,40 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://mathib.github.io/mwv-d-taxonomy/ [R=303,NE,L]
+
+# In case of accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://mathib.github.io/mwv-d-taxonomy/ontology.ttl [R=303,NE,L]
+
+# In case of accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://mathib.github.io/mwv-d-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^mwv.ttl$ https://mathib.github.io/mwv-d-taxonomy/ontology.ttl [R=303,NE,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^mwv.html$ https://mathib.github.io/mwv-d-taxonomy/ [R=303,NE,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^mwv.rdf$ https://mathib.github.io/mwv-d-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix jsonld, redirect to jsonld version
+RewriteRule ^mwv.jsonld$ https://mathib.github.io/mwv-d-taxonomy/ontology.json [R=303,NE,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^mwv.nt$ https://mathib.github.io/mwv-d-taxonomy/ontology.nt [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://mathib.github.io/mwv-d-taxonomy/ [R=303,NE,L]

--- a/con-tax/materials/aat-mat/.htaccess
+++ b/con-tax/materials/aat-mat/.htaccess
@@ -1,0 +1,40 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://mathib.github.io/aat-mat-taxonomy/ [R=303,NE,L]
+
+# In case of accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://mathib.github.io/aat-mat-taxonomy/ontology.ttl [R=303,NE,L]
+
+# In case of accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://mathib.github.io/aat-mat-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^aat-mat.ttl$ https://mathib.github.io/aat-mat-taxonomy/ontology.ttl [R=303,NE,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^aat-mat.html$ https://mathib.github.io/aat-mat-taxonomy/ [R=303,NE,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^aat-mat.rdf$ https://mathib.github.io/aat-mat-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix jsonld, redirect to jsonld version
+RewriteRule ^aat-mat.jsonld$ https://mathib.github.io/aat-mat-taxonomy/ontology.json [R=303,NE,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^aat-mat.nt$ https://mathib.github.io/aat-mat-taxonomy/ontology.nt [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://mathib.github.io/aat-mat-taxonomy/ [R=303,NE,L]

--- a/con-tax/properties/bhp/.htaccess
+++ b/con-tax/properties/bhp/.htaccess
@@ -1,0 +1,40 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://mathib.github.io/bhp-taxonomy/ [R=303,NE,L]
+
+# In case of accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://mathib.github.io/bhp-taxonomy/ontology.ttl [R=303,NE,L]
+
+# In case of accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://mathib.github.io/bhp-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^bhp.ttl$ https://mathib.github.io/bhp-taxonomy/ontology.ttl [R=303,NE,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^bhp.html$ https://mathib.github.io/bhp-taxonomy/ [R=303,NE,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^bhp.rdf$ https://mathib.github.io/bhp-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix jsonld, redirect to jsonld version
+RewriteRule ^bhp.jsonld$ https://mathib.github.io/bhp-taxonomy/ontology.json [R=303,NE,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^bhp.nt$ https://mathib.github.io/bhp-taxonomy/ontology.nt [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://mathib.github.io/bhp-taxonomy/ [R=303,NE,L]

--- a/con-tax/properties/cp/.htaccess
+++ b/con-tax/properties/cp/.htaccess
@@ -1,0 +1,40 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://mathib.github.io/cp-taxonomy/ [R=303,NE,L]
+
+# In case of accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://mathib.github.io/cp-taxonomy/ontology.ttl [R=303,NE,L]
+
+# In case of accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://mathib.github.io/cp-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^cp.ttl$ https://mathib.github.io/cp-taxonomy/ontology.ttl [R=303,NE,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^cp.html$ https://mathib.github.io/cp-taxonomy/ [R=303,NE,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^cp.rdf$ https://mathib.github.io/cp-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix jsonld, redirect to jsonld version
+RewriteRule ^cp.jsonld$ https://mathib.github.io/cp-taxonomy/ontology.json [R=303,NE,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^cp.nt$ https://mathib.github.io/cp-taxonomy/ontology.nt [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://mathib.github.io/cp-taxonomy/ [R=303,NE,L]

--- a/con-tax/readme.md
+++ b/con-tax/readme.md
@@ -1,0 +1,52 @@
+## ConTax Ontology and related taxonomies
+
+Ontology
+
+* Docs https://mathib.github.io/ConTax-ontology/
+* Turtle https://mathib.github.io/ConTax-ontology/ontology.ttl
+
+ConTax provides an index for taxonomies of classes and properties, located in subnamespaces of https://w3id.org/con-tax
+
+* AAT-ARCH
+-- Docs https://mathib.github.io/aat-arch-taxonomy/
+-- Turtle https://mathib.github.io/aat-arch-taxonomy/ontology.ttl
+* AAT-FURN
+-- Docs https://mathib.github.io/aat-furn-taxonomy/
+-- Turtle https://mathib.github.io/aat-furn-taxonomy/ontology.ttl
+* AAT-MEP
+-- Docs https://mathib.github.io/aat-mep-taxonomy/
+-- Turtle https://mathib.github.io/aat-mep-taxonomy/ontology.ttl
+* AAT-buildingSITES
+-- Docs https://mathib.github.io/aat-buildingSites-taxonomy/
+-- Turtle https://mathib.github.io/aat-buildingSites-taxonomy/ontology.ttl
+* AAT-BUILDINGS
+-- Docs https://mathib.github.io/aat-buildings-taxonomy/
+-- Turtle https://mathib.github.io/aat-buildings-taxonomy/ontology.ttl
+* AAT-STOREYS
+-- Docs https://mathib.github.io/aat-storeys-taxonomy/
+-- Turtle https://mathib.github.io/aat-storeys-taxonomy/ontology.ttl
+* AAT-SPACES
+-- Docs https://mathib.github.io/aat-spaces-taxonomy/
+-- Turtle https://mathib.github.io/aat-spaces-taxonomy/ontology.ttl
+* ET-BUILDINGS
+-- Docs https://mathib.github.io/et-buildings-taxonomy/
+-- Turtle https://mathib.github.io/et-buildings-taxonomy/ontology.ttl
+* AAT-MAT
+-- Docs https://mathib.github.io/aat-mat-taxonomy/
+-- Turtle https://mathib.github.io/aat-mat-taxonomy/ontology.ttl
+* MWV-D
+-- Docs https://mathib.github.io/mwv-d-taxonomy/
+-- Turtle https://mathib.github.io/mwv-d-taxonomy/ontology.ttl
+* MWV-T
+-- Docs https://mathib.github.io/mwv-t-taxonomy/
+-- Turtle https://mathib.github.io/mwv-t-taxonomy/ontology.ttl
+* CP
+-- Docs https://mathib.github.io/cp-taxonomy/
+-- Turtle https://mathib.github.io/cp-taxonomy/ontology.ttl
+* BHP
+-- Docs https://mathib.github.io/bhp-taxonomy/
+-- Turtle https://mathib.github.io/bhp-taxonomy/ontology.ttl
+
+Contact
+
+* Mathias Bonduel mathias.bonduel@kuleuven.be

--- a/con-tax/tasks/mwv/.htaccess
+++ b/con-tax/tasks/mwv/.htaccess
@@ -1,0 +1,40 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://mathib.github.io/mwv-t-taxonomy/ [R=303,NE,L]
+
+# In case of accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://mathib.github.io/mwv-t-taxonomy/ontology.ttl [R=303,NE,L]
+
+# In case of accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://mathib.github.io/mwv-t-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^mwv.ttl$ https://mathib.github.io/mwv-t-taxonomy/ontology.ttl [R=303,NE,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^mwv.html$ https://mathib.github.io/mwv-t-taxonomy/ [R=303,NE,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^mwv.rdf$ https://mathib.github.io/mwv-t-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix jsonld, redirect to jsonld version
+RewriteRule ^mwv.jsonld$ https://mathib.github.io/mwv-t-taxonomy/ontology.json [R=303,NE,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^mwv.nt$ https://mathib.github.io/mwv-t-taxonomy/ontology.nt [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://mathib.github.io/mwv-t-taxonomy/ [R=303,NE,L]

--- a/con-tax/zones/aat-buildingSites/.htaccess
+++ b/con-tax/zones/aat-buildingSites/.htaccess
@@ -1,0 +1,40 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://mathib.github.io/aat-buildingSites-taxonomy/ [R=303,NE,L]
+
+# In case of accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://mathib.github.io/aat-buildingSites-taxonomy/ontology.ttl [R=303,NE,L]
+
+# In case of accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://mathib.github.io/aat-buildingSites-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^aat-buildingSites.ttl$ https://mathib.github.io/aat-buildingSites-taxonomy/ontology.ttl [R=303,NE,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^aat-buildingSites.html$ https://mathib.github.io/aat-buildingSites-taxonomy/ [R=303,NE,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^aat-buildingSites.rdf$ https://mathib.github.io/aat-buildingSites-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix jsonld, redirect to jsonld version
+RewriteRule ^aat-buildingSites.jsonld$ https://mathib.github.io/aat-buildingSites-taxonomy/ontology.json [R=303,NE,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^aat-buildingSites.nt$ https://mathib.github.io/aat-buildingSites-taxonomy/ontology.nt [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://mathib.github.io/aat-buildingSites-taxonomy/ [R=303,NE,L]

--- a/con-tax/zones/aat-buildings/.htaccess
+++ b/con-tax/zones/aat-buildings/.htaccess
@@ -1,0 +1,40 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://mathib.github.io/aat-buildings-taxonomy/ [R=303,NE,L]
+
+# In case of accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://mathib.github.io/aat-buildings-taxonomy/ontology.ttl [R=303,NE,L]
+
+# In case of accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://mathib.github.io/aat-buildings-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^aat-buildings.ttl$ https://mathib.github.io/aat-buildings-taxonomy/ontology.ttl [R=303,NE,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^aat-buildings.html$ https://mathib.github.io/aat-buildings-taxonomy/ [R=303,NE,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^aat-buildings.rdf$ https://mathib.github.io/aat-buildings-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix jsonld, redirect to jsonld version
+RewriteRule ^aat-buildings.jsonld$ https://mathib.github.io/aat-buildings-taxonomy/ontology.json [R=303,NE,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^aat-buildings.nt$ https://mathib.github.io/aat-buildings-taxonomy/ontology.nt [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://mathib.github.io/aat-buildings-taxonomy/ [R=303,NE,L]

--- a/con-tax/zones/aat-spaces/.htaccess
+++ b/con-tax/zones/aat-spaces/.htaccess
@@ -1,0 +1,40 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://mathib.github.io/aat-spaces-taxonomy/ [R=303,NE,L]
+
+# In case of accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://mathib.github.io/aat-spaces-taxonomy/ontology.ttl [R=303,NE,L]
+
+# In case of accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://mathib.github.io/aat-spaces-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^aat-spaces.ttl$ https://mathib.github.io/aat-spaces-taxonomy/ontology.ttl [R=303,NE,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^aat-spaces.html$ https://mathib.github.io/aat-spaces-taxonomy/ [R=303,NE,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^aat-spaces.rdf$ https://mathib.github.io/aat-spaces-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix jsonld, redirect to jsonld version
+RewriteRule ^aat-spaces.jsonld$ https://mathib.github.io/aat-spaces-taxonomy/ontology.json [R=303,NE,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^aat-spaces.nt$ https://mathib.github.io/aat-spaces-taxonomy/ontology.nt [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://mathib.github.io/aat-spaces-taxonomy/ [R=303,NE,L]

--- a/con-tax/zones/aat-storeys/.htaccess
+++ b/con-tax/zones/aat-storeys/.htaccess
@@ -1,0 +1,40 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://mathib.github.io/aat-storeys-taxonomy/ [R=303,NE,L]
+
+# In case of accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://mathib.github.io/aat-storeys-taxonomy/ontology.ttl [R=303,NE,L]
+
+# In case of accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://mathib.github.io/aat-storeys-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^aat-storeys.ttl$ https://mathib.github.io/aat-storeys-taxonomy/ontology.ttl [R=303,NE,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^aat-storeys.html$ https://mathib.github.io/aat-storeys-taxonomy/ [R=303,NE,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^aat-storeys.rdf$ https://mathib.github.io/aat-storeys-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix jsonld, redirect to jsonld version
+RewriteRule ^aat-storeys.jsonld$ https://mathib.github.io/aat-storeys-taxonomy/ontology.json [R=303,NE,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^aat-storeys.nt$ https://mathib.github.io/aat-storeys-taxonomy/ontology.nt [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://mathib.github.io/aat-storeys-taxonomy/ [R=303,NE,L]

--- a/con-tax/zones/et-buildings/.htaccess
+++ b/con-tax/zones/et-buildings/.htaccess
@@ -1,0 +1,40 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://mathib.github.io/et-buildings-taxonomy/ [R=303,NE,L]
+
+# In case of accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://mathib.github.io/et-buildings-taxonomy/ontology.ttl [R=303,NE,L]
+
+# In case of accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://mathib.github.io/et-buildings-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^et-buildings.ttl$ https://mathib.github.io/et-buildings-taxonomy/ontology.ttl [R=303,NE,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^et-buildings.html$ https://mathib.github.io/et-buildings-taxonomy/ [R=303,NE,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^et-buildings.rdf$ https://mathib.github.io/et-buildings-taxonomy/ontology.xml [R=303,NE,L]
+
+# If suffix jsonld, redirect to jsonld version
+RewriteRule ^et-buildings.jsonld$ https://mathib.github.io/et-buildings-taxonomy/ontology.json [R=303,NE,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^et-buildings.nt$ https://mathib.github.io/et-buildings-taxonomy/ontology.nt [R=303,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://mathib.github.io/et-buildings-taxonomy/ [R=303,NE,L]


### PR DESCRIPTION
Hi,

I've added a series of redirects, incl. content negotation, to a set of new OWL ontologies and their HTML documentation from Widoco. 

I assumed that it's correct to add a single working .htaccess file in subfolders to arrange redirects per subpath. I reused one of my older .htaccess files from https://w3id.org/gom and adapted it per new ontology. Unfortunatly, I'm currently unable to test this on Apache, so please inform me if I'm doing anything wrong! Here is an overview of what I try to accomplish:

con-tax => https://mathib.github.io/ConTax-ontology OR https://mathib.github.io/ConTax-ontology/ontology.ttl  OR ...
con-tax/components/aat-arch => https://mathib.github.io/aat-arch-taxonomy OR https://mathib.github.io/aat-arch-taxonomy/ontology.ttl  OR ...
con-tax/components/aat-furn => etc.
con-tax/components/aat-mep
con-tax/zones/aat-buildingSites
con-tax/zones/aat-buildings
con-tax/zones/aat-storeys
con-tax/zones/aat-spaces
con-tax/zones/et-buildings
con-tax/materials/aat-mat
con-tax/damages/mwv
con-tax/tasks/mwv
con-tax/properties/cp
con-tax/properties/bhp

Best regards,

Mathias