### PR TITLE
chore(csolink): gh-pages renamed to linkmodel.github.io

### DIFF
--- a/csolink/.htaccess
+++ b/csolink/.htaccess
@@ -11,4 +11,4 @@ RewriteRule ^([^\/]*)$ csolink-model/$1
 
 
 # Rewrite Base URL
-RewriteRule ^(.*)$ https://csolink.github.io/$1 [R=302]
+RewriteRule ^(.*)$ https://linkmodel.github.io/$1 [R=302]

--- a/csolink/README.md
+++ b/csolink/README.md
@@ -3,12 +3,10 @@ Csolink: Computer Science Ontology
 This ontology defines concepts, features, attributes for Computer Sciences.
 
 # Homepages
-* https://csolink.github.io/csolink-model/ -- Csolink model
-* https://biolink.github.io/biolinkml/ -- Biolink modeling language
+* https://linkmodel.github.io/csolink-model/ -- Csolink model
 
 # Docs
-* https://csolink.github.io/csolink-model/docs
-* https://biolink.github.io/biolinkml/docs
+* https://linkmodel.github.io/csolink-model/docs
 
 # Vocabulary Usage
     @prefix csolink: <https://w3id.org/csolink/v0.0.1#>
@@ -18,4 +16,4 @@ This ontology defines concepts, features, attributes for Computer Sciences.
 
 # Notes
 Csolink was originally forked of biolink-model for computer science domain.
-Csolink leverages `biolinkml` (alias `linkml`) for model transformations.
+Csolink leverages `linkml` for model transformations.


### PR DESCRIPTION
This PR is required to update csolink because the github organisation was renamed (from csolink to linkmodel).

See https://linkmodel.github.io/csolink-model/