### PR TITLE
update BOT redirects and readme 

### DIFF
--- a/bot/.htaccess
+++ b/bot/.htaccess
@@ -12,39 +12,84 @@ AddType text/n3 .n3
 AddType application/n-triples .nt
 AddType application/ld+json .json
 
-### internal redirection for home page
 
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml|text/turtle|text/n3|application/n-triples|application/ld\+json
-RewriteRule  ^/?$  bot
+### Rewrite rules for latest version
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://w3c-lbd-cg.github.io/bot/ [R=303,L]
 
-RewriteCond %{HTTP_ACCEPT} !(application/rdf\+xml|text/turtle|text/n3|application/n-triples|application/ld\+json)
-RewriteRule  ^/?$  index.html
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle 
+RewriteRule ^$ https://w3c-lbd-cg.github.io/bot/bot.ttl [R=303,L]
 
-### internal redirection to append extension for content negotiation
-
-# redirects requests for a particular bot version to the canonical Turtle representation
-RewriteCond %{HTTP_ACCEPT} !(text/html)
-RewriteRule  ^/?-?([0-9]+\.[0-9]+\.[0-9]+)$  bot-$1.ttl [L]
-
-# redirects .*/abcd to .*/abcd.html
-RewriteCond %{HTTP_ACCEPT} !(application/rdf\+xml|text/turtle|text/n3|application/n-triples|application/ld\+json)
-RewriteRule  ^(.*/)?([^\./]*)$  $1$2.html [L]
-
-RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule  ^(.*/)?([^\./]*)$  $1$2.ttl [L]
-
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule  ^(.*/)?([^\./]*)$  $1$2.jsonld [L]
+RewriteRule ^$ https://w3c-lbd-cg.github.io/bot/bot.jsonld [R=303,L]
 
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule  ^(.*/)?([^\./]*)$  $1$2.rdf [L]
+RewriteRule ^$ https://w3c-lbd-cg.github.io/bot/bot.rdf [R=303,L]
 
-RewriteCond %{HTTP_ACCEPT} text/n3
-RewriteRule  ^(.*/)?([^\./]*)$  $1$2.n3 [L]
-
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule  ^(.*/)?([^\./]*)$  $1$2.nt [L]
+RewriteRule ^$ https://w3c-lbd-cg.github.io/bot/bot.nt [R=303,L]
 
-### external redirections
+# Rewrite rule to serve N3 content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} ^.*text/n3.* [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/n3 
+RewriteRule ^$ https://w3c-lbd-cg.github.io/bot/bot.n3 [R=303,L]
 
-RewriteRule ^(.*)$ https://w3c-lbd-cg.github.io/bot/$1 [R=302,L]
+# If suffix ttl, redirect to turtle version
+RewriteRule ^bot.ttl$ https://w3c-lbd-cg.github.io/bot/bot.ttl [R=303,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^bot.html$ https://w3c-lbd-cg.github.io/bot/ [R=303,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^bot.rdf$ https://w3c-lbd-cg.github.io/bot/bot.rdf [R=303,L]
+
+# If suffix jsonld, redirect to jsonld version
+RewriteRule ^bot.jsonld$ https://w3c-lbd-cg.github.io/bot/bot.jsonld [R=303,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^bot.nt$ https://w3c-lbd-cg.github.io/bot/bot.nt [R=303,L]
+
+# If suffix n3, redirect to N3 version
+RewriteRule ^bot.n3$ https://w3c-lbd-cg.github.io/bot/bot.n3 [R=303,L]
+
+
+### Rewrite rules for any other version
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^bot-?([0-9]+\.[0-9]+\.[0-9]+)$ https://w3c-lbd-cg.github.io/bot/bot-$1.ttl [R=302,NE,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^bot-?([0-9]+\.[0-9]+\.[0-9]+)$ https://w3c-lbd-cg.github.io/bot/bot-$1.jsonld [R=302,NE,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^bot-?([0-9]+\.[0-9]+\.[0-9]+)$ https://w3c-lbd-cg.github.io/bot/bot-$1.rdf [R=302,NE,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^bot-?([0-9]+\.[0-9]+\.[0-9]+)$ https://w3c-lbd-cg.github.io/bot/bot-$1.nt [R=302,NE,L]
+
+# Rewrite rule to serve N3 content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} ^.*text/n3.* [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/n3 
+RewriteRule ^bot-?([0-9]+\.[0-9]+\.[0-9]+)$ https://w3c-lbd-cg.github.io/bot/bot-$1.n3 [R=302,NE,L]
+
+### Default response
+RewriteRule ^$ https://w3c-lbd-cg.github.io/bot/ [R=303,L]

--- a/bot/README.md
+++ b/bot/README.md
@@ -12,3 +12,7 @@ Contacts
 * Pieter Pauwels <pipauwel.pauwels@ugent.be>
 * Maxime Lefrançois <maxime.lefrancois@emse.fr>
 * Georg Schneider <georg.schneider@ibp.fraunhofer.de>
+* Mathias Bonduel <mathias.bonduel@kuleuven.be>
+* Anna Wagner <annawagner1337@gmail.com>
+* Katja Breitenfelder <katja.breitenfelder@ibp.fraunhofer.de>
+* Karl Hammer <karl.hammar@ju.se>

--- a/bot/README.md
+++ b/bot/README.md
@@ -15,4 +15,4 @@ Contacts
 * Mathias Bonduel <mathias.bonduel@kuleuven.be>
 * Anna Wagner <annawagner1337@gmail.com>
 * Katja Breitenfelder <katja.breitenfelder@ibp.fraunhofer.de>
-* Karl Hammer <karl.hammar@ju.se>
+* Karl Hammar <karl.hammar@ju.se>


### PR DESCRIPTION
Dear w3id maintainers,

I just uploaded a new, tested version of the .htaccess file:

* added N3 serialization redirects
* versioned IRIs of BOT - tested to work with Protégé

The readme file is also updated, listing the new chairs of the [W3C Linked Building Data Community Group](https://www.w3.org/community/lbd/), including myself

Kind regards,

Mathias Bonduel