### PR TITLE
Change fair-enough namespace redirect status codes

### DIFF
--- a/fair-enough/.htaccess
+++ b/fair-enough/.htaccess
@@ -2,6 +2,6 @@ Header set Access-Control-Allow-Origin *
 Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^$ https://fair-enough.semanticscience.org [R=302,L]
-RewriteRule ^metrics/tests/(.*)$ https://metrics.api.fair-enough.semanticscience.org/tests/$1 [R=302,L]
-RewriteRule ^(.*)$ https://api.fair-enough.semanticscience.org/$1 [R=302,L]
+RewriteRule ^$ https://fair-enough.semanticscience.org [R=307,L]
+RewriteRule ^metrics/tests/(.*)$ https://metrics.api.fair-enough.semanticscience.org/tests/$1 [R=307,L]
+RewriteRule ^(.*)$ https://api.fair-enough.semanticscience.org/$1 [R=307,L]


### PR DESCRIPTION
Change status code for the `fair-enough` namespace from 302 to 307 to support forwarding post payloads (follow up from https://github.com/perma-id/w3id.org/pull/2588)