### PR TITLE
Add SSSOM id space

### DIFF
--- a/sssom/.htaccess
+++ b/sssom/.htaccess
@@ -1,0 +1,5 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Rewrite Base URL
+RewriteRule ^(.*)$ https://github.com/OBOFoundry/SSSOM/$1 [R=302]

--- a/sssom/README.md
+++ b/sssom/README.md
@@ -1,0 +1,13 @@
+# Simple Standard for Sharing Ontology Mappings (SSSOM)
+
+Homepages
+* https://github.com/OBOFoundry/SSSOM -- SSSOM specification, context and docs
+* https://github.com/cmungall/sssom-py -- sssom-py - python package to read and write SSSOM mapping files
+
+Docs
+* https://github.com/OBOFoundry/SSSOM/blob/master/SSSOM.md
+* https://github.com/cmungall/sssom-py/tree/master/docs
+
+Contact
+* Chris Mungall cjmungall AT lbl DOT gov @cmungall
+* Nicolas Matentzoglu nicolas.matentzoglu AT gmail DOT com @matentzn


### PR DESCRIPTION
Hey all,

adding an idspace for https://github.com/OBOFoundry/SSSOM, a Simple Standard for Sharing Ontology Mappings (SSSOM) and its associated vocabs.

Thank you for considering!