### PR TITLE
dpv: content negotiation for rdf, ttl, n3, jsonld

### DIFF
--- a/dpv/.htaccess
+++ b/dpv/.htaccess
@@ -8,8 +8,7 @@ Options -MultiViews
 
 # Directive to ensure *.rdf files served as appropriate content type,
 # if not present in main apache config
-AddType application/rdf+xml .rdf
-AddType application/rdf+xml .owl
+AddType application/rdf+xml .rdf .owl
 AddType text/turtle .ttl
 AddType application/n-triples .n3
 AddType application/ld+json .jsonld
@@ -18,6 +17,27 @@ Header set Access-Control-Allow-Origin *
 Options +FollowSymLinks
 RewriteEngine on
 
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://w3c.github.io/dpv/dpv.rdf [R=302,L]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(.*)$ https://w3c.github.io/dpv/$1.rdf [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^$ https://w3c.github.io/dpv/dpv.ttl [R=302,L]
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^(.*)$ https://w3c.github.io/dpv/$1.ttl [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n\-triples
+RewriteRule ^$ https://w3c.github.io/dpv/dpv.n3 [R=302,L]
+RewriteCond %{HTTP_ACCEPT} application/n\-triples
+RewriteRule ^(.*)$ https://w3c.github.io/dpv/$1.n3 [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://w3c.github.io/dpv/dpv.jsonld [R=302,L]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(.*)$ https://w3c.github.io/dpv/$1.jsonld [R=302,L]
+
+# Default
 # w3id.org/dpv
 RewriteRule ^$ https://w3c.github.io/dpv/dpv [R=302,L]
 # w3id.org/dpv/*


### PR DESCRIPTION
Added conditions to rewrite/redirect based on content type requested for
semantic web (rdf, etc.) files. Default rule is to serve HTML.

See w3c/dpv#32