### PR TITLE
Redirect to new institute URIs.

### DIFF
--- a/mpilhlt/.htaccess
+++ b/mpilhlt/.htaccess
@@ -1,0 +1,4 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^polmat/(.*) https://skohub.io/mpilhlt/vocabs-polmat/heads/main/w3id.org/mpilhlt/polmat/$1 [R=302,L]
+RewriteRule ^worktime/(.*) https://mpilhlt.github.io/vocabs-worktime/w3id.org/mpilhlt/worktime/$1 [R=302,L]

--- a/mpilhlt/README.md
+++ b/mpilhlt/README.md
@@ -4,8 +4,6 @@ Homepage:
 
 * <https://www.lhlt.mpg.de/en>
 
-*Note that after the renaming of the MPI, URIs beginning with `https://w3id.org/rg-mpg-de/` are maintained only for backwards compatibility. They are in fact redirections to the new URIs beginning with `https://w3id.org/mpilhlt/`. If possible, it is preferable to use the new ones (mpilhlt) now.*
-
 Vocabularies:
 
 * <https://w3id.org/rhonda/polmat>

--- a/rg-mpg-de/.htaccess
+++ b/rg-mpg-de/.htaccess
@@ -1,4 +1,5 @@
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^polmat/(.*) https://skohub.io/rg-mpg-de/vocabs-polmat/heads/main/w3id.org/rg-mpg-de/polmat/$1 [R=302,L]
-RewriteRule ^worktime/(.*) https://rg-mpg-de.github.io/vocabs-worktime/w3id.org/rg-mpg-de/worktime/$1 [R=302,L]
+
+# Redirect everything to renamed institute w3id top-level path
+RewriteRule ^/(.*) https://w3id.org/mpilhlt/$1 [R=301,L]


### PR DESCRIPTION
After our institute's name has changed, I have opened a new top-level directory and made the old one (301-)redirect to it. The new one contains (302) redirections to the actual data (vocabularies).