### PR TITLE
typo: .htaccess files regex fix

### DIFF
--- a/coypu/coy_wikidata/.htaccess
+++ b/coypu/coy_wikidata/.htaccess
@@ -2,5 +2,8 @@ RewriteEngine on
 
 RewriteRule ^$ https://schema.coypu.org/coy_wikidata [R=302,L]
 
-#with version
-RewriteRule ^([0-9]).([0-9])) https://schema.coypu.org/coy_wikidata [R=302,L]
+#with version (double digit) 
+RewriteRule ^([0-9]).([0-9])$ https://schema.coypu.org/coy_wikidata [R=302,L]  
+
+#with version (triple digit) 
+RewriteRule ^([0-9]).([0-9]).([0-9])$ https://schema.coypu.org/coy_wikidata [R=302,L]

--- a/coypu/em-dat/.htaccess
+++ b/coypu/em-dat/.htaccess
@@ -3,4 +3,7 @@ RewriteEngine on
 RewriteRule ^$ https://schema.coypu.org/em-dat [R=302,L]
 
 #with version
-RewriteRule ^([0-9]).([0-9])) https://schema.coypu.org/em-dat [R=302,L]
+RewriteRule ^([0-9]).([0-9])$ https://schema.coypu.org/em-dat [R=302,L]
+
+#with version (triple digit) 
+RewriteRule ^([0-9]).([0-9]).([0-9])$ https://schema.coypu.org/em-dat [R=302,L]

--- a/coypu/global/.htaccess
+++ b/coypu/global/.htaccess
@@ -3,4 +3,7 @@ RewriteEngine on
 RewriteRule ^$ https://schema.coypu.org/global [R=302,L]
 
 #with version
-RewriteRule ^([0-9]).([0-9])) https://schema.coypu.org/global [R=302,L]
+RewriteRule ^([0-9]).([0-9])$ https://schema.coypu.org/global [R=302,L]
+
+#with version (triple digit) 
+RewriteRule ^([0-9]).([0-9]).([0-9])$ https://schema.coypu.org/global [R=302,L]

--- a/coypu/gta/.htaccess
+++ b/coypu/gta/.htaccess
@@ -3,4 +3,7 @@ RewriteEngine on
 RewriteRule ^$ https://schema.coypu.org/gta [R=302,L]
 
 #with version
-RewriteRule ^([0-9]).([0-9])) https://schema.coypu.org/gta [R=302,L]
+RewriteRule ^([0-9]).([0-9])$ https://schema.coypu.org/gta [R=302,L]
+
+#with version (triple digit) 
+RewriteRule ^([0-9]).([0-9]).([0-9])$ https://schema.coypu.org/gta [R=302,L]

--- a/coypu/ta/.htaccess
+++ b/coypu/ta/.htaccess
@@ -3,4 +3,7 @@ RewriteEngine on
 RewriteRule ^$ https://schema.coypu.org/ta [R=302,L]
 
 #with version
-RewriteRule ^([0-9]).([0-9])) https://schema.coypu.org/ta [R=302,L]
+RewriteRule ^([0-9]).([0-9])$ https://schema.coypu.org/ta [R=302,L]
+
+#with version (triple digit) 
+RewriteRule ^([0-9]).([0-9]).([0-9])$ https://schema.coypu.org/ta [R=302,L]

--- a/coypu/world-port-index/.htaccess
+++ b/coypu/world-port-index/.htaccess
@@ -3,4 +3,7 @@ RewriteEngine on
 RewriteRule ^$ https://schema.coypu.org/world-port-index [R=302,L]
 
 #with version
-RewriteRule ^([0-9]).([0-9])) https://schema.coypu.org/world-port-index [R=302,L]
+RewriteRule ^([0-9]).([0-9])$ https://schema.coypu.org/world-port-index [R=302,L]
+
+#with version (triple digit) 
+RewriteRule ^([0-9]).([0-9]).([0-9])$ https://schema.coypu.org/world-port-index [R=302,L]


### PR DESCRIPTION
Small fixes to nonworking regex: spare ")" character. Redirect for versions with 3 digit also added as a rule. 