### PR TITLE
dpv: fix incorrect redirect path

### DIFF
--- a/dpv/.htaccess
+++ b/dpv/.htaccess
@@ -18,22 +18,22 @@ Options +FollowSymLinks
 RewriteEngine on
 
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^$ https://w3c.github.io/dpv/dpv.rdf [R=302,L]
+RewriteRule ^$ https://w3c.github.io/dpv/dpv/dpv.rdf [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
 RewriteRule ^(.*)$ https://w3c.github.io/dpv/$1.rdf [R=302,L]
 
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^$ https://w3c.github.io/dpv/dpv.ttl [R=302,L]
+RewriteRule ^$ https://w3c.github.io/dpv/dpv/dpv.ttl [R=302,L]
 RewriteCond %{HTTP_ACCEPT} text/turtle
 RewriteRule ^(.*)$ https://w3c.github.io/dpv/$1.ttl [R=302,L]
 
 RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^$ https://w3c.github.io/dpv/dpv.n3 [R=302,L]
+RewriteRule ^$ https://w3c.github.io/dpv/dpv/dpv.n3 [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/n\-triples
 RewriteRule ^(.*)$ https://w3c.github.io/dpv/$1.n3 [R=302,L]
 
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^$ https://w3c.github.io/dpv/dpv.jsonld [R=302,L]
+RewriteRule ^$ https://w3c.github.io/dpv/dpv/dpv.jsonld [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
 RewriteRule ^(.*)$ https://w3c.github.io/dpv/$1.jsonld [R=302,L]
 


### PR DESCRIPTION
Earlier commit incorrectly specified redirect path (i.e. /dpv instead of
/dpv/dpv). This has been fixed.

Addresses w3c/dpv#32