### PR TITLE
Update to reflect new NISO URLs

### DIFF
--- a/credit/.htaccess
+++ b/credit/.htaccess
@@ -1,6 +1,6 @@
 Options +FollowSymLinks
 
 RewriteEngine on
-RewriteRule ^$ https://casrai.org/credit/ [R=302,L]
-RewriteRule ^taxonomy(/.*)?$ https://dictionary.casrai.org/Contributor_Roles$1 [R=302,L]
+RewriteRule ^$ https://credit.niso.org/ [R=302,L]
+RewriteRule ^taxonomy(/.*)?$ https://credit.niso.org/contributor-roles$1 [R=302,L]
 RewriteRule ^ontology$ https://raw.githubusercontent.com/data2health/credit-ontology/master/credit.owl [R=302,L]

--- a/credit/README.md
+++ b/credit/README.md
@@ -1,6 +1,11 @@
 # CRediT
 
-CRediT is a high-level taxonomy, including 14 roles, that can be used to represent the roles typically played by contributors to scientific scholarly output. The roles describe each contributor’s specific contribution to the scholarly output.  The CRediT Ontology is an OWL implementation of the taxonomy.
+CRediT is a high-level taxonomy, including 14 roles, that can be used to represent the roles 
+typically played by contributors to scientific scholarly output. The roles describe each 
+contributor’s specific contribution to the scholarly output. Originally created by CASRAI, 
+the maintenance of CRediT was taken over by NISO in 2022. The CRediT Ontology is an OWL 
+implementation of the taxonomy created under the purview of the NIH CTSA Program National Center 
+for Data to Health (CD2H) to support development of the Contribtutor Role Ontology (CRO).
 
 
 CRediT Homepage:


### PR DESCRIPTION
NISO took over maintenance of CRediT from CASRAI this year, which means there are new URLs to redirect to.