### PR TITLE
add route mappings for `gensc/mixs`

### DIFF
--- a/gensc/.htaccess
+++ b/gensc/.htaccess
@@ -1,3 +1,10 @@
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^(.*) https://gensc.org/ [R=307,L]
+
+<!-- gensc/mixs ednpoint route -->
+RewriteRule ^mixs$ https://genomicsstandardsconsortium.github.io/mixs/$1 [R=302,L]
+
+<!-- TODO: gensc/terms endpoint -->
+
+<!-- Rewrite Base URL -->
+RewriteRule ^(.*)$ https://gensc.org/$1 [R=302,L]

--- a/mixs/.htaccess
+++ b/mixs/.htaccess
@@ -10,16 +10,14 @@ RewriteRule ^vocab\/(.*)$ https://genomicsstandardsconsortium.github.io/mixs/$1 
 RewriteRule ^mixs.yaml$ https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/model/schema/mixs.yaml [R=302,L]
 
 # if suffix is schema.json, redirect to JSON Schema
-RewriteRule ^mixs.schema.json$ https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/generated/jsonschema/mixs.schema.json [R=302,L]
+RewriteRule ^mixs.schema.json$ https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/release/jsonschema/mixs.schema.json [R=302,L]
 
 # if suffix is context.jsonld, redirect to JSON LD context
-RewriteRule ^mixs.context.jsonld$ https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/generated/jsonld/mixs.context.jsonld [R=302,L]
+RewriteRule ^mixs.context.jsonld$ https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/release/jsonld/mixs.context.jsonld [R=302,L]
 
-# if suffix is jsonld, redirect to JSON LD
-RewriteRule ^mixs.jsonld$ https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/generated/jsonld/mixs.jsonld [R=302,L]
+# if suffix is owl, redirect to OWL
+RewriteRule ^mixs.owl.ttl$ https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/release/jsonld/mixs.owl.ttl [R=302,L]
 
-# if suffix is jsonld, redirect to JSON LD
-RewriteRule ^mixs.jsonld$ https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/generated/jsonld/mixs.jsonld [R=302,L]
 
 # Schema elements use Github Pages
 # Rewrite Base URL

--- a/mixs/.htaccess
+++ b/mixs/.htaccess
@@ -10,13 +10,13 @@ RewriteRule ^vocab\/(.*)$ https://genomicsstandardsconsortium.github.io/mixs/$1 
 RewriteRule ^mixs.yaml$ https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/model/schema/mixs.yaml [R=302,L]
 
 # if suffix is schema.json, redirect to JSON Schema
-RewriteRule ^mixs.schema.json$ https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/release/jsonschema/mixs.schema.json [R=302,L]
+RewriteRule ^mixs.schema.json$ https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/mixs/jsonschema/mixs.schema.json [R=302,L]
 
 # if suffix is context.jsonld, redirect to JSON LD context
-RewriteRule ^mixs.context.jsonld$ https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/release/jsonld/mixs.context.jsonld [R=302,L]
+RewriteRule ^mixs.context.jsonld$ https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/mixs/jsonld/mixs.jsonld [R=302,L]
 
 # if suffix is owl, redirect to OWL
-RewriteRule ^mixs.owl.ttl$ https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/release/jsonld/mixs.owl.ttl [R=302,L]
+RewriteRule ^mixs.owl.ttl$ https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/mixs/owl/mixs.owl.ttl [R=302,L]
 
 
 # Schema elements use Github Pages


### PR DESCRIPTION
In the most recent MIxS standards technical meeting it was decided that we would not deprecate gensc as was presumed on PR #2697.

See the files changed for the new route mappings.

CC: @turbomam @ramonawalls 