### PR TITLE
Add /hospex/ namespace - a vocabulary for Hospitality Exchange

### DIFF
--- a/hospex/.htaccess
+++ b/hospex/.htaccess
@@ -1,0 +1,5 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+RewriteRule ^.*$ https://raw.githubusercontent.com/OpenHospitalityNetwork/ohn-solid/main/src/vocabularies/hospex.ttl [R=302,L]

--- a/hospex/README.md
+++ b/hospex/README.md
@@ -1,0 +1,16 @@
+# Hospitality Exchange vocabulary namespace
+
+# /hospex/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for hospitality exchange (hospex) vocabulary.
+
+## Uses
+- Hospex vocabulary : https://w3id.org/hospex/ns# --> https://raw.githubusercontent.com/OpenHospitalityNetwork/ohn-solid/main/src/vocabularies/hospex.ttl
+
+## Contact
+**mrkvon**
+- email: mrkvon at protonmail dot com
+- GitHub: [mrkvon](https://github.com/mrkvon)
+
+**Open Hospitality Network**
+- Website: [openhospitality.network](https://openhospitality.network)
+- GitHub: [OpenHospitalityNetwork](https://github.com/OpenHospitalityNetwork)


### PR DESCRIPTION
This namespace will represent a **vocabulary for hospitality exchange communities**.
It's created as a part of efforts of [Open Hospitality Network](https://openhospitality.network), which aims to decentralize/federate hospitality exchange.
The vocabulary is currently used e.g. in https://github.com/OpenHospitalityNetwork/ohn-solid