### PR TITLE
AllowEncodedSlashes conf, NoEscape rewrite flag

### DIFF
--- a/rhonda/.htaccess
+++ b/rhonda/.htaccess
@@ -1,6 +1,6 @@
 Options +FollowSymLinks
 RewriteEngine on
-AllowEncodedSlashes On
+AllowEncodedSlashes NoDecode
 
 # RewriteRule ^polmat/(.*)    https://rhonda-org.github.io/vocabs-polmat/w3id.org/rhonda/polmat/$1 [R=302,L]
 RewriteRule ^polmat/(.*)    https://c111-064.cloud.gwdg.de/vocabs/rhonda-org/vocabs-worktime/heads/main/w3id.org/rhonda/polmat/$1 [R=302,L]

--- a/rhonda/.htaccess
+++ b/rhonda/.htaccess
@@ -1,7 +1,9 @@
 Options +FollowSymLinks
 RewriteEngine on
+AllowEncodedSlashes On
+
 # RewriteRule ^polmat/(.*)    https://rhonda-org.github.io/vocabs-polmat/w3id.org/rhonda/polmat/$1 [R=302,L]
 RewriteRule ^polmat/(.*)    https://c111-064.cloud.gwdg.de/vocabs/rhonda-org/vocabs-worktime/heads/main/w3id.org/rhonda/polmat/$1 [R=302,L]
 
 # Reconciliation API
-RewriteRule ^reconcile/(.*) https://c111-064.cloud.gwdg.de/reconc/rhonda-org/$1 [R=307,L]
+RewriteRule ^reconcile/(.*) https://c111-064.cloud.gwdg.de/reconc/rhonda-org/$1 [R=307,NE,L]


### PR DESCRIPTION
As in #2845, trying to get redirection of requests where the path contains urlencoded URLs to work. Presumably, the problem occurs when encountering encoded forward slashes, as curl -I https://w3id.org/rhonda/reconcile/https%3A is working correctly (gives a 307-redirection), whereas curl -I https://w3id.org/rhonda/reconcile/https%3A%2F does not (gives a 404).