### PR TITLE
renamed airiv to vair

### DIFF
--- a/vair/.htaccess
+++ b/vair/.htaccess
@@ -1,0 +1,3 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ https://delaramglp.github.io/vair [R=302,L]

--- a/vair/README.md
+++ b/vair/README.md
@@ -1,0 +1,10 @@
+# vair
+**VAIR: Vocabulary of AI Risks**
+
+**Contact:**  
+This ontology is created and maintained by:  
+Delaram Golpayegani  
+PhD Researcher  
+ADAPT Centre, Trinity College Dublin, Dublin, Ireland  
+delaram.golpayegani@adaptcentre.ie  
+GitHub: @delaramglp


### PR DESCRIPTION
The change has made to make the ontology's name clearer.