### PR TITLE
feat(csolink): request w3id for csolink ontology

### DIFF
--- a/csolink/.htaccess
+++ b/csolink/.htaccess
@@ -1,0 +1,14 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# vocab/ --> csolink-model/docs
+RewriteRule ^vocab$ csolink-model/docs
+RewriteRule ^vocab\/(.*)$ csolink-model/docs
+
+# / --> csolink-model/
+RewriteRule ^$ csolink-model/
+RewriteRule ^([^\/]*)$ csolink-model/$1
+
+
+# Rewrite Base URL
+RewriteRule ^(.*)$ https://csolink.github.io/$1 [R=302]

--- a/csolink/README.md
+++ b/csolink/README.md
@@ -1,0 +1,24 @@
+Csolink: Computer Science Ontology
+=======
+This ontology defines concepts, features, attributes for Computer Sciences.
+
+# Homepages
+* https://csolink.github.io/csolink-model/ -- Csolink model
+* https://biolink.github.io/biolinkml/ -- Biolink modeling language
+
+# Docs
+* https://csolink.github.io/csolink-model/docs
+* https://biolink.github.io/biolinkml/docs
+
+# Vocabulary Usage
+    @prefix cocoon: <https://w3id.org/cocoon/v0.0.1#>
+
+# Contact
+* noel McLoughlin @gmail.com
+
+# Status
+* EXPERIMENTAL
+
+# Notes
+Csolink was originally forked of biolink-model for computer science domain.
+Csolink leverages `biolinkml` modeling language.

--- a/csolink/biolinkml/.htaccess
+++ b/csolink/biolinkml/.htaccess
@@ -1,0 +1,77 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+
+# meta/ --> docs
+RewriteRule ^meta\/(.*)$ docs
+
+RewriteRule ^type\/(.*)$ docs/types
+
+# mapping/ --> docs/mappings
+RewriteRule ^mapping\/(.*)$ docs/mappings
+
+# extension/ --> docs/extensions
+RewriteRule ^extension\/(.*)$ docs/extensions
+
+# annotation/ --> docs/annotations
+RewriteRule ^annotation\/(.*)$ docs/annotations
+
+# types --> includes/types
+RewriteRule ^types(\/?)$ includes/types
+
+# mappings --> includes/mappings
+RewriteRule ^mappings(\/?)$ includes/mappings
+
+# extensions --> includes/extensions
+RewriteRule ^extensions(\/?)$ includes/extensions
+
+# annotations --> includes/annotations
+RewriteRule ^annotations(\/?)$ includes/annotations
+
+# types.sfx --> includes/types.sfx
+RewriteRule ^(types\.)(.+)$ includes/types.$2
+
+# mappings.sfx --> includes/mappings.sfx
+RewriteRule ^(mappings\.)(.+)$ includes/mappings.$2
+
+# extensions.sfx --> includes/extensions.sfx
+RewriteRule ^(extensions\.)(.+)$ includes/extensions.$2
+
+# annotations.sfx --> includes/annotations.sfx
+RewriteRule ^(annotations\.)(.+)$ includes/annotations.$2
+
+
+# Poor man's conneg
+# ------------------------------------
+RewriteCond %{HTTP_ACCEPT} ^text/turtle
+RewriteRule ^(.*/)([^./]+)$ $1$2.ttl [L]
+
+RewriteCond %{HTTP_ACCEPT} ^text/turtle
+RewriteRule ^(meta)$ meta.ttl [L]
+
+RewriteCond %{HTTP_ACCEPT} ^text/yaml
+RewriteRule ^(.*/)([^./]+)$ $1$2.yaml [L]
+
+RewriteCond %{HTTP_ACCEPT} ^text/yaml
+RewriteRule ^(meta)$ meta.yaml [L]
+
+RewriteCond %{HTTP_ACCEPT} ^application/json
+RewriteRule ^(.*/)([^./]+)$ $1$2.jsonld [L]
+
+RewriteCond %{HTTP_ACCEPT} ^application/json
+RewriteRule ^(meta)$ meta.jsonld [L]
+
+RewriteCond %{HTTP_ACCEPT} ^text/shex
+RewriteRule ^(.*/)([^./]+)$ $1$2.shex [L]
+
+RewriteCond %{HTTP_ACCEPT} ^text/shex
+RewriteRule ^(meta)$ meta.shex [L]
+
+# RewriteCond %{HTTP_ACCEPT} ^text/html
+# RewriteRule ^(.*/)[^./]+)$ $1$2.html [L]
+
+# RewriteCond %{HTTP_ACCEPT} ^text/html
+# RewriteRule ^(meta)$ meta.html [L]
+
+# Rewrite Base URL
+RewriteRule ^(.*)$ https://biolink.github.io/biolinkml/$1 [R=302,L]


### PR DESCRIPTION
Could you add w3id for csolink?

* `README`
* `.htaccess`
* `biolinkml/.htacces`s (because this is a common modeling language. Csolink is a fork of Biolink. , already hosted here).