### PR TITLE
Update redirection for /um namespace

### DIFF
--- a/um/.htaccess
+++ b/um/.htaccess
@@ -3,6 +3,8 @@ Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,
 Options +FollowSymLinks
 RewriteEngine on
 RewriteRule ^$ https://www.maastrichtuniversity.nl [R=302,L]
-RewriteRule ^cbcm/eu-cm-ontology(.*)$ https://maastrichtu-ids.github.io/cbcm-ontology$1 [R=302,L]
+RewriteRule ^cbcm/eu-cm-ontology.owl$ https://raw.githubusercontent.com/MaastrichtU-IDS/cbcm-ontology/master/working_copy/eu-cm-ontology.owl [R=302,L]
+RewriteRule ^cbcm/eu-cm-ontology$ https://raw.githubusercontent.com/MaastrichtU-IDS/cbcm-ontology/master/working_copy/eu-cm-ontology.owl [R=302,L]
+RewriteRule ^cbcm/eu-cm-ontology(.*)$ https://maastrichtu-ids.github.io/cbcm-ontology/docs/browse/class-eu-cm-ontology$1 [R=302,L]
 RewriteRule ^ids/shapes(.*)$ https://maastrichtu-ids.github.io/shapes-of-you/ [R=302,L]
 RewriteRule ^ids/projects(.*)$ https://maastrichtu-ids.github.io/projects/ [R=302,L]


### PR DESCRIPTION
Update redirection for https://w3id.org/um/cbcm/eu-cm-ontology to the OWL ontology file on GitHub