### PR TITLE
Fix /vdl/v1 target.

### DIFF
--- a/vdl/.htaccess
+++ b/vdl/.htaccess
@@ -10,5 +10,5 @@ Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,
 Options +FollowSymLinks
 RewriteEngine on
 RewriteRule ^$ https://w3c-ccg.github.io/vdl-vocab/ [R=302,L]
-RewriteRule ^v1$ https://w3c-ccg.github.io/vdl-vocab/context/v1 [R=302,L]
+RewriteRule ^v1$ https://w3c-ccg.github.io/vdl-vocab/context/v1.jsonld [R=302,L]
 RewriteRule ^interop-reports$ https://w3c-ccg.github.io/vdl-test-suite/


### PR DESCRIPTION
- Updating the redirect to the target since it had an extension added
  here: https://github.com/w3c-ccg/vdl-vocab/pull/5