### PR TITLE
rail/topo: add redirect to version ontology

### DIFF
--- a/rail/topo/.htaccess
+++ b/rail/topo/.htaccess
@@ -13,7 +13,7 @@ RewriteEngine On
 
 # Forward to most recent version
 
-RewriteRule ^$ /v1.0 [L]
+RewriteRule ^$ v1.0 [L]
 
 # Version-specific redirects
 

--- a/rail/topo/.htaccess
+++ b/rail/topo/.htaccess
@@ -11,37 +11,43 @@ AddType application/ld+json .jsonld
 # Rewrite engine setup
 RewriteEngine On
 
+# Forward to most recent version
+
+RewriteRule ^$ /v1.0 [L]
+
+# Version-specific redirects (anything starting with "v")
+
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/index-en.html [R=303,L]
+RewriteRule ^(v[^/]+)$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/$1/index-en.html [R=303,L]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/ontology.jsonld [R=303,L]
+RewriteRule ^(v[^/]+)$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/$1/ontology.jsonld [R=303,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/ontology.rdf [R=303,L]
+RewriteRule ^(v[^/]+)$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/$1/ontology.rdf [R=303,L]
 
 # Rewrite rule to serve N-Triples content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/ontology.nt [R=303,L]
+RewriteRule ^(v[^/]+)$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/$1/ontology.nt [R=303,L]
 
 # Rewrite rule to serve TTL content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
-RewriteCond %{HTTP_ACCEPT} \*/turtle 
-RewriteRule ^$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/ontology.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^(v[^/]+)$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/$1/ontology.ttl [R=303,L]
 
 # 406 Not Acceptable
 RewriteCond %{HTTP_ACCEPT} .+
-RewriteRule ^$ https://siemens.github.io/ProductConfigurationWithSHACL/406.html [R=406,L]
+RewriteRule ^(v[^/]+)$ https://siemens.github.io/ProductConfigurationWithSHACL/406.html [R=406,L]
 
 # Default response
 # ---------------------------
 # Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
-RewriteRule ^$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/ontology.rdf [R=303,L]
+RewriteRule ^(v[^/]+)$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/$1/ontology.rdf [R=303,L]

--- a/rail/topo/.htaccess
+++ b/rail/topo/.htaccess
@@ -15,39 +15,39 @@ RewriteEngine On
 
 RewriteRule ^$ /v1.0 [L]
 
-# Version-specific redirects (anything starting with "v")
+# Version-specific redirects
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(v[^/]+)$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/$1/index-en.html [R=303,L]
+RewriteRule ^([^/]+)$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/$1/index-en.html [R=303,L]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^(v[^/]+)$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/$1/ontology.jsonld [R=303,L]
+RewriteRule ^([^/]+)$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/$1/ontology.jsonld [R=303,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^(v[^/]+)$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/$1/ontology.rdf [R=303,L]
+RewriteRule ^([^/]+)$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/$1/ontology.rdf [R=303,L]
 
 # Rewrite rule to serve N-Triples content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^(v[^/]+)$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/$1/ontology.nt [R=303,L]
+RewriteRule ^([^/]+)$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/$1/ontology.nt [R=303,L]
 
 # Rewrite rule to serve TTL content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle
-RewriteRule ^(v[^/]+)$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/$1/ontology.ttl [R=303,L]
+RewriteRule ^([^/]+)$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/$1/ontology.ttl [R=303,L]
 
 # 406 Not Acceptable
 RewriteCond %{HTTP_ACCEPT} .+
-RewriteRule ^(v[^/]+)$ https://siemens.github.io/ProductConfigurationWithSHACL/406.html [R=406,L]
+RewriteRule ^([^/]+)$ https://siemens.github.io/ProductConfigurationWithSHACL/406.html [R=406,L]
 
 # Default response
 # ---------------------------
 # Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
-RewriteRule ^(v[^/]+)$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/$1/ontology.rdf [R=303,L]
+RewriteRule ^([^/]+)$ https://siemens.github.io/ProductConfigurationWithSHACL/topo/$1/ontology.rdf [R=303,L]


### PR DESCRIPTION
- redirect from generic to most recent version, currently v1.0
- fix redirects for ontology version URIs