### PR TITLE
RiverBench: fix redirects to latest version of docs

### DIFF
--- a/riverbench/.htaccess
+++ b/riverbench/.htaccess
@@ -50,7 +50,21 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^schema/([a-z0-9-]+)/?$ https://riverbench.github.io/schema/dev/$1 [R=302,L]
+RewriteRule ^schema/([a-z0-9-]+)/?$ https://riverbench.github.io/schema/$1/dev [R=302,L]
+
+# Redirect /datasets/{name} to /datasets/{name}/dev
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^datasets/([a-z0-9-]+)/?$ https://riverbench.github.io/datasets/$1/dev [R=302,L]
+
+# Redirect /profiles/{name} to /profiles/{name}/dev
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^profiles/([a-z0-9-]+)/?$ https://riverbench.github.io/profiles/$1/dev [R=302,L]
 
 # Serve HTML if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)


### PR DESCRIPTION
- Redirections to schema docs used an invalid URL structure that was inconsistent with ontology IRIs. This is fixed now.
- Added redirections to the latest version of profiles and datasets from their non-versioned URLs.

I tested these changes with a local instance of Apache.