### PR TITLE
Necessary Changes for xAPI Profile Server

### DIFF
--- a/xapi/.htaccess
+++ b/xapi/.htaccess
@@ -52,11 +52,11 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^adl/verbs/abandoned/?$ http://xapi.vocab.pub/describe/?url=https://w3id.org/xapi/adl/verbs/abandoned [R=303]
-RewriteRule ^adl/verbs/satisfied/?$ http://xapi.vocab.pub/describe/?url=https://w3id.org/xapi/adl/verbs/satisfied [R=303]
-RewriteRule ^adl/verbs/waived/?$ http://xapi.vocab.pub/describe/?url=https://w3id.org/xapi/adl/verbs/waived [R=303]
-RewriteRule ^adl/verbs/logged-in/?$ http://xapi.vocab.pub/describe/?url=https://w3id.org/xapi/adl/verbs/logged-in [R=303]
-RewriteRule ^adl/verbs/logged-out/?$ http://xapi.vocab.pub/describe/?url=https://w3id.org/xapi/adl/verbs/logged-out [R=303]
+RewriteRule ^adl/verbs/abandoned/?$ https://profiles.adlnet.gov/profile/a929b474-9518-45a2-bd47-24696c602754/concepts/63799980-a0fb-4ead-9ed2-25f7a65734f5 [R=303]
+RewriteRule ^adl/verbs/satisfied/?$ https://profiles.adlnet.gov/profile/a929b474-9518-45a2-bd47-24696c602754/concepts/e3212e03-237f-4684-8f65-e27c7375d30b [R=303]
+RewriteRule ^adl/verbs/waived/?$ https://profiles.adlnet.gov/profile/a929b474-9518-45a2-bd47-24696c602754/concepts/582cbd06-8920-4748-917f-5c1af8244a82 [R=303]
+RewriteRule ^adl/verbs/logged-in/?$ https://profiles.adlnet.gov/profile/c752b257-047f-4718-b353-d29238fef2c2/concepts/b5bea04f-3f49-4b9d-a7e9-4202af00dd4c [R=303]
+RewriteRule ^adl/verbs/logged-out/?$ https://profiles.adlnet.gov/profile/c752b257-047f-4718-b353-d29238fef2c2/concepts/7ce10260-ffa0-4d0f-a5c3-ed795e60b276 [R=303]
 
 
 # Serve HTML content at profile IRI if requested based on redirect on old ADL website and also handle ADL's cmi5 verbs
@@ -64,8 +64,8 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^adl/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ http://xapi.vocab.pub/describe/?url=http://adlnet.gov/expapi/$1/$2 [R=303]
-
+# Old Rule RewriteRule ^adl/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ http://xapi.vocab.pub/describe/?url=http://adlnet.gov/expapi/$1/$2 [R=303]
+RewriteRule ^adl/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ http://xapi.vocab.pub/api/profile?iri=http://adlnet.gov/expapi/$1/$2 [R=303]
 
 #######################################################################################################
 #################### XAPI Published Profiles | HTML Content Negotiation RULES #########################
@@ -78,7 +78,8 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^([0-9a-zA-Z\-]+)/?$ http://xapi.vocab.pub/describe/?url=https://w3id.org/xapi/$1 [R=303]
+# Old Rule RewriteRule ^([0-9a-zA-Z\-]+)/?$ http://xapi.vocab.pub/describe/?url=https://w3id.org/xapi/$1 [R=303]
+RewriteRule ^([0-9a-zA-Z\-]+)/?$ http://xapi.vocab.pub/api/profile?iri=https://w3id.org/xapi/$1 [R=303]
 
 # Serve HTML content at profile IRI if x.x.x version requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)

--- a/xapi/.htaccess
+++ b/xapi/.htaccess
@@ -79,35 +79,39 @@ RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 # Old Rule RewriteRule ^([0-9a-zA-Z\-]+)/?$ http://xapi.vocab.pub/describe/?url=https://w3id.org/xapi/$1 [R=303]
-RewriteRule ^([0-9a-zA-Z\-]+)/?$ http://xapi.vocab.pub/api/profile?iri=https://w3id.org/xapi/$1 [R=303]
+RewriteRule ^([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.gov/api/profile?iri=https://w3id.org/xapi/$1 [R=303]
 
 # Serve HTML content at profile IRI if x.x.x version requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^([0-9a-zA-Z\-]+)/v[0-9][0-9.]*/?$ http://xapi.vocab.pub/describe/?url=https://w3id.org/xapi/$1 [R=303]
+# Old Rule RewriteRule ^([0-9a-zA-Z\-]+)/v[0-9][0-9.]*/?$ http://xapi.vocab.pub/describe/?url=https://w3id.org/xapi/$1 [R=303]
+RewriteRule ^([0-9a-zA-Z\-]+)/v[0-9][0-9.]*/?$ https://profiles.adlnet.gov/api/profile?iri=https://w3id.org/xapi/$1 [R=303]
 
 # Serve HTML content at type IRI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ http://xapi.vocab.pub/describe/?url=https://w3id.org/xapi/$1 [R=303]
+# Old Rule RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ http://xapi.vocab.pub/describe/?url=https://w3id.org/xapi/$1 [R=303]
+RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.gov/api/profile?iri=https://w3id.org/xapi/$1 [R=303]
 
 # Serve HTML content at vocabulary term IRI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ http://xapi.vocab.pub/describe/?url=https://w3id.org/xapi/$1/$2/$3 [R=303]
+# Old Rule RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ http://xapi.vocab.pub/describe/?url=https://w3id.org/xapi/$1/$2/$3 [R=303]
+RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.gov/api/profile?iri=https://w3id.org/xapi/$1/$2/$3 [R=303]
 
 # Serve HTML content at vocabulary term IRI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ http://xapi.vocab.pub/describe/?url=https://w3id.org/xapi/$1/$2/$3/$4 [R=303]
+# Old Rule RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ http://xapi.vocab.pub/describe/?url=https://w3id.org/xapi/$1/$2/$3/$4 [R=303]
+RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.gov/api/profile?iri=https://w3id.org/xapi/$1/$2/$3/$4 [R=303]
 
 #######################################################################################################
 ##################### XAPI Authored Profiles | RDF Content Negotiation RULES ##########################


### PR DESCRIPTION
The base URLs and even rule structures changed and are currently not functioning.  These changes will restore basic functionality to our Profile Server application https://profiles.adlnet.gov replaces http://xapi.vocab.pub.  Not all are replaced yet as some functions are not yet working.