### PR TITLE
Remove AllowEncodedSlashes option

### DIFF
--- a/mpilhlt/.htaccess
+++ b/mpilhlt/.htaccess
@@ -1,6 +1,6 @@
 Options +FollowSymLinks
 RewriteEngine on
-AllowEncodedSlashes NoDecode
+# AllowEncodedSlashes NoDecode
 
 # Vocabularies webpages
 RewriteRule ^polmat/(.*)                https://skohub.io/mpilhlt/vocabs-polmat/heads/main/w3id.org/mpilhlt/polmat/$1 [R=307,L]


### PR DESCRIPTION
Apparently, setting the AllowEncodedSlashes option is illegal in htaccess context. My redirections with this option enabled have resulted in 500 Server errors, probably because it has been a bad htaccess file. I will try something without the option, but if they still won't work I will open an issue...