### PR TITLE
Adding rules to OAIS-IP

### DIFF
--- a/tib/README.md
+++ b/tib/README.md
@@ -1,0 +1,16 @@
+# /tib/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for [OAIS-IP](https://github.com/fengel/OAIS-IP) and examples: [Terminology OAIS-IP](https://git.tib.eu/terminology/sandbox/oais-ip-ontology-collection/-/tree/master/dev/abox).
+
+## Contact
+This space is administered by:  
+
+**Mark Vanin**  
+*Software engineer*  
+[Technische Informationsbibliothek](https://www.tib.eu)
+<br />
+Hannover, Germany  
+<mark.vanin@tib.eu>
+<br />
+GitHub: [mmannings](https://github.com/mmannings)
+<br />
+ORCID: [0000-0003-4647-7886](https://orcid.org/0000-0003-4647-7886)

--- a/tib/oais/README.md
+++ b/tib/oais/README.md
@@ -1,0 +1,16 @@
+# /tib/oais/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for [OAIS-IP](https://github.com/fengel/OAIS-IP) and examples: [Terminology OAIS-IP](https://git.tib.eu/terminology/sandbox/oais-ip-ontology-collection/-/tree/master/dev/abox).
+
+## Contact
+This space is administered by:  
+
+**Mark Vanin**  
+*Software engineer*  
+[Technische Informationsbibliothek](https://www.tib.eu)
+<br />
+Hannover, Germany  
+<mark.vanin@tib.eu>
+<br />
+GitHub: [mmannings](https://github.com/mmannings)
+<br />
+ORCID: [0000-0003-4647-7886](https://orcid.org/0000-0003-4647-7886)

--- a/tib/oais/ip/.htaccess
+++ b/tib/oais/ip/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine on
+
+RewriteRule ^$ https://raw.githubusercontent.com/fengel/OAIS-IP-Ontology/master/dev/tbox/oais-ip-tbox.owl [R=302,L]

--- a/tib/oais/ip/EC1/.htaccess
+++ b/tib/oais/ip/EC1/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine on
+
+RewriteRule ^$ https://raw.githubusercontent.com/fengel/OAIS-IP-Ontology/master/dev/abox/example-collection.owl [R=302,L]

--- a/tib/oais/ip/EC1/AIP1/.htaccess
+++ b/tib/oais/ip/EC1/AIP1/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine on
+
+RewriteRule ^$ https://git.tib.eu/terminology/sandbox/oais-ip-ontology-collection/raw/master/dev/abox/example-1-aip.owl [R=302,L]

--- a/tib/oais/ip/EC1/AIP1/README.md
+++ b/tib/oais/ip/EC1/AIP1/README.md
@@ -1,0 +1,16 @@
+# /tib/oais/ip/EC1/AIP1
+This [W3ID](https://w3id.org) provides a persistent URI namespace for [OAIS-IP](https://github.com/fengel/OAIS-IP) and examples: [Terminology OAIS-IP](https://git.tib.eu/terminology/sandbox/oais-ip-ontology-collection/-/tree/master/dev/abox).
+
+## Contact
+This space is administered by:  
+
+**Mark Vanin**  
+*Software engineer*  
+[Technische Informationsbibliothek](https://www.tib.eu)
+<br />
+Hannover, Germany  
+<mark.vanin@tib.eu>
+<br />
+GitHub: [mmannings](https://github.com/mmannings)
+<br />
+ORCID: [0000-0003-4647-7886](https://orcid.org/0000-0003-4647-7886)

--- a/tib/oais/ip/EC1/AIP2/.htaccess
+++ b/tib/oais/ip/EC1/AIP2/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine on
+
+RewriteRule ^$ https://git.tib.eu/terminology/sandbox/oais-ip-ontology-collection/raw/master/dev/abox/example-2-aip.owl [R=302,L]

--- a/tib/oais/ip/EC1/AIP2/README.md
+++ b/tib/oais/ip/EC1/AIP2/README.md
@@ -1,0 +1,16 @@
+# /tib/oais/ip/EC1/AIP2
+This [W3ID](https://w3id.org) provides a persistent URI namespace for [OAIS-IP](https://github.com/fengel/OAIS-IP) and examples: [Terminology OAIS-IP](https://git.tib.eu/terminology/sandbox/oais-ip-ontology-collection/-/tree/master/dev/abox).
+
+## Contact
+This space is administered by:  
+
+**Mark Vanin**  
+*Software engineer*  
+[Technische Informationsbibliothek](https://www.tib.eu)
+<br />
+Hannover, Germany  
+<mark.vanin@tib.eu>
+<br />
+GitHub: [mmannings](https://github.com/mmannings)
+<br />
+ORCID: [0000-0003-4647-7886](https://orcid.org/0000-0003-4647-7886)

--- a/tib/oais/ip/EC1/README.md
+++ b/tib/oais/ip/EC1/README.md
@@ -1,0 +1,16 @@
+# /tib/oais/ip/EC1/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for [OAIS-IP](https://github.com/fengel/OAIS-IP) and examples: [Terminology OAIS-IP](https://git.tib.eu/terminology/sandbox/oais-ip-ontology-collection/-/tree/master/dev/abox).
+
+## Contact
+This space is administered by:  
+
+**Mark Vanin**  
+*Software engineer*  
+[Technische Informationsbibliothek](https://www.tib.eu)
+<br />
+Hannover, Germany  
+<mark.vanin@tib.eu>
+<br />
+GitHub: [mmannings](https://github.com/mmannings)
+<br />
+ORCID: [0000-0003-4647-7886](https://orcid.org/0000-0003-4647-7886)

--- a/tib/oais/ip/README.md
+++ b/tib/oais/ip/README.md
@@ -1,0 +1,16 @@
+# /tib/oais/ip/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for [OAIS-IP](https://github.com/fengel/OAIS-IP) and examples: [Terminology OAIS-IP](https://git.tib.eu/terminology/sandbox/oais-ip-ontology-collection/-/tree/master/dev/abox).
+
+## Contact
+This space is administered by:  
+
+**Mark Vanin**  
+*Software engineer*  
+[Technische Informationsbibliothek](https://www.tib.eu)
+<br />
+Hannover, Germany  
+<mark.vanin@tib.eu>
+<br />
+GitHub: [mmannings](https://github.com/mmannings)
+<br />
+ORCID: [0000-0003-4647-7886](https://orcid.org/0000-0003-4647-7886)


### PR DESCRIPTION
 URI namespace for [https://github.com/fengel/OAIS-IP](https://github.com/fengel/OAIS-IP) and example ontology files: [https://git.tib.eu/terminology/sandbox/oais-ip-ontology-collection/-/tree/master/dev/abox](https://git.tib.eu/terminology/sandbox/oais-ip-ontology-collection/-/tree/master/dev/abox).