### PR TITLE
TUBES system ontology (tso): fixed typo for content type redirection on application/ld+json 

### DIFF
--- a/tso/.htaccess
+++ b/tso/.htaccess
@@ -31,7 +31,7 @@ RewriteRule  ^(.*/)?([^\./]*)$  $1$2.html [L]
 RewriteCond %{HTTP_ACCEPT} text/turtle
 RewriteRule  ^(.*/)?([^\./]*)$  $1$2.ttl [L]
 
-RewriteCond %{HTTP_ACCEPT} application/ld+json
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
 RewriteRule  ^(.*/)?([^\./]*)$  $1$2.json [L]
 
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml


### PR DESCRIPTION
unfortunately I was missing a slash to escape the "+" ...