### PR TITLE
Add legalhtml namespace

### DIFF
--- a/legalhtml/.htaccess
+++ b/legalhtml/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine On
+
+RewriteRule (.*) https://art.uniroma2.it/legalhtml/$1 [R=302,L,QSA]

--- a/legalhtml/README.md
+++ b/legalhtml/README.md
@@ -4,10 +4,10 @@ This [W3ID](https://w3id.org) provides a persistent URI namespace for LegalHTML 
 ## Contact
 This space is administered by:
 
-**Manuel Fiorelli**
-*Research Fellow*
-[University of Rome Tor Vergata](https://web.uniroma2.it/)
-Roma, Italy
-<manuel.fiorelli@uniroma2.it>
-GitHub: [manuelfiorelli](https://github.com/manuelfiorelli)
+**Manuel Fiorelli**  
+*Research Fellow*  
+[University of Rome Tor Vergata](https://web.uniroma2.it/)  
+Roma, Italy  
+<manuel.fiorelli@uniroma2.it>  
+GitHub: [manuelfiorelli](https://github.com/manuelfiorelli)  
 ORCID: [0000-0001-7079-8941](https://orcid.org/0000-0001-7079-8941)

--- a/legalhtml/README.md
+++ b/legalhtml/README.md
@@ -1,0 +1,13 @@
+# /legalhtml/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for LegalHTML resources.
+
+## Contact
+This space is administered by:
+
+**Manuel Fiorelli**
+*Research Fellow*
+[University of Rome Tor Vergata](https://web.uniroma2.it/)
+Roma, Italy
+<manuel.fiorelli@uniroma2.it>
+GitHub: [manuelfiorelli](https://github.com/manuelfiorelli)
+ORCID: [0000-0001-7079-8941](https://orcid.org/0000-0001-7079-8941)


### PR DESCRIPTION
This namespace will host the resources of LegalHTML, an extension of HTML designed for representing legal acts.