### PR TITLE
Icon added new URI

### DIFF
--- a/icon/.htaccess
+++ b/icon/.htaccess
@@ -10,3 +10,7 @@ RewriteRule ^ontology(.*)$ https://raw.githubusercontent.com/br0ast/ICON/main/On
 RewriteRule ^docs(.*)$ https://br0ast.github.io/ICON/ICONOntologyDocumentation/index-en.html [R=303,L]
 RewriteRule ^development(.*)$ https://github.com/br0ast/ICON/tree/main/Development [R=303,L]
 
+
+RewriteRule ^data(.*)$ https://raw.githubusercontent.com/SofiBar/IconologyDataset/main/data/icondataset.ttl [R=303,L]
+
+

--- a/icon/README.md
+++ b/icon/README.md
@@ -6,6 +6,7 @@ This namespace is broken down into different different parts:
 * [https://w3id.org/icon/docs/](https://w3id.org/icon/docs/) leads to a [widoco](https://github.com/dgarijo/Widoco) visualization of the ontology.
 * [https://w3id.org/icon/ontology/](https://w3id.org/icon/ontology/) leads to a raw owl file of the ontology (useful for imports)
 * [https://w3id.org/icon/development/](https://w3id.org/icon/development/) leads to a github repository that contains the development documentation of the ontology.
+* [https://w3id.org/icon/data/](https://w3id.org/icon/data/) leads to a RDF dataset of iconological interpretations described with the ICON ontology.
 
 This space is administered by:  
 


### PR DESCRIPTION
A new URI (https://w3id.org/icon/data/) has been added to the "Icon" folder. Therefore, both the .htaccess and the permanent URI document were modified. 