### PR TITLE
Add namespace MoRe-SFB1475

### DIFF
--- a/MoRe-SFB1475/.htaccess
+++ b/MoRe-SFB1475/.htaccess
@@ -1,0 +1,10 @@
+RewriteEngine On
+
+# Redirect to website for the root URI
+RewriteRule	  ^$ https://sfb1475.ruhr-uni-bochum.de/ [R=302,L]
+
+# Redirect to vocabulary overview
+RewriteRule   ^CT/?$ http://eris.vm.rub.de/Skosmos/ct/ [R=303,L,QSA]
+# Redirect individual concepts
+RewriteRule   ^CT/concepts/(.+)$ http://eris.vm.rub.de/Skosmos/ct/page/$1 [R=303,L,QSA]
+

--- a/MoRe-SFB1475/README.md
+++ b/MoRe-SFB1475/README.md
@@ -1,0 +1,22 @@
+# /diga/
+
+This [W3ID](https://w3id.org) provides a persistent URI namespace for a thesaurus and connected resources from the Collaborative Research Center (in German: SFB) 1475 ["Metaphors of Religion"](https://sfb1475.ruhr-uni-bochum.de/en/).
+
+## Uses
+
+The namespace currently only contains the project website and the conceptual thesaurus itself:
+
+* **`/MoRe-SFB1475/`** redirects to the project website
+* **`/MoRe-SFB1475/CT/`** is the entry point to the thesaurus
+* **`/MoRe-SFB1475/CT/concepts/`** is used for the individual concepts
+
+## Contact
+
+This space is administered by:  
+
+**Henning Gebhard**   
+[Center for Religous Studies](https://ceres.rub.de/de/)  
+Ruhr University Bochum, Germany  
+<henning.gebhard@rub.de>  
+GitHub: [ben-tinc](https://github.com/ben-tinc)  
+ORCID: [https://orcid.org/0000-0001-7853-1950](https://orcid.org/0000-0001-7853-1950)  


### PR DESCRIPTION
Namespace for website and conceptual thesaurus of the collaborative research center "Metaphors of Religion" (https://sfb1475.ruhr-uni-bochum.de/en/). We would love to simply use "MoRe" but deemed it too generic, hence the "SFB1475" suffix. 