### PR TITLE
Change redirect target for sec/jws-2020

### DIFF
--- a/security/.htaccess
+++ b/security/.htaccess
@@ -56,8 +56,8 @@ RewriteRule ^suites/blockchain-2021/v1$ https://or13.github.io/lds-blockchain202
 
 # http://w3id.org/security/suites/jws-2020
 
-RewriteRule ^suites/jws-2020$ https://w3c-ccg.github.io/lds-jws2020 [R=302,L]
-RewriteRule ^suites/jws-2020/v1$ https://w3c-ccg.github.io/lds-jws2020/contexts/v1 [R=302,L]
+RewriteRule ^suites/jws-2020$ https://w3c.github.io/vc-jws-2020/ [R=302,L]
+RewriteRule ^suites/jws-2020/v1$ https://w3c.github.io/vc-jws-2020/contexts/v1/ [R=302,L]
 
 # http://w3id.org/security/suites/bls12381-2020
 


### PR DESCRIPTION
This PR changes the redirects for Json Web Signature 2020 from the W3C CCG to the W3C!