### PR TITLE
Add subcontext splitting redirects

### DIFF
--- a/security/.htaccess
+++ b/security/.htaccess
@@ -6,3 +6,23 @@ RewriteRule ^$ https://w3c-ccg.github.io/security-vocab/ [R=302,L]
 RewriteRule ^v1$ https://w3c-ccg.github.io/security-vocab/contexts/security-v1.jsonld [R=302,L]
 RewriteRule ^v2$ https://w3c-ccg.github.io/security-vocab/contexts/security-v2.jsonld [R=302,L]
 RewriteRule ^v3-unstable$ https://w3c-ccg.github.io/security-vocab/contexts/security-v3-unstable.jsonld [R=302,L]
+
+# https://w3id.org/security/jws
+
+RewriteRule ^jws$ https://w3c-ccg.github.io/lds-jws2020/ [R=302,L]
+RewriteRule ^jws/v1$ https://w3c-ccg.github.io/lds-jws2020/contexts/v1/ [R=302,L]
+
+# https://w3id.org/security/pgp
+
+RewriteRule ^pgp$ https://or13.github.io/lds-pgp2021/ [R=302,L]
+RewriteRule ^pgp/v1$ https://or13.github.io/lds-pgp2021/contexts/pgp-v1.jsonld [R=302,L]
+
+# https://w3id.org/security/bbs
+
+RewriteRule ^bbs$ https://github.com/w3c-ccg/ldp-bbs2020/ [R=302,L]
+RewriteRule ^bbs/v1$ https://w3c-ccg.github.io/ldp-bbs2020/contexts/v1/ [R=302,L]
+
+# https://w3id.org/security/blockchain
+
+RewriteRule ^blockchain$ https://or13.github.io/lds-blockchain2021/ [R=302,L]
+RewriteRule ^blockchain/v1$ https://or13.github.io/lds-blockchain2021/contexts/blockchain-v1.jsonld [R=302,L]


### PR DESCRIPTION
This PR implements context splitting for https://w3id.org/security 

If this PR is merged, we should remove:

- https://w3id.org/pgp/v1
- https://w3id.org/jws/v1
- https://w3id.org/bbs/v1

And instead use:

- https://w3id.org/security/pgp/v1
- https://w3id.org/security/jws/v1
- https://w3id.org/security/bbs/v1

If this PR is not merged, the above will continue to work :)
