### PR TITLE
adding redirect for ecfo ontology

### DIFF
--- a/ecfo/.htaccess
+++ b/ecfo/.htaccess
@@ -1,0 +1,47 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
+
+RewriteEngine on
+
+# Rewrite rule for latest version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://eats-uoa.github.io/ECFO-Emission-conversion-Factor-Ontology/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://eats-uoa.github.io/ECFO-Emission-conversion-Factor-Ontology/ecfo.json [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://eats-uoa.github.io/ECFO-Emission-conversion-Factor-Ontology/ecfo.xml [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://eats-uoa.github.io/ECFO-Emission-conversion-Factor-Ontology/ecfo.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle 
+RewriteRule ^$ https://eats-uoa.github.io/ECFO-Emission-conversion-Factor-Ontology/ecfo.ttl [R=303,L]
+
+
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^(.*)$ https://eats-uoa.github.io/ECFO-Emission-conversion-Factor-Ontology/406.html [R=406,L]
+# Default response
+# ---------------------------
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^$ https://eats-uoa.github.io/ECFO-Emission-conversion-Factor-Ontology/ecfo.xml [R=303,L]

--- a/ecfo/readme.md
+++ b/ecfo/readme.md
@@ -1,0 +1,29 @@
+
+
+# /rains
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the Emission Conversion Factors Ontology (ECFO).
+
+
+Redirects: 
+
+https://eats-uoa.github.io/ECFO-Emission-conversion-Factor-Ontology/index-en.html
+
+https://eats-uoa.github.io/ECFO-Emission-conversion-Factor-Ontology/ecfo.json
+
+https://eats-uoa.github.io/ECFO-Emission-conversion-Factor-Ontology/ecfo.nt
+
+https://eats-uoa.github.io/ECFO-Emission-conversion-Factor-Ontology/ecfo.xml
+
+https://eats-uoa.github.io/ECFO-Emission-conversion-Factor-Ontology/ecfo.ttl
+
+## Uses
+The ontology is aimed at providing a  vocabulary for describing emission conversion factors that are used in the calculations of carbon footprint.  
+
+## Contact
+This space is administered by:  
+
+**Milan Markovic**  ,
+GIthub ID: m-markovic,
+https://www.abdn.ac.uk/ncs/profiles/milan.markovic/,
+University of Aberdeen, UK 
+


### PR DESCRIPTION
adding redirect for ecfo ontology hosted in https://eats-uoa.github.io/ECFO-Emission-conversion-Factor-Ontology/