### PR TITLE
Add multikey 2021

### DIFF
--- a/security/.htaccess
+++ b/security/.htaccess
@@ -39,10 +39,10 @@ RewriteRule ^suites/hmac-2019$ https://digitalbazaar.github.io/sha256-hmac-key-2
 RewriteRule ^suites/hmac-2019/v1$ https://digitalbazaar.github.io/sha256-hmac-key-2019-context/contexts/sha256-hmac-2019-v1.jsonld [R=302,L]
 
 
-# http://w3id.org/security/suites/multibase-2021
+# http://w3id.org/security/suites/multikey-2021
 
-RewriteRule ^suites/multibase-2021$ https://ns.did.ai/suites/multibase-2021 [R=302,L]
-RewriteRule ^suites/multibase-2021/v1$ https://ns.did.ai/suites/multibase-2021/v1 [R=302,L]
+RewriteRule ^suites/multikey-2021$ https://ns.did.ai/suites/multikey-2021 [R=302,L]
+RewriteRule ^suites/multikey-2021/v1$ https://ns.did.ai/suites/multikey-2021/v1 [R=302,L]
 
 # http://w3id.org/security/suites/secp256k1recovery-2020
 

--- a/security/.htaccess
+++ b/security/.htaccess
@@ -38,6 +38,12 @@ RewriteRule ^suites/aes-2019/v1$ https://digitalbazaar.github.io/aes-key-wrappin
 RewriteRule ^suites/hmac-2019$ https://digitalbazaar.github.io/sha256-hmac-key-2019-context [R=302,L]
 RewriteRule ^suites/hmac-2019/v1$ https://digitalbazaar.github.io/sha256-hmac-key-2019-context/contexts/sha256-hmac-2019-v1.jsonld [R=302,L]
 
+
+# http://w3id.org/security/suites/multibase-2021
+
+RewriteRule ^suites/multibase-2021$ https://ns.did.ai/suites/multibase-2021 [R=302,L]
+RewriteRule ^suites/multibase-2021/v1$ https://ns.did.ai/suites/multibase-2021/v1 [R=302,L]
+
 # http://w3id.org/security/suites/secp256k1recovery-2020
 
 RewriteRule ^suites/secp256k1recovery-2020$ https://identity.foundation/EcdsaSecp256k1RecoverySignature2020/ [R=302,L]


### PR DESCRIPTION
This PR is sadly necessary to handle cases where there is no JSON-LD support for standard NIST curves like P256.

I did my best not to trigger you @msporny but we can't possible support did:key without this, hopefully its acceptable.

My sense is that the LD Sec WG Suite imp guide will have a large section on best practices in this regard, and we can elaborate on the pro's and con's of `type` there.