### PR TITLE
use more generic ruleset in root-level  .htaccess

### DIFF
--- a/permafrost/.htaccess
+++ b/permafrost/.htaccess
@@ -1,1 +1,8 @@
+Options +FollowSymLinks
 RewriteEngine on
+
+RewriteRule ^v/([^/]*)/scheme/? http://vocab.permafrostnet.ca/vocab/$1 [R=303,L,NE]
+
+RewriteRule ^v/([^/]*)/(.+)/? http://vocab.permafrostnet.ca/vocab/$1/$2 [R=303,L,NE]
+
+RewriteRule ^v/([^/]*)/? http://vocab.permafrostnet.ca/collection/$1 [R=303,L,NE]


### PR DESCRIPTION
use generic rules in root-level .htaccess instead of subfolders (for vocabularies)