### PR TITLE
Adding the fair-enough namespace

### DIFF
--- a/fair-enough/.htaccess
+++ b/fair-enough/.htaccess
@@ -1,0 +1,7 @@
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ https://fair-enough.semanticscience.org [R=302,L]
+RewriteRule ^metrics/tests/(.*)$ https://metrics.api.fair-enough.semanticscience.org/tests/$1 [R=302,L]
+RewriteRule ^(.*)$ https://api.fair-enough.semanticscience.org/rest/$1 [R=302,L]

--- a/fair-enough/README.md
+++ b/fair-enough/README.md
@@ -1,0 +1,9 @@
+# FAIR Enough (fair-enough)
+
+A namespace for FAIR evaluations published by the FAIR enough service (https://fair-enough.semanticscience.org) hosted by [Maastricht University](https://maastrichtuniversity.nl/) 
+
+Example: https://w3id.org/fair-enough
+
+## Maintainers
+
+- Vincent Emonet (@vemonet)


### PR DESCRIPTION
Hi, I added the `fair-enough` namespace, to redirect to a service to evaluate how much a resource is FAIR (Findable, Accessible, Interoperable, Reusable) and provide persistent identifiers for the objects published in this service:  https://fair-enough.semanticscience.org

Thanks a lot!