### PR TITLE
Adds redirection to new hsu-aut ontology 

### DIFF
--- a/hsu-aut/ieee1872.2/.htaccess
+++ b/hsu-aut/ieee1872.2/.htaccess
@@ -1,0 +1,21 @@
+RewriteEngine on
+
+# Redirect ontology version IRI to the given version
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^(\d\.\d\.\d)/?$ https://raw.githubusercontent.com/hsu-aut/IndustrialStandard-ODP-IEEE1872.2/v$1/AuR_IEEE1872-2.owl [R=303,NC,L]
+
+# Redirect ontology IRI (withouth version) to the current main branch version
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^/?$ https://raw.githubusercontent.com/hsu-aut/IndustrialStandard-ODP-IEEE1872.2/main/AuR_IEEE1872-2.owl [R=303,NC,L]
+
+# Redirect HTML requests to the main repository page
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(\d\.\d\.\d)?/?$ https://github.com/hsu-aut/IndustrialStandard-ODP-IEEE1872.2 [R=302,NC,L]
+

--- a/hsu-aut/readme.md
+++ b/hsu-aut/readme.md
@@ -11,6 +11,7 @@ List of ontologies that are currently redirected:
 - CSS: Ontology implementation of the abstract reference model for capabilities, skills and services
 - CaSk: An ontology detailing the concepts of the CSS ontology
 - CaSkMan: A more detailed ontology further extending the concepts of `CaSk` for the domain of manufacturing.
+- IEEE 1872.2: Ontology implementation of the Standard for Autonomous Robotics (AuR)
 
 
 ## Maintainers


### PR DESCRIPTION
Adds a new folder for one ontology to parent folder for ontologies created by the Institute of Automation of Helmut Schmidt University in Hamburg hsu-aut. New directory contains an .htaccess file that takes care of redirecting requests to that particular ontology.