### PR TITLE
modify APD redirect (Add NE to prvent hash being escaped)

### DIFF
--- a/APD/glossary/.htaccess
+++ b/APD/glossary/.htaccess
@@ -18,7 +18,7 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(.+)$ https://traitecoevo.github.io/APD/#$1 [R=303,L]
+RewriteRule ^(.+)$ https://traitecoevo.github.io/APD/#$1 [R=303,L,NE]
 
 # Rewrite rule to serve JSON-LD
 RewriteCond %{HTTP_ACCEPT} application/ld\+json

--- a/APD/traits/.htaccess
+++ b/APD/traits/.htaccess
@@ -18,7 +18,9 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(.+)$ https://traitecoevo.github.io/APD/#$1 [R=303,L]
+RewriteRule ^(.+)$ https://traitecoevo.github.io/APD/#$1 [R=303,L,NE]
+
+# Omitting the [NE] in above will result in the # being converted to its hexcode equivalent, %23, which will then result in a 404 Not Found error condition.
 
 # Rewrite rule to serve JSON-LD
 RewriteCond %{HTTP_ACCEPT} application/ld\+json


### PR DESCRIPTION
Apologies for the extra PR. We noticed that a `#` is getting converted into `%23`, the NE flag in rewrite rule should prevent this.