### PR TITLE
Adds docmaps

### DIFF
--- a/docmaps/.htaccess
+++ b/docmaps/.htaccess
@@ -1,0 +1,9 @@
+RewriteEngine on
+
+AddType application/ld+json .jsonld
+
+# JSON-LD Context
+RewriteRule ^context.jsonld$ https://cdn.jsdelivr.net/gh/knowledgefutures/docmaps@main/docmaps-context.jsonld [R=302,L]
+
+# Rewrite Base URL
+RewriteRule ^(.*)$ https://docmaps.knowledgefutures.org/pub/sgkf1pqa/release/7 [R=302,L]

--- a/docmaps/readme.md
+++ b/docmaps/readme.md
@@ -1,0 +1,19 @@
+# DocMaps
+
+A community-endorsed framework for capturing valuable context about the processes used to create documents in a machine-readable way.
+
+## Homepage
+
+https://docmaps.knowledgefutures.org
+
+## Docs
+
+https://docmaps.knowledgefutures.org/pub/sgkf1pqa/release/7
+
+## JSON-LD Context
+
+https://cdn.jsdelivr.net/gh/knowledgefutures/docmaps@main/docmaps-context.jsonld
+
+## Contact
+
+Gabriel Stein, gabe AT knowledgefutures DOT org


### PR DESCRIPTION
Hello! My .htaccess config knowledge is a bit rusty, but I'm attempting to add redirects for documentation at the `/docmaps` root (or any other match), and for a `/docmaps/context.jsonld` file that others can use in the pilot we're running.

Eventually, the plan is to host a more complete set of ontology files and documentation.