### PR TITLE
Adding redirect to the unified engineering ontology

### DIFF
--- a/unified-engineering/.htaccess
+++ b/unified-engineering/.htaccess
@@ -2,4 +2,4 @@ Header set Access-Control-Allow-Origin *
 Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^demo$ https://github.com/codepasta/autonomous-buildings/blob/main/demo/bridges-demo.ttl [R=302,L]
+RewriteRule ^demo$ https://raw.githubusercontent.com/codepasta/autonomous-buildings/main/demo/bridges-demo.ttl [R=302,L]

--- a/unified-engineering/.htaccess
+++ b/unified-engineering/.htaccess
@@ -1,0 +1,5 @@
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^demo$ https://github.com/codepasta/autonomous-buildings/blob/main/demo/bridges-demo.ttl [R=302,L]

--- a/unified-engineering/README.md
+++ b/unified-engineering/README.md
@@ -1,0 +1,13 @@
+# An ontology that integrates existing engineering ontologies for the purpose of building autonomous systems
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the interaction ontology (InterOnt) resources.
+
+
+## Contact
+This space is administered by:  
+
+**Ganesh Ramanathan**  
+*Doctoral Researcher*  
+[University of St. Gallen](https://unisg.ch)  
+Switzerland
+<ganesh.ramanathan@student.unisg.ch>  
+

--- a/unified-engineering/README.md
+++ b/unified-engineering/README.md
@@ -8,6 +8,6 @@ This space is administered by:
 **Ganesh Ramanathan**  
 *Doctoral Researcher*  
 [University of St. Gallen](https://unisg.ch)  
-Switzerland
+Switzerland  
 <ganesh.ramanathan@student.unisg.ch>  
 


### PR DESCRIPTION
The first version redirects to a demo ontology. This will be later extended with redirect paths to individual ontologies.