### PR TITLE
Align README and web index, add joining info

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ There is a growing group of organizations in a consortium that have pledged
 responsibility to ensure the operation of this website. These organizations
 are: [Digital Bazaar](http://digitalbazaar.com/),
 [3 Round Stones](http://3roundstones.com/),
-[OpenLink Software](http://www.openlinksw.com/),
+[OpenLink Software](https://www.openlinksw.com/),
 [Applied Testing and Technology](http://www.aptest.com/),
 [Openspring](http://openspring.net/), and
 [Bosatsu Consulting](http://bosatsu.net/). They are responsible for all

--- a/README.md
+++ b/README.md
@@ -120,14 +120,27 @@ your modification.
 
 ### Naming Policy
 
-There is no official policy on identifier names. The current practice is to claim a top-level directory name and add project specific second level identifiers. For instance, `https://w3id.org/PROJECT-ID/SUB-ID...`. Shared top-levels are also available such as `https://w3id.org/people/PERSON-ID`. There is no official list or policy for reserved identifiers. However, the administrators may deny requests for identifiers that are too generic, could cause confusion, are inappropriate or offensive, or otherwise may be needed for future service expansion.
+There is no official policy on identifier names. The current practice
+is to claim a top-level directory name and add project specific second
+level identifiers. For instance, `https://w3id.org/PROJECT-ID/SUB-ID...`.
+Shared top-levels are also available such as
+`https://w3id.org/people/PERSON-ID`. There is no official list or policy
+for reserved identifiers. However, the administrators may deny requests
+for identifiers that are too generic, could cause confusion, are
+inappropriate or offensive, or otherwise may be needed for future
+service expansion.
 
 ### W3ID Community
 
-If you wish to engage the community in discussion about this service for your Web application, please send an e-mail to the [public-perma-id@w3.org mailing list](http://lists.w3.org/Archives/Public/public-perma-id/).
+If you wish to engage the community in discussion about this service for
+your Web application, please send an e-mail to the
+[public-perma-id@w3.org mailing list](http://lists.w3.org/Archives/Public/public-perma-id/).
 
 * * *
 
 ### Disclaimer
 
-The letters 'w3' in the domain name for this site stand for "World Wide Web". Other than hosting the software for the Permanent Identifier Community Group, the "World Wide Web Consortium" (W3C) is not involved in the support or management of this website in any way.
+The letters 'w3' in the domain name for this site stand for "World Wide
+Web". Other than hosting the software for the Permanent Identifier
+Community Group, the "World Wide Web Consortium" (W3C) is not involved
+in the support or management of this website in any way.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ Web applications that deal with [Linked Data](http://en.wikipedia.org/wiki/Linke
 
 ### Management
 
-There are a growing group of organizations that have pledged responsibility to ensure the operation of this website. These organizations are: [Digital Bazaar](http://digitalbazaar.com/), [3 Round Stones](http://3roundstones.com/), [OpenLink Software](http://www.openlinksw.com/), [Applied Testing and Technology](http://www.aptest.com/), [Openspring](http://openspring.net/), and [Bosatsu Consulting](http://bosatsu.net/). They are responsible for all administrative tasks associated with operating the service. The social contract between these organizations gives each of them full access to all information required to maintain and operate the website. The agreement is setup such that a number of these companies could fail, lose interest, or become unavailable for long periods of time without negatively affecting the operation of the site.
+There is a growing group of organizations in a consortium that have pledged responsibility to ensure the operation of this website. These organizations are: [Digital Bazaar](http://digitalbazaar.com/), [3 Round Stones](http://3roundstones.com/), [OpenLink Software](http://www.openlinksw.com/), [Applied Testing and Technology](http://www.aptest.com/), [Openspring](http://openspring.net/), and [Bosatsu Consulting](http://bosatsu.net/). They are responsible for all administrative tasks associated with operating the service. The social contract between these organizations gives each of them full access to all information required to maintain and operate the website. The agreement is setup such that a number of these companies could fail, lose interest, or become unavailable for long periods of time without negatively affecting the operation of the site.
+
+#### Joining the Management consortium 
+
+To join the management consortium, please make yourself known to the W3ID comminuty via participation in the mailing list (see the [W3ID Community](#w3id-community) section below) and then, if you are still keen to join, please submit an Issue to the [GitHub Issue Tracker](https://github.com/perma-id/w3id.org/issues) with the title *Seeking to join the W3ID Consortium* and include your details.
 
 ### System Operations
 
@@ -31,6 +35,7 @@ This website operates in HTTPS-only mode to ensure end-to-end security. This mea
 
 All identifiers associated with this website are intended to be around for as long as the Web is around. This means decades, if not centuries. If the final destination for popular identifiers used by this service fail in such a way as to be a major inconvenience or danger to the Web, the community will mirror the information for the popular identifier and setup a working redirect to restore service to the rest of the Web.
 
+<a id="new"></a>
 ## Creating a New Identifier
 
 If you would like to add or update a permanent identifier of the form `https://w3id.org/...`, the preferred procedure is to perform the following steps:

--- a/README.md
+++ b/README.md
@@ -17,23 +17,61 @@ This repository holds the website source code for <https://w3id.org/>.
 
 ### Purpose
 
-The purpose of this website is to provide a secure, permanent [URL](http://en.wikipedia.org/wiki/URL) re-direction service for Web applications. This service is run by the [W3C Permanent Identifier Community Group](http://www.w3.org/community/perma-id/).
+The purpose of this website is to provide a secure, permanent
+[URL](http://en.wikipedia.org/wiki/URL) re-direction service for Web
+applications. This service is run by the
+[W3C Permanent Identifier Community Group](http://www.w3.org/community/perma-id/).
 
-Web applications that deal with [Linked Data](http://en.wikipedia.org/wiki/Linked_data) often need to specify and use URLs that are very stable. They utilize services such as this one to ensure that applications using their URLs will always be re-directed to a working website. This website operates like a [switchboard](http://en.wikipedia.org/wiki/Telephone_switchboard), connecting requests for information with the true location of the information on the Web. The switchboard can be reconfigured to point to a new location if the old location stops working.
+Web applications that deal with
+[Linked Data](http://en.wikipedia.org/wiki/Linked_data) often need to
+specify and use URLs that are very stable. They utilize services such
+as this one to ensure that applications using their URLs will always
+be re-directed to a working website. This website operates like a
+[switchboard](http://en.wikipedia.org/wiki/Telephone_switchboard),
+connecting requests for information with the true location of the
+information on the Web. The switchboard can be reconfigured to point
+to a new location if the old location stops working.
 
 ### Management
 
-There is a growing group of organizations in a consortium that have pledged responsibility to ensure the operation of this website. These organizations are: [Digital Bazaar](http://digitalbazaar.com/), [3 Round Stones](http://3roundstones.com/), [OpenLink Software](http://www.openlinksw.com/), [Applied Testing and Technology](http://www.aptest.com/), [Openspring](http://openspring.net/), and [Bosatsu Consulting](http://bosatsu.net/). They are responsible for all administrative tasks associated with operating the service. The social contract between these organizations gives each of them full access to all information required to maintain and operate the website. The agreement is setup such that a number of these companies could fail, lose interest, or become unavailable for long periods of time without negatively affecting the operation of the site.
+There is a growing group of organizations in a consortium that have pledged
+responsibility to ensure the operation of this website. These organizations
+are: [Digital Bazaar](http://digitalbazaar.com/),
+[3 Round Stones](http://3roundstones.com/),
+[OpenLink Software](http://www.openlinksw.com/),
+[Applied Testing and Technology](http://www.aptest.com/),
+[Openspring](http://openspring.net/), and
+[Bosatsu Consulting](http://bosatsu.net/). They are responsible for all
+administrative tasks associated with operating the service. The social
+contract between these organizations gives each of them full access to
+all information required to maintain and operate the website. The
+agreement is setup such that a number of these companies could fail,
+lose interest, or become unavailable for long periods of time without
+negatively affecting the operation of the site.
 
 #### Joining the Management consortium 
 
-To join the management consortium, please make yourself known to the W3ID comminuty via participation in the mailing list (see the [W3ID Community](#w3id-community) section below) and then, if you are still keen to join, please submit an Issue to the [GitHub Issue Tracker](https://github.com/perma-id/w3id.org/issues) with the title *Seeking to join the W3ID Consortium* and include your details.
+To join the management consortium, please make yourself known to the
+W3ID community via participation in the mailing list (see the
+[W3ID Community](#w3id-community) section below) and then, if you are
+still keen to join, please submit an Issue to the
+[GitHub Issue Tracker](https://github.com/perma-id/w3id.org/issues)
+with the title *Seeking to join the W3ID Consortium* and include
+your details.
 
 ### System Operations
 
-This website operates in HTTPS-only mode to ensure end-to-end security. This means that it may be used for Linked Data applications that require high levels of security such as those found in the financial, medical, and public infrastructure sectors.
+This website operates in HTTPS-only mode to ensure end-to-end security.
+This means that it may be used for Linked Data applications that require
+high levels of security such as those found in the financial, medical,
+and public infrastructure sectors.
 
-All identifiers associated with this website are intended to be around for as long as the Web is around. This means decades, if not centuries. If the final destination for popular identifiers used by this service fail in such a way as to be a major inconvenience or danger to the Web, the community will mirror the information for the popular identifier and setup a working redirect to restore service to the rest of the Web.
+All identifiers associated with this website are intended to be around
+for as long as the Web is around. This means decades, if not centuries.
+If the final destination for popular identifiers used by this service
+fail in such a way as to be a major inconvenience or danger to the Web,
+the community will mirror the information for the popular identifier
+and setup a working redirect to restore service to the rest of the Web.
 
 <a id="new"></a>
 ## Creating a New Identifier

--- a/README.md
+++ b/README.md
@@ -1,89 +1,65 @@
 Permanent Identifiers for the Web
 =================================
 
-[![Build Status](https://travis-ci.org/perma-id/w3id.org.svg)](https://travis-ci.org/perma-id/w3id.org)
-
 This repository holds the website source code for <https://w3id.org/>.
 
-The purpose of w3id.org is to provide a secure, permanent URL re-direction
-service for Web applications. This service is run by the [W3C Permanent
-Identifier Community Group](http://www.w3.org/community/perma-id/).
+[![Build Status](https://travis-ci.org/perma-id/w3id.org.svg)](https://travis-ci.org/perma-id/w3id.org)
 
-Web applications that deal with Linked Data often need to specify and use URLs
-that are very stable. Entities minting such URLs utilize services such as this one to ensure that
-applications using their URLs will always be re-directed to a working
-website. This website operates like a switchboard, connecting requests for
-information with the true location of the information on the Web. The
-switchboard can be reconfigured to point to a new location if the old
-location stops working.
+#### Content
 
-A growing group of organizations has pledged responsibility
-to ensure the operation of this website. These organizations include
-[Digital Bazaar](https://digitalbazaar.com/),
-[3 Round Stones](http://3roundstones.com/),
-[OpenLink Software](https://www.openlinksw.com/),
-[Applied Testing and Technology](http://www.aptest.com/),
-[Openspring](http://openspring.net/), and
-[Bosatsu Consulting](https://bosatsu.net/).
-They are responsible for all administrative
-tasks associated with operating the service. The social contract between
-these organizations gives each of them full access to all information required
-to maintain and operate the website. The agreement has been set up such that a
-number of these companies could fail, lose interest, or become unavailable
-for long periods of time without negatively affecting the operation of the site.
+*   [Purpose](#purpose)
+*   [Management](#management)
+*   [System Operations](#system-operations)
+*   [**Creating a New Identifier**](#new)
+*   [Naming Policy](#naming-policy)
+*   [W3ID Community](#w3id-community)
+*   [Disclaimer](#disclaimer)
 
-This website operates in HTTPS-only mode to ensure end-to-end security.
-This means that it may be used for Linked Data applications that require
-high levels of security such as those found in the financial, medical, and
-public infrastructure sectors.
+### Purpose
 
-All identifiers associated with this website are intended to be around for
-as long as the Web is around. This means decades, if not centuries. If the
-final destinations for popular identifiers used by this service fail in
-such a way as to be a major inconvenience or danger to the Web, the community
-will mirror the information for the popular identifiers and setup a working
-redirect to restore service to the rest of the Web.
+The purpose of this website is to provide a secure, permanent [URL](http://en.wikipedia.org/wiki/URL) re-direction service for Web applications. This service is run by the [W3C Permanent Identifier Community Group](http://www.w3.org/community/perma-id/).
 
-Adding a Permanent Identifier to w3id.org
-=========================================
+Web applications that deal with [Linked Data](http://en.wikipedia.org/wiki/Linked_data) often need to specify and use URLs that are very stable. They utilize services such as this one to ensure that applications using their URLs will always be re-directed to a working website. This website operates like a [switchboard](http://en.wikipedia.org/wiki/Telephone_switchboard), connecting requests for information with the true location of the information on the Web. The switchboard can be reconfigured to point to a new location if the old location stops working.
 
-For the technically savvy, the preferred way to create the redirect yourself is
-by following these steps:
+### Management
 
-1. Fork the [`perma-id/w3id.org`](https://github.com/perma-id/w3id.org)
-   source code repository.
-2. Add a new re-direct entry. For a simple example, see
-   [`security/.htaccess`](security/.htaccess)
-3. (Optional) Add a `README.md` detailing contact persons and
-   (a subset of) your permanent identifiers. For an example,
-   see [`rdw/README.md`](rdw/README.md)
-4. Commit your changes and submit a
-   [pull request](https://github.com/perma-id/w3id.org/pulls).
-5. w3id.org administrators will review your pull request and merge it if
-   everything looks correct. Once the pull request is merged, the changes go
-   live immediately.
+There are a growing group of organizations that have pledged responsibility to ensure the operation of this website. These organizations are: [Digital Bazaar](http://digitalbazaar.com/), [3 Round Stones](http://3roundstones.com/), [OpenLink Software](http://www.openlinksw.com/), [Applied Testing and Technology](http://www.aptest.com/), [Openspring](http://openspring.net/), and [Bosatsu Consulting](http://bosatsu.net/). They are responsible for all administrative tasks associated with operating the service. The social contract between these organizations gives each of them full access to all information required to maintain and operate the website. The agreement is setup such that a number of these companies could fail, lose interest, or become unavailable for long periods of time without negatively affecting the operation of the site.
 
-You can also send a request to add a redirect to the
-[public-perma-id@w3.org](http://lists.w3.org/Archives/Public/public-perma-id/)
-mailing list. Make sure to include the URL that you want on w3id.org, the
-URL that you want to redirect to, and the HTTP code that you want to use
-when redirecting. An administrator will then create the redirect for you.
+### System Operations
 
-Guidelines on Identifiers
--------------------------
+This website operates in HTTPS-only mode to ensure end-to-end security. This means that it may be used for Linked Data applications that require high levels of security such as those found in the financial, medical, and public infrastructure sectors.
 
-1. Do not link-squat. If you are going to claim a permanent identifier,
-   make sure you or your organization intends for it to be around for
-   at least 20+ years.
-2. Make sure the link you redirect to works. If not, we will most
-   likely reject your requested addition.
-3. If you are creating a link to your personal website, please do so under
-   the `/people/` subdirectory. A simple redirect should be placed in
-   `/people/.htaccess`. A complex redirect should be placed under a
-   directory like `/people/rubarb/.htaccess`.
+All identifiers associated with this website are intended to be around for as long as the Web is around. This means decades, if not centuries. If the final destination for popular identifiers used by this service fail in such a way as to be a major inconvenience or danger to the Web, the community will mirror the information for the popular identifier and setup a working redirect to restore service to the rest of the Web.
 
-Link checking
--------------
+## Creating a New Identifier
+
+If you would like to add or update a permanent identifier of the form `https://w3id.org/...`, the preferred procedure is to perform the following steps:
+
+1.  _Fork_ [the _Repository_ for this system](https://github.com/perma-id/w3id.org) on Github.
+2.  Add or update a new redirect entry and commit your changes.
+3.  Submit a _Pull Request_ for your changes.
+
+The maintainers of this system will then act on that _Pull Request_ and merge it into this system's content. You will then be able to see your changes in the repository and via resolution of the identifier you created or edited.
+
+If the terms _Fork_ and _Pull Request_ are new to you, you need to familiarize yourself with the [Git](https://git-scm.com/) version control system and [GitHub](https://github.com/), the platform used to host this system. Please see this documentation:
+
+*   [Forking a Repository](https://docs.github.com/en/github-ae@latest/github/getting-started-with-github/fork-a-repo)
+*   [Creating a Pull Request across Forks](https://docs.github.com/en/github-ae@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork)
+
+#### Suitable PR content
+
+Please help out the maintainers of the service with the following in your Pull Requests:
+
+*   **contact info** in a README.md or .htaccess comment.
+    *   See this example of a good README file: [w3id.org/dggs/ README](https://github.com/perma-id/w3id.org/tree/master/dggs)
+*   **test your changes** with a local checkout of the site.
+*   **_Squash_ multiple commits** into one commit before a pull request if appropriate.
+    *   here is information on _squashing_ commits: [How to Squash Commits in Git](https://www.git-tower.com/learn/git/faq/git-squash/)
+*   **use descriptive commit messages**. In particular, include your project name in the commit message. For those using the GitHub interface, please modify the default "Create/Update/Delete .htaccess" message.
+
+You can also send a request to add a redirect to the [public-perma-id@w3.org](http://lists.w3.org/Archives/Public/public-perma-id/) mailing list. Make sure to include the URL that you want on w3id.org, the URL that you want to redirect to, and the HTTP code that you want to use when redirecting. An administrator will then create the redirect for you.
+
+#### Link checking
 A simple [Travis-CI](https://travis-ci.org/perma-id/w3id.org) job
 (see [`.travis.yml`](.travis.yml)) will extract all https://w3id.org/
 URIs from `*/README.md` and check them with
@@ -99,3 +75,16 @@ Travis might comment on your Pull Request if this test reveals an error.
 Check its output logs to ensure the errors are not caused by
 your modification.
 
+### Naming Policy
+
+There is no official policy on identifier names. The current practice is to claim a top-level directory name and add project specific second level identifiers. For instance, `https://w3id.org/PROJECT-ID/SUB-ID...`. Shared top-levels are also available such as `https://w3id.org/people/PERSON-ID`. There is no official list or policy for reserved identifiers. However, the administrators may deny requests for identifiers that are too generic, could cause confusion, are inappropriate or offensive, or otherwise may be needed for future service expansion.
+
+### W3ID Community
+
+If you wish to engage the community in discussion about this service for your Web application, please send an e-mail to the [public-perma-id@w3.org mailing list](http://lists.w3.org/Archives/Public/public-perma-id/).
+
+* * *
+
+### Disclaimer
+
+The letters 'w3' in the domain name for this site stand for "World Wide Web". Other than hosting the software for the Permanent Identifier Community Group, the "World Wide Web Consortium" (W3C) is not involved in the support or management of this website in any way.

--- a/README.md
+++ b/README.md
@@ -76,31 +76,50 @@ and setup a working redirect to restore service to the rest of the Web.
 <a id="new"></a>
 ## Creating a New Identifier
 
-If you would like to add or update a permanent identifier of the form `https://w3id.org/...`, the preferred procedure is to perform the following steps:
+If you would like to add or update a permanent identifier of the form
+`https://w3id.org/...`, the preferred procedure is to perform the
+following steps:
 
-1.  _Fork_ [the _Repository_ for this system](https://github.com/perma-id/w3id.org) on Github.
-2.  Add or update a new redirect entry and commit your changes.
-3.  Submit a _Pull Request_ for your changes.
+1. _Fork_ [the _Repository_ for this system](https://github.com/perma-id/w3id.org) 
+   on Github.
+2. Add or update a new redirect entry and commit your changes.
+3. Submit a _Pull Request_ for your changes.
 
-The maintainers of this system will then act on that _Pull Request_ and merge it into this system's content. You will then be able to see your changes in the repository and via resolution of the identifier you created or edited.
+The maintainers of this system will then act on that _Pull Request_ and 
+merge it into this system's content. You will then be able to see your 
+changes in the repository and via resolution of the identifier you 
+created or edited.
 
-If the terms _Fork_ and _Pull Request_ are new to you, you need to familiarize yourself with the [Git](https://git-scm.com/) version control system and [GitHub](https://github.com/), the platform used to host this system. Please see this documentation:
+If the terms _Fork_ and _Pull Request_ are new to you, you need to 
+familiarize yourself with the [Git](https://git-scm.com/) version 
+control system and [GitHub](https://github.com/), the platform used 
+to host this system. Please see this documentation:
 
-*   [Forking a Repository](https://docs.github.com/en/github-ae@latest/github/getting-started-with-github/fork-a-repo)
-*   [Creating a Pull Request across Forks](https://docs.github.com/en/github-ae@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork)
+* [Forking a Repository](https://docs.github.com/en/github-ae@latest/github/getting-started-with-github/fork-a-repo)
+* [Creating a Pull Request across Forks](https://docs.github.com/en/github-ae@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork)
 
 #### Suitable PR content
 
-Please help out the maintainers of the service with the following in your Pull Requests:
+Please help out the maintainers of the service with the following in your 
+Pull Requests:
 
-*   **contact info** in a README.md or .htaccess comment.
-    *   See this example of a good README file: [w3id.org/dggs/ README](https://github.com/perma-id/w3id.org/tree/master/dggs)
-*   **test your changes** with a local checkout of the site.
-*   **_Squash_ multiple commits** into one commit before a pull request if appropriate.
-    *   here is information on _squashing_ commits: [How to Squash Commits in Git](https://www.git-tower.com/learn/git/faq/git-squash/)
-*   **use descriptive commit messages**. In particular, include your project name in the commit message. For those using the GitHub interface, please modify the default "Create/Update/Delete .htaccess" message.
+* **contact info** in a README.md or .htaccess comment.
+  * See this example of a good README file: 
+    [w3id.org/dggs/ README](https://github.com/perma-id/w3id.org/tree/master/dggs)
+* **test your changes** with a local checkout of the site.
+* **_Squash_ multiple commits** into one commit before a pull request 
+  if appropriate.
+  * here is information on _squashing_ commits: 
+    [How to Squash Commits in Git](https://www.git-tower.com/learn/git/faq/git-squash/)
+* **use descriptive commit messages**. In particular, include your project 
+  name in the commit message. For those using the GitHub interface, please 
+  modify the default "Create/Update/Delete `.htaccess`" message.
 
-You can also send a request to add a redirect to the [public-perma-id@w3.org](http://lists.w3.org/Archives/Public/public-perma-id/) mailing list. Make sure to include the URL that you want on w3id.org, the URL that you want to redirect to, and the HTTP code that you want to use when redirecting. An administrator will then create the redirect for you.
+You can also send a request to add a redirect to the 
+[public-perma-id@w3.org](http://lists.w3.org/Archives/Public/public-perma-id/) 
+mailing list. Make sure to include the URL that you want on w3id.org, the 
+URL that you want to redirect to, and the HTTP code that you want to use 
+when redirecting. An administrator will then create the redirect for you.
 
 #### Link checking
 A simple [Travis-CI](https://travis-ci.org/perma-id/w3id.org) job

--- a/index.html
+++ b/index.html
@@ -85,8 +85,8 @@ old location stops working.
         </p>
         <h3 id="management">Management</h3>
         <p>
-There are a growing group of organizations that have 
-pledged responsibility to ensure the operation of this website. 
+There is a growing group of organizations in a consortium that have 
+pledged responsibility in a consortium to ensure the operation of this website. 
 These organizations are: 
 <a href="http://digitalbazaar.com/">Digital Bazaar</a>, 
 <a href="http://3roundstones.com/">3 Round Stones</a>, 
@@ -101,6 +101,10 @@ to maintain and operate the website. The agreement is setup such that
 a number of these companies could fail, lose interest, or become unavailable
 for long periods of time without negatively affecting the operation of the
 site.
+        </p>
+        <h4>Joining the Management consortium</h4>
+        <p>
+To join the management consortium, please make yourself known to the W3ID comminuty via participation in the mailing list (see the <a href="#w3id-community">W3ID Community</a> section below) and then, if you are still keen to join, please submit an Issue to the <a href="https://github.com/perma-id/w3id.org/issues">GitHub Issue Tracker</a> with the title <em>Seeking to join the W3ID Consortium</em> and include your details.        
         </p>
         <h3 id="system-operations">System Operations</h3>
 	<p>

--- a/index.html
+++ b/index.html
@@ -174,6 +174,26 @@ mailing list. Make sure to include the URL that you want on w3id.org, the
 URL that you want to redirect to, and the HTTP code that you want to use
 when redirecting. An administrator will then create the redirect for you.
         </p>
+        <h4>Link checking</h4>
+        <p>
+A simple <a herf="https://travis-ci.org/perma-id/w3id.org">Travis-CI</a> job
+(see <a href="https://github.com/perma-id/w3id.org/blob/master/.travis.yml">.travis.yml</a>) will extract all https://w3id.org/
+URIs from <code>*/README.md</code> and check them with
+<code><a href="https://wummel.github.io/linkchecker/">linkchecker</a></code>.
+In theory, this will catch two kinds of errors:
+        </p>
+        <ol>
+          <li>Following a redirection gives a <code>404 Not Found</code></li>
+          <li>An error in <code>.htaccess</code> causes a <code>500 Server Error</code>.</li>
+        </ol>
+        <p>
+Note that this only checks URIs that are listed in the `README.md` files.
+        </p>
+        <p>
+Travis might comment on your Pull Request if this test reveals an error.
+Check its output logs to ensure the errors are not caused by
+your modification.        
+        </p>
         <h3 id="naming-policy">Naming Policy</h3>
         <p>
 There is no official policy on identifier names. The current practice

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@ old location stops working.
         <h3 id="management">Management</h3>
         <p>
 There is a growing group of organizations in a consortium that have 
-pledged responsibility in a consortium to ensure the operation of this website. 
+pledged responsibility as a consortium to ensure the operation of this website. 
 These organizations are: 
 <a href="http://digitalbazaar.com/">Digital Bazaar</a>, 
 <a href="http://3roundstones.com/">3 Round Stones</a>, 

--- a/index.html
+++ b/index.html
@@ -85,8 +85,8 @@ old location stops working.
         </p>
         <h3 id="management">Management</h3>
         <p>
-There is a growing group of organizations in a consortium that have 
-pledged responsibility as a consortium to ensure the operation of this website. 
+A growing group of organizations have pledged responsibility as a
+consortium to ensure the operation of this website.
 These organizations are: 
 <a href="http://digitalbazaar.com/">Digital Bazaar</a>, 
 <a href="http://3roundstones.com/">3 Round Stones</a>, 


### PR DESCRIPTION
Apologies for destroying the linebreaks in the README - I auto-generated the Markdown from the recently updated index.html, while preserving the travis build note etc.