### PR TITLE
Common Provenance Model identifier

### DIFF
--- a/cpm/ro-crate/01/readme.md
+++ b/cpm/ro-crate/01/readme.md
@@ -1,0 +1,3 @@
+Common Provenance Model RO Crate profile 0.1 version
+
+Primary contact: Rudolf Wittner wittner@ics.muni.cz; rudolf.wittner@bbmri-eric.eu


### PR DESCRIPTION
I would like to create a new permatnent identifier for the Common Provenance Model RO Crate profile. 