### PR TITLE
add wrfy namespace

### DIFF
--- a/wrfy/.htaccess
+++ b/wrfy/.htaccess
@@ -1,0 +1,4 @@
+Options +FollowSymLinks
+RewriteEngine On
+
+RewriteRule   "^(.*)$" https://warr.fyi/perm/$1 [R=301,L,QSA]

--- a/wrfy/README.md
+++ b/wrfy/README.md
@@ -1,0 +1,12 @@
+# /wrfy/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for digital receipts provided by [warrify](https://warrify.com) resources.
+
+## Contact
+This space is administered by:  
+
+**Matthias Pichler**  
+*Chief Technology Officer*  
+[warrify smart product assistance GmbH](https://warrify.com)  
+Vienna, Austria  
+<m.pichler@warrify.com>  
+GitHub: [matthias-pichler-warrify](https://github.com/matthias-pichler-warrify) 


### PR DESCRIPTION
The wrfy namespace it used for permalinks to digital receipts created by [warrify](https://warrify.com).