### PR TITLE
carsa-loci

### DIFF
--- a/carsa-loci/.htaccess
+++ b/carsa-loci/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine on
+
+RewriteRule (.*) https://carsa-loci.surroundaustralia.com/$1 [R=302,L]

--- a/carsa-loci/README.md
+++ b/carsa-loci/README.md
@@ -1,0 +1,19 @@
+# carsa-loci
+This `/carsa-loci/` path segment within `w3id.org` is used for creating persistent IRIs for _Linked Data_ system resources for the [Climate and Resilience Services Australia (CaRSA)](https://minister.awe.gov.au/ley/media-releases/australia-commits-climate-resilience) [Location Index (LocI)](https://www.ga.gov.au/locationindex) demonstrator system.
+
+Data for the CaRSA-LocI system uses persistent identifiers provided by the [Australian Government Linked Data Working Group](https://www.linked.data.gov.au) using the `linked.data.gov.au` persistent ID namespace, however that PID system doesn't provide system IRIs, thus W3ID is used.
+
+## Implementations
+The following list of PIDs are implemented within this namespace path segment:
+
+* [/](https://w3id.org/carsa-loci/) - system splash page
+* [/catalogue](https://w3id.org/carsa-loci/catalogue) - CaRSA-LocI resource catalogue
+* _... more to come..._
+
+## Contacts
+**Nicholas Car**  
+*Data Systems Architect*  
+SURROUND Australia Pty Ltd  
+<nicholas.car@surroundaustralia.com>  
+<http://surroundaustralia.com>  
+<https://orcid.org/0000-0002-8742-7730>  


### PR DESCRIPTION
A simple PID for a Linked Data system - CaRSA LocI.

These PIDs will be used to ensure that references to the CaRSA LocI system in papers and in catalogues don't break as the system gets handed from the builder (my company) to the operator (government department).