### PR TITLE
Add folder for GSC MIxS

### DIFF
--- a/mixs/.htaccess
+++ b/mixs/.htaccess
@@ -1,0 +1,6 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Schema elements use github pages
+# Rewrite Base URL
+RewriteRule ^(.*)$ https://genomicsstandardsconsortium.github.io/mixs/$1 [R=302,L]

--- a/mixs/.htaccess
+++ b/mixs/.htaccess
@@ -1,6 +1,26 @@
 Options +FollowSymLinks
 RewriteEngine on
 
-# Schema elements use github pages
+# vocab/ end point
+RewriteRule ^vocab$ https://genomicsstandardsconsortium.github.io/mixs/$1
+RewriteRule ^vocab\/(.*)$ https://genomicsstandardsconsortium.github.io/mixs/$1 [R=301,L]
+
+# Schema artefacts use raw Github URLs
+# if suffix is yaml, redirect to LinkML YAML schema
+RewriteRule ^mixs.yaml$ https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/model/schema/mixs.yaml [R=302,L]
+
+# if suffix is schema.json, redirect to JSON Schema
+RewriteRule ^mixs.schema.json$ https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/generated/jsonschema/mixs.schema.json [R=302,L]
+
+# if suffix is context.jsonld, redirect to JSON LD context
+RewriteRule ^mixs.context.jsonld$ https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/generated/jsonld/mixs.context.jsonld [R=302,L]
+
+# if suffix is jsonld, redirect to JSON LD
+RewriteRule ^mixs.jsonld$ https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/generated/jsonld/mixs.jsonld [R=302,L]
+
+# if suffix is jsonld, redirect to JSON LD
+RewriteRule ^mixs.jsonld$ https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/generated/jsonld/mixs.jsonld [R=302,L]
+
+# Schema elements use Github Pages
 # Rewrite Base URL
 RewriteRule ^(.*)$ https://genomicsstandardsconsortium.github.io/mixs/$1 [R=302,L]

--- a/mixs/README.md
+++ b/mixs/README.md
@@ -9,5 +9,6 @@ Documentation:
 
 
 Contact:
-* Mark Andrew Miller <MAM@lbl.gov>
-* Sujay Patil <spatil@lbl.gov>
+* Ramona Walls rlwalls2008 AT gmail DOT com @ramonawalls
+* Mark Andrew Miller MAM AT lbl DOT gov @turbomam
+* Sujay Patil spatil AT lbl DOT gov @sujaypatil96

--- a/mixs/README.md
+++ b/mixs/README.md
@@ -1,0 +1,13 @@
+MIxS
+====
+
+Homepage:
+* https://genomicsstandardsconsortium.github.io/gensc.github.io/
+
+Documentation:
+* https://genomicsstandardsconsortium.github.io/mixs/
+
+
+Contact:
+* Mark Andrew Miller <MAM@lbl.gov>
+* Sujay Patil <spatil@lbl.gov>


### PR DESCRIPTION
Based on the requirement on https://github.com/GenomicsStandardsConsortium/mixs/issues/390 we want to add a folder for the genomic standards consortium MIxS community.

We want to deprecate the [gensc](https://github.com/perma-id/w3id.org/tree/master/gensc) folder we already have registered with w3id.

CC: @ramonawalls @turbomam 