### PR TITLE
Aria

### DIFF
--- a/italia/lombardia/README.md
+++ b/italia/lombardia/README.md
@@ -1,0 +1,14 @@
+Repository (italia/lombardia) for redirecting to ontologies and data of the Linked data system (the Linked Open Data and the network of ontologies of Region Lombardia of Italy
+===================
+
+We intend to use w3id.org to provide persistent URIs for the network of ontologies and data we are developing in the context of the system. The network is developed by Region Lombardia.
+
+We initially plan to create:
++ `w3id.org/italia/lombardia/onto` for all the ontologies of the network mentioned above
++ `w3id.org/italia/lombardia/vocab` for all the controlled vocabularies
++ `w3id.org/italia/lombardia/data` for all the other types of data
+
+
+Contacts:
+
++ Gianluca Carletti: email (gianluca.carletti@ariaspa.it)

--- a/italia/lombardia/data/.htaccess
+++ b/italia/lombardia/data/.htaccess
@@ -1,6 +1,6 @@
 Header set Access-Control-Allow-Origin * 
 Options +FollowSymLinks 
 RewriteEngine on 
-SetEnvIf Request_URI ^.*$ ROOT_URL=http://18.102.46.55:18082/lodview
+SetEnvIf Request_URI ^.*$ ROOT_URL=http://18.102.46.55:18082/data
 
 RewriteRule ^(.*)/?$ %{ENV:ROOT_URL}$1 [R=303,L]

--- a/italia/lombardia/data/.htaccess
+++ b/italia/lombardia/data/.htaccess
@@ -1,0 +1,6 @@
+Header set Access-Control-Allow-Origin * 
+Options +FollowSymLinks 
+RewriteEngine on 
+SetEnvIf Request_URI ^.*$ ROOT_URL=http://18.102.46.55:18082/lodview
+
+RewriteRule ^(.*)/?$ %{ENV:ROOT_URL}$1 [R=303,L]


### PR DESCRIPTION
Repository (italia/lombardia) for redirecting to ontologies and data of the Linked data system (the Linked Open Data and the network of ontologies of Region Lombardia of Italy
===================

We intend to use w3id.org to provide persistent URIs for the network of ontologies and data we are developing in the context of the system. The network is developed by Region Lombardia.

We initially plan to create:
+ `w3id.org/italia/lombardia/onto` for all the ontologies of the network mentioned above
+ `w3id.org/italia/lombardia/vocab` for all the controlled vocabularies
+ `w3id.org/italia/lombardia/data` for all the other types of data


Contacts:

+ Gianluca Carletti: email (gianluca.carletti@ariaspa.it)