### PR TITLE
update(nen2660): add sparql endpoint, v2022

### DIFF
--- a/nen2660/.htaccess
+++ b/nen2660/.htaccess
@@ -8,6 +8,7 @@ RewriteRule ^skos/term$ https://bimloket.github.io/nen2660/data/nen2660-skos.ttl
 RewriteRule ^rdfs/def$ https://bimloket.github.io/nen2660/data/nen2660-rdfs.ttl [R=302,L]
 RewriteRule ^owl/def$ https://bimloket.github.io/nen2660/data/nen2660-owl.ttl [R=302,L]
 RewriteRule ^shacl/def$ https://bimloket.github.io/nen2660/data/nen2660-shacl.ttl [R=302,L]
+RewriteRule ^sparql$ https://hub.laces.tech/crow/nen2660/all/sparql [R=302,L]
 
 
 # 2: Non-explicit URL, explicit Accept-header

--- a/nen2660/README.md
+++ b/nen2660/README.md
@@ -1,7 +1,9 @@
 # /nen2660/
-This [W3ID](https://w3id.org) provides a persistent URI namespace for the normative NEN 2660-2:2021 resources.
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the normative NEN 2660-2:2022 resources.
 
-NEN 2660-2:2021 is the Dutch Norm “_Rules for information modelling of the built environment_”.
+[NEN 2660-2:2022][nen] is the Dutch Norm “_Rules for information modelling of the built environment_”.
+
+[nen]: https://www.nen.nl/nen-2660-2-2022-nl-291667
 
 ## Uses
 This namespace contains 


### PR DESCRIPTION
This update adds a SPARQL endpoint queriable via w3id.org/nen2660/sparql

It also updates the norm reference, as it was published in 2022.

Thanks!