### PR TITLE
Add pgp vocabulary

### DIFF
--- a/pgp/.htaccess
+++ b/pgp/.htaccess
@@ -1,0 +1,7 @@
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ https://or13.github.io/lds-pgp2021/ [R=302,L]
+RewriteRule ^v1$ https://or13.github.io/lds-pgp2021/contexts/pgp-v1.jsonld [R=302,L]
+

--- a/pgp/README.md
+++ b/pgp/README.md
@@ -1,0 +1,8 @@
+# PGP Vocabulary
+
+- https://github.com/OR13/lds-pgp2021
+- https://or13.github.io/lds-pgp2021/
+
+## Maintainers
+
+- Orie Steele (@OR13)


### PR DESCRIPTION
The purpose of this is to provide a template for context splitting associated with https://w3id.org/security vocab.

In the future, we would prefer to programmatically build security vocab, from smaller contexts like this one.