### PR TITLE
added /risk and /sense paths in order to redirect to corresponding ontology web sites. Author: Hervé Pruvost from Fraunhofer IIS/EAS

### DIFF
--- a/risk/.htaccess
+++ b/risk/.htaccess
@@ -37,5 +37,5 @@ RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/risk/doc/ind
 #RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
 #RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/ontology.ttl [R=303,NE,L]
 
-#default response: owl
+#default response: html
 RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/risk/doc/index.html [R=303,NE,L]

--- a/risk/.htaccess
+++ b/risk/.htaccess
@@ -1,0 +1,41 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
+
+### Rewrite rules
+
+#RewriteRule ^$ http://ontology.tno.nl/saref [R=302,L]
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*|\*/\*)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml 
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/risk/doc/index.html  [R=303,NE,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+#RewriteCond %{HTTP_ACCEPT} application/ld\+json
+#RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+#RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.* 
+#RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/ontology.rdf [R=303,NE,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+#RewriteCond %{HTTP_ACCEPT} application/n-triples
+#RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+#RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+#RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/ontology.ttl [R=303,NE,L]
+
+#default response: owl
+RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/risk/doc/index.html [R=303,NE,L]

--- a/risk/README.md
+++ b/risk/README.md
@@ -1,0 +1,20 @@
+# RISK
+
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the RISK ontology.
+
+## Uses
+
+The RISK ontology is a graph data structure that conceptualizes the domain of risk management by providing terms about risk identification, analysis and mitigation. It applies currently to the domain of engineering in the construction and facility management sector. But it aims at universally cover any domain.
+
+## Contact
+
+This space is administered by:
+
+**Hervé Pruvost**  
+_R&D Engineer_  
+[Fraunhofer IIS/EAS](hhttps://www.eas.iis.fraunhofer.de/)  
+Dresden, Germany  
+<herve.pruvost@eas.iis.fraunhofer.de>  
+GitHub: [HervePruvost](https://github.com/HervePruvost)
+Linkedin: [Hervé Pruvost](https://www.linkedin.com/in/hervepruvost/)
+ORCID: [0000-0001-7604-8543](https://orcid.org/0000-0001-7604-8543)

--- a/sense/.htaccess
+++ b/sense/.htaccess
@@ -37,5 +37,5 @@ RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/ontology.nt 
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
 RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/ontology.ttl [R=303,NE,L]
 
-#default response: owl
+#default response
 RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/ [R=303,NE,L]

--- a/sense/.htaccess
+++ b/sense/.htaccess
@@ -1,0 +1,41 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
+
+### Rewrite rules
+
+#RewriteRule ^$ http://ontology.tno.nl/saref [R=302,L]
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*|\*/\*)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml 
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/  [R=303,NE,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.* 
+RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/ontology.rdf [R=303,NE,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/ontology.ttl [R=303,NE,L]
+
+#default response: owl
+RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/ [R=303,NE,L]

--- a/sense/README.md
+++ b/sense/README.md
@@ -1,0 +1,20 @@
+# SENSE
+
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the SENSE ontology.
+
+## Uses
+
+SENSE is a semantic composition that conceptualizes building energy systems in their operation phase. It follows a graph data structure that aggregates further ontologies that all together enable a full description of a building at metadata level. 
+
+## Contact
+
+This space is administered by:
+
+**Hervé Pruvost**  
+_R&D Engineer_  
+[Fraunhofer IIS/EAS](hhttps://www.eas.iis.fraunhofer.de/)  
+Dresden, Germany  
+<herve.pruvost@eas.iis.fraunhofer.de>  
+GitHub: [HervePruvost](https://github.com/HervePruvost)
+Linkedin: [Hervé Pruvost](https://www.linkedin.com/in/hervepruvost/)
+ORCID: [0000-0001-7604-8543](https://orcid.org/0000-0001-7604-8543)


### PR DESCRIPTION
Hello,
I need 2 perma-id URLs for my newly added folders ./risk and ./sense.
README.md and .htaccess files are ready in both folders.

I hope everything works
Thank you in advance
BR
Hervé Pruvost