### PR TITLE
Fix trailing slashes in /ga4gh .htaccess

### DIFF
--- a/ga4gh/.htaccess
+++ b/ga4gh/.htaccess
@@ -40,13 +40,13 @@ RewriteRule ^minutes/case-discovery$ https://docs.google.com/document/d/1k-YyTA4
 RewriteRule ^minutes/phenopackets$ https://docs.google.com/document/d/1gxRaduk2bv6_cCSiDVJomVtfMD2AOFeDVGELsShh21U/edit?usp=sharing [R=302,L]
 
 # Refget links
-RewriteRule ^vr-refget(.+)$ https://193.62.54.154/$1 [R=302,B,L]
-RewriteRule ^serverless-refget(.+)$ https://cl9lba3no5.execute-api.us-east-2.amazonaws.com/Prod/$1 [R=302,B,L]
+RewriteRule ^vr-refget(.*)$ https://193.62.54.154$1 [R=302,L]
+RewriteRule ^serverless-refget(.*)$ https://cl9lba3no5.execute-api.us-east-2.amazonaws.com/Prod$1 [R=302,L]
 RewriteRule ^refget$ https://github.com/ga4gh/large-scale-genomics-wiki/blob/master/refget.md [R=302,L]
-RewriteRule ^refget/reference(.+)$ https://refget.herokuapp.com/$1 [R=302,B,L]
+RewriteRule ^refget/reference(.*)$ https://refget.herokuapp.com$1 [R=302,L]
 RewriteRule ^refget/compliance$ https://ga4gh.github.io/refget-compliance [R=302,L]
-RewriteRule ^refget/aws-container(.+)$ https://refget-insdc.jeremy-codes.com/$1 [R=302,B,L]
-RewriteRule ^refget/aws-serverless(.+)$ https://spjb6ejone.execute-api.us-east-2.amazonaws.com/Prod/$1 [R=302,B,L]
+RewriteRule ^refget/aws-container(.*)$ https://refget-insdc.jeremy-codes.com$1 [R=302,L]
+RewriteRule ^refget/aws-serverless(.*)$ https://spjb6ejone.execute-api.us-east-2.amazonaws.com/Prod$1 [R=302,L]
 
 # Discovery Links
 RewriteRule ^discovery/service-info-v1.yaml$ https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-info/develop/service-info.yaml [R=302,B,L]


### PR DESCRIPTION
A number of URLs had a trailing slash in their rewritten form. This was being interpreted by the rewrite code as an extra slash. We have also moved the capture to a 0 or many wildcard to allow for URLs without an extension to be used. All `B` directives have been removed as they were causing the redirected strings to become broken and unresolvable. Redirects have been tested on a local `httpd 2.4` docker image and were working