### PR TITLE
IDSA: Adding new Contact and new Path Segment

### DIFF
--- a/idsa/.htaccess
+++ b/idsa/.htaccess
@@ -19,40 +19,40 @@ RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/\* 
-RewriteRule ^(core|code)/?$ https://international-data-spaces-association.github.io/InformationModel/docs/index.html#$2 [NE,R=303]
+RewriteRule ^(core|code|metamodel)/?$ https://international-data-spaces-association.github.io/InformationModel/docs/index.html#$2 [NE,R=303]
 
 # TURTLE
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
-RewriteRule ^(core|code)(/|#)* https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.ttl [R=303]
-RewriteRule ^(core|code).ttl https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.ttl [R=303]
+RewriteRule ^(core|code|metamodel)(/|#)* https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.ttl [R=303]
+RewriteRule ^(core|code|metamodel).ttl https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.ttl [R=303]
 
 # N3
 RewriteCond %{HTTP_ACCEPT} ^.*text/n3.* 
-RewriteRule ^(core|code)(/|#)* https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.n3 [R=303]
-RewriteRule ^(core|code).n3 https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.n3 [R=303]
+RewriteRule ^(core|code|metamodel)(/|#)* https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.n3 [R=303]
+RewriteRule ^(core|code|metamodel).n3 https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.n3 [R=303]
 
 # RDF/XML
 RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*  [OR]
 RewriteCond %{HTTP_ACCEPT} ^.*application/xml.* [OR]
 RewriteCond %{HTTP_ACCEPT} ^.*text/xml.*
-RewriteRule ^(core|code)(/|#)*(.*) https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.rdf  [R=303]
-RewriteRule ^(core|code).rdf https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.rdf [R=303]
-RewriteRule ^(core|code).xml https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.rdf [R=303]
+RewriteRule ^(core|code|metamodel)(/|#)*(.*) https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.rdf  [R=303]
+RewriteRule ^(core|code|metamodel).rdf https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.rdf [R=303]
+RewriteRule ^(core|code|metamodel).xml https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.rdf [R=303]
 
 # JSON-LD
 RewriteCond %{HTTP_ACCEPT} ^.*application/ld\+json.*
-RewriteRule ^(core|code)(/|#)*(.*) https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.jsonld [R=303]
-RewriteRule ^(core|code).jsonld https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.jsonld [R=303]
+RewriteRule ^(core|code|metamodel)(/|#)*(.*) https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.jsonld [R=303]
+RewriteRule ^(core|code|metamodel).jsonld https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.jsonld [R=303]
 
 # JSON
 RewriteCond %{HTTP_ACCEPT} ^.*application/json.*
-RewriteRule ^(core|code)(/|#)*(.*) https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.json [R=303]
-RewriteRule ^(core|code).json https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.json [R=303]
+RewriteRule ^(core|code|metamodel)(/|#)*(.*) https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.json [R=303]
+RewriteRule ^(core|code|metamodel).json https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.json [R=303]
 
 # N-TRIPLES
 RewriteCond %{HTTP_ACCEPT} ^.*application/n-triples.*
-RewriteRule ^(core|code)(/|#)* https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.nt [R=303]
-RewriteRule ^(core|code).nt https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.nt [R=303]
+RewriteRule ^(core|code|metamodel)(/|#)* https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.nt [R=303]
+RewriteRule ^(core|code|metamodel).nt https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.nt [R=303]
 
 # context.json(ld)
 RewriteRule ^contexts/context.json$ https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/4.0.0/context.jsonld [R=303]
@@ -63,7 +63,7 @@ RewriteRule ^contexts/([0-9][.][0-9][.][0-9])/context.json$ https://jira.iais.fr
 RewriteRule ^contexts/([0-9][.][0-9][.][0-9])/context.jsonld$ https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/$1/context.jsonld [R=303]
 
 # 
-RewriteRule ^(core|code)/(.+) https://international-data-spaces-association.github.io/InformationModel/docs/index.html#/$2 [R=303,NE]
+RewriteRule ^(core|code|metamodel)/(.+) https://international-data-spaces-association.github.io/InformationModel/docs/index.html#/$2 [R=303,NE]
 RewriteRule ^shacl/(.+) https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/develop/testing/$1.ttl [R=303,NE]
 RewriteRule ^shacl https://github.com/International-Data-Spaces-Association/InformationModel/releases/download/v4.0.0/ValidationShapesv400.zip [R=303]
 

--- a/idsa/README.md
+++ b/idsa/README.md
@@ -6,11 +6,11 @@ Homepage:
 
 Redirections:
 * https://w3id.org/idsa --> https://www.internationaldataspaces.org/ 
-* https://w3id.org/idsa/core, https://w3id.org/idsa/code --> https://International-Data-Spaces-Association.github.io/InformationModel/
+* https://w3id.org/idsa/core, https://w3id.org/idsa/code, https://w3id.org/idsa/metamodel, --> https://International-Data-Spaces-Association.github.io/InformationModel/
 * https://w3id.org/idsa/core, https://w3id.org/idsa/code with "Accept: text/turtle" --> https://International-Data-Spaces-Association.github.io/InformationModel/docs/serializations/ontology.ttl
 * https://w3id.org/idsa/core.ttl, https://w3id.org/idsa/code.ttl --> https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.ttl
-* https://w3id.org/idsa/core[.rdf|.xml|.json|.nt], https://w3id.org/idsa/code[.rdf|.xml|.json|.nt] --> https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology[.rdf|.xml|.json|.nt]
-* https://w3id.org/idsa/core, https://w3id.org/idsa/code with "Accept: application/[rdf+xml|xml|json|ld+json|n-triples]" or "Accept: text/[turtle|n3]" --> https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology[.rdf|.xml|.json|.nt]
+* https://w3id.org/idsa/core[.rdf|.xml|.json|.nt], https://w3id.org/idsa/code[.rdf|.xml|.json|.nt] --> https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology[.rdf|.xml|.json|.jsonld|.nt]
+* https://w3id.org/idsa/core, https://w3id.org/idsa/code with "Accept: application/[rdf+xml|xml|json|ld+json|n-triples]" or "Accept: text/[turtle|n3]" --> https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology[.rdf|.xml|.json|.jsonld|.nt]
 * https://w3id.org/idsa/contexts/context.[jsonld|json] --> https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/4.0.0/context.jsonld
 * https://w3id.org/idsa/contexts/[a.b.c]/context.[jsonld|json] --> https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/[a.b.c]/context.jsonld
 * https://w3id.org/idsa/contexts/context-dev.[jsonld|json] --> https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/4.0.0/context.jsonld
@@ -25,3 +25,4 @@ Support:
 Contacts: 
 * [Christoph Lange](https://github.com/clange/) <christoph.lange-bever@fit.fraunhofer.de>
 * [Sebastian Bader](https://github.com/sebbader) <sebastian.bader@iais.fraunhofer.de>
+* [Haydar Akyuerek](https://github.com/HaydarAk) <haydar.akyuerek@fit.fraunhofer.de>


### PR DESCRIPTION
* (Haydar Akyuerek](https://github.com/HaydarAk) is a responsible maintainer of the IDSA subnamespace, which is now also reflected in the contact list.
* The ./idsa/metamodel path is used in the ids ontology, now also added to the redirection links for LOV combatibility.