### PR TITLE
RiverBench: fix rewrite ordering

### DIFF
--- a/riverbench/.htaccess
+++ b/riverbench/.htaccess
@@ -10,6 +10,28 @@ RewriteEngine on
 RewriteRule ^datasets/([a-z0-9-]+)/dev/files/(.+)$ https://github.com/RiverBench/dataset-$1/releases/download/dev/$2 [R=302,L]
 RewriteRule ^datasets/([a-z0-9-]+)/([a-z0-9.-]+)/files/(.+)$ https://github.com/RiverBench/dataset-$1/releases/download/v$2/$3 [R=302,L]
 
+### EXPLICIT EXTENSIONS ###
+
+# Schema – explicit extension for dev release
+RewriteRule ^schema/([a-z0-9-]+)(/dev)?\.(rdf|ttl|nt)([#?].*)?$ https://github.com/RiverBench/schema/releases/download/dev/$1.$3 [R=302,L]
+
+# Schema – explicit extension for tagged releases
+RewriteRule ^schema/([a-z0-9-]+)/([a-z0-9.-]+)\.(rdf|ttl|nt)([#?].*)?$ https://github.com/RiverBench/schema/releases/download/v$2/$1.$3 [R=302,L]
+
+# Main metadata – explicit extension for dev release
+RewriteRule ^(v/dev)?\.(rdf|ttl|nt)([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/dev/metadata.$2 [R=302,L]
+
+# Main metadata – explicit extension for tagged releases
+RewriteRule ^v/([a-z0-9.-]+)\.(rdf|ttl|nt)([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/v$1/metadata.$2 [R=302,L]
+
+# Dataset metadata – explicit extension for dev release
+RewriteRule ^datasets/([a-z0-9-]+)(/dev)?\.(rdf|ttl|nt)([#?].*)?$ https://github.com/RiverBench/dataset-$1/releases/download/dev/metadata.$3 [R=302,L]
+
+# Dataset metadata – explicit extension for tagged releases
+RewriteRule ^datasets/([a-z0-9-]+)/([a-z0-9.-]+)\.(rdf|ttl|nt)([#?].*)?$ https://github.com/RiverBench/dataset-$1/releases/download/v$2/metadata.$3 [R=302,L]
+
+### SERVING HTML ###
+
 # Serve HTML if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
@@ -18,12 +40,6 @@ RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 RewriteRule ^(.+)$ https://riverbench.github.io/$1 [R=302,L]
 
 ### SERVING SCHEMAS (ONTOLOGIES) ###
-
-# Schema – explicit extension for dev release
-RewriteRule ^schema/([a-z0-9-]+)(/dev)?\.(rdf|ttl|nt)([#?].*)?$ https://github.com/RiverBench/schema/releases/download/dev/$1.$3 [R=302,L]
-
-# Schema – explicit extension for tagged releases
-RewriteRule ^schema/([a-z0-9-]+)/([a-z0-9.-]+)\.(rdf|ttl|nt)([#?].*)?$ https://github.com/RiverBench/schema/releases/download/v$2/$1.$3 [R=302,L]
 
 # Schema – RDF/XML for dev release
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
@@ -54,12 +70,6 @@ RewriteCond %{HTTP_ACCEPT} \*/turtle
 RewriteRule ^schema/([a-z0-9-]+)/([a-z0-9.-]+)/?([#?].*)?$ https://github.com/RiverBench/schema/releases/download/v$2/$1.ttl [R=302,L]
 
 ### SERVING MAIN METADATA ###
-
-# Main metadata – explicit extension for dev release
-RewriteRule ^(v/dev)?\.(rdf|ttl|nt)([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/dev/metadata.$2 [R=302,L]
-
-# Main metadata – explicit extension for tagged releases
-RewriteRule ^v/([a-z0-9.-]+)\.(rdf|ttl|nt)([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/v$1/metadata.$2 [R=302,L]
 
 # Main metadata – RDF/XML for dev release
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
@@ -126,12 +136,6 @@ RewriteCond %{HTTP_ACCEPT} \*/turtle
 RewriteRule ^profiles/([a-z0-9-]+)/([a-z0-9.-]+)/?([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/v$2/profile-$1.ttl [R=302,L]
 
 ### SERVING DATASET METADATA ###
-
-# Dataset metadata – explicit extension for dev release
-RewriteRule ^datasets/([a-z0-9-]+)(/dev)?\.(rdf|ttl|nt)([#?].*)?$ https://github.com/RiverBench/dataset-$1/releases/download/dev/metadata.$3 [R=302,L]
-
-# Dataset metadata – explicit extension for tagged releases
-RewriteRule ^datasets/([a-z0-9-]+)/([a-z0-9.-]+)\.(rdf|ttl|nt)([#?].*)?$ https://github.com/RiverBench/dataset-$1/releases/download/v$2/metadata.$3 [R=302,L]
 
 # Dataset metadata – RDF/XML for dev release
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml

--- a/riverbench/README.md
+++ b/riverbench/README.md
@@ -6,6 +6,22 @@ The .htaccess file is rather long, as it needs to serve various metadata for dat
 
 The docs are hosted on GitHub Pages, and the data and metadata files are stored as releases on GitHub.
 
+### Test links
+Some test links that should always give a 200 response:
+
+- https://w3id.org/riverbench/v/dev
+- https://w3id.org/riverbench/v/dev.rdf
+- https://w3id.org/riverbench/v/dev.nt
+- https://w3id.org/riverbench/v/dev.ttl
+- https://w3id.org/riverbench/profiles/stream-triples
+- https://w3id.org/riverbench/profiles/stream-triples.rdf
+- https://w3id.org/riverbench/profiles/stream-triples.nt
+- https://w3id.org/riverbench/profiles/stream-triples.ttl
+- https://w3id.org/riverbench/profiles/stream-triples/dev
+- https://w3id.org/riverbench/profiles/stream-triples/dev.rdf
+- https://w3id.org/riverbench/profiles/stream-triples/dev.nt
+- https://w3id.org/riverbench/profiles/stream-triples/dev.ttl
+
 ## Maintainers
 Piotr Sowiński \
 GitHub: https://github.com/Ostrzyciel \


### PR DESCRIPTION
This PR fixes the ordering of rewrites in RiverBench's htaccess file. I didn't catch this in testing, because the error only becomes apparent on clients requesting HTML in the Accept header, and I was testing with Postman.

I've also added some test links, so that the CI can help catch any similar errors in the future.