### PR TITLE
Fixing a broken URL for https://w3id.org/ooxml/onlineInfomativeAnnexes/

### DIFF
--- a/ooxml/README.md
+++ b/ooxml/README.md
@@ -1,3 +1,3 @@
 Descritpion: OOXML (ISO/IEC 29500)
 
-Contact: eb2mmrt@gmail.com
+Contact: MURATA Makoto (eb2mmrt@gmail.com), ISO/IEC JTC1/SC34/WG4(OOXML) convenor

--- a/ooxml/onlineInfomativeAnnexes/.htaccess
+++ b/ooxml/onlineInfomativeAnnexes/.htaccess
@@ -1,3 +1,3 @@
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^$ https://app.assembla.com/spaces/IS29500/wiki/Online_Informative_Annexes_for_OOXML [R=302,L]
+RewriteRule ^$ https://sc34wg4.github.io/OOXMLSchemas/web/onlineInfomativeAnnexes.html [R=302,L]


### PR DESCRIPTION
When OOXML URLs are changed, I forgot to update this permanent identifier.