### PR TITLE
Update idsa context paths from jira to gitlab.

### DIFF
--- a/idsa/.htaccess
+++ b/idsa/.htaccess
@@ -84,12 +84,13 @@ RewriteCond %{HTTP_ACCEPT} ^.*application/n-triples.*
 RewriteRule ^core-([0-9])([0-9])([0-9]) https://international-data-spaces-association.github.io/InformationModel/docs/$1.$2.$3/serializations/ontology.nt [L,R=303]
 
 # context.json(ld)
-RewriteRule ^contexts/context.json$ https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/4.0.0/context.jsonld [R=303]
-RewriteRule ^contexts/context.jsonld$ https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/4.0.0/context.jsonld [R=303]
-RewriteRule ^contexts/context-dev.json$ https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/4.0.0/context.jsonld [R=303]
-RewriteRule ^contexts/context-dev.jsonld$ https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/4.0.0/context.jsonld [R=303]
-RewriteRule ^contexts/([0-9][.][0-9][.][0-9])/context.json$ https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/$1/context.jsonld [R=303]
-RewriteRule ^contexts/([0-9][.][0-9][.][0-9])/context.jsonld$ https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/$1/context.jsonld [R=303]
+RewriteRule ^contexts/context.json$ https://gitlab.cc-asp.fraunhofer.de/eis-ids/ids-infomodel-commons/-/raw/master/jsonld-context/4.0.0/context.jsonld [R=303]
+RewriteRule ^contexts/context.jsonld$ https://gitlab.cc-asp.fraunhofer.de/eis-ids/ids-infomodel-commons/-/raw/master/jsonld-context/4.0.0/context.jsonld [R=303]
+RewriteRule ^contexts/context-dev.json$ https://gitlab.cc-asp.fraunhofer.de/eis-ids/ids-infomodel-commons/-/raw/master/jsonld-context/4.0.0/context.jsonld [R=303]
+RewriteRule ^contexts/context-dev.jsonld$ https://gitlab.cc-asp.fraunhofer.de/eis-ids/ids-infomodel-commons/-/raw/master/jsonld-context/4.0.0/context.jsonld [R=303]
+RewriteRule ^contexts/([0-9][.][0-9][.][0-9])/context.json$ https://gitlab.cc-asp.fraunhofer.de/eis-ids/ids-infomodel-commons/-/raw/master/jsonld-context/$1/context.jsonld [R=303]
+RewriteRule ^contexts/([0-9][.][0-9][.][0-9])/context.jsonld$ https://gitlab.cc-asp.fraunhofer.de/eis-ids/ids-infomodel-commons/-/raw/master/jsonld-context/$1/context.jsonld [R=303]
+
 
 #
 RewriteRule ^(core|code|metamodel)/(.+) https://international-data-spaces-association.github.io/InformationModel/docs/index.html#/$2 [R=303,NE]

--- a/idsa/README.md
+++ b/idsa/README.md
@@ -11,9 +11,9 @@ Redirections:
 * https://w3id.org/idsa/core.ttl, https://w3id.org/idsa/code.ttl --> https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology.ttl
 * https://w3id.org/idsa/core[.rdf|.xml|.json|.nt], https://w3id.org/idsa/code[.rdf|.xml|.json|.nt] --> https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology[.rdf|.xml|.json|.jsonld|.nt]
 * https://w3id.org/idsa/core, https://w3id.org/idsa/code with "Accept: application/[rdf+xml|xml|json|ld+json|n-triples]" or "Accept: text/[turtle|n3]" --> https://international-data-spaces-association.github.io/InformationModel/docs/serializations/ontology[.rdf|.xml|.json|.jsonld|.nt]
-* https://w3id.org/idsa/contexts/context.[jsonld|json] --> https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/4.0.0/context.jsonld
-* https://w3id.org/idsa/contexts/[a.b.c]/context.[jsonld|json] --> https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/[a.b.c]/context.jsonld
-* https://w3id.org/idsa/contexts/context-dev.[jsonld|json] --> https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-commons/raw/jsonld-context/4.0.0/context.jsonld
+* https://w3id.org/idsa/contexts/context.[jsonld|json] --> https://gitlab.cc-asp.fraunhofer.de/eis-ids/ids-infomodel-commons/-/raw/master/jsonld-context/4.0.0/context.jsonld
+* https://w3id.org/idsa/contexts/[a.b.c]/context.[jsonld|json] --> https://gitlab.cc-asp.fraunhofer.de/eis-ids/ids-infomodel-commons/-/raw/master/jsonld-context/[a.b.c]/context.jsonld
+* https://w3id.org/idsa/contexts/context-dev.[jsonld|json] --> https://gitlab.cc-asp.fraunhofer.de/eis-ids/ids-infomodel-commons/-/raw/master/jsonld-context/4.0.0/context.jsonld
 * https://w3id.org/idsa/ids-messages --> http://htmlpreview.github.io/?https://github.com/International-Data-Spaces-Association/InformationModel/blob/feature/message_taxonomy_description/model/communication/Message_Description.htm
 * https://w3id.org/idsa/shacl/ --> https://github.com/International-Data-Spaces-Association/InformationModel/releases/download/v4.0.0/ValidationShapesv400.zip
 * https://w3id.org/idsa/shacl/* --> https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/develop/testing/*


### PR DESCRIPTION
We moved the hosting of a set of resources from jira to gitlab and would like to update the paths accordingly.