### PR TITLE
add redirects for version 1.0

### DIFF
--- a/gso/.htaccess
+++ b/gso/.htaccess
@@ -3,7 +3,8 @@ RewriteEngine on
 
 # .htaccess rewrite rule tester (doen't do HTTP:Accept header conditions)  https://htaccess.madewithlove.be/
 # Rewrite rule to serve turtle content from the vocabulary URI if requested
-#  https://rawcdn.githack.com/Loop3D/GKM/21bfaae4fc3c281d74b0a9212f8dd70bd6cd97ff/Loop3D-GSO/Examples/GSO-ExampleComplexContacts.ttl
+#  unversioned URIs (https://w3id.org/gso/.... )will resolve here to the current master branch in githup
+
 RewriteCond %{HTTP:Accept} text/turtle [NC]
 RewriteRule       ^ex-complexcontact(/$|/ontology$){1}         https://rawcdn.githack.com/Loop3D/GKM/21bfaae4fc3c281d74b0a9212f8dd70bd6cd97ff/Loop3D-GSO/Examples/GSO-ExampleComplexContacts.ttl [R=303,L]
 RewriteCond %{HTTP:Accept} text/turtle [NC]

--- a/gso/1.0/.htaccess
+++ b/gso/1.0/.htaccess
@@ -1,0 +1,264 @@
+Options +FollowSymLinks
+RewriteEngine on 
+
+# .htaccess rewrite rule tester (doen't do HTTP:Accept header conditions)  https://htaccess.madewithlove.be/
+# Rewrite rule to serve turtle content from the vocabulary URI if requested
+#  https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleComplexContacts.ttl
+# update bug fix number if there are bug fixes. all http://w3id.org/gso/1.0/.... URIs will resolve here
+
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^ex-complexcontact(/$|/ontology$){1}         https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleComplexContacts.ttl [R=303,L]
+                                                                
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^ex-event1(/$|/ontology$){1}                 https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleEvents1.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^ex-stratlexicon2-bc(/$|/ontology$){1}       https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleBritishColumbiaStrat-v2.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^ex-timelowerjurassic(/$|/ontology$){1}      https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleEpochLowerJurassic.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^ex-faults(/$|/ontology$){1}                 https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleFault2.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^faultKannaV4Model(/$|/ontology$){1}         https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleFaultKannaV4Model.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^foldexample(/$|/ontology$){1}               https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleFold.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^ex-formationJs(/$|/ontology$){1}            https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleFormationJs.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^ex-ausstratunit(/$|/ontology$){1}           https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleGeosciAustraliaStratUnit.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^ex-history(/$|/ontology$){1}                https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleHistory.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^ex-islewightstrat(/$|/ontology$){1}         https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleIsleOfWightStrat-pm1.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^ex-plutontojiza(/$|/ontology$){1}           https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleLaTojizaPluton.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^ex-petrophysics-bc(/$|/ontology$){1}        https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExamplePetrophysicalProperties_v2.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^ex-materialCb(/$|/ontology$){1}             https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleRockMaterialBolsaQuartzite.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^ex-roles(/$|/ontology$){1}                  https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleRoles.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^alterationtype-bc(/$|/ontology$){1}         https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleVocabularyExtension-Alteration_Type-BC.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^ec-lardeaustrat(/$|/ontology$){1}           https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-LardeauGroup.ttl [R=303,L]
+
+
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^master(/$|/ontology$){1}                   https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/GSO-Master.ttl [R=303,L]
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^common(/$|/ontology$){1}                   https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/GSO-Common.ttl [R=303,L]
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^geology(/$|/ontology$){1}                  https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/GSO-Geology.ttl [R=303,L]
+
+#  https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Mineral.ttl
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^element(/$|/ontology$){1}                  https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Element.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^feature(/$|/ontology$){1}                  https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Feature.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^geologicevent(/$|/ontology$){1}            https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Event.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^geologicfeature(/$|/ontology$){1}          https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Feature.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^granularmaterial(/$|/ontology$){1}         https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Granular_Material.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^mineral(/$|/ontology$){1}                  https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Mineral.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^geologicprocess(/$|/ontology$){1}          https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Process.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^geologicquality(/$|/ontology$){1}          https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Quality.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^geologicreferencesystem(/$|/ontology$){1}  https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Reference_System.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^geologicrelation(/$|/ontology$){1}         https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Relation.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^rockmaterial(/$|/ontology$){1}             https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Rock_Material.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^rockobject(/$|/ontology$){1}               https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Rock_Object.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^geologicrole(/$|/ontology$){1}             https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Role.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^geologicsetting(/$|/ontology$){1}          https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Setting.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^geologiccontact(/$|/ontology$){1}          https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Structure_Contact.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^geologicfault(/$|/ontology$){1}            https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Structure_Fault.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^geologicfold(/$|/ontology$){1}             https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Structure_Fold.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^geologicfoliation(/$|/ontology$){1}        https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Structure_Foliation.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^geologiclineation(/$|/ontology$){1}        https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Structure_Lineation.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^geologicstructure(/$|/ontology$){1}        https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Structure.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^ischart(/$|/ontology$){1}                  https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Time_Ischart.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^geologictime(/$|/ontology$){1}             https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Time.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^geologicunit(/$|/ontology$){1}             https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Unit.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^hydrology(/$|/ontology$){1}                https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Hydrology.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^perdurant(/$|/ontology$){1}                https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Perdurant.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^quality(/$|/ontology$){1}                  https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Quality.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^qudt/voc(/$|/ontology$){1}                 https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-QUDTvoc.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^skos/annotation(/$|/ontology$){1}          https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-skos_annotation.ttl [R=303,L]
+
+# Choose the default response
+# ---------------------------
+#allow .ttl or .html file extensions
+
+RewriteRule       ^ex-complexcontact/ontology.ttl         https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleComplexContacts.ttl [R=303,L]
+
+RewriteRule       ^ex-event1/ontology.ttl                 https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleEvents1.ttl [R=303,L]
+
+RewriteRule       ^ex-stratlexicon2-bc/ontology.ttl       https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleBritishColumbiaStrat-v2.ttl [R=303,L]
+
+RewriteRule       ^ex-timelowerjurassic/ontology.ttl      https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleEpochLowerJurassic.ttl [R=303,L]
+
+RewriteRule       ^ex-faults/ontology.ttl                 https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleFault2.ttl [R=303,L]
+
+RewriteRule       ^faultKannaV4Model/ontology.ttl         https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleFaultKannaV4Model.ttl [R=303,L]
+
+RewriteRule       ^foldexample/ontology.ttl               https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleFold.ttl [R=303,L]
+
+
+RewriteRule       ^ex-formationJs/ontology.ttl            https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleFormationJs.ttl [R=303,L]
+
+RewriteRule       ^ex-ausstratunit/ontology.ttl           https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleGeosciAustraliaStratUnit.ttl [R=303,L]
+
+RewriteRule       ^ex-history/ontology.ttl                https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleHistory.ttl [R=303,L]
+
+RewriteRule       ^ex-islewightstrat/ontology.ttl         https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleIsleOfWightStrat-pm1.ttl [R=303,L]
+
+RewriteRule       ^ex-plutontojiza/ontology.ttl           https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleLaTojizaPluton.ttl [R=303,L]
+
+RewriteRule       ^ex-petrophysics-bc/ontology.ttl        https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExamplePetrophysicalProperties_v2.ttl [R=303,L]
+
+RewriteRule       ^ex-materialCb/ontology.ttl             https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleRockMaterialBolsaQuartzite.ttl [R=303,L]
+
+RewriteRule       ^ex-roles/ontology.ttl                  https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleRoles.ttl [R=303,L]
+
+RewriteRule       ^alterationtype-bc/ontology.ttl         https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-ExampleVocabularyExtension-Alteration_Type-BC.ttl [R=303,L]
+
+RewriteRule       ^ec-lardeaustrat/ontology.ttl           https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Examples/GSO-LardeauGroup.ttl [R=303,L]
+
+RewriteRule       ^master/ontology.ttl        https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/GSO-Master.ttl [R=303,L]
+RewriteRule       ^common/ontology.ttl        https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/GSO-Common.ttl [R=303,L]
+RewriteRule       ^geology/ontology.ttl       https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/GSO-Geology.ttl [R=303,L]
+
+RewriteRule       ^element/ontology.ttl       https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Element.ttl [R=303,L]
+
+RewriteRule       ^feature/ontology.ttl       https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Feature.ttl [R=303,L]
+
+RewriteRule       ^geologicevent/ontology.ttl            https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Event.ttl [R=303,L]
+
+RewriteRule       ^geologicfeature/ontology.ttl          https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Feature.ttl [R=303,L]
+
+RewriteRule       ^granularmaterial/ontology.ttl         https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Granular_Material.ttl [R=303,L]
+
+RewriteRule       ^mineral/ontology.ttl                  https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Mineral.ttl [R=303,L]
+
+RewriteRule       ^geologicprocess/ontology.ttl          https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Process.ttl [R=303,L]
+
+RewriteRule       ^geologicquality/ontology.ttl          https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Quality.ttl [R=303,L]
+
+RewriteRule       ^geologicreferencesystem/ontology.ttl  https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Reference_System.ttl [R=303,L]
+
+RewriteRule       ^geologicrelation/ontology.ttl         https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Relation.ttl [R=303,L]
+
+RewriteRule       ^rockmaterial/ontology.ttl             https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Rock_Material.ttl [R=303,L]
+
+RewriteRule       ^rockobject/ontology.ttl               https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Rock_Object.ttl [R=303,L]
+
+RewriteRule       ^geologicrole/ontology.ttl             https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Role.ttl [R=303,L]
+
+RewriteRule       ^geologicsetting/ontology.ttl          https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Setting.ttl [R=303,L]
+
+RewriteRule       ^geologiccontact/ontology.ttl          https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Structure_Contact.ttl [R=303,L]
+
+RewriteRule       ^geologicfault/ontology.ttl            https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Structure_Fault.ttl [R=303,L]
+
+RewriteRule       ^geologicfold/ontology.ttl             https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Structure_Fold.ttl [R=303,L]
+
+RewriteRule       ^geologicfoliation/ontology.ttl        https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Structure_Foliation.ttl [R=303,L]
+
+RewriteRule       ^geologiclineation/ontology.ttl        https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Structure_Lineation.ttl [R=303,L]
+
+RewriteRule       ^geologicstructure/ontology.ttl        https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Structure.ttl [R=303,L]
+
+RewriteRule       ^ischart/ontology.ttl                  https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Time_Ischart.ttl [R=303,L]
+
+RewriteRule       ^geologictime/ontology.ttl             https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Time.ttl [R=303,L]
+
+RewriteRule       ^geologicunit/ontology.ttl             https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Geologic_Unit.ttl [R=303,L]
+
+RewriteRule       ^hydrology/ontology.ttl                https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Hydrology.ttl [R=303,L]
+
+RewriteRule       ^perdurant/ontology.ttl                https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Perdurant.ttl [R=303,L]
+
+RewriteRule       ^quality/ontology.ttl      https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-Quality.ttl [R=303,L]
+RewriteRule       ^qudt/voc/ontology.ttl     https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-QUDTvoc.ttl [R=303,L]
+
+RewriteRule       ^skos/annotation/ontology.ttl          https://rawcdn.githack.com/Loop3D/GKM/1.0.2/Loop3D-GSO/Modules/GSO-skos_annotation.ttl [R=303,L]
+
+# html pages for the release are in the /docs for the release
+
+
+RewriteRule    ^skos/annotation/ontology.html$     https://rawcdn.githack.com/Loop3D/GKM/1.0.2/docs/skos_annotation.html   [R=303,L]
+RewriteRule    ^qudt/voc/ontology.html$     https://rawcdn.githack.com/Loop3D/GKM/1.0.2/docs/qudt_voc.html  [R=303,L]
+RewriteRule    ^([a-z-]+)/ontology.html$    https://rawcdn.githack.com/Loop3D/GKM/1.0.2/docs/$1.html [R=303,L]
+
+#handle classes and properties; redirect will go to html representation of the module if the fragment ID generated by pyLODE is not the same as the URI final token.
+RewriteRule    ^([a-z-]+)/([A-Za-z_]+)$     https://rawcdn.githack.com/Loop3D/GKM/1.0.2/docs/$1.html#$2 [NE,R=303,L]
+
+# final default is html
+RewriteRule       ^([a-z-]*)(/$|/ontology$){1}                 https://rawcdn.githack.com/Loop3D/GKM/1.0.2/docs/$1.html [R=303,L]

--- a/gso/1.0/README.md
+++ b/gso/1.0/README.md
@@ -1,0 +1,16 @@
+
+# /gso/1.0
+
+**Name of the project:** [GeoScienceOntology Loop3d version 1.0](https://github.com/Loop3D/GKM)
+
+**Description:** redirects for Geoscience Ontology.  This ontology for describes Geologic features, properties and relationships.
+
+catches https://w3id.org/gso/1.0/....
+
+Redirects /, /ontology and /ontology.html to pyLODE generated html pages in the Loop3D.github.io/GKM site.
+/{class or property} gets redirected to the html page for the containing module
+Accept text/turtle in header or /ontology.ttl gets the turtle file for the module. Use [githack](https://raw.githack.com/) production URLs to return .ttl files with proper HTTP headers.
+
+**Contacts:**
+* Stephen Richard <smrTucson@gmail.com> - GitHub: https://github.com/smrgeoinfo
+* Boyan Brodaric  


### PR DESCRIPTION
make sub folder for version 1, minor .0.  
Will update redirects for bug fixes. gso/1.0 uris redirected here; URI w/0 version number will go to github master for ttl and https://loop3d.github.io/GKM/ for html. 