### PR TITLE
Adding LANDRS drone ontology w3id 

### DIFF
--- a/drone/.htaccess
+++ b/drone/.htaccess
@@ -1,0 +1,24 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
+
+RewriteEngine on
+
+
+##############################
+# https://w3id.org/ammo/
+##############################
+
+# Rewrite rule for html for project
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://www.landrs.org/drone [R=303,L]

--- a/drone/ont/.htaccess
+++ b/drone/ont/.htaccess
@@ -1,0 +1,77 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
+
+RewriteEngine on
+
+
+##############################
+# https://w3id.org/drone/ont/
+##############################
+
+# Rewrite rule for latest version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://www.landrs.org/drone/release/ontology/latest/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://www.landrs.org/drone/release/ontology/latest/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://www.landrs.org/drone/release/ontology/latest/ontology.rdf [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://www.landrs.org/drone/release/ontology/latest/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ https://www.landrs.org/drone/release/ontology/latest/ontology.ttl [R=303,L]
+
+# Rewrite rules for any other version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(.+)$ https://www.landrs.org/drone/release/ontology/$1/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(.+)$ https://www.landrs.org/drone/release/ontology/$1/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(.+)$ https://www.landrs.org/drone/release/ontology/$1/ontology.rdf [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(.+)$ https://www.landrs.org/drone/release/ontology/$1/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^(.+)$ https://www.landrs.org/drone/release/ontology/$1/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^(.*)$ https://www.landrs.org/drone/release/ontology/latest/406.html [R=406,L]
+# Default response
+# ---------------------------
+# Rewrite rule to serve the Turtle content from the vocabulary URI by default
+RewriteRule ^$ https://raw.githack.com/landrs-toolkit/drone/main/release/ontology/latest/ontology.ttl [R=303,L]
+

--- a/drone/readme.md
+++ b/drone/readme.md
@@ -1,0 +1,26 @@
+## Linked-data API for Networked Drones (LANDRS), Drone Ontology
+
+This permanent w3id is meant to provide a persistent namespace for the [LANDRS](https://www.landrs.org) project. The drone ontology provides support for using linked data collection on unmanned, remotely piloted or robotic vehicles. We provide two namespaces, in these redirects. One for rdf/owl ontologies at https://w3id.org/drone/ont, and one for SHACL shapes https://w3id.org/drone/shapes/shacl. The URIs are structured to support Shex versions of the shapes at a later date.
+
+Ontology development and issue submissions are in the Github repository [https://github.com/landrs-toolkit/drone](https://github.com/landrs-toolkit/drone). For more information on the project see our homepage [LANDRS](https://www.landrs.org).
+
+https://w3id.org/drone redirects to https://www.landrs.org/drone for the ontology overview documentation
+
+https://w3id.org/drone/ont redirects to https://www.landrs.org/drone/release/ontology/latest/index-en.html for the html human readable content type.
+
+https://w3id.org/drone/ont/{version} redirects to https://www.landrs.org/drone/release/ontology/{version}/index-en.html for the html human readable content type.
+
+https://w3id.org/drone/shapes/shacl redirects to https://www.landrs.org/drone/release/shapes/shacl/latest/index-en.html for the html human readable content type.
+
+https://w3id.org/drone/shapes/shacl/{version} redirects to https://www.landrs.org/drone/release/shapes/shacl/index-en.html for the html human readable content type.
+
+Each w3id URI supports content-negotiation for text/turtle, application/rdf+xml, application/n-triples, application/ld+json
+
+---
+
+Maintainer:
+
+**Charles F. Vardeman**  
+_Research Assistant Professor_  
+_Center for Research Computing, University of Notre Dame_  
+<cvardema@nd.edu>

--- a/drone/readme.md
+++ b/drone/readme.md
@@ -1,6 +1,6 @@
 ## Linked-data API for Networked Drones (LANDRS), Drone Ontology
 
-This permanent w3id is meant to provide a persistent namespace for the [LANDRS](https://www.landrs.org) project. The drone ontology provides support for using linked data collection on unmanned, remotely piloted or robotic vehicles. We provide two namespaces, in these redirects. One for rdf/owl ontologies at https://w3id.org/drone/ont, and one for SHACL shapes https://w3id.org/drone/shapes/shacl. The URIs are structured to support Shex versions of the shapes at a later date.
+This permanent w3id is meant to provide a persistent namespace for the [LANDRS](https://www.landrs.org) project. The drone ontology provides support for using linked data collection on unmanned, remotely piloted, or robotic vehicles. We provide two namespaces in these redirects: one for RDF/OWL ontologies at <https://w3id.org/drone/ont>; and one for SHACL shapes <https://w3id.org/drone/shapes/shacl>. The URIs are structured to support ShEx versions of the shapes at a later date.
 
 Ontology development and issue submissions are in the Github repository [https://github.com/landrs-toolkit/drone](https://github.com/landrs-toolkit/drone). For more information on the project see our homepage [LANDRS](https://www.landrs.org).
 

--- a/drone/shapes/shacl/.htaccess
+++ b/drone/shapes/shacl/.htaccess
@@ -1,0 +1,77 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
+
+RewriteEngine on
+
+
+##############################
+# https://w3id.org/drone/shape/
+##############################
+
+# Rewrite rule for latest version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://www.landrs.org/drone/release/shapes/shacl/latest/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://www.landrs.org/drone/release/shapes/shacl/latest/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://www.landrs.org/drone/release/shapes/shacl/latest/ontology.rdf [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://www.landrs.org/drone/release/shapes/shacl/latest/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ https://www.landrs.org/drone/release/shapes/shacl/latest/ontology.ttl [R=303,L]
+
+# Rewrite rules for any other version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(.+)$ https://www.landrs.org/drone/release/shapes/shacl/$1/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(.+)$ https://www.landrs.org/drone/release/shapes/shacl/$1/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(.+)$ https://www.landrs.org/drone/release/shapes/shacl/$1/ontology.rdf [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(.+)$ https://www.landrs.org/drone/release/shapes/shacl/$1/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^(.+)$ https://www.landrs.org/drone/release/shapes/shacl/$1/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^(.*)$ https://www.landrs.org/drone/release/shapes/shacl/latest/406.html [R=406,L]
+# Default response
+# ---------------------------
+# Rewrite rule to serve the Turtle content from the vocabulary URI by default
+RewriteRule ^$ https://raw.githack.com/landrs-toolkit/drone/main/release/shapes/shacl/latest/ontology.ttl [R=303,L]
+


### PR DESCRIPTION
Adding support for [LANDRS](https://www.landrs.org) Drone Ontology/Shapes W3ID Redirects. 