### PR TITLE
Rules for N2T service redirection

### DIFF
--- a/n2t/.htaccess
+++ b/n2t/.htaccess
@@ -1,0 +1,10 @@
+# w3id .htaccess rules for n2t
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# Any identifier resolution request (/scheme:value)
+RewriteRule ^([a-z0-9]+):(.+)$ https://n2t.net/$1:$2 [R=303,L]
+
+# Anything else that doesn't smell like an identifier
+RewriteRule ^(.*)$ https://n2t.net/$1 [R=302,L]

--- a/n2t/README.md
+++ b/n2t/README.md
@@ -1,0 +1,52 @@
+# `N2T`
+
+Provides a persistent, high level entry point to the [N2T identifier resolution service](https://n2t.net/).
+
+
+## Contact
+
+```yaml
+---
+maintainer:
+  name: Dave Vieglais
+  id:
+    - email:vieglais@ku.edu
+    - github:datadavev
+    - orcid:0000-0002-6513-4996
+```
+
+## Development and Testing
+
+Use the [Apache .htaccess Tester](https://github.com/chaseconey/htaccess-tester)
+
+In the parent of this folder (i.e. root of a checkout of https://github.com/perma-id/w3id.org.git):
+
+1. Fire up docker:
+
+```
+cd w3id.org
+docker run -p 6080:80 -v "$PWD:/usr/local/apache2/htdocs" chaseconey/htaccess-tester
+```
+
+2. Evaluate some links
+
+```
+curl -s -o /dev/null -w "%{response_code}: %{redirect_url}" "http://localhost:6080/n2t/"
+302: https://n2t.net/
+
+curl -s -o /dev/null -w "%{response_code}: %{redirect_url}" "http://localhost:6080/n2t/about.html"
+302: https://n2t.net/about.html
+
+curl -s -o /dev/null -w "%{response_code}: %{redirect_url}" "http://localhost:6080/n2t/ark:/13030/m5rx99d1"
+303: http://n2t.net/ark:/13030/m5rx99d1
+```
+
+## Examples for Testing
+
+| Value | Expected |
+| -- | -- |
+| https://w3id.org/n2t/ | https://n2t.net/ |
+| https://w3id.org/n2t/about.html | https://n2t.net/about.html |
+| https://w3id.org/n2t/ark:/13030/m5rx99d1 | https://n2t.net/ark:/13030/m5rx99d1 |
+| https://w3id.org/n2t/igsn:AU1243 | https://n2t.net/igsn:AU1243 |
+


### PR DESCRIPTION
New permanent identifier request for `n2t` to provide persistent locator for the N2T resolution service.