### PR TITLE
feat(id): add w3id.org/td namespace

### DIFF
--- a/td/.htaccess
+++ b/td/.htaccess
@@ -1,0 +1,5 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Rewrite Base URL
+RewriteRule ^(.*)$ https://www.td.com/$1 [R=302]

--- a/td/README.md
+++ b/td/README.md
@@ -1,0 +1,14 @@
+# /td/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for Toronto-Domion Bank resources.
+
+## Uses
+This namespace is broken down into different parts for TD identifiers, whole TD datasets and a few other things. See <https://www.td.com> for full details.
+
+## Contact
+This space is administered by:  
+
+**Noel McLoughlin**
+*Site Reliability Engineering*
+[TD Securities](https://tdsecurities.com)  
+<noel.mcloughlin@tdsecurities.com>  
+GitHub: [noelmcloughlin](https://github.com/noelmcloughlin)


### PR DESCRIPTION
This PR add `td` namespace to `w3id.org`  for Toronto-Dominion (TD).