### PR TITLE
Add Merkle Disclosure to Security

### DIFF
--- a/security/.htaccess
+++ b/security/.htaccess
@@ -27,6 +27,12 @@ RewriteRule ^suites/aes-2019/v1$ https://digitalbazaar.github.io/aes-key-wrappin
 RewriteRule ^suites/hmac-2019$ https://digitalbazaar.github.io/sha256-hmac-key-2019-context [R=302,L]
 RewriteRule ^suites/hmac-2019/v1$ https://digitalbazaar.github.io/sha256-hmac-key-2019-context/contexts/sha256-hmac-2019-v1.jsonld [R=302,L]
 
+# http://w3id.org/security/suites/merkle-disclosure-2021
+
+RewriteRule ^suites/merkle-disclosure-2021$ https://w3c-ccg.github.io/Merkle-Disclosure-2021/ [R=302,L]
+RewriteRule ^suites/merkle-disclosure-2021/v1$ https://w3c-ccg.github.io/Merkle-Disclosure-2021/contexts/v1 [R=302,L]
+
+
 # http://w3id.org/security/suites/multikey-2021
 
 RewriteRule ^suites/multikey-2021$ https://ns.did.ai/suites/multikey-2021 [R=302,L]


### PR DESCRIPTION
This PR reserves the `merkle-disclosure-2021` path under the security vocab.