### PR TITLE
Add EthereumEip712Signature2021 to security

### DIFF
--- a/security/.htaccess
+++ b/security/.htaccess
@@ -57,6 +57,11 @@ RewriteRule ^suites/jws-2020/v1$ https://w3c-ccg.github.io/lds-jws2020/contexts/
 RewriteRule ^suites/bls12381-2020$ https://w3c-ccg.github.io/ldp-bbs2020/ [R=302,L]
 RewriteRule ^suites/bls12381-2020/v1$ https://w3c-ccg.github.io/ldp-bbs2020/contexts/v1 [R=302,L]
 
+# http://w3id.org/security/suites/eip712sig-2021
+
+RewriteRule ^suites/eip712sig-2021$ https://w3c-ccg.github.io/ethereum-eip712-signature-2021-spec [R=302,L]
+RewriteRule ^suites/eip712sig-2021/v1$ https://w3c-ccg.github.io/ethereum-eip712-signature-2021-spec/contexts/v1 [R=302,L]
+
 # http://w3id.org/security/suites/secp256k1-2020
 
 RewriteRule ^suites/secp256k1-2020$ https://ns.did.ai/suites/secp256k1-2020 [R=302,L]


### PR DESCRIPTION
The target context file is being added in https://github.com/w3c-ccg/ethereum-eip712-signature-2021-spec/pull/22