### PR TITLE
Add /zcap/cacao for CACAO-zCap

### DIFF
--- a/zcap/cacao/.htaccess
+++ b/zcap/cacao/.htaccess
@@ -1,0 +1,14 @@
+# CACAO Authorization Capabilities (CACAO-zCap)
+#
+# homepage:
+#   https://w3id.org/zcap/cacao/
+# maintainers:
+#   @clehner
+#   @awoie
+#
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ https://demo.didkit.dev/2022/cacao-zcap/ [R=302,L]
+RewriteRule ^v1$ https://demo.didkit.dev/2022/cacao-zcap/contexts/v1.json [R=302,L]


### PR DESCRIPTION
This is a request to add a namespace for CACAO-zCap: https://github.com/spruceid/cacao-zcap

CACAO-zCap is a partial transformation between Chain-Agnostic CApability Objects (CACAOs) and Authorization Capabilities (zCaps).
A JSON-LD context file and linked data vocabulary document are added as redirects.
The target files would be updated in https://github.com/spruceid/cacao-zcap/pull/7 to use the new URIs if this PR is accepted.

Is under `/zcap` a good location for this? Or would somewhere else make more sense?

Requesting review from `/zcap` maintainers: @msporny @dlongley @dmitrizagidulin @davidlehn

Cc: @awoie