### PR TITLE
yarrrml: add repository link

### DIFF
--- a/yarrrml/.htaccess
+++ b/yarrrml/.htaccess
@@ -11,6 +11,8 @@ RewriteRule ^matey\/screencast-target http://rml.io/yarrrml/matey/screencast-tar
 RewriteRule ^matey\/screencast-target/ http://rml.io/yarrrml/matey/screencast-target.html [R=302,L]
 RewriteRule ^matey\/screencast http://rml.io/yarrrml/matey/screencast.html [R=302,L]
 RewriteRule ^matey\/screencast/ http://rml.io/yarrrml/matey/screencast.html [R=302,L]
+RewriteRule ^matey\/repository http://github.com/RMLio/matey [R=302,L]
+RewriteRule ^matey\/repository/ http://github.com/RMLio/matey [R=302,L]
 RewriteRule ^matey$ http://rml.io/yarrrml/matey/ [R=302,L]
 RewriteRule ^matey/$ http://rml.io/yarrrml/matey/ [R=302,L]
 RewriteRule ^(.*)$ http://rml.io/$1 [R=302,L]

--- a/yarrrml/README.MD
+++ b/yarrrml/README.MD
@@ -10,6 +10,9 @@ Specification:
 YARRRML's Matey:
 * https://w3id.org/yarrrml/matey
 
+YARRRML's Matey repository:
+* https://w3id.org/yarrrml/matey/repository
+
 YARRRML's screencasts:
 * https://w3id.org/yarrrml/matey/screencast
 * https://w3id.org/yarrrml/matey/screencast-target


### PR DESCRIPTION
YARRRML's Matey is now publicly available on Github, created a w3id.org perma-id for it. 