### PR TITLE
Update of readme information and redirect rules for w3id.org/italia

### DIFF
--- a/italia/controlled-vocabulary/.htaccess
+++ b/italia/controlled-vocabulary/.htaccess
@@ -15,15 +15,15 @@ RewriteCond %{ENV:SYNTAX} ^(rdf|ttl|jsonld)$
 RewriteRule ^(theme-subtheme-mapping|public-event-types|poi-category-classification|licences)(/)?$ %{ENV:ROOT_URL}/$1/$1.%{ENV:SYNTAX} [R=303,L]
 
 RewriteCond %{ENV:SYNTAX} ^html$
-RewriteRule ^(theme-subtheme-mapping|public-event-types|poi-category-classification|licences)(/)?$ https://ontopia-lodview.agid.gov.it/controlled-vocabulary/$1 [R=303,L]
+RewriteRule ^(theme-subtheme-mapping|public-event-types|poi-category-classification|licences)(/)?$ https://schema.gov.it/lodview/controlled-vocabulary/$1 [R=303,L]
 
 RewriteCond %{ENV:SYNTAX} ^html$
-RewriteRule ^(theme-subtheme-mapping|public-event-types|poi-category-classification|licences)(/[a-zA-Z-_0-9]+)?$ https://ontopia-lodview.agid.gov.it/controlled-vocabulary/$1$2 [R=303,L]
+RewriteRule ^(theme-subtheme-mapping|public-event-types|poi-category-classification|licences)(/[a-zA-Z-_0-9]+)?$ https://schema.gov.it/lodview/controlled-vocabulary/$1$2 [R=303,L]
 
 RewriteCond %{ENV:SYNTAX} ^(rdf|ttl|jsonld)$
 RewriteRule ^([a-zA-Z-_0-9]+)/([a-zA-Z-_0-9]+)$ %{ENV:ROOT_URL}/$1/$2/$2.%{ENV:SYNTAX} [R=303,L]
 
 RewriteCond %{ENV:SYNTAX} ^html$
-RewriteRule ^([a-zA-Z-_0-9]+)/([a-zA-Z-_0-9]+)$ https://ontopia-lodview.agid.gov.it/controlled-vocabulary/$1/$2 [R=303,L]
+RewriteRule ^([a-zA-Z-_0-9]+)/([a-zA-Z-_0-9]+)$ https://schema.gov.it/lodview/controlled-vocabulary/$1/$2 [R=303,L]
 
-RewriteRule ^(.+)/(.+)/(.+)$ https://ontopia-lodview.agid.gov.it/controlled-vocabulary/$1/$2/$3 [R=303,L]
+RewriteRule ^(.+)/(.+)/(.+)$ https://schema.gov.it/lodview/controlled-vocabulary/$1/$2/$3 [R=303,L]

--- a/italia/data/.htaccess
+++ b/italia/data/.htaccess
@@ -1,7 +1,7 @@
 Header set Access-Control-Allow-Origin *
 Options +FollowSymLinks
 RewriteEngine on
-SetEnvIf Request_URI ^.*$ ROOT_URL=https://ontopia-lodview.agid.gov.it/data/
+SetEnvIf Request_URI ^.*$ ROOT_URL=https://schema.gov.it/lodview/data/
 
 RewriteRule ^(.*)$ %{ENV:ROOT_URL}$1 [R=303,L]
 RewriteRule ^(.*)/$ %{ENV:ROOT_URL}$1 [R=303,L]

--- a/italia/metadata/.htaccess
+++ b/italia/metadata/.htaccess
@@ -1,7 +1,7 @@
 Header set Access-Control-Allow-Origin *
 Options +FollowSymLinks
 RewriteEngine on
-SetEnvIf Request_URI ^.*$ ROOT_URL=https://dati.gov.it
+SetEnvIf Request_URI ^.*$ ROOT_URL=https://schema.gov.it
 
 RewriteCond %{HTTP_ACCEPT} ^.*text/html.*
 RewriteRule ^$ %{ENV:ROOT_URL} [R=303,L]

--- a/italia/onto/.htaccess
+++ b/italia/onto/.htaccess
@@ -13,8 +13,8 @@ RewriteCond %{ENV:SYNTAX} ^(rdf|ttl|jsonld)$
 RewriteRule ^([a-zA-Z-_0-9]+)(/?)$ %{ENV:ROOT_URL}$1/latest/$1-AP_IT.%{ENV:SYNTAX} [R=303,L]
 
 RewriteCond %{ENV:SYNTAX} ^html$
-RewriteRule ^(.+)(/.+)$ https://ontopia-lodview.agid.gov.it/onto/$1$2 [R=303,L]
+RewriteRule ^(.+)(/.+)$ https://schema.gov.it/lodview/onto/$1$2 [R=303,L]
 RewriteCond %{ENV:SYNTAX} ^html$
-RewriteRule ^(.+)/$ https://ontopia-lode.agid.gov.it/lode/extract?url=https://w3id.org/italia/onto/$1 [R=303,L]
+RewriteRule ^(.+)/$ https://schema.gov.it/lode/extract?url=https://w3id.org/italia/onto/$1 [R=303,L]
 RewriteCond %{ENV:SYNTAX} ^html$
-RewriteRule ^(.+)$ https://ontopia-lode.agid.gov.it/lode/extract?url=https://w3id.org/italia/onto/$1 [R=303,L]
+RewriteRule ^(.+)$ https://schema.gov.it/lode/extract?url=https://w3id.org/italia/onto/$1 [R=303,L]

--- a/italia/readme.md
+++ b/italia/readme.md
@@ -16,5 +16,5 @@ Contacts:
 + Matteo Fortini: github (https://github.com/mfortini) - email (matteo.fortini@teamdigitale.governo.it)
 + Giorgia Lodi: github (https://github.com/giorgialodi) - email (giorgia.lodi@aistc.cnr.it)
 
-For any other inquires, please contact contatti@developers.italia.it
+For any other enquiries, please contact contatti@developers.italia.it
 

--- a/italia/readme.md
+++ b/italia/readme.md
@@ -1,4 +1,4 @@
-Repository for redirecting to ontologies and controlled vocabularies of the Italian Public Administrations.
+Persistent URIs for ontologies and controlled vocabularies of the Italian Public Sector
 ===================
 
 We intend to use w3id.org in order to obtain persistent URIs for the [Italian network of ontologies and controlled vocabularies for the Public Administrations](https://github.com/italia/daf-ontologie-vocabolari-controllati). The network is also currently maintained in collaboration with the Institute of Cognitive Sciences and Technologies (Semantic Technologies Laboratory - STLab) of the Italian National Research Council (ISTC-CNR).

--- a/italia/readme.md
+++ b/italia/readme.md
@@ -1,18 +1,20 @@
 Repository for redirecting to ontologies and controlled vocabularies of the Italian Public Administrations.
 ===================
 
-We intend to use w3id.org in order to obtain persistent URIs for the [Italian network of ontologies and controlled vocabularies (OntoPiA) for the Public Administrations](https://github.com/italia/daf-ontologie-vocabolari-controllati). The network is developed also in collaboration with the Institute of Cognitive Sciences and Technologies (Semantic Technologies Laboratory - STLab) of the Italian National Research Council (CNR).
-OntoPiA is used in the context of the Italian [Data and Analytics Framework (DAF)](http://daf-docs.readthedocs.io/en/latest/), the big data infrastructure that Italy is currently constructing under the supervision of the Italian Digital Transformation Team and the Italian Digital Agency of the Presidency of the Council of Ministers.
+We intend to use w3id.org in order to obtain persistent URIs for the [Italian network of ontologies and controlled vocabularies for the Public Administrations](https://github.com/italia/daf-ontologie-vocabolari-controllati). The network is also currently maintained in collaboration with the Institute of Cognitive Sciences and Technologies (Semantic Technologies Laboratory - STLab) of the Italian National Research Council (ISTC-CNR).
+The network is used in the context of the Italian public sector and, in particolar, it is the principal content of the so-called NDC - National Data Catalogue whose implementation is currently deployed under the form of the Italian [National Catalogue of Semantic Assets named schema.gov.it](https://schema.gov.it).
+We also intend to use w3id.org/italia for national persistent URIs of the public sector. Therefore, we will include rules for specific public sector domains owned by single Italian Public Administrations that want to publish ontologies and data using w3id.org/italia namespace in their persistent URIs.
 
-We are planning to create: 
+We define: 
 + w3id.org/italia/onto for all the ontologies of the network mentioned above;
 + w3id.org/italia/controlled-vocabulary for all the controlled vocabularies;
-+ w3id.org/italia/metadata for all metadata defined for annotating data, ontologies and vocabularies for the Italian Public Administration.
++ w3id.org/italia/data for the linked open data that is produced in the above context
  
-The initial redirect will be to the github repository we are using as working repo, open to all communities. When DAF will be in production in the upcoming months, it is likely that we will change the redirect to the official domain.
-Afterwards, when linked (open) data will be produced and published, we are also planning to create a specific directory italia/data.
-
 Contacts:
 
-+ Giorgia Lodi (giorgia.lodi@agid.gov.it)
-+ Andrea Giovanni Nuzzolese (andreagiovanni.nuzzolese@cnr.it)
++ Fabio Bonelli: github (https://github.com/bfabio) - email (fabio.bonelli@teamdigitale.governo.it)
++ Matteo Fortini: github (https://github.com/mfortini) - email (matteo.fortini@teamdigitale.governo.it)
++ Giorgia Lodi: github (https://github.com/giorgialodi) - email (giorgia.lodi@aistc.cnr.it)
+
+For any other inquires, please contact contatti@developers.italia.it
+


### PR DESCRIPTION
Please accept the new changes we applied to the readme of the project italia in w3id.org and the new rules to redirect to a brand-new Itailan National Digital Platform named schema.gov.it 