### PR TITLE
add new directory for Genomic Standards Consortium

### DIFF
--- a/gensc/.htaccess
+++ b/gensc/.htaccess
@@ -1,0 +1,3 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^(.*) https://gensc.org/ [R=307,L]

--- a/gensc/README.md
+++ b/gensc/README.md
@@ -1,0 +1,13 @@
+## Redirect for the Genomics Standards Consortium
+
+w3id.org/gensc
+
+This redirect is used to direct URIs for terms, checklists, packages and other documents related to GSC standards.
+
+The top-level redirects to the GSC website, which is currently house on a private server but will soon be hosted on github at https://github.com/GenomicsStandardsConsortium/gensc.github.io.
+
+The Minimum Information about any (x) sequence standards are the first to get permanent URIs and will be in a sub-domain of this redirect which is wid.org/gensc/mixs
+
+maintainer of this w3id:  Ramoan Walls rlwalls2008@gmail.org.
+
+Questions should be directed to https://github.com/GenomicsStandardsConsortium/mixs/issues.


### PR DESCRIPTION
We are requesting a new w3id redirect that will be used to redirect term and package URIs for the Genomics Standards Consortium.