### PR TITLE
updated directory 'brainteaser' for the Horizon2020 Brainteaser project

### DIFF
--- a/brainteaser/.htaccess
+++ b/brainteaser/.htaccess
@@ -1,0 +1,37 @@
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
+Options +FollowSymLinks
+
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+
+# Rewrite engine setup
+RewriteEngine On
+RewriteBase /def
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^ontology$ http://brainteaser.dei.unipd.it/ontology/
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^ontology$ http://brainteaser.dei.unipd.it/ontology/brainteaser.owl [R=303]
+
+# Rewrite rule to serve turtle content from the vocabulary URI if requested
+#RewriteCond %{HTTP_ACCEPT} text/turtle
+#RewriteRule ^ontology$ http://brainteaser.dei.unipd.it/ontology/brainteaser.ttl [R=303]
+
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^ontology$ http://brainteaser.dei.unipd.it/ontology/brainteaser.owl [R=303]
+
+RewriteRule ^ontology(.*)$ http://brainteaser.dei.unipd.it/ontology$1 [R=302,L]
+RewriteRule ^resource(.*)$ http://brainteaser.dei.unipd.it/resource/$1 [R=302,L]

--- a/brainteaser/README.md
+++ b/brainteaser/README.md
@@ -1,0 +1,8 @@
+# /BRAINTEASER Ontology/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the Brainteaser Ontology. 
+The project has received funding from the European Union’s Horizon 2020 research and innovation programme under the grant agreement No GA101017598. See <https://brainteaser.health/> for more details.
+
+## Contact:
+* **Dennis Dosso** (<dosso@dei.unipd.it>)
+* **Gianmaria Silvello** (<silvello@dei.unipd.it>)
+* **Nicola Ferro** (<ferro@dei.unipd.it>) 


### PR DESCRIPTION
We added a directory 'brainteaser', containing the README.md and .htaccess files about the website brainteaser.dei.unipd.it, hosted by the university of Padua, Italy, that will contain the documentation about the new ontology that we are developing in the context of the Brainteaser Horizon2020 European project.