### PR TITLE
Fix: Update link to Docmaps-project github organization

### DIFF
--- a/docmaps/.htaccess
+++ b/docmaps/.htaccess
@@ -3,7 +3,7 @@ RewriteEngine on
 AddType application/ld+json .jsonld
 
 # JSON-LD Context
-RewriteRule ^context.jsonld$ https://cdn.jsdelivr.net/gh/knowledgefutures/docmaps@main/docmaps-context.jsonld [R=302,L]
+RewriteRule ^context.jsonld$ https://cdn.jsdelivr.net/gh/docmaps-project/docmaps@main/docmaps-context.jsonld [R=302,L]
 
 # Rewrite Base URL
 RewriteRule ^(.*)$ https://docmaps.knowledgefutures.org/pub/sgkf1pqa/release/7 [R=302,L]

--- a/docmaps/readme.md
+++ b/docmaps/readme.md
@@ -12,8 +12,9 @@ https://docmaps.knowledgefutures.org/pub/sgkf1pqa/release/7
 
 ## JSON-LD Context
 
-https://cdn.jsdelivr.net/gh/knowledgefutures/docmaps@main/docmaps-context.jsonld
+https://cdn.jsdelivr.net/gh/docmaps-project/docmaps@main/docmaps-context.jsonld
 
 ## Contact
 
 Gabriel Stein, gabe AT knowledgefutures DOT org
+eve, eve AT knowledgefutures DOT org, github DOT com SLASH ships


### PR DESCRIPTION
This Github repository was re-homed in a new org: https://github.com/Docmaps-Project/docmaps .