### PR TITLE
Update rules in /ga4gh

### DIFF
--- a/ga4gh/.htaccess
+++ b/ga4gh/.htaccess
@@ -42,6 +42,11 @@ RewriteRule ^minutes/phenopackets$ https://docs.google.com/document/d/1gxRaduk2b
 # Refget links
 RewriteRule ^vr-refget(.+)$ https://193.62.54.154/$1 [R=302,B,L]
 RewriteRule ^serverless-refget(.+)$ https://cl9lba3no5.execute-api.us-east-2.amazonaws.com/Prod/$1 [R=302,B,L]
+RewriteRule ^refget$ https://github.com/ga4gh/large-scale-genomics-wiki/blob/master/refget.md [R=302,L]
+RewriteRule ^refget/reference(.+)$ https://refget.herokuapp.com/$1 [R=302,B,L]
+RewriteRule ^refget/compliance$ https://ga4gh.github.io/refget-compliance [R=302,L]
+RewriteRule ^refget/aws-container(.+)$ https://refget-insdc.jeremy-codes.com/$1 [R=302,B,L]
+RewriteRule ^refget/aws-serverless(.+)$ https://spjb6ejone.execute-api.us-east-2.amazonaws.com/Prod/$1 [R=302,B,L]
 
 # Discovery Links
 RewriteRule ^discovery/service-info-v1.yaml$ https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-info/develop/service-info.yaml [R=302,B,L]


### PR DESCRIPTION
Adding in a set of Refget URLs supporting a pre-print publication of refget. Adding a generic redirect to get to our cave entrance, redirects for compliance reports and to our implementations (2 on AWS and one on Heroku)