### PR TITLE
uri4uri namespace

### DIFF
--- a/uri4uri/.htaccess
+++ b/uri4uri/.htaccess
@@ -1,0 +1,9 @@
+RewriteEngine On
+RewriteOptions AllowAnyURI
+
+# MergeSlashes workaround - get the original path from THE_REQUEST
+RewriteCond %{THE_REQUEST} /+[uU][rR][iI]4[uU][rR][iI]/+([^\ ]*)
+RewriteRule . https://uri4uri.is4.site/%1 [R=302,NE,L]
+
+# Fallback
+RewriteRule (.*) https://uri4uri.is4.site/$1 [R=302,NE,L]

--- a/uri4uri/README.md
+++ b/uri4uri/README.md
@@ -1,0 +1,9 @@
+# `/uri4uri/`
+A persistent URI namespace for the [**uri4uri** service](https://uri4uri.is4.site/) and corresponding resources.
+
+## Uses
+This namespace contains sub-namespaces for identifying URIs, their components, or related identifiers and resources, e.g. `/uri/` for URIs, `/scheme/` for URI schemes, `/mime/` for MIME types, `/suffix/` for file extensions, `/port/` for ports etc.
+The description of all sub-namespaces and their format and usage can be found at <https://uri4uri.is4.site/> or at <https://uri4uri.is4.site/.well-known/void> in VoID.
+
+## Contact
+This space is administered by: **[IS4](https://is4.site/)** ([GitHub repository](https://github.com/IllidanS4/uri4uri)).


### PR DESCRIPTION
Contains a workaround for `MergeSlashes On`, but due to `AllowEncodedSlashes Off`, `%2F` cannot be used in an identifier (see #2934). This is a potential issue only for `/uri/`, but the normalized identifiers never use `%2F` in path anyway (it's either `/` or doubly-encoded `%252F`) so it's not an issue if the URI is produced accordingly.