### PR TITLE
Hopefully fix redirection for former institute's name.

### DIFF
--- a/rg-mpg-de/.htaccess
+++ b/rg-mpg-de/.htaccess
@@ -2,4 +2,4 @@ Options +FollowSymLinks
 RewriteEngine on
 
 # Redirect everything to renamed institute w3id top-level path
-RewriteRule ^/(.*) https://w3id.org/mpilhlt/$1 [R=301,L]
+RewriteRule ^(.*) https://w3id.org/mpilhlt/$1 [R=301,L]


### PR DESCRIPTION
Apparently there was a forward slash too many in the RewriteRule. Hopefully this fixes it. I cannot test it due to the project name being somehow automatically injected on the w3id.org instance, but I think this is how it should look like.