### PR TITLE
Add redirect `orcidio` for ORCID in OWL

### DIFF
--- a/orcidio/.htaccess
+++ b/orcidio/.htaccess
@@ -1,0 +1,6 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Make ontology artifacts resolvable
+RewriteRule ^orcidio.ofn$ https://raw.githubusercontent.com/cthoyt/orcidio/main/orcidio.ofn [R=302,L]
+RewriteRule ^orcidio.owl$ https://raw.githubusercontent.com/cthoyt/orcidio/main/orcidio.owl [R=302,L]

--- a/orcidio/README.md
+++ b/orcidio/README.md
@@ -1,0 +1,16 @@
+# ORCID in OWL
+
+This [W3ID](https://w3id.org/) provides a persistent URI namespace for ORCID in OWL resources.
+
+## Uses
+
+ORCID in OWL is an ontology that wraps notable ORCID identifiers as named individuals so they can be more easily included in other ontologies (e.g., OBO Ontologies) and empower Protege to show rich label information for `dc:contributor` annotations.
+
+The artifacts referenced by this entry are versionioned in the following GitHub repository: https://github.com/cthoyt/orcidio
+
+## Contact
+
+Charles Tapley Hoyt
+Email: cthoyt@gmail.com
+GitHub: [@cthoyt](https://github.com/cthoyt/)
+ORCID: [0000-0003-4423-4370](https://orcid.org/0000-0003-4423-4370)


### PR DESCRIPTION
ORCID in OWL is an ontology that wraps notable ORCID identifiers as named individuals so they can be more easily included in other ontologies (e.g., OBO Ontologies) and empower Protege to show rich label information for `dc:contributor` annotations.

The goal of having an entry in w3id.org is to endow this ontology with a PURL as its ontology IRI.