### PR TITLE
Adding the noria namespace

### DIFF
--- a/noria/.htaccess
+++ b/noria/.htaccess
@@ -1,10 +1,20 @@
-# === Directory: /noria/ ===
+# === Directory: /noria/ ======================================================
+
 Options +FollowSymLinks
 RewriteEngine on
 
-# === Rewrite Rules ===
+# === Rewrite Rules ===========================================================
 
 # Main reference: https://github.com/Orange-OpenSource/noria-ontology
+RewriteRule ^$ https://github.com/Orange-OpenSource/noria-ontology [R=302,L]
 
-# Direct access to versioned ontology file:
-RewriteRule ^(.*-\d+\.\d+)$ https://raw.githubusercontent.com/Orange-OpenSource/noria-ontology/main/ontology/$1.ttl [R=302,L]
+# Direct access to versioned ontology file
+RewriteRule ^ontology/(.*-\d+\.\d+)$ https://raw.githubusercontent.com/Orange-OpenSource/noria-ontology/main/ontology/$1.ttl [R=302,L]
+
+# Redirect for documentation
+RewriteRule ^doc/?$ https://genears.github.io/pubs/noria/doc/index-en.html [R=302,L]
+
+# Redirect anything to code repo
+RewriteRule (.*) https://github.com/Orange-OpenSource/noria-ontology/$1 [R=302,L]
+
+# === END =====================================================================

--- a/noria/.htaccess
+++ b/noria/.htaccess
@@ -1,0 +1,10 @@
+# === Directory: /noria/ ===
+Options +FollowSymLinks
+RewriteEngine on
+
+# === Rewrite Rules ===
+
+# Main reference: https://github.com/Orange-OpenSource/noria-ontology
+
+# Direct access to versioned ontology file:
+RewriteRule ^(.*-\d+\.\d+)$ https://raw.githubusercontent.com/Orange-OpenSource/noria-ontology/main/ontology/$1.ttl [R=302,L]

--- a/noria/README.md
+++ b/noria/README.md
@@ -1,10 +1,14 @@
 # /noria/
+
 This [W3ID](https://w3id.org) provides a persistent URI namespace for the *machiNe learning, Ontology and Reasoning for the Identification of Anomalies* (NORIA) resources.
 
 ## Uses
-TBD
+
+This namespace is subdivided into varied subspaces depending on the targeted function.
+The main related resource is [https://github.com/Orange-OpenSource/noria-ontology](https://github.com/Orange-OpenSource/noria-ontology).
 
 ## Contact
+
 This space is administered by:
-* Lionel Tailhardat
-* Yoan Chabot 
+* [Lionel Tailhardat](https://genears.github.io/)
+* [Yoan Chabot](https://yoanchabot.github.io/)

--- a/noria/README.md
+++ b/noria/README.md
@@ -1,0 +1,10 @@
+# /noria/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the *machiNe learning, Ontology and Reasoning for the Identification of Anomalies* (NORIA) resources.
+
+## Uses
+TBD
+
+## Contact
+This space is administered by:
+* Lionel Tailhardat
+* Yoan Chabot 


### PR DESCRIPTION
First release of the *noria* namespace with `README.md` and `.htaccess` files.
Redirect rules tested with the https://htaccess.madewithlove.com/ tool