### PR TITLE
Add perma-id for dcc

### DIFF
--- a/dcc/.htaccess
+++ b/dcc/.htaccess
@@ -1,0 +1,6 @@
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ https://digitalcredentials.github.io/dcc [R=302,L]
+RewriteRule ^v1$ https://digitalcredentials.github.io/dcc/v1/dcc-context-v1.json [R=302,L]

--- a/dcc/README.md
+++ b/dcc/README.md
@@ -1,0 +1,11 @@
+# Digital Credentials Consortium Vocabulary
+
+- https://digitalcredentials.github.io/dcc
+- https://github.com/digitalcredentials/dcc
+
+## Maintainers
+
+- Kim Hamilton Duffy (@kimdhamilton)
+- @dmitrizagidulin
+- @jchartrand
+- @stuartf


### PR DESCRIPTION
This adds a perma-id `dcc` for the [Digital Credentials Consortium](https://github.com/digitalcredentials) to support stable URLs for our json-ld contexts, etc.

Please let me know if you have any questions/comments. Thanks for your help! 