### PR TITLE
Adds Readme, directory structure and and redirects for hsu-aut ontologies

### DIFF
--- a/hsu-aut/cask/.htaccess
+++ b/hsu-aut/cask/.htaccess
@@ -1,0 +1,19 @@
+RewriteEngine on
+
+# Redirect ontology version IRI to the given version
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^(\d\.\d\.\d)/?$ https://raw.githubusercontent.com/hsu-aut/cask/v$1/cask.owl [R=303,NC,L]
+
+# Redirect ontology IRI (withouth version) to the current main branch version
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^/?$ https://raw.githubusercontent.com/hsu-aut/cask/main/cask.owl [R=303,NC,L]
+
+# Redirect HTML requests to the main repository page
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteRule ^(\d\.\d\.\d)?/?$ https://github.com/hsu-aut/cask [R=301,NC,L]

--- a/hsu-aut/caskman/.htaccess
+++ b/hsu-aut/caskman/.htaccess
@@ -1,0 +1,19 @@
+RewriteEngine on
+
+# Redirect ontology version IRI to the given version
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^(\d\.\d\.\d)/?$ https://raw.githubusercontent.com/aljoshakoecher/caskman/v$1/caskman.owl [R=303,NC,L,skip=1]
+
+# Redirect ontology IRI (withouth version) to the current main branch version
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^/?$ https://raw.githubusercontent.com/aljoshakoecher/caskman/master/caskman.owl [R=303,NC,L]
+
+# Redirect HTML requests to the main repository page
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteRule ^(\d\.\d\.\d)?/?$ https://github.com/aljoshakoecher/caskman [R=301,NC,L]

--- a/hsu-aut/css/.htaccess
+++ b/hsu-aut/css/.htaccess
@@ -1,0 +1,21 @@
+RewriteEngine on
+
+# Redirect ontology version IRI to the given version
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^(\d\.\d\.\d)/?$ https://raw.githubusercontent.com/hsu-aut/css-ontology/v$1/CSS-Ontology.owl [R=303,NC,L]
+
+# Redirect ontology IRI (withouth version) to the current main branch version
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^/?$ https://raw.githubusercontent.com/hsu-aut/css-ontology/main/CSS-Ontology.owl [R=303,NC,L]
+
+# Redirect HTML requests to the main repository page
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(\d\.\d\.\d)?/?$ https://github.com/hsu-aut/css-ontology [R=302,NC,L]
+

--- a/hsu-aut/readme.md
+++ b/hsu-aut/readme.md
@@ -1,0 +1,19 @@
+# HSU AUT
+Redirects for ontologies developed by the Institute of Automation of Helmut Schmidt University in Hamburg, Germany. See https://www.hsu-hh.de/aut/ for infos about us.
+
+## Overview
+We develop and maintain a growing set of ontologies, mostly so-called ontology design patterns based on industry standards. The .htaccess file in this directory sets up redirects for these ontologies so that ontology IRIs can be resolved to proper URLs.
+Content-Negotition is supported which means:
+- If you try to open ontology IRIs with a browser (i.e. request an HTML document), the request is redirected to the corresponding Github repository page / readme.
+- If you request a ttl or rdf-xml version (e.g. when importing an ontology through a tool like Protege), the request will be redirected to the actual ontology file. Versions are also taken into account so that you may import an ontology with a specific version IRI.
+
+List of ontologies that are currently redirected:
+- CSS: Ontology implementation of the abstract reference model for capabilities, skills and services
+- CaSk: An ontology detailing the concepts of the CSS ontology
+- CaSkMan: A more detailed ontology further extending the concepts of `CaSk` for the domain of manufacturing.
+
+
+## Maintainers
+- Aljosha Köcher (@aljoshakoecher)
+- Luis Miguel Vieira da Silva (@Miguel2617)
+- Tom Jeleniewski (@jelenito)


### PR DESCRIPTION
Adds a new parent folder for ontologies created by the Institute of Automation of Helmut Schmidt University in Hamburg `hsu-aut`. 
This parent folder contains a directory structure with redirects for three ontologies. Every directory contains an .htaccess file that takes care of redirecting requests to that particular ontology.