### PR TITLE
Add redirect `rorio` for ROR in OWL

### DIFF
--- a/rorio/.htaccess
+++ b/rorio/.htaccess
@@ -1,0 +1,6 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Make ontology artifacts resolvable
+RewriteRule ^rorio.ofn$ https://raw.githubusercontent.com/cthoyt/rorio/main/rorio.ofn [R=302,L]
+RewriteRule ^rorio.owl$ https://raw.githubusercontent.com/cthoyt/rorio/main/rorio.owl [R=302,L]

--- a/rorio/README.md
+++ b/rorio/README.md
@@ -1,0 +1,16 @@
+# ROR in OWL
+
+This [W3ID](https://w3id.org/) provides a persistent URI namespace for [Research Organization Registry (ROR)](https://ror.org) records in OWL resources.
+
+## Uses
+
+ROR in OWL is an ontology that wraps ROR identifiers as named individuals so they can be more easily included in other ontologies (e.g., OBO Ontologies) and empower the [Protégé](https://protege.stanford.edu/) ontology editor to show rich label information for `dc:contributor` annotations.
+
+The artifacts referenced by this entry are versionioned in the following GitHub repository: https://github.com/cthoyt/rorio
+
+## Contact
+
+Charles Tapley Hoyt
+Email: cthoyt@gmail.com
+GitHub: [@cthoyt](https://github.com/cthoyt/)
+ORCID: [0000-0003-4423-4370](https://orcid.org/0000-0003-4423-4370)


### PR DESCRIPTION
ROR in OWL is an ontology that wraps [Research Organization Registry (ROR)](https://ror.org/) identifiers as named individuals so they can be more easily included in other ontologies (e.g., OBO Ontologies) and empower the [Protégé](https://protege.stanford.edu/) ontology editor to show rich label information for `dc:contributor` annotations.

The goal of having an entry in w3id.org is to endow this ontology with a PURL as its ontology IRI.

This PR is similar in concept to https://github.com/perma-id/w3id.org/pull/3006 but for a different resource (i.e., ROR instead of ORCID)