### PR TITLE
Add the STREAM project as a folder with the MatVoc vocabulary as a subfolder

### DIFF
--- a/STREAM/MatVoc/.htaccess
+++ b/STREAM/MatVoc/.htaccess
@@ -1,0 +1,34 @@
+# Rewrite engine setup
+RewriteEngine on
+
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://stream-project.github.io/index.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://stream-project.github.io/ontology.json [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://stream-project.github.io/ontology.rdf [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://stream-project.github.io/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ https://stream-project.github.io/ontology.ttl [R=303,L]
+
+
+
+# Default response
+# ---------------------------
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^$ https://stream-project.github.io/ [R=303,L]

--- a/STREAM/MatVoc/README.md
+++ b/STREAM/MatVoc/README.md
@@ -1,0 +1,33 @@
+# /STREAM/MatVoc
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the material vocabulary of the STREAM project.
+
+
+## Maintainers
+* [@tboonx](https://github.com/TBoonX)
+
+## Contact
+
+### Coordinator
+[**Dr. Matthias Weber**](mailto:matthias.weber@iwm.fraunhofer.de)
+
+[Fraunhofer-Institut für Werkstoffmechanik (IWM)](https://www.iwm.fraunhofer.de/)
+
+### Partners
+**Dr. Michael Martin**
+
+[Institut für Angewandte Informatik e. V. (InfAI)](https://infai.org/efficient-technology-integration/)
+
+
+[**Dr. Javad Chamanara**](https://www.tib.eu/de/forschung-entwicklung/forschungsgruppen-und-labs/data-science-digital-libraries/mitarbeiterinnen-und-mitarbeiter/javad-chamanara)
+
+[Leibniz-Informationszentrum TEchnik und Naturwisenschaften Universätsbibliothek (TIB)](https://www.tib.eu/de/)
+
+
+## Information:
+
+### STREAM project
+* [Homepage](https://stream-projekt.net)
+* [IWM project website](https://www.iwm.fraunhofer.de/de/geschaeftsfelder/fertigungsprozesse/materialinformatik/stream.html)
+
+### Funding
+STREAM is funded by the [German federal ministry of education and research](https://www.bmbf.de/bmbf/en/home/home_node.html) under the *funding-ID: 16QK11*.

--- a/STREAM/README.md
+++ b/STREAM/README.md
@@ -1,0 +1,6 @@
+# STREAM project
+* [Homepage](https://stream-projekt.net)
+* [IWM project website](https://www.iwm.fraunhofer.de/de/geschaeftsfelder/fertigungsprozesse/materialinformatik/stream.html)
+
+## Funding
+STREAM is funded by the [German federal ministry of education and research](https://www.bmbf.de/bmbf/en/home/home_node.html) under the *funding-ID: 16QK11*.


### PR DESCRIPTION
With this PR I want to create a permanent identifier for the MatVoc RDF vocabulary, originated in the STREAM project.

Because other identifiers in STREAM should be created, I add STREAM as a PROJECT-ID for later PRs.

