### PR TITLE
Add nen2660 namespace

### DIFF
--- a/nen2660/.htaccess
+++ b/nen2660/.htaccess
@@ -1,0 +1,31 @@
+RewriteEngine on
+
+
+# 1: Explicit URL of normative file (no content-negotiation)
+# Only TTL => SKOS | RDFS | OWL | SHACL
+
+RewriteRule ^skos/term$ https://bimloket.github.io/nen2660/data/nen2660-skos.ttl [R=302,L]
+RewriteRule ^rdfs/def$ https://bimloket.github.io/nen2660/data/nen2660-rdfs.ttl [R=302,L]
+RewriteRule ^owl/def$ https://bimloket.github.io/nen2660/data/nen2660-owl.ttl [R=302,L]
+RewriteRule ^shacl/def$ https://bimloket.github.io/nen2660/data/nen2660-shacl.ttl [R=302,L]
+
+
+# 2: Non-explicit URL, explicit Accept-header
+# Serve specific serializations => TriG | JSON-LD | Turtle | RDF/XML
+RewriteCond %{HTTP_ACCEPT} application/trig
+RewriteRule ^$ https://bimloket.github.io/nen2660/data/concat/nen2660.trig [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld+json
+RewriteRule ^$ https://bimloket.github.io/nen2660/data/concat/nen2660.json [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/n3
+RewriteRule ^$ https://bimloket.github.io/nen2660/data/concat/nen2660.ttl [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/owl\+xml
+RewriteRule ^$ https://bimloket.github.io/nen2660/data/concat/nen2660.rdf [R=302,L]
+
+
+# Final, matching anything (includes Accept = text/html)
+RewriteRule ^(.*)$ https://bimloket.github.io/nen2660/$1 [R=302,L]

--- a/nen2660/README.md
+++ b/nen2660/README.md
@@ -1,0 +1,40 @@
+# /nen2660/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the normative NEN 2660-2:2021 resources.
+
+NEN 2660-2:2021 is the Dutch Norm “_Rules for information modelling of the built environment_”.
+
+## Uses
+This namespace contains 
+SKOS terms,
+an RDFS ontology,
+an OWL extension,
+and
+SHACL shapes.
+
+The ontology define terms like 
+`Activity`,
+`AmountOfBulkMatter`,
+`consistsOf`,
+`DiscreteObject`,
+`hasFunctionalPart`,
+`hasUnit`,
+`isImplementedBy`,
+`PhysicalObject`.
+
+The ontology refers to OWL Time, GeoSPARQL and QUDT ontologies.
+
+The ontology can be browsed from <https://bimloket.github.io/nen2660/>, where the constituent files may also be downloaded from. 
+
+## Preferred Prefixes
+```turtle
+prefix nen2660-term: <https://w3id.org/nen2660/term#>
+prefix nen2660:      <https://w3id.org/nen2660/def#>
+```
+
+## Contact
+This space is administered by:
+
+- **Redmer Kronemeijer**   
+E-mail: <redmer.kronemeijer@crow.nl>  
+ORCID: [0000-0001-9821-0193](https://orcid.org/0000-0001-9821-0193)  
+GitHub: [@redmer](https://github.com/redmer)


### PR DESCRIPTION
This PR adds the `nen2660/` namespace (folder) for the to-be published Dutch norm NEN 2660-2:2021. 