### PR TITLE
Add 'uom' entry

### DIFF
--- a/uom/.htaccess
+++ b/uom/.htaccess
@@ -1,0 +1,3 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^([\S]*)$ https://units-of-measurement.org/$1 [R=303,L]

--- a/uom/README.md
+++ b/uom/README.md
@@ -1,0 +1,11 @@
+# /uom/
+
+[Units-of-measurement](https://units-of-measurement.org/) (UOM) provides linked data 
+resources for [Unified Code for Units of Measure](https://ucum.org) (UCUM) codes,
+including mappings to a number of units ontologies and systems.
+
+<https://github.com/units-of-measurement>
+
+## Contact
+
+James A. Overton, [james@overton.ca](mailto:james@overton.ca), GitHub [jamesaoverton](https://github.com/jamesaoverton)


### PR DESCRIPTION
Add entries for <https://units-of-measurement.org/> under `/uom/`.