### PR TITLE
Fix /vc-http-api/test-suite/

### DIFF
--- a/vc-http-api/.htaccess
+++ b/vc-http-api/.htaccess
@@ -5,6 +5,6 @@ RewriteEngine on
 
 RewriteRule ^$ https://w3c-ccg.github.io/vc-http-api/ [R=302,L]
 
-RewriteRule ^/test-suite/(.*)$ https://w3c-ccg.github.io/vc-http-api/test-suite/$1 [R=302,L]
+RewriteRule ^test-suite/(.*)$ https://w3c-ccg.github.io/vc-http-api/test-suite/$1 [R=302,L]
 
 


### PR DESCRIPTION
The route added in #2211 for `/vc-http-api/test-suite` is not working:
```
$ curl https://w3id.org/vc-http-api/test-suite/testResults.json
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>404 Not Found</title>
</head><body>
<h1>Not Found</h1>
<p>The requested URL was not found on this server.</p>
<hr>
<address>Apache/2.4.29 (Ubuntu) Server at w3id.org Port 443</address>
</body></html>
```
I expected instead a redirect to <https://w3c-ccg.github.io/vc-http-api/test-suite/testResults.json>.

I think this change (removing the leading slash) should fix it.

cc @OR13 @davidlehn