### PR TITLE
Update fair-genomes .htaccess with new resource location

### DIFF
--- a/fair-genomes/.htaccess
+++ b/fair-genomes/.htaccess
@@ -2,7 +2,7 @@
 RewriteEngine on
 
 # If a FAIR Genomes term such as 'FG_0000124' is requested, redirect to the corresponding RDF-XML fragment
-RewriteRule ^resource/(FG_[0-9]{7})$ https://fairgenomes.github.io/fairgenomes-semantic-model/generated/resource/$1.rdf [R=302,L]
+RewriteRule ^resource/(FG_[0-9]{7})$ https://fairgenomes.org/fairgenomes-semantic-model/generated/resource/$1.xml [R=302,L]
 
 # If requests starts with 'ontology', redirect to FAIR Genomes LODE page
 RewriteRule ^ontology.*$ https://fairgenomes.github.io/fairgenomes-semantic-model/derived/ontology/lode/ [R=302,L]


### PR DESCRIPTION
FAIR Genomes resource files are now linked via the fairgenomes.org domain and renamed their extension from RDF to XML to fix browser MIME type issues.