### PR TITLE
new rules

### DIFF
--- a/iliad/.htaccess
+++ b/iliad/.htaccess
@@ -33,3 +33,4 @@ RewriteRule ^api/v1.0/Observations\((.*)\)$ https://grlc.io/api-git/ILIAD-ocean-
 
 
 
+

--- a/iliad/.htaccess
+++ b/iliad/.htaccess
@@ -32,3 +32,4 @@ RewriteRule ^api/v1.0/Observations\((.*)\)$ https://grlc.io/api-git/ILIAD-ocean-
 
 
 
+

--- a/iliad/.htaccess
+++ b/iliad/.htaccess
@@ -23,3 +23,12 @@ RewriteRule ^api/v1.0$ https://grlc.io/api-git/ILIAD-ocean-twin/api/base [R=302,
 RewriteRule ^api/v1.0/Observations$ https://grlc.io/api-git/ILIAD-ocean-twin/api/Observations?page=1 [R=302,L]
 RewriteRule ^api/v1.0/Observations\?\$top=(.*)&\$skip=(.*)00$ https://grlc.io/api-git/ILIAD-ocean-twin/api/Observations?page=$2 [R=302,L]
 RewriteRule ^api/v1.0/Observations\((.*)\)$ https://grlc.io/api-git/ILIAD-ocean-twin/api/Observations(id)?id=$1 [R=302,L]
+
+
+
+
+
+
+
+
+

--- a/iliad/.htaccess
+++ b/iliad/.htaccess
@@ -20,16 +20,6 @@ RewriteRule ^oim$ https://github.com/ILIAD-ocean-twin/oim [R=302,L]
 # API
 RewriteRule ^api$ https://grlc.io/api-git/ILIAD-ocean-twin/api/base [R=302,L]
 RewriteRule ^api/v1.0$ https://grlc.io/api-git/ILIAD-ocean-twin/api/base [R=302,L]
-RewriteRule ^api/v1.0/Observations$ https://grlc.io/api-git/ILIAD-ocean-twin/api/Observations [R=302,L]
+RewriteRule ^api/v1.0/Observations$ https://grlc.io/api-git/ILIAD-ocean-twin/api/Observations?page=1 [R=302,L]
+RewriteRule ^api/v1.0/Observations\?\$top=(.*)&\$skip=(.*)00$ https://grlc.io/api-git/ILIAD-ocean-twin/api/Observations?page=$2 [R=302,L]
 RewriteRule ^api/v1.0/Observations\((.*)\)$ https://grlc.io/api-git/ILIAD-ocean-twin/api/Observations(id)?id=$1 [R=302,L]
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Hi @dgarijo 
I have a question. 
I need to make a very simple arithmetic operation during the redirection, e.g., 

[https://w3id.org/iliad/api/v1.0/Observations?$top=100&$skip=100](https://w3id.org/iliad/api/v1.0/Observations?$top=100&$skip=100)

 should be  redirected to 

[https://grlc.io/api-git/ILIAD-ocean-twin/api/Observations?page=2](https://grlc.io/api-git/ILIAD-ocean-twin/api/Observations?page=2)

i made rule 
```
RewriteRule ^api/v1.0/Observations\?\$top=(.*)&\$skip=(.*)00$ https://grlc.io/api-git/ILIAD-ocean-twin/api/Observations?page=$2 [R=302,L]
```
(basically with regex i get from skip, 1 from 100,  2 from 200, 3 from 300,....10 from 1000, etc. and then I add 1.

But i dont know how to add 1 to $2 (skip value)

I found it should be possible: https://stackoverflow.com/questions/20164428/how-to-do-arithmetic-operation-in-rewriterule-function  (see also https://httpd.apache.org/docs/2.4/rewrite/rewritemap.html#prg)
but i dont see any example in w3id.org repo

could you please check if this would be possible in w3id ?

thanks
Raul



