### PR TITLE
Add /ark:57802/

### DIFF
--- a/ark:57802/.htaccess
+++ b/ark:57802/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine On
+
+RewriteRule (.*) https://ns.polyneme.xyz/ark:57802/$1 [R=302,L,QSA]

--- a/ark:57802/README.md
+++ b/ark:57802/README.md
@@ -1,0 +1,22 @@
+# /ark:57802/
+
+This [W3ID](https://w3id.org) provides a persistent URI namespace for resources under the [archival resource key (ARK)](https://arks.org/about) name assigning authority number (NAAN) 57802. That is, this W3ID service acts as an ARK name mapping authority (NMA).
+
+## Uses
+
+This namespace may be broken down using so-called ["shoulders"](https://www.ietf.org/archive/id/draft-kunze-ark-36.html#name-optional-shoulders) at the .htaccess level (i.e. without slashes `/`.), as per the ARK scheme.
+
+Example name: https://w3id.org/ark:57802/dw0/agu retrieves a representation of the American Geophysical Union (AGU) bibliographic index terms as a SKOS ConceptScheme. https://w3id.org/ark:57802/dw0/agu?_mediatype=text/html explicitly requests a text/html representation.
+
+## Contact
+
+This space is administered by:
+
+**Donny Winston**  
+_Metadata Infrastructure Architect_  
+[Polyneme LLC](https://polyneme.xyz/)  
+New York, New York
+<donny@polyneme.xyz>  
+GitHub: [dwinston](https://github.com/dwinston)
+ORCID: [0000-0002-8424-0604](https://orcid.org/0000-0002-8424-0604)
+ActivityPub (i.e. Fediverse, via Mastodon): [@donny@fairpoints.social](https://fairpoints.social/@donny)


### PR DESCRIPTION
This [W3ID](https://w3id.org) provides a persistent URI namespace for resources under the [archival resource key (ARK)](https://arks.org/about) name assigning authority number (NAAN) 57802. That is, this W3ID service acts as an ARK name mapping authority (NMA).

## Uses

This namespace may be broken down using so-called ["shoulders"](https://www.ietf.org/archive/id/draft-kunze-ark-36.html#name-optional-shoulders) at the .htaccess level (i.e. without slashes `/`.), as per the ARK scheme.

Example name: https://w3id.org/ark:57802/dw0/agu (current redirect to https://ns.polyneme.xyz/ark:57802/dw0/agu) retrieves a representation of the American Geophysical Union (AGU) bibliographic index terms as a SKOS ConceptScheme. https://w3id.org/ark:57802/dw0/agu?_mediatype=text/html explicitly requests a text/html representation.

## Contact

I was assigned the NAAN 57802, and I administer it. I've provided contact info in the README as part of this PR.