### PR TITLE
chore(linkml): use raw github content instead

### DIFF
--- a/lmodel/.htaccess
+++ b/lmodel/.htaccess
@@ -2,27 +2,26 @@ Options +FollowSymLinks
 RewriteEngine on
 
 # Schemas
-RewriteRule ^(.*)/schema/(.*)$ https://github.com/lmodel/$1/blob/main/src/$1/schema/$2.yaml [R=302,L]
+RewriteRule ^(.*)/schema/(.*)$ https://raw.githubusercontent.com/lmodel/$1/main/src/$2/schema/$2.yaml [R=302,L]
 
 # Artifacts
-RewriteRule ^(.*)/data/(.*)\.xlsx$ $1/project/excel/$2.xlsx [E=rewritten:1]
-RewriteRule ^(.*)/data/(.*)\.graphql$ $1/project/graphql/$2.graphql [E=rewritten:1]
-RewriteRule ^(.*)/data/(.*\.?)context.json$ $1/project/jsonld/$2.context.jsonld [E=rewritten:1]
-RewriteRule ^(.*)/data/(.*\.?)context.jsonld$ $1/project/jsonld/$2.context.jsonld [E=rewritten:1]
-RewriteRule ^(.*)/data/(.*)\.schema.json$ $1/project/jsonschema/$2.schema.json [E=rewritten:1]
-RewriteRule ^(.*)/data/([^\.]+)\.json$ $1/project/json/$2.json [E=rewritten:1]
-RewriteRule ^(.*)/data/(.*)\.shacl.ttl$ $1/project/shacl/$2.shacl.ttl [E=rewritten:1]
+RewriteRule ^(.*)/data/(.*)\.xlsx$ https://github.com/lmodel/$1/raw/main/project/excel/$2.xlsx [R=302,L]
+RewriteRule ^(.*)/data/(.*)\.graphql$ https://raw.githubusercontent.com/lmodel/$1/main/project/graphql/$2.graphql [R=302,L]
+
+RewriteRule ^(.*)/data/(.*\.?)context.json$ https://raw.githubusercontent.com/lmodel/$1/main/project/jsonld/$2context.jsonld [R=302,L]
+RewriteRule ^(.*)/data/(.*\.?)context.jsonld$ https://raw.githubusercontent.com/lmodel/$1/main/project/jsonld/$2context.jsonld [R=302,L]
+RewriteRule ^(.*)/data/(.*)\.schema.json$ https://raw.githubusercontent.com/lmodel/$1/main/project/jsonschema/$2.schema.json [R=302,L]
+RewriteRule ^(.*)/data/([^\.]+)\.json$ https://raw.githubusercontent.com/lmodel/$1/main/project/json/$2.json [R=302,L]
+RewriteRule ^(.*)/data/(.*)\.shacl.ttl$ https://raw.githubusercontent.com/lmodel/$1/main/project/shacl/$2.shacl.ttl [R=302,L]
 RewriteCond %{REQUEST_URI} !\.owl\.
-RewriteRule ^(.*)/data/(.*)\.ttl$ $1/project/rdf/$2.ttl [E=rewritten:1]
-RewriteRule ^(.*)/data/(.*)\.owl$ $1/project/owl/$2.owl.ttl [E=rewritten:1]
-RewriteRule ^(.*)/data/(.*)\.yaml$ $1/project/prefixmap/$2.yaml [E=rewritten:1]
-RewriteRule ^(.*)/data/(.*)\.proto$ $1/project/protobuf/$2.proto [E=rewritten:1]
-RewriteRule ^(.*)/data/(.*)\.shex$ $1/project/shex/$2.shex [E=rewritten:1]
-RewriteRule ^(.*)/data/(.*)\.shexc$ $1/project/shex/$2.shex [E=rewritten:1]
-RewriteRule ^(.*)/data/(.*)\.shexj$ $1/project/shex/$2.shexj [E=rewritten:1]
-RewriteRule ^(.*)/data/(.*)\.sql$ $1/project/sqlschema/$2.sql [E=rewritten:1]
-RewriteCond "%{ENV:rewritten}" "=1"
-RewriteRule ^(.*)/project/(.*)$ https://github.com/lmodel/$1/blob/main/$2 [R=302,L]
+RewriteRule ^(.*)/data/(.*)\.ttl$ https://raw.githubusercontent.com/lmodel/$1/main/project/rdf/$2.ttl [R=302,L]
+RewriteRule ^(.*)/data/(.*)\.owl$ https://raw.githubusercontent.com/lmodel/$1/main/project/owl/$2.owl.ttl [R=302,L]
+RewriteRule ^(.*)/data/(.*)\.yaml$ https://raw.githubusercontent.com/lmodel/$1/main/project/prefixmap/$2.yaml [R=302,L]
+RewriteRule ^(.*)/data/(.*)\.proto$ https://raw.githubusercontent.com/lmodel/$1/main/project/protobuf/$2.proto [R=302,L]
+RewriteRule ^(.*)/data/(.*)\.shex$ https://raw.githubusercontent.com/lmodel/$1/main/project/shex/$2.shex [R=302,L]
+RewriteRule ^(.*)/data/(.*)\.shexc$ https://raw.githubusercontent.com/lmodel/$1/main/project/shex/$2.shex [R=302,L]
+RewriteRule ^(.*)/data/(.*)\.shexj$ https://raw.githubusercontent.com/lmodel/$1/main/project/shex/$2.shex [R=302,L]
+RewriteRule ^(.*)/data/(.*)\.sql$ https://raw.githubusercontent.com/lmodel/$1/main/project/sqlschema/$2.sql [R=302,L]
 
 # Continue ...
 


### PR DESCRIPTION
This PR redirects to raw.githubcontent.com/xx instead of github.com/xx.  Tested locally on Ubuntu.