### PR TITLE
ID for the digital twin of a crane

### DIFF
--- a/twins/57fc5123-41af-4539-9d43-6403d6c3ab29/.htaccess
+++ b/twins/57fc5123-41af-4539-9d43-6403d6c3ab29/.htaccess
@@ -1,0 +1,4 @@
+Options +FollowSymLinks
+RewriteEngine on
+#Rewrite rules for the digital twin of an overhead crane called Ilmatar
+RewriteRule ^$ https://dtw.dtp.fi/crane-ilmatar [R=302,L]

--- a/twins/57fc5123-41af-4539-9d43-6403d6c3ab29/readme.md
+++ b/twins/57fc5123-41af-4539-9d43-6403d6c3ab29/readme.md
@@ -1,0 +1,3 @@
+# Digital twin identifier
+
+Maintainer: https://github.com/juusoautiosalo

--- a/twins/readme.md
+++ b/twins/readme.md
@@ -1,0 +1,5 @@
+# Digital twin identifiers
+
+This folder contains identifiers for digital twins.
+
+Created and used by https://github.com/juusoautiosalo


### PR DESCRIPTION
Created an identifier for the digital twin of an overhead crane, along with a folder "twins" which can be used for more twin IDs.

This is relates to an ongoing development of a digital twin framework that needs an external ID provider.