### PR TITLE
geotime redirects and docco

### DIFF
--- a/geotime/.htaccess
+++ b/geotime/.htaccess
@@ -1,0 +1,9 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# whole KG
+RewriteCond %{QUERY_STRING} ^_mediatype=text/turtle$ [OR]
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule ^$ https://raw.githack.com/i-c-stratigraphy/geologic-timescale-kg/master/rdf/manifest.ttl [R=302,L]
+RewriteRule ^kg.ttl$ https://raw.githack.com/i-c-stratigraphy/geologic-timescale-kg/master/rdf/manifest.ttl [R=302,L]
+RewriteRule ^$ https://github.com/i-c-stratigraphy/geologic-timescale-kg [R=302,L]

--- a/geotime/README.md
+++ b/geotime/README.md
@@ -1,0 +1,18 @@
+# geotime
+
+Persistent namespace for the Geological Timescale Knowledge Graph (GTKG).
+
+The GTKG is a packaging of the next-generation version of the [Geologic[al] Timescale](http://resource.geosciml.org/vocabulary/timescale/gts2020). Until now, multiple date-based releases of the Geologic Timescale data have existed without integration  however the GTKG incorporates all releases of the Timescale within one integrated dataset. It also includes a _master_ timescale which is a version-independent, abstract version of the Timescale.
+
+This version, when complete, is expected to be endorsed as the point-of-truth geologic timescale data by the [International Commission on Stratigraphy (ICS)](https://stratigraphy.org).
+
+See this KG's online repository for more information:
+
+* https://github.com/i-c-stratigraphy/geologic-timescale-kg
+
+## Contact
+
+**Nicholas Car**  
+*Webmaster*  
+*[International Commission on Stratigraphy](https://stratigraphy.org)*  
+<nicholas.car@surroundaustralia.com>   


### PR DESCRIPTION
A new namespace for the soon-to-be Geologic Timescale Knowledge Graph. The redirects point to test files already, so they do work!