### PR TITLE
added research technology readiness levels

### DIFF
--- a/research-technology-readiness-levels/.htaccess
+++ b/research-technology-readiness-levels/.htaccess
@@ -1,0 +1,10 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/ld+json .jsonld
+
+RewriteEngine on
+
+RewriteRule ^$ https://raw.githubusercontent.com/CLARIAH/tool-discovery/master/schemas/research-technology-readiness-levels.jsonld [R=303,L]

--- a/research-technology-readiness-levels/readme.md
+++ b/research-technology-readiness-levels/readme.md
@@ -1,0 +1,7 @@
+## Research Technology Readiness Levels
+
+This permanent w3id is meant to formalize as a SKOS vocabulary a taxonomy of Technology Readiness Levels for academia (such as for research software). These are formulated by the [CLARIAH](https://clariah.nl) project and are inspired on the TRL scale as used in the EU, reference: 
+
+* Mihaly, Heder (September 2017). "From NASA to EU: the evolution of the TRL scale in Public Sector Innovation" ([PDF](https://web.archive.org/web/20171011071816/https://www.innovation.cc/discussion-papers/22_2_3_heder_nasa-to-eu-trl-scale.pdf)). The Innovation Journal. 22: 1–23. Archived from the original (PDF) on October 11, 2017.
+
+Maintainer: Maarten van Gompel (@proycon)


### PR DESCRIPTION
This permanent w3id is meant to formalize as a SKOS vocabulary a taxonomy of Technology Readiness Levels for academia (such as for research software). These are formulated by the [CLARIAH](https://clariah.nl) project and are inspired on the TRL scale as used in the EU, reference:

* Mihaly, Heder (September 2017). "From NASA to EU: the evolution of the TRL scale in Public Sector Innovation" ([PDF](https://web.archive.org/web/20171011071816/https://www.innovation.cc/discussion-papers/22_2_3_heder_nasa-to-eu-trl-scale.pdf)). The Innovation Journal. 22: 1–23. Archived from the original (PDF) on October 11, 2017.