### PR TITLE
hydra: incorrect redirect to RDF representation

### DIFF
--- a/hydra/extension/.htaccess
+++ b/hydra/extension/.htaccess
@@ -20,13 +20,13 @@ RewriteRule ^$ https://github.com/HydraCG/extensions [R=303,L]
 
 # Redirect RDF serializations to their respective documents
 RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
-RewriteRule ^$ https://hydracg.github.io/extensions.rdf [R=303,L]
+RewriteRule ^$ https://hydracg.github.io/extensions/extensions.rdf [R=303,L]
 RewriteCond %{HTTP_ACCEPT} ^.*application/n-triples.*
-RewriteRule ^$ https://hydracg.github.io/extensions.nt [R=303,L]
+RewriteRule ^$ https://hydracg.github.io/extensions/extensions.nt [R=303,L]
 RewriteCond %{HTTP_ACCEPT} ^.*application/ld\+json.*
-RewriteRule ^$ https://hydracg.github.io/extensions.jsonld [R=303,L]
+RewriteRule ^$ https://hydracg.github.io/extensions/extensions.jsonld [R=303,L]
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.*
-RewriteRule ^$ https://hydracg.github.io/extensions.ttl [R=303,L]
+RewriteRule ^$ https://hydracg.github.io/extensions/extensions.ttl [R=303,L]
 
 # Subpaths are all HTML
 RewriteRule (.*) https://hydracg.github.io/extensions/$1 [R=303,L]


### PR DESCRIPTION
https://hydracg.github.io/extensions.ttl and other do not exist, needed a proper path