### PR TITLE
add kgcl

### DIFF
--- a/kgcl/.htaccess
+++ b/kgcl/.htaccess
@@ -1,0 +1,12 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# schema artefacts use raw github URLs
+RewriteRule ^kgcl.owl.ttl$ https://raw.githubusercontent.com/incatools/kgcl/main/project/owl/kgcl.owl.ttl [R=302]
+RewriteRule ^kgcl.context.jsonld$ https://raw.githubusercontent.com/incatools/kgcl/main/project/jsonld/kgcl.context.jsonld [R=302]
+RewriteRule ^kgcl.shacl.ttl https://raw.githubusercontent.com/INCATools/kgcl/main/project/shacl/kgcl.shacl.ttl [R=302]
+RewriteRule ^kgcl.yaml$ https://raw.githubusercontent.com/incatools/kgcl/main/src/kgcl_schema/schema/kgcl.yaml [R=302]
+
+# Schema elements use github pages
+# Rewrite Base URL
+RewriteRule ^(.*)$ https://incatools.github.io/kgcl/$1 [R=302]

--- a/kgcl/README.md
+++ b/kgcl/README.md
@@ -1,0 +1,15 @@
+# Knowledge Graph Change Language
+
+KGCL (Knowledge Graph Change Language) is a taxonomy, data model, and language for describing changes in ontologies and knowledge graphs
+
+Documentation
+
+* https://incatools.github.io/kgcl/
+
+GitHub Repo
+
+* https://github.com/INCATools/kgcl
+
+Contact
+* Chris Mungall; github: @cmungall email: cjmungall AT lbl DOT gov
+


### PR DESCRIPTION
- set up test redirects for material vocabulary using w3id
- initial request for chemrof
- Apply suggestions from code review
- Apply suggestions from code review
- Apply suggestions from code review
- fix multiple escaping on file hierarchy map
- fix material vocabulary htaccess to catch version numbers
- isamples--> isample in w3id uri, add redirect for pylode view of vocab
- add turtle via content negotiation for vocabulary view
- forgot the [L] to stop processing on the pylode and turtle redirects
- replace %3F with ?.  % is special character in .htaccess
- add sampledFeature vocabulary
- fix a couple typos
- add specimentType vocabulary
- add folder for version
- added htaccess files
- Changed htaccess in root, added README.md
- Corrected RewriteRule to avoid redundancy
- Update .htaccess
- Commented out default response in .htaccess
- Added PET identifier.
- Added entry for iddo
- feat(id): add w3id.org/td namespace
- fix punctuation and typo in README
- Update MDO pages repository
- fip: new entry
- changed port for server
- Update .htaccess
- Create steel ontology domain
- Add bearchaeo.
- New namespace: kgcl (Knowledge Graph Change Language)
