### PR TITLE
add /cpont/mappings/ to CPONT

### DIFF
--- a/cpont/.htaccess
+++ b/cpont/.htaccess
@@ -1,4 +1,12 @@
 Options +FollowSymLinks
 RewriteEngine on
+
+# Link to cpont.owl
 RewriteRule ^cpont.owl$ https://gitlab.c-path.org/c-pathontology/critical-path-ontology/-/raw/main/cpont.owl [R=307,L]
-RewriteRule ^(.*) https://gitlab.c-path.org/c-pathontology/critical-path-ontology/ [R=307,L]
+
+# Mapping commons
+RewriteRule ^mappings/?$ https://gitlab.c-path.org/c-pathontology/mapping-commons/ [R=307,L]
+RewriteRule ^mappings/(.+)$ https://gitlab.c-path.org/c-pathontology/mapping-commons/-/raw/main/mappings/$1 [R=307,L]
+
+# Default to CPONT repo
+RewriteRule ^(.*)$ https://gitlab.c-path.org/c-pathontology/critical-path-ontology/ [R=307,L]

--- a/cpont/README.md
+++ b/cpont/README.md
@@ -7,8 +7,8 @@ The `w3id.org/cpont` redirect is used to direct URIs for terms, documentation, a
 The `w3id.org/cpont/mappings` redirect is used to direct URIs for sssom mapping files in the CPONT Mapping Commons.
 
 ### Homepages
-- https://gitlab.c-path.org/c-pathontology/critical-path-ontology/  --  CPONT
-- https://gitlab.c-path.org/c-pathontology/mapping-commons/  --  Mapping Commons
+- CPONT: https://gitlab.c-path.org/c-pathontology/critical-path-ontology/
+- Mapping Commons: https://gitlab.c-path.org/c-pathontology/mapping-commons/
 
 ## Contact
 This space is primarily administered by:  

--- a/cpont/README.md
+++ b/cpont/README.md
@@ -2,9 +2,13 @@
 
 This [W3ID](https://w3id.org) provides a persistent URI namespace for the [Critical Path](https://c-path.org/) Ontology (CPONT).
 
-The w3id.org/cpont redirect is used to direct URIs for terms, documentation, and repositories related to CPONT.
+The `w3id.org/cpont` redirect is used to direct URIs for terms, documentation, and repositories related to CPONT.
 
-The top-level redirects to the primary GitLab repository for the ontology project, [here](https://gitlab.c-path.org/c-pathontology/critical-path-ontology/).
+The `w3id.org/cpont/mappings` redirect is used to direct URIs for sssom mapping files in the CPONT Mapping Commons.
+
+### Homepages
+- https://gitlab.c-path.org/c-pathontology/critical-path-ontology/  --  CPONT
+- https://gitlab.c-path.org/c-pathontology/mapping-commons/  --  Mapping Commons
 
 ## Contact
 This space is primarily administered by:  

--- a/cpont/README.md
+++ b/cpont/README.md
@@ -4,7 +4,7 @@ This [W3ID](https://w3id.org) provides a persistent URI namespace for the [Criti
 
 The `w3id.org/cpont` redirect is used to direct URIs for terms, documentation, and repositories related to CPONT.
 
-The `w3id.org/cpont/mappings` redirect is used to direct URIs for sssom mapping files in the CPONT Mapping Commons.
+The `w3id.org/cpont/mappings` redirect is used to direct URIs for [sssom](https://mapping-commons.github.io/sssom/) mapping files in the CPONT Mapping Commons.
 
 ### Homepages
 - CPONT: https://gitlab.c-path.org/c-pathontology/critical-path-ontology/


### PR DESCRIPTION
Updated `/cpont/.htaccess` and `/cpont/README.md`.

Added redirects for `/cpont/mappings/` to the CPONT mapping commons repo.