### PR TITLE
Added inmevo redirect.

### DIFF
--- a/inmevo/.htaccess
+++ b/inmevo/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine On
+
+RewriteRule ^inmevo/(.*)$ https://gitlab.irit.fr/melodi/semantics4fair/inmevo/$1 [R=302,L,QSA]

--- a/inmevo/README.md
+++ b/inmevo/README.md
@@ -1,0 +1,11 @@
+# /inmevo/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the International Meteorological Vocabulary (https://public.wmo.int/fr/ressources/meteoterm) (INMEVO).
+
+## Contact
+This space is administered by:  
+
+**Cássia Trojahn**  
+IRIT: Institut de Recherche en Informatique de Toulouse
+Toulouse, France  
+<cassia.trojahn@irit.fr>  
+ORCID: [0000-0003-2840-005X](https://orcid.org/0000-0003-2840-005X)  

--- a/inmevo/README.md
+++ b/inmevo/README.md
@@ -4,6 +4,14 @@ This [W3ID](https://w3id.org) provides a persistent URI namespace for the Intern
 ## Contact
 This space is administered by:  
 
+**Guilherme Henrique**
+IRIT: Institut de Recherche en Informatique de Toulouse
+Toulouse, France  
+Guilherme.Santos-Sousa@irit.fr
+GitHub: guihcs 
+ORCID: [0000-0002-2896-2362](https://orcid.org/0000-0002-2896-2362)  
+
+
 **Cássia Trojahn**  
 IRIT: Institut de Recherche en Informatique de Toulouse
 Toulouse, France  


### PR DESCRIPTION
A request for a permanent link for the International Meteorological Vocabulary (https://public.wmo.int/fr/ressources/meteoterm).