### PR TITLE
Fix redirects for Gaia-X

### DIFF
--- a/gaia-x/.htaccess
+++ b/gaia-x/.htaccess
@@ -17,12 +17,9 @@ RewriteEngine on
 RewriteRule ^$ https://data-infrastructure.eu/ [R=303]
 
 # Direct ontology access: Access respective ontology
-RewriteRule ^core.ttl$      https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/ontology.ttl [L,R=303]
-RewriteRule ^core.rdf$      https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/ontology.xml [L,R=303]
-RewriteRule ^core.xml$      https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/ontology.xml [L,R=303]
-RewriteRule ^core.jsonld$   https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/ontology.json [L,R=303]
-RewriteRule ^core.json$     https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/ontology.json [L,R=303]
-RewriteRule ^core.nt$       https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/ontology.nt [L,R=303]
+RewriteRule ^(core|asset|node|participant|service).(ttl|xml|json|nt)$      https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/\g1/ontology.\g2 [L,R=303]
+RewriteRule ^(core|asset|node|participant|service).rdf$      https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/\g1.xml [L,R=303]
+RewriteRule ^(core|asset|node|participant|service).jsonld$   https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/\g2.json [L,R=303]
 
 # HTML: Visit documentation
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*|\*/\*)
@@ -30,53 +27,53 @@ RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/\*
-RewriteRule ^core           https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/index.html [L,NE,R=303]
+RewriteRule ^(core|asset|node|participant|service)           https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/\g1/\g1.html [L,NE,R=303]
 
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*|\*/\*)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/\*
-RewriteRule ^core/(.*)$     https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/index.html#$1 [L,NE,R=303]
+RewriteRule ^(core|asset|node|participant|service)/(.*)$     https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/\g1/\g1.html#$1 [L,NE,R=303]
 
 # TURTLE: Access TTL ontology
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.*
 RewriteRule ^core           https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/ontology.ttl [L,R=303]
 
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.*
-RewriteRule ^core/(.*)      https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/ontology.ttl [L,R=303]
+RewriteRule ^(core|asset|node|participant|service)/(.*)      https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/\g1/ontology.ttl [L,R=303]
 
 # RDF/XML: Access XML ontology
 RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*  [OR]
 RewriteCond %{HTTP_ACCEPT} ^.*application/xml.* [OR]
 RewriteCond %{HTTP_ACCEPT} ^.*text/xml.*
-RewriteRule ^core           https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/ontology.xml [L,R=303]
+RewriteRule ^(core|asset|node|participant|service)           https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/\g1/ontology.xml [L,R=303]
 
 RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*  [OR]
 RewriteCond %{HTTP_ACCEPT} ^.*application/xml.* [OR]
 RewriteCond %{HTTP_ACCEPT} ^.*text/xml.*
-RewriteRule ^core/(.*)      https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/ontology.xml [L,R=303]
+RewriteRule ^(core|asset|node|participant|service)/(.*)      https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/\g1/ontology.xml [L,R=303]
 
 # JSON-LD: Access JSON(-LD) ontology
 RewriteCond %{HTTP_ACCEPT} ^.*application/ld\+json.*
-RewriteRule ^core           https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/ontology.json [L,R=303]
+RewriteRule ^(core|asset|node|participant|service)           https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/\g1/ontology.json [L,R=303]
 
 RewriteCond %{HTTP_ACCEPT} ^.*application/ld\+json.*
-RewriteRule ^core/(.*)      https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/ontology.json [L,R=303]
+RewriteRule ^(core|asset|node|participant|service)/(.*)      https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/\g1/ontology.json [L,R=303]
 
 # JSON: Access JSON ontology
 RewriteCond %{HTTP_ACCEPT} ^.*application/json.*
-RewriteRule ^core           https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/ontology.json [L,R=303]
+RewriteRule ^(core|asset|node|participant|service)           https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/\1/ontology.json [L,R=303]
 
 RewriteCond %{HTTP_ACCEPT} ^.*application/json.*
-RewriteRule ^core/(.*)      https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/ontology.json [L,R=303]
+RewriteRule ^(core|asset|node|participant|service)/(.*)      https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/\g1/ontology.json [L,R=303]
 
 # N-TRIPLES: Access NT ontology
 RewriteCond %{HTTP_ACCEPT} ^.*application/n-triples.*
-RewriteRule ^core           https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/ontology.nt [L,R=303]
+RewriteRule ^(core|asset|node|participant|service)           https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/\g1/ontology.nt [L,R=303]
 
 RewriteCond %{HTTP_ACCEPT} ^.*application/n-triples.*
-RewriteRule ^core/(.*)      https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/ontology.nt [L,R=303]
+RewriteRule ^(core|asset|node|participant|service)/(.*)      https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/\g1/ontology.nt [L,R=303]
 
 # No matching content type: Visit documentation
-RewriteRule ^core/(.*)      https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/index.html#$1 [L,NE,R=303]
+RewriteRule ^(core|asset|node|participant|service)/(.*)      https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/\g1/index.html#$1 [L,NE,R=303]

--- a/gaia-x/README.md
+++ b/gaia-x/README.md
@@ -22,7 +22,7 @@ Redirections:
   * --> https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/ontology.ttl (or rdf, json, ...)
 
 Support:
-* [GitLab Repository (currently restricted to the GAIA-X community)](https://gitlab.com/gaia-x/gaia-x-community/gaia-x-self-descriptions)
+* GAIA-X Open Work Package "Self-Description" and their [GitLab Repository (currently restricted to the GAIA-X community)](https://gitlab.com/gaia-x/gaia-x-community/gaia-x-self-descriptions)
 
 Contacts:
 * [Johannes Lipp](https://gitlab.com/JohannesL) <johannes.lipp@fit.fraunhofer.de>

--- a/gaia-x/README.md
+++ b/gaia-x/README.md
@@ -9,17 +9,17 @@ Redirections:
   * https://w3id.org/gaia-x
   * --> https://data-infrastructure.eu/
 * Direct ontology access: Access respective ontology
-  * https://w3id.org/gaia-x/core.ttl (or rdf, json, ...)
-  * --> https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/ontology.ttl (or rdf, json, ...)
+  * https://w3id.org/gaia-x/[core|asset|...].ttl (or rdf, json, ...)
+  * --> https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/[core|asset|...]/ontology.ttl (or rdf, json, ...)
 * HTML: Visit documentation
-  * https://w3id.org/gaia-x/core
-  * --> https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/index.html
+  * https://w3id.org/gaia-x/[core|asset|...]
+  * --> https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/[core|asset|...]/*.html
   * ...and...
-  * https://w3id.org/gaia-x/core/Class
-  * --> https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/index.html#Class (jumps to position for convenience)
+  * https://w3id.org/gaia-x/[core|asset|...]/Class
+  * --> https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/[core|asset|...]/*.html#Class (jumps to position for convenience)
 * Accept [ttl/rdf/xml/json-ld/json/nt]: Access respective ontology as whole
-  * https://w3id.org/gaia-x/core or https://w3id.org/gaia-x/core/Class
-  * --> https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/ontology.ttl (or rdf, json, ...)
+  * https://w3id.org/gaia-x/[core|asset|...] or https://w3id.org/gaia-x/[core|asset|...]/Class
+  * --> https://gaia-x.gitlab.io/gaia-x-community/gaia-x-self-descriptions/[core|asset|...]/ontology.ttl (or rdf, json, ...)
 
 Support:
 * GAIA-X Open Work Package "Self-Description" and their [GitLab Repository (currently restricted to the GAIA-X community)](https://gitlab.com/gaia-x/gaia-x-community/gaia-x-self-descriptions)


### PR DESCRIPTION
Fix a bad sytax of regex capture group referencing (i.e., `$1` instead of `\g1`).