### PR TITLE
persistent URIs for the WHOW project

### DIFF
--- a/whow/controlled-vocabulary/.htaccess
+++ b/whow/controlled-vocabulary/.htaccess
@@ -1,0 +1,18 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+SetEnvIf Accept ^.*application/rdf\+xml.* SYNTAX=rdf
+SetEnvIf Accept ^.*text/turtle.* SYNTAX=ttl
+SetEnvIf Accept ^.*application/json-ld.* SYNTAX=jsonld
+SetEnvIf Accept ^.*text/html.* SYNTAX=html
+SetEnvIf Request_URI ^.*$ ROOT_URL=https://raw.githubusercontent.com/whow-project/semantic-assets/main/controlled-vocabularies
+
+
+RewriteCond %{ENV:SYNTAX} ^(rdf|ttl|jsonld)$
+RewriteRule ^([a-zA-Z-_0-9]+)$ %{ENV:ROOT_URL}/$1/$1.%{ENV:SYNTAX} [R=303,L]
+
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^([a-zA-Z-_0-9]+)$ https://semscout.istc.cnr.it/whow/lodview/controlled-vocabulary/$1 [R=303,L]
+
+RewriteRule ^(.+)/(.+)$ https://semscout.istc.cnr.it/whow/lodview/controlled-vocabulary/$1/$2 [R=303,L]

--- a/whow/data/.htaccess
+++ b/whow/data/.htaccess
@@ -1,0 +1,7 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+SetEnvIf Request_URI ^.*$ ROOT_URL=https://semscout.istc.cnr.it/whow/lodview/data/
+
+RewriteRule ^(.*)$ %{ENV:ROOT_URL}$1 [R=303,L]
+RewriteRule ^(.*)/$ %{ENV:ROOT_URL}$1 [R=303,L]

--- a/whow/onto/.htaccess
+++ b/whow/onto/.htaccess
@@ -1,0 +1,18 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+SetEnvIf Accept ^.*application/rdf\+xml.* SYNTAX=rdf
+SetEnvIf Accept ^.*text/turtle.* SYNTAX=ttl
+SetEnvIf Accept ^.*application/json-ld.* SYNTAX=jsonld
+SetEnvIf Accept ^.*text/html.* SYNTAX=html
+SetEnvIf Request_URI ^.*$ ROOT_URL=https://raw.githubusercontent.com/whow-project/semantic-assets/main/ontologies/
+
+RewriteCond %{ENV:SYNTAX} ^(rdf|ttl|jsonld)$
+RewriteRule ^([a-zA-Z-_0-9]+)(/?)$ %{ENV:ROOT_URL}$1/latest/$1.%{ENV:SYNTAX} [R=303,L]
+
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^(.+)(/.+)$ https://semscout.istc.cnr.it/whow/lodview/onto/$1$2 [R=303,L]
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^(.+)/$ https://semscout.istc.cnr.it/whow/lode/extract?url=https://w3id.org/whow/onto/$1 [R=303,L]
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^(.+)$ https://semscout.istc.cnr.it/whow/lode/extract?url=https://w3id.org/whow/onto/$1 [R=303,L]

--- a/whow/readme.md
+++ b/whow/readme.md
@@ -1,0 +1,18 @@
+Repository for redirecting to ontologies of the CEF Open Data-funded European project WHOW - Water Health Open Knowledge
+===================
+
+We intend to use w3id.org in order to obtain persistent URIs for the network of ontologies we are developing in the context of the CEF EU funded project [WHOW Project](https://whowproject.eu). The network is developed by the partners of the project namely Celeris (coordinator), ISPRA (Italian Institute of Environmental Research), Aria SpA (in-house of Italian Lombardy region) and the Institute of Cognitive Sciences and Technologies (Semantic Technologies Laboratory - STLab) of the Italian National Research Council (CNR).
+
+We initially plan to create:
++ `w3id.org/whow/onto` for all the ontologies of the network mentioned above;
++ `w3id.org/whow/controlled-vocabulary` for all the controlled vocabularies;
++ `w3id.org/whow/data` for all the other types of data;
+
+
+Some redirect rules will be to the [github repository of the project](https://github.com/whow-project) we are using as working repo, open to all; others to the CNR server.
+
+Contacts:
+
++ Giorgia Lodi (giorgia.lodi@cnr.it)
++ Andrea Giovanni Nuzzolese (andreagiovanni.nuzzolese@cnr.it)
++ Anna Sofia Lippolis (annasofia.lippolis@istc.cnr.it)


### PR DESCRIPTION
we'd like to add the whow directory for the persistent URIs of the ontologies and linked open data of the WHOW project. Info in the readme.md file