### PR TITLE
Addition of a new /contexts/ sublink that redirects to a taxonomy of cultural contexts related to the simulation project

### DIFF
--- a/simulation/.htaccess
+++ b/simulation/.htaccess
@@ -11,4 +11,5 @@ RewriteRule ^data(.*)$ https://raw.githubusercontent.com/br0ast/simulationontolo
 RewriteRule ^docs(.*)$ https://br0ast.github.io/simulationontology/SimulationOntologyDocs/index-en.html [R=303,L]
 RewriteRule ^development(.*)$ https://github.com/br0ast/simulationontology/tree/main/development [R=303,L]
 RewriteRule ^code(.*)$ https://github.com/br0ast/simulationontology/tree/main/KG/Scripts [R=303,L]
+RewriteRule ^contexts(.*)$ https://raw.githubusercontent.com/br0ast/simulationontology/main/KG/contextsnew.ttl [R=303,L]
 

--- a/simulation/README.md
+++ b/simulation/README.md
@@ -8,6 +8,7 @@ This namespace is broken down into different different parts:
 * [https://w3id.org/simulation/data/](https://w3id.org/simulation/data/) leads to HyperReal, a knowledge graph of cultural symbols that follows the ontology pattern serialized in [turtle](https://www.w3.org/TR/turtle/) 
 * [https://w3id.org/simulation/development/](https://w3id.org/simulation/development/) leads to a github repository that contains the development documentation of the ontology.
 * [https://w3id.org/simulation/code/](https://w3id.org/simulation/code/) leads to a github repository that contains the code of the conversion algorithms used in the Simulation Ontology's based knowledge graph.
+* [https://w3id.org/simulation/contexts/](https://w3id.org/simulation/contexts/) leads to a turtle file of a SKOS taxonomy created from the cultural contexts of HyperReal.
 * https://w3id.org/simulation/query/ will lead to a future queryable SPARQL portal of the knowledge graph. (**not active yet**)
 
 This space is administered by:  


### PR DESCRIPTION
Changed the readme with the new link and the .htaccess file with the new redirect