### PR TITLE
Add redirect entry for ExeKGLib's website

### DIFF
--- a/exe-kg-lib/.htaccess
+++ b/exe-kg-lib/.htaccess
@@ -1,0 +1,6 @@
+Options +FollowSymLinks
+
+RewriteEngine On
+
+# Rewrite rule to serve ExeKGLib website's index page
+RewriteRule ^$ https://boschresearch.github.io/ExeKGLib/ [R=302,L]

--- a/exe-kg-lib/README.md
+++ b/exe-kg-lib/README.md
@@ -1,0 +1,11 @@
+# /exe-kg-lib/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for ExeKGLib resources.
+
+## Contact
+**Antonis Klironomos**  
+*Industrial PhD student in Neuro-symbolic AI*  
+[Robert Bosch GmbH](https://www.bosch.com/research/) and [University of Mannheim](https://www.wim.uni-mannheim.de/)  
+Germany  
+<antonisklironomos@gmail.com>  
+GitHub: [AntonisKl](https://github.com/AntonisKl)
+


### PR DESCRIPTION
This PR adds a redirect entry (`/exe-kg-lib`) for [ExeKGLib's website](https://boschresearch.github.io/ExeKGLib/).