### PR TITLE
Fix 307 redirections for good (I've tested it now)

### DIFF
--- a/mpilhlt/.htaccess
+++ b/mpilhlt/.htaccess
@@ -1,6 +1,10 @@
 Options +FollowSymLinks
 RewriteEngine on
+
+# Vocabularies webpages
 RewriteRule ^polmat/(.*) https://skohub.io/mpilhlt/vocabs-polmat/heads/main/w3id.org/mpilhlt/polmat/$1 [R=307,L]
 RewriteRule ^worktime/(.*) https://mpilhlt.github.io/vocabs-worktime/w3id.org/mpilhlt/worktime/$1 [R=307,L]
 RewriteRule ^worktime_role/(.*) https://c104-131.cloud.gwdg.de/vocabs/w3id.org/mpilhlt/worktime_role/$1 [R=307,L]
-RewriteRule ^reconcile/([^/]+)/(.*) https://c104-131.cloud.gwdg.de/reconc/$1/$2 [R=307,L]
+
+# Reconciliation API
+RewriteRule ^reconcile/(.*) https://c104-131.cloud.gwdg.de/reconc/$1 [R=307,L]


### PR DESCRIPTION
Sorry for the many PRs. I could not test locally how much of my problems was caused by the redirection status code and how much was caused by a wrong path matching regex. Turned out it was all the status code, and all the regex "improvements" needed to be reverted.
(I am redirecting to a Web API that accepts POST requests. But most clients - incorrectly - change the request method to GET when they run into a 302-redirect. 307 explicitly addresses this but I've only learnt about it during this debugging session.)

A big thank you for all your efforts!!