### PR TITLE
New Persistent URI for kgraphx

### DIFF
--- a/kgraphx/.htaccess
+++ b/kgraphx/.htaccess
@@ -1,0 +1,8 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Rewrite Base URL
+# will add $1 suffix later
+# static redirect for now
+
+RewriteRule ^(.*)$ https://github.com/ahemaid/KGraphX [R=302,L]

--- a/kgraphx/readme.md
+++ b/kgraphx/readme.md
@@ -1,5 +1,5 @@
 # /kgraphx/
-This [W3ID](https://w3id.org) provides a persistent URI namespace for kgraphx, which is a tool to make  knowledge graph creation and management easy.
+This [W3ID](https://w3id.org) provides a persistent URI namespace for `kgraphx`, which is a tool to make knowledge graph creation and management easier.
 
 Homepage:
 * https://github.com/ahemaid/KGraphX

--- a/kgraphx/readme.md
+++ b/kgraphx/readme.md
@@ -12,7 +12,7 @@ This space is Maintained by:
 [Fraunhofer-Gesellschaft](https://www.fraunhofer.de/)  
 Sankt Augustin , Germany  
 <ahmad.hemid@fit.fraunhofer.de>  
-GitHub: [ahemaid](https://github.com/ahemaid)
+GitHub: [ahemaid](https://github.com/ahemaid)  
 ORCID: [0000-0002-9811-0579](https://orcid.org/0000-0002-9811-0579)  
 
 

--- a/kgraphx/readme.md
+++ b/kgraphx/readme.md
@@ -1,0 +1,18 @@
+# /kgraphx/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for kgraphx, which is a tool to make  knowledge graph creation and management easy.
+
+Homepage:
+* https://github.com/ahemaid/KGraphX
+
+## Contact
+This space is Maintained by:  
+
+**Ahmad Hemid**  
+*Data Engineer*  
+[Fraunhofer-Gesellschaft](https://www.fraunhofer.de/)  
+Sankt Augustin , Germany  
+<ahmad.hemid@fit.fraunhofer.de>  
+GitHub: [ahemaid](https://github.com/ahemaid)
+ORCID: [0000-0002-9811-0579](https://orcid.org/0000-0002-9811-0579)  
+
+


### PR DESCRIPTION
Dear Author,

I have created a new tool called kgraphx which is a tool to make  knowledge graph creation and management easy.
and I would like to have a persistent URI namespace for it.
I wanted to publish it online using your permanent id. Thus I forked your repository (w3id.org), I added files (.htaccess, README) in the subdirectory (kgraphx).

Please let me know if you approve that and what will be the following steps.
Thanks!

