### PR TITLE
Add /user

### DIFF
--- a/user/.htaccess
+++ b/user/.htaccess
@@ -1,0 +1,3 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ https://melvincarvalho.github.io/user/vocab.json [R=302,L]

--- a/user/README.md
+++ b/user/README.md
@@ -1,0 +1,11 @@
+# User: A JSON based Ontology for User Profiles
+
+## A modern vocab taking inspiration from FOAF, vcard, activity streams and schema.org
+
+## Persistent URI 
+https://w3id.org/user 
+
+## Contacts    
+**Melvin Carvalho**  
+ <melvincarvalho@gmail.com>  
+ https://github.com/melvincarvalho


### PR DESCRIPTION
User vocab is a modern vocab based on JSON-LD that tries to capture the useful parts of FOAF, vcard, activity streams, schema.org and other user related vocabs

The aim is to create a simple, practical and documented set of examples to allow users to publish linked data user profiles to the web

I've spoken to danbri, and he said there isnt an issue with trying this out

Contact: Melvin Carvalho
Email: melvincarvalho@gmail.com
WebID: https://melvincarvalho.com/#me
I also chair the w3c read write web community group: https://www.w3.org/community/rww/