### PR TITLE
/tern - update config

### DIFF
--- a/tern/.htaccess
+++ b/tern/.htaccess
@@ -11,42 +11,42 @@ RewriteEngine On
 RewriteCond %{QUERY_STRING} ^_format=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
 RewriteRule ^ontologies/org\/(.+)$ https://lodview-proxy.deta.dev/api/v1/lodview?IRI=https://w3id.org/tern/ontologies/org/$1&sparql=https://graphdb.tern.org.au/repositories/knowledge_graph_core?infer=false&output=text/turtle [R=303,L]
-RewriteRule ^ontologies/org/?$ https://raw.githack.com/ternaustralia/ontology_tern-org/master/docs/tern-org.ttl [R=303,L]
-RewriteRule ^ontologies/org.ttl$ https://raw.githack.com/ternaustralia/ontology_tern-org/master/docs/tern-org.ttl [R=303,L]
+RewriteRule ^ontologies/org/?$ https://ternaustralia.github.io/ontology_tern-org/tern-org.ttl [R=303,L]
+RewriteRule ^ontologies/org.ttl$ https://ternaustralia.github.io/ontology_tern-org/tern-org.ttl [R=303,L]
 
 # RDF/XML
 RewriteCond %{QUERY_STRING} ^_format=application/rdf\+xml$ [OR]
 RewriteCond %{HTTP:Accept} application/rdf\+xml [NC]
 RewriteRule ^ontologies/org\/(.+)$ https://lodview-proxy.deta.dev/api/v1/lodview?IRI=https://w3id.org/tern/ontologies/org/$1&sparql=https://graphdb.tern.org.au/repositories/knowledge_graph_core?infer=false&output=application/rdf+xml [R=303,L]
-RewriteRule ^ontologies/org/?$ https://raw.githack.com/ternaustralia/ontology_tern-org/master/docs/tern-org.rdf [R=303,L]
-RewriteRule ^ontologies/org.rdf$ https://raw.githack.com/ternaustralia/ontology_tern-org/master/docs/tern-org.rdf [R=303,L]
+RewriteRule ^ontologies/org/?$ https://ternaustralia.github.io/ontology_tern-org/tern-org.rdf [R=303,L]
+RewriteRule ^ontologies/org.rdf$ https://ternaustralia.github.io/ontology_tern-org/tern-org.rdf [R=303,L]
 
 # N-Triples
 RewriteCond %{QUERY_STRING} ^_format=application/n-triples$ [OR]
 RewriteCond %{HTTP:Accept} application/n-triples [NC]
 RewriteRule ^ontologies/org\/(.+)$ https://lodview-proxy.deta.dev/api/v1/lodview?IRI=https://w3id.org/tern/ontologies/org/$1&sparql=https://graphdb.tern.org.au/repositories/knowledge_graph_core?infer=false&output=application/n-triples [R=303,L]
-RewriteRule ^ontologies/org/?$ https://raw.githack.com/ternaustralia/ontology_tern-org/master/docs/tern-org.nt [R=303,L]
-RewriteRule ^ontologies/org.nt$ https://raw.githack.com/ternaustralia/ontology_tern-org/master/docs/tern-org.nt [R=303,L]
+RewriteRule ^ontologies/org/?$ https://ternaustralia.github.io/ontology_tern-org/tern-org.nt [R=303,L]
+RewriteRule ^ontologies/org.nt$ https://ternaustralia.github.io/ontology_tern-org/tern-org.nt [R=303,L]
 
 # JSON-LD
 RewriteCond %{QUERY_STRING} ^_format=application/ld\+json$ [OR]
 RewriteCond %{HTTP:Accept} application/ld\+json [NC]
 RewriteRule ^ontologies/org\/(.+)$ https://lodview-proxy.deta.dev/api/v1/lodview?IRI=https://w3id.org/tern/ontologies/org/$1&sparql=https://graphdb.tern.org.au/repositories/knowledge_graph_core?infer=false&output=application/ld+json [R=303,L]
-RewriteRule ^ontologies/org/?$ https://raw.githack.com/ternaustralia/ontology_tern-org/master/docs/tern-org.jsonld [R=303,L]
-RewriteRule ^ontologies/org.jsonld$ https://raw.githack.com/ternaustralia/ontology_tern-org/master/docs/tern-org.jsonld [R=303,L]
+RewriteRule ^ontologies/org/?$ https://ternaustralia.github.io/ontology_tern-org/tern-org.jsonld [R=303,L]
+RewriteRule ^ontologies/org.jsonld$ https://ternaustralia.github.io/ontology_tern-org/tern-org.jsonld [R=303,L]
 
 # Notation3
 RewriteCond %{QUERY_STRING} ^_format=text/n3$ [OR]
 RewriteCond %{HTTP:Accept} text/n3 [NC]
-RewriteRule ^ontologies/org/?$ https://raw.githack.com/ternaustralia/ontology_tern-org/master/docs/tern-org.n3 [R=303,L]
-RewriteRule ^ontologies/org.n3$ https://raw.githack.com/ternaustralia/ontology_tern-org/master/docs/tern-org.n3 [R=303,L]
+RewriteRule ^ontologies/org/?$ https://ternaustralia.github.io/ontology_tern-org/tern-org.n3 [R=303,L]
+RewriteRule ^ontologies/org.n3$ https://ternaustralia.github.io/ontology_tern-org/tern-org.n3 [R=303,L]
 
 # .owl file extension
-RewriteRule ^ontologies/org.owl$ https://raw.githack.com/ternaustralia/ontology_tern-org/master/docs/tern-org.ttl [R=303,L]
+RewriteRule ^ontologies/org.owl$ https://ternaustralia.github.io/ontology_tern-org/tern-org.ttl [R=303,L]
 
 # HTML
 # Individual resources
-RewriteRule ^ontologies/org\/(.+)$ https://linkeddata-dev.tern.org.au/viewers/tern-org-ontology?uri=https://w3id.org/tern/ontologies/org/$1 [R=303,L]
+RewriteRule ^ontologies/org\/(.+)$ https://linkeddata.tern.org.au/viewers/tern-org-ontology?uri=https://w3id.org/tern/ontologies/org/$1 [R=303,L]
 # Whole-level
 RewriteRule ^ontologies/org/?$ https://ternaustralia.github.io/ontology_tern-org/ [R=303,L]
 
@@ -58,35 +58,35 @@ RewriteRule ^ontologies/org/?$ https://ternaustralia.github.io/ontology_tern-org
 # Turtle
 RewriteCond %{QUERY_STRING} ^_format=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule ^ontologies/skos/?$ https://raw.githack.com/ternaustralia/ontology_tern-skos/master/docs/tern-skos.ttl [R=303,L]
-RewriteRule ^ontologies/skos.ttl$ https://raw.githack.com/ternaustralia/ontology_tern-skos/master/docs/tern-skos.ttl [R=303,L]
+RewriteRule ^ontologies/skos/?$ https://ternaustralia.github.io/ontology_tern-skos/tern-skos.ttl [R=303,L]
+RewriteRule ^ontologies/skos.ttl$ https://ternaustralia.github.io/ontology_tern-skos/tern-skos.ttl [R=303,L]
 
 # RDF/XML
 RewriteCond %{QUERY_STRING} ^_format=application/rdf\+xml$ [OR]
 RewriteCond %{HTTP:Accept} application/rdf\+xml [NC]
-RewriteRule ^ontologies/skos/?$ https://raw.githack.com/ternaustralia/ontology_tern-skos/master/docs/tern-skos.rdf [R=303,L]
-RewriteRule ^ontologies/skos.rdf$ https://raw.githack.com/ternaustralia/ontology_tern-skos/master/docs/tern-skos.rdf [R=303,L]
+RewriteRule ^ontologies/skos/?$ https://ternaustralia.github.io/ontology_tern-skos/tern-skos.rdf [R=303,L]
+RewriteRule ^ontologies/skos.rdf$ https://ternaustralia.github.io/ontology_tern-skos/tern-skos.rdf [R=303,L]
 
 # N-Triples
 RewriteCond %{QUERY_STRING} ^_format=application/n-triples$ [OR]
 RewriteCond %{HTTP:Accept} application/n-triples [NC]
-RewriteRule ^ontologies/skos/?$ https://raw.githack.com/ternaustralia/ontology_tern-skos/master/docs/tern-skos.nt [R=303,L]
-RewriteRule ^ontologies/skos.nt$ https://raw.githack.com/ternaustralia/ontology_tern-skos/master/docs/tern-skos.nt [R=303,L]
+RewriteRule ^ontologies/skos/?$ https://ternaustralia.github.io/ontology_tern-skos/tern-skos.nt [R=303,L]
+RewriteRule ^ontologies/skos.nt$ https://ternaustralia.github.io/ontology_tern-skos/tern-skos.nt [R=303,L]
 
 # JSON-LD
 RewriteCond %{QUERY_STRING} ^_format=application/ld\+json$ [OR]
 RewriteCond %{HTTP:Accept} application/ld\+json [NC]
-RewriteRule ^ontologies/skos/?$ https://raw.githack.com/ternaustralia/ontology_tern-skos/master/docs/tern-skos.jsonld [R=303,L]
-RewriteRule ^ontologies/skos.jsonld$ https://raw.githack.com/ternaustralia/ontology_tern-skos/master/docs/tern-skos.jsonld [R=303,L]
+RewriteRule ^ontologies/skos/?$ https://ternaustralia.github.io/ontology_tern-skos/tern-skos.jsonld [R=303,L]
+RewriteRule ^ontologies/skos.jsonld$ https://ternaustralia.github.io/ontology_tern-skos/tern-skos.jsonld [R=303,L]
 
 # Notation3
 RewriteCond %{QUERY_STRING} ^_format=text/n3$ [OR]
 RewriteCond %{HTTP:Accept} text/n3 [NC]
-RewriteRule ^ontologies/skos/?$ https://raw.githack.com/ternaustralia/ontology_tern-skos/master/docs/tern-skos.n3 [R=303,L]
-RewriteRule ^ontologies/skos.n3$ https://raw.githack.com/ternaustralia/ontology_tern-skos/master/docs/tern-skos.n3 [R=303,L]
+RewriteRule ^ontologies/skos/?$ https://ternaustralia.github.io/ontology_tern-skos/tern-skos.n3 [R=303,L]
+RewriteRule ^ontologies/skos.n3$ https://ternaustralia.github.io/ontology_tern-skos/tern-skos.n3 [R=303,L]
 
 # .owl file extension
-RewriteRule ^ontologies/skos.owl$ https://raw.githack.com/ternaustralia/ontology_tern-skos/master/docs/tern-skos.ttl [R=303,L]
+RewriteRule ^ontologies/skos.owl$ https://ternaustralia.github.io/ontology_tern-skos/tern-skos.ttl [R=303,L]
 
 # HTML
 RewriteRule ^ontologies/skos/?$ https://ternaustralia.github.io/ontology_tern-skos/ [R=303,L]
@@ -99,35 +99,35 @@ RewriteRule ^ontologies/skos/?$ https://ternaustralia.github.io/ontology_tern-sk
 # Turtle
 RewriteCond %{QUERY_STRING} ^_format=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule ^ontologies/ssn/?$ https://raw.githack.com/ternaustralia/ontology_tern-ssn/master/docs/tern-ssn.ttl [R=303,L]
-RewriteRule ^ontologies/ssn.ttl$ https://raw.githack.com/ternaustralia/ontology_tern-ssn/master/docs/tern-ssn.ttl [R=303,L]
+RewriteRule ^ontologies/ssn/?$ https://ternaustralia.github.io/ontology_tern-ssn/tern-ssn.ttl [R=303,L]
+RewriteRule ^ontologies/ssn.ttl$ https://ternaustralia.github.io/ontology_tern-ssn/tern-ssn.ttl [R=303,L]
 
 # RDF/XML
 RewriteCond %{QUERY_STRING} ^_format=application/rdf\+xml$ [OR]
 RewriteCond %{HTTP:Accept} application/rdf\+xml [NC]
-RewriteRule ^ontologies/ssn/?$ https://raw.githack.com/ternaustralia/ontology_tern-ssn/master/docs/tern-ssn.rdf [R=303,L]
-RewriteRule ^ontologies/ssn.rdf$ https://raw.githack.com/ternaustralia/ontology_tern-ssn/master/docs/tern-ssn.rdf [R=303,L]
+RewriteRule ^ontologies/ssn/?$ https://ternaustralia.github.io/ontology_tern-ssn/tern-ssn.rdf [R=303,L]
+RewriteRule ^ontologies/ssn.rdf$ https://ternaustralia.github.io/ontology_tern-ssn/tern-ssn.rdf [R=303,L]
 
 # N-Triples
 RewriteCond %{QUERY_STRING} ^_format=application/n-triples$ [OR]
 RewriteCond %{HTTP:Accept} application/n-triples [NC]
-RewriteRule ^ontologies/ssn/?$ https://raw.githack.com/ternaustralia/ontology_tern-ssn/master/docs/tern-ssn.nt [R=303,L]
-RewriteRule ^ontologies/ssn.nt$ https://raw.githack.com/ternaustralia/ontology_tern-ssn/master/docs/tern-ssn.nt [R=303,L]
+RewriteRule ^ontologies/ssn/?$ https://ternaustralia.github.io/ontology_tern-ssn/tern-ssn.nt [R=303,L]
+RewriteRule ^ontologies/ssn.nt$ https://ternaustralia.github.io/ontology_tern-ssn/tern-ssn.nt [R=303,L]
 
 # JSON-LD
 RewriteCond %{QUERY_STRING} ^_format=application/ld\+json$ [OR]
 RewriteCond %{HTTP:Accept} application/ld\+json [NC]
-RewriteRule ^ontologies/ssn/?$ https://raw.githack.com/ternaustralia/ontology_tern-ssn/master/docs/tern-ssn.jsonld [R=303,L]
-RewriteRule ^ontologies/ssn.jsonld$ https://raw.githack.com/ternaustralia/ontology_tern-ssn/master/docs/tern-ssn.jsonld [R=303,L]
+RewriteRule ^ontologies/ssn/?$ https://ternaustralia.github.io/ontology_tern-ssn/tern-ssn.jsonld [R=303,L]
+RewriteRule ^ontologies/ssn.jsonld$ https://ternaustralia.github.io/ontology_tern-ssn/tern-ssn.jsonld [R=303,L]
 
 # Notation3
 RewriteCond %{QUERY_STRING} ^_format=text/n3$ [OR]
 RewriteCond %{HTTP:Accept} text/n3 [NC]
-RewriteRule ^ontologies/ssn/?$ https://raw.githack.com/ternaustralia/ontology_tern-ssn/master/docs/tern-ssn.n3 [R=303,L]
-RewriteRule ^ontologies/ssn.n3$ https://raw.githack.com/ternaustralia/ontology_tern-ssn/master/docs/tern-ssn.n3 [R=303,L]
+RewriteRule ^ontologies/ssn/?$ https://ternaustralia.github.io/ontology_tern-ssn/tern-ssn.n3 [R=303,L]
+RewriteRule ^ontologies/ssn.n3$ https://ternaustralia.github.io/ontology_tern-ssn/tern-ssn.n3 [R=303,L]
 
 # .owl file extension
-RewriteRule ^ontologies/ssn.owl$ https://raw.githack.com/ternaustralia/ontology_tern-ssn/master/docs/tern-ssn.ttl [R=303,L]
+RewriteRule ^ontologies/ssn.owl$ https://ternaustralia.github.io/ontology_tern-ssn/tern-ssn.ttl [R=303,L]
 
 # HTML
 RewriteRule ^ontologies/ssn/?$ https://ternaustralia.github.io/ontology_tern-ssn/ [R=303,L]
@@ -141,42 +141,42 @@ RewriteRule ^ontologies/ssn/?$ https://ternaustralia.github.io/ontology_tern-ssn
 RewriteCond %{QUERY_STRING} ^_format=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
 RewriteRule ^ontologies/loc\/(.+)$ https://lodview-proxy.deta.dev/api/v1/lodview?IRI=https://w3id.org/tern/ontologies/loc/$1&sparql=https://graphdb.tern.org.au/repositories/knowledge_graph_core?infer=false&output=text/turtle [R=303,L]
-RewriteRule ^ontologies/loc/?$ https://raw.githack.com/ternaustralia/ontology_tern-loc/master/docs/tern-loc.ttl [R=303,L]
-RewriteRule ^ontologies/loc.ttl$ https://raw.githack.com/ternaustralia/ontology_tern-loc/master/docs/tern-loc.ttl [R=303,L]
+RewriteRule ^ontologies/loc/?$ https://ternaustralia.github.io/ontology_tern-loc/tern-loc.ttl [R=303,L]
+RewriteRule ^ontologies/loc.ttl$ https://ternaustralia.github.io/ontology_tern-loc/tern-loc.ttl [R=303,L]
 
 # RDF/XML
 RewriteCond %{QUERY_STRING} ^_format=application/rdf\+xml$ [OR]
 RewriteCond %{HTTP:Accept} application/rdf\+xml [NC]
 RewriteRule ^ontologies/loc\/(.+)$ https://lodview-proxy.deta.dev/api/v1/lodview?IRI=https://w3id.org/tern/ontologies/loc/$1&sparql=https://graphdb.tern.org.au/repositories/knowledge_graph_core?infer=false&output=application/rdf+xml [R=303,L]
-RewriteRule ^ontologies/loc/?$ https://raw.githack.com/ternaustralia/ontology_tern-loc/master/docs/tern-loc.rdf [R=303,L]
-RewriteRule ^ontologies/loc.rdf$ https://raw.githack.com/ternaustralia/ontology_tern-loc/master/docs/tern-loc.rdf [R=303,L]
+RewriteRule ^ontologies/loc/?$ https://ternaustralia.github.io/ontology_tern-loc/tern-loc.rdf [R=303,L]
+RewriteRule ^ontologies/loc.rdf$ https://ternaustralia.github.io/ontology_tern-loc/tern-loc.rdf [R=303,L]
 
 # N-Triples
 RewriteCond %{QUERY_STRING} ^_format=application/n-triples$ [OR]
 RewriteCond %{HTTP:Accept} application/n-triples [NC]
 RewriteRule ^ontologies/loc\/(.+)$ https://lodview-proxy.deta.dev/api/v1/lodview?IRI=https://w3id.org/tern/ontologies/loc/$1&sparql=https://graphdb.tern.org.au/repositories/knowledge_graph_core?infer=false&output=application/n-triples [R=303,L]
-RewriteRule ^ontologies/loc/?$ https://raw.githack.com/ternaustralia/ontology_tern-loc/master/docs/tern-loc.nt [R=303,L]
-RewriteRule ^ontologies/loc.nt$ https://raw.githack.com/ternaustralia/ontology_tern-loc/master/docs/tern-loc.nt [R=303,L]
+RewriteRule ^ontologies/loc/?$ https://ternaustralia.github.io/ontology_tern-loc/tern-loc.nt [R=303,L]
+RewriteRule ^ontologies/loc.nt$ https://ternaustralia.github.io/ontology_tern-loc/tern-loc.nt [R=303,L]
 
 # JSON-LD
 RewriteCond %{QUERY_STRING} ^_format=application/ld\+json$ [OR]
 RewriteCond %{HTTP:Accept} application/ld\+json [NC]
 RewriteRule ^ontologies/loc\/(.+)$ https://lodview-proxy.deta.dev/api/v1/lodview?IRI=https://w3id.org/tern/ontologies/loc/$1&sparql=https://graphdb.tern.org.au/repositories/knowledge_graph_core?infer=false&output=application/ld+json [R=303,L]
-RewriteRule ^ontologies/loc/?$ https://raw.githack.com/ternaustralia/ontology_tern-loc/master/docs/tern-loc.jsonld [R=303,L]
-RewriteRule ^ontologies/loc.jsonld$ https://raw.githack.com/ternaustralia/ontology_tern-loc/master/docs/tern-loc.jsonld [R=303,L]
+RewriteRule ^ontologies/loc/?$ https://ternaustralia.github.io/ontology_tern-loc/tern-loc.jsonld [R=303,L]
+RewriteRule ^ontologies/loc.jsonld$ https://ternaustralia.github.io/ontology_tern-loc/tern-loc.jsonld [R=303,L]
 
 # Notation3
 RewriteCond %{QUERY_STRING} ^_format=text/n3$ [OR]
 RewriteCond %{HTTP:Accept} text/n3 [NC]
-RewriteRule ^ontologies/loc/?$ https://raw.githack.com/ternaustralia/ontology_tern-loc/master/docs/tern-loc.n3 [R=303,L]
-RewriteRule ^ontologies/loc.n3$ https://raw.githack.com/ternaustralia/ontology_tern-loc/master/docs/tern-loc.n3 [R=303,L]
+RewriteRule ^ontologies/loc/?$ https://ternaustralia.github.io/ontology_tern-loc/tern-loc.n3 [R=303,L]
+RewriteRule ^ontologies/loc.n3$ https://ternaustralia.github.io/ontology_tern-loc/tern-loc.n3 [R=303,L]
 
 # .owl file extension
-RewriteRule ^ontologies/loc.owl$ https://raw.githack.com/ternaustralia/ontology_tern-loc/master/docs/tern-loc.ttl [R=303,L]
+RewriteRule ^ontologies/loc.owl$ https://ternaustralia.github.io/ontology_tern-loc/tern-loc.ttl [R=303,L]
 
 # HTML
 # Individual resources
-RewriteRule ^ontologies/loc\/(.+)$ https://linkeddata-dev.tern.org.au/viewers/tern-loc-ontology?uri=https://w3id.org/tern/ontologies/loc/$1 [R=303,L]
+RewriteRule ^ontologies/loc\/(.+)$ https://linkeddata.tern.org.au/viewers/tern-loc-ontology?uri=https://w3id.org/tern/ontologies/loc/$1 [R=303,L]
 # Whole-level
 RewriteRule ^ontologies/loc/?$ https://ternaustralia.github.io/ontology_tern-loc/ [R=303,L]
 
@@ -189,42 +189,42 @@ RewriteRule ^ontologies/loc/?$ https://ternaustralia.github.io/ontology_tern-loc
 RewriteCond %{QUERY_STRING} ^_format=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
 RewriteRule ^ontologies/tern\/(.+)$ https://lodview-proxy.deta.dev/api/v1/lodview?IRI=https://w3id.org/tern/ontologies/tern/$1&sparql=https://graphdb.tern.org.au/repositories/knowledge_graph_core?infer=false&output=text/turtle [R=303,L]
-RewriteRule ^ontologies/tern/?$ https://raw.githack.com/ternaustralia/ontology_tern/master/docs/tern.ttl [R=303,L]
-RewriteRule ^ontologies/tern.ttl$ https://raw.githack.com/ternaustralia/ontology_tern/master/docs/tern.ttl [R=303,L]
+RewriteRule ^ontologies/tern/?$ https://ternaustralia.github.io/ontology_tern/tern.ttl [R=303,L]
+RewriteRule ^ontologies/tern.ttl$ https://ternaustralia.github.io/ontology_tern/tern.ttl [R=303,L]
 
 # RDF/XML
 RewriteCond %{QUERY_STRING} ^_format=application/rdf\+xml$ [OR]
 RewriteCond %{HTTP:Accept} application/rdf\+xml [NC]
 RewriteRule ^ontologies/tern\/(.+)$ https://lodview-proxy.deta.dev/api/v1/lodview?IRI=https://w3id.org/tern/ontologies/tern/$1&sparql=https://graphdb.tern.org.au/repositories/knowledge_graph_core?infer=false&output=application/rdf+xml [R=303,L]
-RewriteRule ^ontologies/tern/?$ https://raw.githack.com/ternaustralia/ontology_tern/master/docs/tern.rdf [R=303,L]
-RewriteRule ^ontologies/tern.rdf$ https://raw.githack.com/ternaustralia/ontology_tern/master/docs/tern.rdf [R=303,L]
+RewriteRule ^ontologies/tern/?$ https://ternaustralia.github.io/ontology_tern/tern.rdf [R=303,L]
+RewriteRule ^ontologies/tern.rdf$ https://ternaustralia.github.io/ontology_tern/tern.rdf [R=303,L]
 
 # N-Triples
 RewriteCond %{QUERY_STRING} ^_format=application/n-triples$ [OR]
 RewriteCond %{HTTP:Accept} application/n-triples [NC]
 RewriteRule ^ontologies/tern\/(.+)$ https://lodview-proxy.deta.dev/api/v1/lodview?IRI=https://w3id.org/tern/ontologies/tern/$1&sparql=https://graphdb.tern.org.au/repositories/knowledge_graph_core?infer=false&output=application/n-triples [R=303,L]
-RewriteRule ^ontologies/tern/?$ https://raw.githack.com/ternaustralia/ontology_tern/master/docs/tern.nt [R=303,L]
-RewriteRule ^ontologies/tern.nt$ https://raw.githack.com/ternaustralia/ontology_tern/master/docs/tern.nt [R=303,L]
+RewriteRule ^ontologies/tern/?$ https://ternaustralia.github.io/ontology_tern/tern.nt [R=303,L]
+RewriteRule ^ontologies/tern.nt$ https://ternaustralia.github.io/ontology_tern/tern.nt [R=303,L]
 
 # JSON-LD
 RewriteCond %{QUERY_STRING} ^_format=application/ld\+json$ [OR]
 RewriteCond %{HTTP:Accept} application/ld\+json [NC]
 RewriteRule ^ontologies/tern\/(.+)$ https://lodview-proxy.deta.dev/api/v1/lodview?IRI=https://w3id.org/tern/ontologies/tern/$1&sparql=https://graphdb.tern.org.au/repositories/knowledge_graph_core?infer=false&output=application/ld+json [R=303,L]
-RewriteRule ^ontologies/tern/?$ https://raw.githack.com/ternaustralia/ontology_tern/master/docs/tern.jsonld [R=303,L]
-RewriteRule ^ontologies/tern.jsonld$ https://raw.githack.com/ternaustralia/ontology_tern/master/docs/tern.jsonld [R=303,L]
+RewriteRule ^ontologies/tern/?$ https://ternaustralia.github.io/ontology_tern/tern.jsonld [R=303,L]
+RewriteRule ^ontologies/tern.jsonld$ https://ternaustralia.github.io/ontology_tern/tern.jsonld [R=303,L]
 
 # Notation3
 RewriteCond %{QUERY_STRING} ^_format=text/n3$ [OR]
 RewriteCond %{HTTP:Accept} text/n3 [NC]
-RewriteRule ^ontologies/tern/?$ https://raw.githack.com/ternaustralia/ontology_tern/master/docs/tern.n3 [R=303,L]
-RewriteRule ^ontologies/tern.n3$ https://raw.githack.com/ternaustralia/ontology_tern/master/docs/tern.n3 [R=303,L]
+RewriteRule ^ontologies/tern/?$ https://ternaustralia.github.io/ontology_tern/tern.n3 [R=303,L]
+RewriteRule ^ontologies/tern.n3$ https://ternaustralia.github.io/ontology_tern/tern.n3 [R=303,L]
 
 # .owl file extension
-RewriteRule ^ontologies/tern.owl$ https://raw.githack.com/ternaustralia/ontology_tern/master/docs/tern.ttl [R=303,L]
+RewriteRule ^ontologies/tern.owl$ https://ternaustralia.github.io/ontology_tern/tern.ttl [R=303,L]
 
 # HTML
 # Individual resources
-RewriteRule ^ontologies/tern\/(.+)$ https://linkeddata-dev.tern.org.au/viewers/tern-ontology?uri=https://w3id.org/tern/ontologies/tern/$1 [R=303,L]
+RewriteRule ^ontologies/tern\/(.+)$ https://linkeddata.tern.org.au/viewers/tern-ontology?uri=https://w3id.org/tern/ontologies/tern/$1 [R=303,L]
 # Whole-level
 RewriteRule ^ontologies/tern/?$ https://ternaustralia.github.io/ontology_tern/ [R=303,L]
 
@@ -236,35 +236,35 @@ RewriteRule ^ontologies/tern/?$ https://ternaustralia.github.io/ontology_tern/ [
 # Turtle
 RewriteCond %{QUERY_STRING} ^_format=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule ^ontologies/sd/?$ https://raw.githack.com/ternaustralia/ontology_tern-sd/master/docs/tern-sd.ttl [R=303,L]
-RewriteRule ^ontologies/sd.ttl$ https://raw.githack.com/ternaustralia/ontology_tern-sd/master/docs/tern-sd.ttl [R=303,L]
+RewriteRule ^ontologies/sd/?$ https://ternaustralia.github.io/ontology_tern-sd/tern-sd.ttl [R=303,L]
+RewriteRule ^ontologies/sd.ttl$ https://ternaustralia.github.io/ontology_tern-sd/tern-sd.ttl [R=303,L]
 
 # RDF/XML
 RewriteCond %{QUERY_STRING} ^_format=application/rdf\+xml$ [OR]
 RewriteCond %{HTTP:Accept} application/rdf\+xml [NC]
-RewriteRule ^ontologies/sd/?$ https://raw.githack.com/ternaustralia/ontology_tern-sd/master/docs/tern-sd.rdf [R=303,L]
-RewriteRule ^ontologies/sd.rdf$ https://raw.githack.com/ternaustralia/ontology_tern-sd/master/docs/tern-sd.rdf [R=303,L]
+RewriteRule ^ontologies/sd/?$ https://ternaustralia.github.io/ontology_tern-sd/tern-sd.rdf [R=303,L]
+RewriteRule ^ontologies/sd.rdf$ https://ternaustralia.github.io/ontology_tern-sd/tern-sd.rdf [R=303,L]
 
 # N-Triples
 RewriteCond %{QUERY_STRING} ^_format=application/n-triples$ [OR]
 RewriteCond %{HTTP:Accept} application/n-triples [NC]
-RewriteRule ^ontologies/sd/?$ https://raw.githack.com/ternaustralia/ontology_tern-sd/master/docs/tern-sd.nt [R=303,L]
-RewriteRule ^ontologies/sd.nt$ https://raw.githack.com/ternaustralia/ontology_tern-sd/master/docs/tern-sd.nt [R=303,L]
+RewriteRule ^ontologies/sd/?$ https://ternaustralia.github.io/ontology_tern-sd/tern-sd.nt [R=303,L]
+RewriteRule ^ontologies/sd.nt$ https://ternaustralia.github.io/ontology_tern-sd/tern-sd.nt [R=303,L]
 
 # JSON-LD
 RewriteCond %{QUERY_STRING} ^_format=application/ld\+json$ [OR]
 RewriteCond %{HTTP:Accept} application/ld\+json [NC]
-RewriteRule ^ontologies/sd/?$ https://raw.githack.com/ternaustralia/ontology_tern-sd/master/docs/tern-sd.jsonld [R=303,L]
-RewriteRule ^ontologies/sd.jsonld$ https://raw.githack.com/ternaustralia/ontology_tern-sd/master/docs/tern-sd.jsonld [R=303,L]
+RewriteRule ^ontologies/sd/?$ https://ternaustralia.github.io/ontology_tern-sd/tern-sd.jsonld [R=303,L]
+RewriteRule ^ontologies/sd.jsonld$ https://ternaustralia.github.io/ontology_tern-sd/tern-sd.jsonld [R=303,L]
 
 # Notation3
 RewriteCond %{QUERY_STRING} ^_format=text/n3$ [OR]
 RewriteCond %{HTTP:Accept} text/n3 [NC]
-RewriteRule ^ontologies/sd/?$ https://raw.githack.com/ternaustralia/ontology_tern-sd/master/docs/tern-sd.n3 [R=303,L]
-RewriteRule ^ontologies/sd.n3$ https://raw.githack.com/ternaustralia/ontology_tern-sd/master/docs/tern-sd.n3 [R=303,L]
+RewriteRule ^ontologies/sd/?$ https://ternaustralia.github.io/ontology_tern-sd/tern-sd.n3 [R=303,L]
+RewriteRule ^ontologies/sd.n3$ https://ternaustralia.github.io/ontology_tern-sd/tern-sd.n3 [R=303,L]
 
 # .owl file extension
-RewriteRule ^ontologies/sd.owl$ https://raw.githack.com/ternaustralia/ontology_tern-sd/master/docs/tern-sd.ttl [R=303,L]
+RewriteRule ^ontologies/sd.owl$ https://ternaustralia.github.io/ontology_tern-sd/tern-sd.ttl [R=303,L]
 
 # HTML
 RewriteRule ^ontologies/sd/?$ https://ternaustralia.github.io/ontology_tern-sd/ [R=303,L]
@@ -277,11 +277,26 @@ RewriteRule ^ontologies/sd/?$ https://ternaustralia.github.io/ontology_tern-sd/ 
 # tern-org shapes
 RewriteCond %{QUERY_STRING} ^_format=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule ^shacl/org/?$ https://raw.githack.com/ternaustralia/shacl_tern-org/master/docs/tern-org.shapes.ttl [R=303,L]
-RewriteRule ^shacl/org.ttl$ https://raw.githack.com/ternaustralia/shacl_tern-org/master/docs/tern-org.shapes.ttl [R=303,L]
+RewriteRule ^shacl/org/?$ https://ternaustralia.github.io/ontology_tern-org/tern-org.shapes.ttl [R=303,L]
+RewriteRule ^shacl/org.ttl$ https://ternaustralia.github.io/ontology_tern-org/tern-org.shapes.ttl [R=303,L]
+# tern-org catch-all
+RewriteRule ^shacl/org/?$ https://ternaustralia.github.io/ontology_tern-org/tern-org.shapes.ttl [R=303,L]
 
-# catch-all
-RewriteRule ^shacl/org/?$ https://raw.githack.com/ternaustralia/shacl_tern-org/master/docs/tern-org.shapes.ttl [R=303,L]
+# tern ontology shapes
+RewriteCond %{QUERY_STRING} ^_format=text/turtle$ [OR]
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule ^shacl/tern/profiles/base/?$ https://ternaustralia.github.io/ontology_tern/tern.shacl.ttl [R=303,L]
+RewriteRule ^shacl/tern/profiles/base.ttl$ https://ternaustralia.github.io/ontology_tern/tern.shacl.ttl [R=303,L]
+# tern-org catch-all
+RewriteRule ^shacl/tern/profiles/base/?$ https://ternaustralia.github.io/ontology_tern/tern.shacl.ttl [R=303,L]
+
+# tern ontology ecoplots profile shapes
+RewriteCond %{QUERY_STRING} ^_format=text/turtle$ [OR]
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule ^shacl/tern/profiles/ecoplots/?$ https://ternaustralia.github.io/ontology_tern/tern.ecoplots.shacl.ttl [R=303,L]
+RewriteRule ^shacl/tern/profiles/ecoplots.ttl$ https://ternaustralia.github.io/ontology_tern/tern.ecoplots.shacl.ttl [R=303,L]
+# tern-org catch-all
+RewriteRule ^shacl/tern/profiles/ecoplots/?$ https://ternaustralia.github.io/ontology_tern/tern.ecoplots.shacl.ttl [R=303,L]
 
 
 ##################################


### PR DESCRIPTION
Fixes https://github.com/ternaustralia/ontology_tern/issues/116

- Update redirects to linkeddata.tern.org.au to prod version.
- Change links from raw.githack.com to GH pages.
- Add redirects for TERN Ontology's SHACL shapes.

Contact information: https://github.com/perma-id/w3id.org/tree/master/tern
