### PR TITLE
Add /security/suites/secp256k1recovery-2020/v2

### DIFF
--- a/security/.htaccess
+++ b/security/.htaccess
@@ -36,6 +36,7 @@ RewriteRule ^suites/multikey-2021/v1$ https://ns.did.ai/suites/multikey-2021/v1 
 
 RewriteRule ^suites/secp256k1recovery-2020$ https://identity.foundation/EcdsaSecp256k1RecoverySignature2020/ [R=302,L]
 RewriteRule ^suites/secp256k1recovery-2020/v1$ https://identity.foundation/EcdsaSecp256k1RecoverySignature2020/lds-ecdsa-secp256k1-recovery2020-0.0.jsonld [R=302,L]
+RewriteRule ^suites/secp256k1recovery-2020/v2$ https://identity.foundation/EcdsaSecp256k1RecoverySignature2020/lds-ecdsa-secp256k1-recovery2020-2.0.jsonld [R=302,L]
 
 # http://w3id.org/security/suites/pgp-2021
 


### PR DESCRIPTION
Add redirect for new context file being added here: https://github.com/decentralized-identity/EcdsaSecp256k1RecoverySignature2020/pull/24.

The previous (v1) context file redirect for this suite was added in https://github.com/perma-id/w3id.org/pull/2108 with some discussion. The proposed new context file (v2) aims to address feedback and follow best practices as much as possible for this existing signature suite.

Requesting review from namespace maintainers: @dlongley, @davidlehn, @msporny, @OR13