### PR TITLE
Remove all security suites not under /security/suites

### DIFF
--- a/security/.htaccess
+++ b/security/.htaccess
@@ -10,17 +10,6 @@ RewriteRule ^v2$ https://w3c-ccg.github.io/security-vocab/contexts/security-v2.j
 
 RewriteRule ^v3-unstable$ https://w3c-ccg.github.io/security-vocab/contexts/security-v3-unstable.jsonld [R=302,L]
 
-# TODO: remove "suites" not rooted under  "suites"
-
-RewriteRule ^jws$ https://w3c-ccg.github.io/lds-jws2020/ [R=302,L]
-RewriteRule ^jws/v1$ https://w3c-ccg.github.io/lds-jws2020/contexts/v1/ [R=302,L]
-RewriteRule ^pgp$ https://or13.github.io/lds-pgp2021/ [R=302,L]
-RewriteRule ^pgp/v1$ https://or13.github.io/lds-pgp2021/contexts/pgp-v1.jsonld [R=302,L]
-RewriteRule ^bbs$ https://github.com/w3c-ccg/ldp-bbs2020/ [R=302,L]
-RewriteRule ^bbs/v1$ https://w3c-ccg.github.io/ldp-bbs2020/contexts/v1/ [R=302,L]
-RewriteRule ^blockchain$ https://or13.github.io/lds-blockchain2021/ [R=302,L]
-RewriteRule ^blockchain/v1$ https://or13.github.io/lds-blockchain2021/contexts/blockchain-v1.jsonld [R=302,L]
-
 # https://w3id.org/security/suites
 
 # TODO: update registry to reflect this file.


### PR DESCRIPTION
@msporny @dlongley @tplooker @dmitrizagidulin 

This PR removes any chance that our non suite "suite" registries will continue to survive... I think its worth it, but expect it might break a few things.