### PR TITLE
Remove portal.aws.biochemistry.gwu.edu links

### DIFF
--- a/biocompute/.htaccess
+++ b/biocompute/.htaccess
@@ -21,9 +21,9 @@ RewriteRule ^portal/OMX(.*)$ https://data.oncomx.org/OMX$1 [R=302,L]
 RewriteRule ^portal/GLY(.*)$ https://data.glygen.org/GLY$1 [R=302,L]
 
 # Any specific portal object 
-RewriteRule ^portal/(.*)$ https://portal.aws.biochemistry.gwu.edu/bco/$1 [R=302,L]
+RewriteRule ^portal/(.*)$ https://biocomputeobject.org/bco/$1 [R=302,L]
 
-RewriteRule ^portal(.*)$ https://portal.aws.biochemistry.gwu.edu/$1 [R=302,L]
+RewriteRule ^portal(.*)$ https://biocomputeobject.org/$1 [R=302,L]
 
 # Any specific version - 
 RewriteRule ^(\d+.\d+.\d+)$ https://github.com/biocompute-objects/BCO_Specification/tree/$1 [R=302,L]
@@ -32,10 +32,10 @@ RewriteRule ^(\d+.\d+.\d+)$ https://github.com/biocompute-objects/BCO_Specificat
 RewriteRule ^(\d+.\d+.\d+.*)$ https://github.com/biocompute-objects/BCO_Specification/blob/$1 [R=302,L]
 
 # registry 1
-RewriteRule ^registry$ https://portal.aws.biochemistry.gwu.edu/registry [R=302,L]
+RewriteRule ^registry$ https://biocomputeobject.org/registry [R=302,L]
 
 # registry 2
-RewriteRule ^registry.html$ https://portal.aws.biochemistry.gwu.edu/registry [R=302,L]
+RewriteRule ^registry.html$ https://biocomputeobject.org/registry [R=302,L]
 
 # All releases 
 RewriteRule ^releases$ https://github.com/biocompute-objects/BCO_Specification/releases [R=302,L]


### PR DESCRIPTION
Update .htaccess to remove `portal.aws.biochemistry.gwu.edu` links