### PR TITLE
Add /metadocencia for the MetaDocencia project

### DIFF
--- a/metadocencia/.htaccess
+++ b/metadocencia/.htaccess
@@ -1,0 +1,9 @@
+RewriteEngine On
+
+################################
+# https://w3id.org/metadocencia/
+################################
+
+# Short link to Slack
+
+RewriteRule ^slack$ https://join.slack.com/t/metadocencia/shared_invite/zt-1a3cri0ht-_Ws~Eq2VkkQ9L64rvu2czA1 [R=301,NE,L]

--- a/metadocencia/README.md
+++ b/metadocencia/README.md
@@ -1,0 +1,16 @@
+# /metadocencia/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the [MetaDocencia](https://www.metadocencia.org/en/) project.
+
+
+## Contact
+This space is administered by:  
+
+Melissa Black
+
+Infrastructure and Impact Measurement Coordinator @ MetaDocencia
+
+[Email](mblack@metadocencia.org)
+
+[Github](https://github.com/melibleq)
+
+Project's repository: [https://github.com/MetaDocencia](https://github.com/MetaDocencia)


### PR DESCRIPTION
Requesting a namespace for the MetaDocencia project. See more at [https://www.metadocencia.org/en/](https://www.metadocencia.org/en/)