### PR TITLE
Content Profiles / Linked Documents (NISO)

### DIFF
--- a/cpld/.htaccess
+++ b/cpld/.htaccess
@@ -1,0 +1,13 @@
+RewriteEngine on
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType text/n3 .n3
+AddType application/n-triples .nt
+AddType application/ld+json .jsonld
+
+# CPLD Schema and Context
+RewriteRule ^$ https://github.com/niso-standards/cpld/raw/main/schema/cpld.schema.jsonld [R=302,L]

--- a/cpld/README.md
+++ b/cpld/README.md
@@ -1,0 +1,21 @@
+# /cpld/
+
+This W3ID provides a persistent URI namespace for the Content Profiles / Linked Documents (CP/LD) standard. CP/LD is intended to be a new National Information Standards Organization(NISO) standard for representing scholarly publications as HTML and JSON-LD.
+
+This standard will be published on the [NISO Website](https://niso.org)
+
+# Uses
+The CP/LD namespace is <https://w3id.org/cpld/> and redirects to <https://github.com/niso-standards/cpld/raw/main/schema/cpld.schema.jsonld>, which hosts the CP/LD JSON-LD context and ontology.
+
+Note that this is currently a private GitHub repository which will be opened for read access once the standard has been approved. It is expected that this namespace will be expanded to cover more finegrained redirects to additional resources.
+
+# Contact
+
+This space is administered on behalf of the [NISO CP/LD Working Group](https://niso.org) by:
+
+**Rinke Hoekstra**  
+*Lead Architect - Knowledge*  
+[Elsevier](https://elsevier.com)    
+Amsterdam, The Netherlands  
+<r.hoekstra@elsevier.com>  
+GitHub: [RinkeHoekstra](https://github.com/RinkeHoekstra) ORCID: [0000-0001-7076-9083](https://orcid.org/0000-0001-7076-9083)


### PR DESCRIPTION
This W3ID provides a persistent URI namespace for the Content Profiles / Linked Documents (CP/LD) standard. CP/LD is intended to be a new National Information Standards Organization(NISO) standard for representing scholarly publications as HTML and JSON-LD.

The CP/LD namespace is <https://w3id.org/cpld/> and redirects to <https://github.com/niso-standards/cpld/raw/main/schema/cpld.schema.jsonld>, which hosts the CP/LD JSON-LD context and ontology.

Note that this is currently a private GitHub repository which will be opened for read access once the standard has been approved. It is expected that this namespace will be expanded to cover more finegrained redirects to additional resources.