### PR TITLE
Update SKOSMOS redirect target URLs for DiGA

### DIFF
--- a/diga/.htaccess
+++ b/diga/.htaccess
@@ -4,8 +4,8 @@ RewriteEngine On
 RewriteRule	  ^$ https://diga.ceres.rub.de/ [R=302,L]
 
 # DiGA Terms
-RewriteRule   ^terms/?$ https://skosmos.ub.rub.de/diga/ [R=303,L,QSA]
-RewriteRule   ^terms/(.+)$ https://skosmos.ub.rub.de/diga/page/$1 [R=303,L,QSA]
+RewriteRule   ^terms/?$ https://diga.skosmos.ub.rub.de/thesaurus/ [R=303,L,QSA]
+RewriteRule   ^terms/(.+)$ https://diga.skosmos.ub.rub.de/thesaurus/page/$1 [R=303,L,QSA]
 
 # DiGA Sources
 RewriteRule   ^source/?$ http://pages.ceres.rub.de/diga/diga_sources.rdf [R=303,L,QSA]
@@ -27,5 +27,5 @@ RewriteRule   ^illustrations/?$ https://pages.ceres.rub.de/diga/diga_illustratio
 RewriteRule   ^illustrations/(.+)$ https://pages.ceres.rub.de/diga/illustrations/$1.png [R=303,L,QSA]
 
 # DiGA Gazetteer
-RewriteRule   ^gazetteer/?$ https://skosmos.ub.rub.de/diga-gazetteer/ [R=303,L,QSA]
-RewriteRule   ^gazetteer/(.+)$ https://skosmos.ub.rub.de/diga-gazetteer/page/$1 [R=303,L,QSA]
+RewriteRule   ^gazetteer/?$ https://diga.skosmos.ub.rub.de/gazetteer/ [R=303,L,QSA]
+RewriteRule   ^gazetteer/(.+)$ https://diga.skosmos.ub.rub.de/gazetteer/page/$1 [R=303,L,QSA]


### PR DESCRIPTION
Our university library has changed the SKOSMOS URLs for our vocabularies (creating a separate subdomain for each project), so we need to update the redirects. Thanks!