### PR TITLE
fix: bbs context repo rename

### DIFF
--- a/bbs/.htaccess
+++ b/bbs/.htaccess
@@ -2,6 +2,6 @@ Header set Access-Control-Allow-Origin *
 Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^$ https://w3c-ccg.github.io/ldp-bbs2020/ [R=302,L]
-RewriteRule ^v1$ https://w3c-ccg.github.io/ldp-bbs2020/contexts/v1/ [R=302,L]
+RewriteRule ^$ https://w3c-ccg.github.io/vc-di-bbs/ [R=302,L]
+RewriteRule ^v1$ https://w3c-ccg.github.io/vc-di-bbs/contexts/v1/ [R=302,L]
 

--- a/bbs/README.md
+++ b/bbs/README.md
@@ -1,7 +1,7 @@
 # BBS Vocabulary
 
-- https://github.com/w3c-ccg/ldp-bbs2020/
-- https://w3c-ccg.github.io/ldp-bbs2020/
+- https://github.com/w3c-ccg/vc-di-bbs/
+- https://w3c-ccg.github.io/vc-di-bbs/
 
 ## Maintainers
 

--- a/security/.htaccess
+++ b/security/.htaccess
@@ -71,8 +71,8 @@ RewriteRule ^suites/jws-2020/v1$ https://w3c.github.io/vc-jws-2020/contexts/v1/ 
 
 # http://w3id.org/security/suites/bls12381-2020
 
-RewriteRule ^suites/bls12381-2020$ https://w3c-ccg.github.io/ldp-bbs2020/ [R=302,L]
-RewriteRule ^suites/bls12381-2020/v1$ https://w3c-ccg.github.io/ldp-bbs2020/contexts/v1 [R=302,L]
+RewriteRule ^suites/bls12381-2020$ https://w3c-ccg.github.io/vc-di-bbs/ [R=302,L]
+RewriteRule ^suites/bls12381-2020/v1$ https://w3c-ccg.github.io/vc-di-bbs/contexts/v1 [R=302,L]
 
 # http://w3id.org/security/suites/eip712sig-2021
 
@@ -111,7 +111,7 @@ RewriteRule ^jws$ https://w3c-ccg.github.io/lds-jws2020/ [R=302,L]
 RewriteRule ^jws/v1$ https://w3c-ccg.github.io/lds-jws2020/contexts/v1/ [R=302,L]
 RewriteRule ^pgp$ https://or13.github.io/lds-pgp2021/ [R=302,L]
 RewriteRule ^pgp/v1$ https://or13.github.io/lds-pgp2021/contexts/pgp-v1.jsonld [R=302,L]
-RewriteRule ^bbs$ https://github.com/w3c-ccg/ldp-bbs2020/ [R=302,L]
-RewriteRule ^bbs/v1$ https://w3c-ccg.github.io/ldp-bbs2020/contexts/v1/ [R=302,L]
+RewriteRule ^bbs$ https://github.com/w3c-ccg/vc-di-bbs/ [R=302,L]
+RewriteRule ^bbs/v1$ https://w3c-ccg.github.io/vc-di-bbs/contexts/v1/ [R=302,L]
 RewriteRule ^blockchain$ https://or13.github.io/lds-blockchain2021/ [R=302,L]
 RewriteRule ^blockchain/v1$ https://or13.github.io/lds-blockchain2021/contexts/blockchain-v1.jsonld [R=302,L]


### PR DESCRIPTION
Updating the url re-write rule to reflect the new repository name for the vc-di-bbs suite.