### PR TITLE
new namespace: linkml

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,7 +1,0 @@
-# w3id.org global rewrites
-
-Options +FollowSymLinks
-RewriteEngine on
-
-# redirect here vs in a UN directory due to case insensitive file systems issue
-RewriteRule ^UN(.*)$ /un$1

--- a/biolinkml/biolinkml/.htaccess
+++ b/biolinkml/biolinkml/.htaccess
@@ -1,0 +1,61 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+
+# meta/ --> docs
+RewriteRule ^meta\/(.*)$ docs
+
+# type/ --> docs/types
+RewriteRule ^type\/(.*)$ docs/types
+
+# mapping/ --> docs/types
+RewriteRule ^mapping\/(.*)$ docs/mappings
+
+# types --> includes/types
+RewriteRule ^types(\/?)$ includes/types
+
+# mappings --> includes/mappings
+RewriteRule ^mappings(\/?)$ includes/mappings
+
+# types.sfx --> includes/types.sfx
+RewriteRule ^(types\.)(.+)$ includes/types.$2
+
+# mappings.sfx --> includes/mappings.sfx
+RewriteRule ^(mappings\.)(.+)$ includes/mappings.$2
+
+
+# Poor man's conneg
+# ------------------------------------
+RewriteCond %{HTTP_ACCEPT} ^text/turtle
+RewriteRule ^(.*/)([^./]+)$ $1$2.ttl [L]
+
+RewriteCond %{HTTP_ACCEPT} ^text/turtle
+RewriteRule ^(meta)$ meta.ttl [L]
+
+RewriteCond %{HTTP_ACCEPT} ^text/yaml
+RewriteRule ^(.*/)([^./]+)$ $1$2.yaml [L]
+
+RewriteCond %{HTTP_ACCEPT} ^text/yaml
+RewriteRule ^(meta)$ meta.yaml [L]
+
+RewriteCond %{HTTP_ACCEPT} ^application/json
+RewriteRule ^(.*/)([^./]+)$ $1$2.jsonld [L]
+
+RewriteCond %{HTTP_ACCEPT} ^application/json
+RewriteRule ^(meta)$ meta.jsonld [L]
+
+RewriteCond %{HTTP_ACCEPT} ^text/shex
+RewriteRule ^(.*/)([^./]+)$ $1$2.shex [L]
+
+RewriteCond %{HTTP_ACCEPT} ^text/shex
+RewriteRule ^(meta)$ meta.shex [L]
+
+# RewriteCond %{HTTP_ACCEPT} ^text/html
+# RewriteRule ^(.*/)[^./]+)$ $1$2.html [L]
+
+# RewriteCond %{HTTP_ACCEPT} ^text/html
+# RewriteRule ^(meta)$ meta.html [L]
+
+# Rewrite Base URL
+RewriteRule ^(.*)$ https://biolink.github.io/biolinkml/$1 [R=302,L]
+

--- a/linkml/.htaccess
+++ b/linkml/.htaccess
@@ -1,0 +1,77 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+
+# meta/ --> docs
+RewriteRule ^meta\/(.*)$ docs
+
+RewriteRule ^type\/(.*)$ docs/types
+
+# mapping/ --> docs/mappings
+RewriteRule ^mapping\/(.*)$ docs/mappings
+
+# extension/ --> docs/extensions
+RewriteRule ^extension\/(.*)$ docs/extensions
+
+# annotation/ --> docs/annotations
+RewriteRule ^annotation\/(.*)$ docs/annotations
+
+# types --> includes/types
+RewriteRule ^types(\/?)$ includes/types
+
+# mappings --> includes/mappings
+RewriteRule ^mappings(\/?)$ includes/mappings
+
+# extensions --> includes/extensions
+RewriteRule ^extensions(\/?)$ includes/extensions
+
+# annotations --> includes/annotations
+RewriteRule ^annotations(\/?)$ includes/annotations
+
+# types.sfx --> includes/types.sfx
+RewriteRule ^(types\.)(.+)$ includes/types.$2
+
+# mappings.sfx --> includes/mappings.sfx
+RewriteRule ^(mappings\.)(.+)$ includes/mappings.$2
+
+# extensions.sfx --> includes/extensions.sfx
+RewriteRule ^(extensions\.)(.+)$ includes/extensions.$2
+
+# annotations.sfx --> includes/annotations.sfx
+RewriteRule ^(annotations\.)(.+)$ includes/annotations.$2
+
+
+# Poor man's conneg
+# ------------------------------------
+RewriteCond %{HTTP_ACCEPT} ^text/turtle
+RewriteRule ^(.*/)([^./]+)$ $1$2.ttl [L]
+
+RewriteCond %{HTTP_ACCEPT} ^text/turtle
+RewriteRule ^(meta)$ meta.ttl [L]
+
+RewriteCond %{HTTP_ACCEPT} ^text/yaml
+RewriteRule ^(.*/)([^./]+)$ $1$2.yaml [L]
+
+RewriteCond %{HTTP_ACCEPT} ^text/yaml
+RewriteRule ^(meta)$ meta.yaml [L]
+
+RewriteCond %{HTTP_ACCEPT} ^application/json
+RewriteRule ^(.*/)([^./]+)$ $1$2.jsonld [L]
+
+RewriteCond %{HTTP_ACCEPT} ^application/json
+RewriteRule ^(meta)$ meta.jsonld [L]
+
+RewriteCond %{HTTP_ACCEPT} ^text/shex
+RewriteRule ^(.*/)([^./]+)$ $1$2.shex [L]
+
+RewriteCond %{HTTP_ACCEPT} ^text/shex
+RewriteRule ^(meta)$ meta.shex [L]
+
+# RewriteCond %{HTTP_ACCEPT} ^text/html
+# RewriteRule ^(.*/)[^./]+)$ $1$2.html [L]
+
+# RewriteCond %{HTTP_ACCEPT} ^text/html
+# RewriteRule ^(meta)$ meta.html [L]
+
+# Rewrite Base URL
+RewriteRule ^(.*)$ https://linkml.github.io/linkml/$1 [R=302,L]

--- a/linkml/README.md
+++ b/linkml/README.md
@@ -1,0 +1,12 @@
+LinkML
+======
+
+This will be the new home for the project formerly known as [biolinkml](https://biolink.github.io/biolinkml)
+
+
+Docs
+* https://linkml.github.io/linkml/ (TODO)
+
+Contact
+* Chris Mungall cjmungall AT lbl DOT gov @cmungall
+* Harold Solbrig @hsolbrig


### PR DESCRIPTION
We are currently splitting out the linkml namespace, which is currently a sub-namespace of biolink (see #1055) 

Note that we do not have github pages in place yet, but we thought it good to have the w3id redirects in place; apologies if this is premature

thanks cc @hsolbrig 
