### PR TITLE
Update to Qual-o namespace

### DIFF
--- a/qual-o/.htaccess
+++ b/qual-o/.htaccess
@@ -1,0 +1,7 @@
+Options +FollowSymLinks
+
+# Rewrite engine setup
+RewriteEngine On
+
+# Redirect 
+RewriteRule	^$ https://raw.githubusercontent.com/dcorsar/Qual-O/master/Qual-O.ttl [R=303,NE,L]

--- a/qual-o/.htaccess
+++ b/qual-o/.htaccess
@@ -5,3 +5,4 @@ RewriteEngine On
 
 # Redirect 
 RewriteRule	^$ https://raw.githubusercontent.com/dcorsar/Qual-O/master/Qual-O.ttl [R=303,NE,L]
+

--- a/qual-o/readme.md
+++ b/qual-o/readme.md
@@ -1,0 +1,9 @@
+# The Qual-O ontology 
+The Qual-O ontology implements the QUAL provenance-aware quality model for quality assessment over linked data. For more details regarding the QUAL model see:
+
+Baillie, C., Edwards, P., & Pignotti, E. (2015). QUAL: A Provenance-Aware Quality Model. International Journal of Data & Information Quality, 5(3), [12]. [https://doi.org/10.1145/2700413](https://doi.org/10.1145/2700413)
+
+# Author
+* [Chris Baillie](https://github.com/cbaillie)
+
+Updated to w3id.org namespace by [David Corsar](https://github.com/dcorsar)


### PR DESCRIPTION
The Qual-O ontology was defined with a namespace which is no longer accessible; this update changes the namespace to w3id to simplify reuse of the ontology.