### PR TITLE
fixed another problem with landing URL

### DIFF
--- a/67375/.htaccess
+++ b/67375/.htaccess
@@ -11,4 +11,4 @@ AddType application/ld+json .jsonld
 RewriteEngine On
 
 # test.skohub 67375
-RewriteRule ^TSO/(.*) https://skohub.io/raphlap/test_so/heads/main/w3id.org/67375/$1 [R=302,L]
+RewriteRule ^TSO/(.*) https://skohub.io/raphlap/test_so/heads/main/w3id.org/67375/TSO/$1 [R=302,L]


### PR DESCRIPTION
Right now https://w3id.org/67375/TSO/B4WKXG50-6 is redirecting on https://skohub.io/raphlap/test_so/heads/main/w3id.org/67375/B4WKXG50-6 (which gives a 404) instead of https://skohub.io/raphlap/test_so/heads/main/w3id.org/67375/TSO/B4WKXG50-6 (which works properly). Hopefully this commit should fix it ?
It seems that I hadn't completely understood how the redirection is working.