### PR TITLE
Update path for Biopragmatics resources

### DIFF
--- a/biopragmatics/.htaccess
+++ b/biopragmatics/.htaccess
@@ -2,5 +2,5 @@ Options +FollowSymLinks
 RewriteEngine on
 
 # Make ontology artifacts in the "export" folder (https://github.com/biopragmatics/obo-db-ingest/tree/main/export) resolvable.
-# For example, we want https://w3id.org/biopragmatics/obo/interpro/92.0/interpro.obo to redirect to https://github.com/biopragmatics/obo-db-ingest/raw/main/export/interpro/92.0/interpro.obo
-RewriteRule ^obo/(.+) https://github.com/biopragmatics/obo-db-ingest/raw/main/export/$1
+# For example, we want https://w3id.org/biopragmatics/resources/interpro/92.0/interpro.obo to redirect to https://github.com/biopragmatics/obo-db-ingest/raw/main/export/interpro/92.0/interpro.obo
+RewriteRule ^resources/(.+) https://github.com/biopragmatics/obo-db-ingest/raw/main/export/$1

--- a/biopragmatics/README.md
+++ b/biopragmatics/README.md
@@ -12,7 +12,7 @@ Biomedical databases such as the [HUGO Gene Nomenclature Committee (HGNC)](https
 
 The https://github.com/biopragmatics/obo-db-ingest repository on GitHub solves this issue by converting these and several other databases into ontology formats, running updates on a chronological basis. W3ID PURLs make these ontology artifacts more accessible.
 
-Concretely, this W3ID entry makes ontology artifacts in the "export" folder (https://github.com/biopragmatics/obo-db-ingest/tree/main/export) resolvable. For example, https://w3id.org/biopragmatics/obo/interpro/92.0/interpro.obo redirects to https://github.com/biopragmatics/obo-db-ingest/raw/main/export/interpro/92.0/interpro.obo
+Concretely, this W3ID entry makes ontology artifacts in the "export" folder (https://github.com/biopragmatics/obo-db-ingest/tree/main/export) resolvable. For example, https://w3id.org/biopragmatics/resources/interpro/92.0/interpro.obo redirects to https://github.com/biopragmatics/obo-db-ingest/raw/main/export/interpro/92.0/interpro.obo
 
 ## Contact
 

--- a/biopragmatics/README.md
+++ b/biopragmatics/README.md
@@ -16,7 +16,7 @@ Concretely, this W3ID entry makes ontology artifacts in the "export" folder (htt
 
 ## Contact
 
-Charles Tapley Hoyt
-Email: cthoyt@gmail.com
-GitHub: [@cthoyt](https://github.com/cthoyt/)
+Charles Tapley Hoyt  
+Email: cthoyt@gmail.com  
+GitHub: [@cthoyt](https://github.com/cthoyt/)  
 ORCID: [0000-0003-4423-4370](https://orcid.org/0000-0003-4423-4370)


### PR DESCRIPTION
After suggestion from @matentzn, it makes more sense to have a generic redirect subspace "resources" instead of "obo" to show that things appearing in this path might not have anything to do with the OBO Foundry nor OBO flat file format