### PR TITLE
Fix redirect from old personal repository to new org. repository

### DIFF
--- a/steel/.htaccess
+++ b/steel/.htaccess
@@ -32,7 +32,7 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(.+)$ https://kibubu.github.io/SteelDigitalOntology/$1.html [R=303,L]
+RewriteRule ^(.+)$ https://materialdigital.github.io/stahldigital-ontology-public/$1.html [R=303,L]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json


### PR DESCRIPTION
Paths were redirected to the old personal repository instead of the new repository governed by the organisation. 