### PR TITLE
Add OBPD and OBO to perma-id

### DIFF
--- a/obo/.htaccess
+++ b/obo/.htaccess
@@ -1,0 +1,23 @@
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .owl
+
+
+### Rewrite rules for latest version
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://github.com/PerformanceInformatics/OBO [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle 
+RewriteRule ^$ https://github.com/PerformanceInformatics/OBO/blob/main/OBO.owl [R=303,L]

--- a/obo/readme.md
+++ b/obo/readme.md
@@ -1,0 +1,9 @@
+# Ontology for Building Objects
+
+## Documentation
+- https://github.com/PerformanceInformatics/OBO
+- Owl Source File: https://github.com/PerformanceInformatics/OBO
+
+## Maintainers
+- Eleanna Panagoulia ([epanagoulia3@gatech.edu](epanagoulia3@gatech.edu))
+- Zachary Lancaster ([zlancaster@gatech.edu](zlancaster@gatech.edu))

--- a/obpd/.htaccess
+++ b/obpd/.htaccess
@@ -1,0 +1,23 @@
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .owl
+
+
+### Rewrite rules for latest version
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://github.com/PerformanceInformatics/OBPD [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle 
+RewriteRule ^$ https://github.com/PerformanceInformatics/OBPD/blob/main/OBPD.owl [R=303,L]

--- a/obpd/readme.md
+++ b/obpd/readme.md
@@ -1,8 +1,8 @@
 # Ontology for Building Objects
 
 ## Documentation
-- https://github.com/PerformanceInformatics/OBO
-- Owl Source File: https://github.com/PerformanceInformatics/OBO/blob/main/OBO.owl
+- https://github.com/PerformanceInformatics/OBPD
+- Owl Source File: https://github.com/PerformanceInformatics/OBPD/blob/main/OBPD.owl
 
 ## Maintainers
 - Eleanna Panagoulia ([epanagoulia3@gatech.edu](epanagoulia3@gatech.edu))


### PR DESCRIPTION
Adding folders and access files to point to projects for Ontology for Building Objects and Ontology for Building Performance Data to the perma-id project.