### PR TITLE
update .htaccess to resolve typo on one redirect for documentation

### DIFF
--- a/iSeeOnto/.htaccess
+++ b/iSeeOnto/.htaccess
@@ -19,7 +19,7 @@ RewriteRule ^aimethodevaluation$ https://isee4xai.github.io/iSeeOnto/docs/aimeth
 RewriteRule ^evaluation$ https://isee4xai.github.io/iSeeOnto/docs/evaluation-en.html [R=303,L]
 RewriteRule ^explainer$ https://isee4xai.github.io/iSeeOnto/docs/explainer-en.html [R=303,L]
 RewriteRule ^user$ https://isee4xai.github.io/iSeeOnto/docs/user-en.html [R=303,L]
-RewriteRule ^userevaluation$ https://isee4xai.github.io/docs/iSeeOnto/userevaluation-en.html [R=303,L]
+RewriteRule ^userevaluation$ https://isee4xai.github.io/iSeeOnto/docs/userevaluation-en.html [R=303,L]
 RewriteRule ^workflow$ https://isee4xai.github.io/iSeeOnto/docs/workflow-en.html [R=303,L]
 RewriteRule ^explanationexperience$ https://isee4xai.github.io/iSeeOnto/docs/explanationexperience-en.html [R=303,L]
 RewriteRule ^SimilarityKnowledge$ https://isee4xai.github.io/iSeeOnto/docs/SimilarityKnowledge-en.html [R=303,L]


### PR DESCRIPTION
Identified a topo in documentation redirect previously setup, updated to correct this, thanks.