### PR TITLE
Introduce env/ path under italia/ for Italian environmental information

### DIFF
--- a/italia/env/README.md
+++ b/italia/env/README.md
@@ -4,9 +4,9 @@ Repository (italia/env) for redirecting to ontologies and data of the Linked ISP
 We intend to use w3id.org to provide persistent URIs for the network of ontologies and data we are developing in the context of the [Linked ISPRA](https://dati.isprambiente.it) system. The network is developed by ISPRA (The Italian Institute for Environmental Protection and Research, ISPRA — Istituto Superiore per la Protezione e la Ricerca Ambientale). We intend to use **w3id.org/italia/env** for national persistent URIs for environmental information of the public sector.
 
 We initially plan to create:
-+ `w3id.org/italia/env/onto` for all the ontologies of the network mentioned above;
-+ `w3id.org/italia/env/vocab` for all the controlled vocabularies;
-+ `w3id.org/italia/env/ld` for all the other types of data;
++ `w3id.org/italia/env/onto` for all the ontologies of the network mentioned above
++ `w3id.org/italia/env/vocab` for all the controlled vocabularies
++ `w3id.org/italia/env/ld` for all the other types of data
 
 
 Some redirect rules will be to the [github repository of ISPRA](https://github.com/isprambiente/dati-semantic) we are using as semantic assets repo, open to all; others to the ISPRA server.

--- a/italia/env/README.md
+++ b/italia/env/README.md
@@ -1,0 +1,18 @@
+Repository (italia/env) for redirecting to ontologies and data of the Linked ISPRA system (the Linked Open Data and the network of ontologies of the Italian Institute for Environmental Protection and Research, ISPRA)
+===================
+
+We intend to use w3id.org in order to obtain persistent URIs for the network of ontologies and data we are developing in the context of the [Linked ISPRA](https://dati.isprambiente.it) system. The network is developed by ISPRA (The Italian Institute for Environmental Protection and Research, ISPRA - Istituto Superiore per la Protezione e la Ricerca Ambientale). We intend to use **w3id.org/italia/env** for national persistent URIs of the environmental information of public sector.
+
+We initially plan to create:
++ `w3id.org/italia/env/onto` for all the ontologies of the network mentioned above;
++ `w3id.org/italia/env/vocab` for all the controlled vocabularies;
++ `w3id.org/italia/env/ld` for all the other types of data;
+
+
+Some redirect rules will be to the [github repository of ISPRA](https://github.com/isprambiente/dati-semantic) we are using as semantic assets repo, open to all; others to the ISPRA server.
+
+Contacts:
+
++ Elio Giulianelli: github (https://github.com/eliogiu) - email (elio.giulianelli@isprambiente.it)
++ Marco Picone: github (https://github.com/marcopicone) - email (marco.picone@isprambiente.it)
++ Giulio Settanta: github (https://github.com/sgiulio70) - email (giulio.settanta@isprambiente.it)

--- a/italia/env/README.md
+++ b/italia/env/README.md
@@ -1,7 +1,7 @@
 Repository (italia/env) for redirecting to ontologies and data of the Linked ISPRA system (the Linked Open Data and the network of ontologies of the Italian Institute for Environmental Protection and Research, ISPRA)
 ===================
 
-We intend to use w3id.org in order to obtain persistent URIs for the network of ontologies and data we are developing in the context of the [Linked ISPRA](https://dati.isprambiente.it) system. The network is developed by ISPRA (The Italian Institute for Environmental Protection and Research, ISPRA - Istituto Superiore per la Protezione e la Ricerca Ambientale). We intend to use **w3id.org/italia/env** for national persistent URIs of the environmental information of public sector.
+We intend to use w3id.org to provide persistent URIs for the network of ontologies and data we are developing in the context of the [Linked ISPRA](https://dati.isprambiente.it) system. The network is developed by ISPRA (The Italian Institute for Environmental Protection and Research, ISPRA — Istituto Superiore per la Protezione e la Ricerca Ambientale). We intend to use **w3id.org/italia/env** for national persistent URIs for environmental information of the public sector.
 
 We initially plan to create:
 + `w3id.org/italia/env/onto` for all the ontologies of the network mentioned above;

--- a/italia/env/ld/.htaccess
+++ b/italia/env/ld/.htaccess
@@ -1,0 +1,7 @@
+Header set Access-Control-Allow-Origin * 
+Options +FollowSymLinks 
+RewriteEngine on 
+SetEnvIf Request_URI ^.*$ ROOT_URL=https://dati.isprambiente.it/ld/
+
+RewriteRule ^(.*)$ %{ENV:ROOT_URL}$1 [R=303,L]
+RewriteRule ^(.*)/$ %{ENV:ROOT_URL}$1 [R=303,L]

--- a/italia/env/ld/.htaccess
+++ b/italia/env/ld/.htaccess
@@ -3,5 +3,4 @@ Options +FollowSymLinks
 RewriteEngine on 
 SetEnvIf Request_URI ^.*$ ROOT_URL=https://dati.isprambiente.it/ld/
 
-RewriteRule ^(.*)$ %{ENV:ROOT_URL}$1 [R=303,L]
-RewriteRule ^(.*)/$ %{ENV:ROOT_URL}$1 [R=303,L]
+RewriteRule ^(.*)/?$ %{ENV:ROOT_URL}$1 [R=303,L]

--- a/italia/env/onto/.htaccess
+++ b/italia/env/onto/.htaccess
@@ -1,0 +1,20 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+SetEnvIf Accept ^.*application/rdf\+xml.* SYNTAX=rdf
+SetEnvIf Accept ^.*text/turtle.* SYNTAX=ttl
+SetEnvIf Accept ^.*application/json-ld.* SYNTAX=jsonld
+SetEnvIf Accept ^.*text/html.* SYNTAX=html
+SetEnvIf Request_URI ^.*$ ROOT_URL=https://raw.githubusercontent.com/isprambiente/dati-semantic/main/assets/ontologies/
+
+
+RewriteCond %{ENV:SYNTAX} ^(rdf|ttl|jsonld)$
+RewriteRule ^([a-zA-Z-_0-9]+)(/?)$ %{ENV:ROOT_URL}$1/latest/$1.%{ENV:SYNTAX} [R=303,L]
+
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^(.+)(/.+)$ https://dati.isprambiente.it/lodview/onto/$1$2 [R=303,L]
+
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^([a-zA-Z-_0-9]+)(/?)$  https://dati.isprambiente.it/lode/extract?url=%{ENV:ROOT_URL}$1/latest/$1.rdf [R=303,L]
+#RewriteRule ^(.+)/$ https://dati.isprambiente.it/lode/extract?url=http://w3id.org/italia/env/onto/$1 [R=303,L]
+

--- a/italia/env/vocab/.htaccess
+++ b/italia/env/vocab/.htaccess
@@ -1,0 +1,20 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+SetEnvIf Accept ^.*application/rdf\+xml.* SYNTAX=rdf
+SetEnvIf Accept ^.*text/turtle.* SYNTAX=ttl
+SetEnvIf Accept ^.*application/json-ld.* SYNTAX=jsonld
+SetEnvIf Accept ^.*text/html.* SYNTAX=html
+SetEnvIf Request_URI ^.*$ ROOT_URL=https://raw.githubusercontent.com/isprambiente/dati-semantic/main/assets/controlled-vocabularies
+
+
+RewriteCond %{ENV:SYNTAX} ^(rdf|ttl|jsonld)$
+RewriteRule ^([a-zA-Z-_0-9]+)/([a-zA-Z-_0-9]+)$  %{ENV:ROOT_URL}/$1/$2/$2.%{ENV:SYNTAX} [R=303,L]
+
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^([a-zA-Z-_0-9]+)/([a-zA-Z-_0-9]+)$  https://dati.isprambiente.it/lodview/vocab/$1/$2 [R=303,L]
+
+RewriteRule ^(.+)/(.+)/(.+)$  https://dati.isprambiente.it/lodview/vocab/$1/$2/$3 [R=303,L]
+
+


### PR DESCRIPTION
We intend to use w3id.org in order to obtain persistent URIs for the network of ontologies and data of the Italian Institute for Environmental Protection and Research (ISPRA)