### PR TITLE
AllowEncodedSlashes conf, NoEscaping Rewrite flag.

### DIFF
--- a/mpilhlt/.htaccess
+++ b/mpilhlt/.htaccess
@@ -1,5 +1,6 @@
 Options +FollowSymLinks
 RewriteEngine on
+AllowEncodedSlashes On
 
 # Vocabularies webpages
 RewriteRule ^polmat/(.*)                https://skohub.io/mpilhlt/vocabs-polmat/heads/main/w3id.org/mpilhlt/polmat/$1 [R=307,L]
@@ -13,4 +14,4 @@ RewriteRule ^worktime_role/(.*)         https://c111-064.cloud.gwdg.de/vocabs/mp
 RewriteRule ^worktime_term/(.*)         https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_term/$1 [R=307,L]
 
 # Reconciliation API
-RewriteRule ^reconcile/(.*)             https://c111-064.cloud.gwdg.de/reconc/mpilhlt/$1 [R=307,L]
+RewriteRule ^reconcile/(.*)             https://c111-064.cloud.gwdg.de/reconc/mpilhlt/$1 [R=307,NE,L]


### PR DESCRIPTION
Trying to get redirection of requests where the path contains urlencoded URLs to work. Presumably, the problem occurs when encountering encoded forward slashes, as `curl -I https://w3id.org/mpilhlt/reconcile/https%3A` is working correctly (gives a 307-redirection), whereas `curl -I https://w3id.org/mpilhlt/reconcile/https%3A%2F` does not (gives a 404).