### PR TITLE
hydra/extension redirect to GitHub

### DIFF
--- a/hydra/extension/.htaccess
+++ b/hydra/extension/.htaccess
@@ -16,7 +16,7 @@ RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://hydracg.github.io/extensions/ [R=303,L]
+RewriteRule ^$ https://github.com/HydraCG/extensions [R=303,L]
 
 # Redirect RDF serializations to their respective documents
 RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*


### PR DESCRIPTION
@alien-mcl, we don't have a dedicated "spec" page for the extensions in general so might actually go to GH instead and expand on the readme