### PR TITLE
DSTV Ontology round#2

### DIFF
--- a/dstv/.htaccess
+++ b/dstv/.htaccess
@@ -5,12 +5,24 @@ RewriteEngine on
 Options -MultiViews
 
 AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
 
-# Rewrite rule to serve HTML content from the vocabulary URI if requested
-RewriteRule ^$ https://ip.pages.rwth-aachen.de/ioc/dstv-ontologie/
-
-# If suffix ttl, redirect to turtle version
+# If accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
 RewriteRule ^$ https://ip.pages.rwth-aachen.de/ioc/dstv-ontologie/ontology.ttl
 
+# If accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://ip.pages.rwth-aachen.de/ioc/dstv-ontologie/ontology.xml
+
+# If suffix ttl, redirect to turtle 
+RewriteRule ^.ttl$ https://ip.pages.rwth-aachen.de/ioc/dstv-ontologie/ontology.ttl
+
+# If suffix html, redirect to html 
+RewriteRule ^.html$ https://ip.pages.rwth-aachen.de/ioc/dstv-ontologie/
+
+# If suffix rdf, redirect to rdf 
+RewriteRule ^.rdf$ https://ip.pages.rwth-aachen.de/ioc/dstv-ontologie/ontology.xml
+
 # Default response: html
-RewriteRule ^$ https://ip.pages.rwth-aachen.de/ioc/dstv-ontologie/ 
+RewriteRule ^$ https://ip.pages.rwth-aachen.de/ioc/dstv-ontologie/

--- a/dstv/.htaccess
+++ b/dstv/.htaccess
@@ -1,0 +1,16 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteRule ^$ https://ip.pages.rwth-aachen.de/ioc/dstv-ontologie/
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^$ https://ip.pages.rwth-aachen.de/ioc/dstv-ontologie/ontology.ttl
+
+# Default response: html
+RewriteRule ^$ https://ip.pages.rwth-aachen.de/ioc/dstv-ontologie/ 

--- a/dstv/README.md
+++ b/dstv/README.md
@@ -1,0 +1,16 @@
+# /dstv/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the DSTV - Ontology for Steel construction.
+
+## Uses
+Interconnecting Data in Construction Processes - focus on steel construction and usage of the DSTV-NC standard
+See http://www.internet-of-construction.com/index_en.html
+
+## Contact
+This space is administered by:  
+
+**Lukas Kirner**  
+  *Researcher*  
+Individualized Production, RWTH Aachen, Germany.  
+https://github.com/kirner-ip
+<kirner@ip.rwth-aachen.de>  
+ORCID: [0000-0001-9753-2422](https://orcid.org/0000-0001-9753-2422) 

--- a/dstv/README.md
+++ b/dstv/README.md
@@ -2,8 +2,8 @@
 This [W3ID](https://w3id.org) provides a persistent URI namespace for the DSTV - Ontology for Steel construction.
 
 ## Uses
-Interconnecting Data in Construction Processes - focus on steel construction and usage of the DSTV-NC standard
-See http://www.internet-of-construction.com/index_en.html
+Interconnecting Data in Construction Processes - focus on steel construction and usage of the DSTV-NC standard  
+See http://www.internet-of-construction.com/index_en.html  
 
 ## Contact
 This space is administered by:  
@@ -11,6 +11,6 @@ This space is administered by:
 **Lukas Kirner**  
   *Researcher*  
 Individualized Production, RWTH Aachen, Germany.  
-https://github.com/kirner-ip
+https://github.com/kirner-ip  
 <kirner@ip.rwth-aachen.de>  
 ORCID: [0000-0001-9753-2422](https://orcid.org/0000-0001-9753-2422) 


### PR DESCRIPTION
Added a redirect for the DSTV Ontology, which represents an owl extension of the existing DSTV standard for steel construction.
The ontology is part of the project Internet of Construction (see readme) and a future extension which is called BAUFEST 4.0.

Sorry for misforming the .htaccess. TBH, I wildly copy&pasted it around without having a look at the actual rewrite conditions. Hope it works better like this.

thanks for the help :)