### PR TITLE
Update default top-level domain

### DIFF
--- a/ixo/.htaccess
+++ b/ixo/.htaccess
@@ -17,4 +17,4 @@ RewriteRule ^rubrics(.*)? https://github.com/ixofoundation/ixo-protocol/tree/mas
 RewriteRule ^specification(.*)? https://github.com/ixofoundation/ixo-protocol/tree/master/specification/ [R=302,L]
 RewriteRule ^tokens(.*)? https://github.com/ixofoundation/ixo-protocol/tree/master/tokens/ [R=302,L]
 RewriteRule ^vocab(.*)? https://github.com/ixofoundation/ixo-protocol/tree/master/vocab/ [R=302,L]
-RewriteRule ^(.*) https://protocol.ixo.foundation/ [R=302,L]
+RewriteRule ^(.*) https://github.com/ixofoundation/ [R=302,L]


### PR DESCRIPTION
Replaces the (.*) old route `https://protocol.ixo.foundation/` with `https://github.com/ixofoundation/`