### PR TITLE
New namespace for Inrupt resources

### DIFF
--- a/inrupt/.htaccess
+++ b/inrupt/.htaccess
@@ -1,0 +1,6 @@
+Options +FollowSymLinks
+
+RewriteEngine On
+
+RewriteRule (.*) https://data.inrupt.com/w3id.org/inrupt/$1 [R=302,L,QSA]
+

--- a/inrupt/README.md
+++ b/inrupt/README.md
@@ -1,0 +1,25 @@
+Inrupt Ontology
+===
+
+This W3ID provides a persistent URI namespace for Inrupt resources (i.e.,
+ vocabularies, example datasets, documentation, JSON-LD contexts, etc.).
+
+Namespace:
+ * https://w3id.org/inrupt/
+
+GitHub repository for Inrupt vocabularies:
+ * https://github.com/inrupt/solid-common-vocab-rdf
+
+Contact
+===
+
+This space is administered by:
+
+ * Pat McBennett
+   Technical Architect, [Inrupt, Inc.](https://inrupt.com)
+   <patm@inrupt.com>
+   
+ * Nicolas A. Seydoux
+   Devtools Developer, [Inrupt, Inc.](https://inrupt.com)
+   <nseydoux@inrupt.com>
+


### PR DESCRIPTION
This is the initial request for an Inrupt namespace, intended to provide PURL services for a number of Inrupt resources (including vocabularies, example datasets, documentation, JSON-LD contexts, etc.).