### PR TITLE
added identifier space for /madmp/

### DIFF
--- a/madmp/.htaccess
+++ b/madmp/.htaccess
@@ -1,0 +1,4 @@
+Options +FollowSymLinks
+RewriteEngine on
+#Set of rules for the applications (302, no Content negotiation)
+RewriteRule ^$ https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard [R=302,L]

--- a/madmp/README.md
+++ b/madmp/README.md
@@ -1,0 +1,11 @@
+# Permanent identifier space for the Machine Actionable Data Managment Plans (maDMP) Common Standard
+
+This namespace covers the documentation for the [Machine Actionable Data Managment Plans (maDMP) Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard) developed by the [RDA DMP Common Standard WG](https://www.rd-alliance.org/groups/dmp-common-standards-wg)
+
+This project is managed by the co-Chairs of the RDA DMP Common Standard WG:
+
+* Tomasz Miksa (tomasz.miksa@tuwien.ac.at)
+* Paul Walk (paul@paulwalk.net)
+* Peter Neish (peter.neish@unimelb.edu.au)
+
+


### PR DESCRIPTION
This namespace covers the documentation for the [Machine Actionable Data Managment Plans (maDMP) Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard) developed by the [RDA DMP Common Standard WG](https://www.rd-alliance.org/groups/dmp-common-standards-wg)

This project is managed by the co-Chairs of the RDA DMP Common Standard WG:

* Tomasz Miksa (tomasz.miksa@tuwien.ac.at)
* Paul Walk (paul@paulwalk.net)
* Peter Neish (peter.neish@unimelb.edu.au)
