### PR TITLE
[ICDDL] added to perma-id/w3id.org

### DIFF
--- a/icddl/.htaccess
+++ b/icddl/.htaccess
@@ -1,0 +1,48 @@
+# Selected Options [+ on] [- off]
+Options +FollowSymLinks
+
+# Runtime rewriting engine
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+AddType application/ld+json .jsonld
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://philhag.github.io/icdd-shacl-validation/icddl/ [R=302,NE,L]
+
+# In case of accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://philhag.github.io/icdd-shacl-validation/icddl/icddl.ttl [R=303,NE,L]
+
+# In case of accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://philhag.github.io/icdd-shacl-validation/icddl/icddl.rdf [R=302,NE,L]
+
+# In case of accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*application/ld+json.* 
+RewriteRule ^$ https://philhag.github.io/icdd-shacl-validation/icddl/icddl.jsonld [R=303,NE,L]
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^icddl.ttl$ https://philhag.github.io/icdd-shacl-validation/icddl/icddl.ttl [R=302,NE,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^icddl.html$ https://philhag.github.io/icdd-shacl-validation/icddl/ [R=302,NE,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^icddl.rdf$ https://philhag.github.io/icdd-shacl-validation/icddl/icddl.rdf [R=302,NE,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^icddl.nt$ https://philhag.github.io/icdd-shacl-validation/icddl/icddl.nt [R=302,NE,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^icddl.jsonld$ https://philhag.github.io/icdd-shacl-validation/icddl/icddl.jsonld [R=302,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://philhag.github.io/icdd-shacl-validation/icddl/ [R=303,NE,L]

--- a/icddl/readme.md
+++ b/icddl/readme.md
@@ -1,0 +1,22 @@
+# ICDD Link Predicates (ICDDL)
+
+## Description
+An ontology to provide link predicates on the basis of the ICDD ontology schemes for links and extended links.
+
+## Ontology resources
+* HTML      https://philhag.github.io/icdd-shacl-validation/icddl/
+* Turtle    https://philhag.github.io/icdd-shacl-validation/icddl/icddl.ttl
+* RDF/XML   https://philhag.github.io/icdd-shacl-validation/icddl/icddl.rdf
+* GitHub    https://github.com/philhag/icdd-shacl-validation
+
+
+## Contact
+This space is administered by:  
+
+**Philipp Hagedorn**  
+*Research Assistant, Ruhr-University Bochum, Germany*  
+
+* GitHub: [philhag](https://github.com/philhag)
+* ResearchGate: [Link](https://www.researchgate.net/profile/Philipp-Hagedorn)
+* ORDiD: [Link](https://orcid.org/0000-0002-6249-243X)
+* LinkedIn: [Link](https://www.linkedin.com/in/hagedorn-philipp/)


### PR DESCRIPTION
Add icddl ontology  to [perma-id](https://github.com/perma-id) / [w3id.org](https://github.com/perma-id/w3id.org)