### PR TITLE
Add rhonda redirection.

### DIFF
--- a/rhonda/.htaccess
+++ b/rhonda/.htaccess
@@ -1,0 +1,3 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^polmat/(.*) https://rhonda-org.github.io/vocabs-polmat/w3id.org/rhonda/polmat/$1 [R=302,L]

--- a/rhonda/README.md
+++ b/rhonda/README.md
@@ -1,0 +1,17 @@
+# RHONDA
+## Research in Historical legal Ordinances and Normative DAta
+
+Homepage:
+
+* <https://github.com/rhonda-org/PoliceOrdinances/wiki>
+
+Vocabularies:
+
+* <https://w3id.org/rhonda/polmat>
+  * @prefix polmat: <https://w3id.org/rhonda/polmat/>
+  * source: <https://github.com/rhonda-org/vocabs-polmat/>
+  * seeAlso: <https://policey.lhlt.mpg.de/>/<https://www.lhlt.mpg.de/research-project/repertory-of-policeyordnungen>
+
+## Contacts
+
+* Andreas Wagner ([@awagner-mainz](https://github.com/awagner-mainz)) <wagner@lhlt.mpg.de>


### PR DESCRIPTION
This will provide access to Vocabularies and other data from the [Research in Historical legal Ordinances and Normatice DAta (RHONDA) Consortium](https://github.com/rhonda-org/PoliceOrdinances/wiki). For now, there is only one SKOS concept scheme.