### PR TITLE
Update rule

### DIFF
--- a/iliad/.htaccess
+++ b/iliad/.htaccess
@@ -20,8 +20,9 @@ RewriteRule ^oim$ https://github.com/ILIAD-ocean-twin/oim [R=302,L]
 # API
 RewriteRule ^api$ https://grlc.io/api-git/ILIAD-ocean-twin/api/base [R=302,L]
 RewriteRule ^api/v1.0$ https://grlc.io/api-git/ILIAD-ocean-twin/api/base [R=302,L]
-RewriteCond %{QUERY_STRING} ^\$top=(.*)&\$skip=(.*)00$
-RewriteRule ^api/v1.0/Observations$ https://grlc.io/api-git/ILIAD-ocean-twin/api/Observations?page=%2 [R=302,L]
+#RewriteCond %{QUERY_STRING} ^\$top=(.*)&\$skip=(.*)00$
+RewriteCond %{QUERY_STRING} (?:^|&)\$skip=([1-9]+[0-9]*)00
+RewriteRule ^api/v1.0/Observations$ https://grlc.io/api-git/ILIAD-ocean-twin/api/Observations?page=%1 [R=302,L]
 RewriteRule ^api/v1.0/Observations$ https://grlc.io/api-git/ILIAD-ocean-twin/api/Observations?page=1 [R=302,L]
 RewriteRule ^api/v1.0/Observations\((.*)\)$ https://grlc.io/api-git/ILIAD-ocean-twin/api/Observations(id)?id=$1 [R=302,L]
 


### PR DESCRIPTION
Hi @davidlehn 
Thanks a lot for your suggestions in [this comment](https://github.com/perma-id/w3id.org/pull/2898)
I have updated the rule to use your first (simpler) approach. 

In fact, my last rule (below) is not working either (after it was merged). 
I don't understand why as it is working on my tests in [here](https://htaccess.madewithlove.com?share=abf24f88-fd43-43f4-8c18-9d2001343ebf)

```
RewriteCond %{QUERY_STRING} ^\$top=(.*)&\$skip=(.*)00$
RewriteRule ^api/v1.0/Observations$ https://grlc.io/api-git/ILIAD-ocean-twin/api/Observations?page=%2 [R=302,L]
```

I was also checking your second approach in https://htaccess.madewithlove.com/ but its returning only the variable number (%1) as you can see [here](https://htaccess.madewithlove.com?share=62fd308a-6f06-4881-b831-5d86bb78aa51)

Maybe this testing tool is not totally correct....