### PR TITLE
added /baf path for providing perma URL to the BAF ontology

### DIFF
--- a/baf/.htaccess
+++ b/baf/.htaccess
@@ -1,0 +1,41 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
+
+### Rewrite rules
+
+#RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/baf/doc/index.html [R=302,L]
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*|\*/\*)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml 
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/baf/doc/index.html  [R=303,NE,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+#RewriteCond %{HTTP_ACCEPT} application/ld\+json
+#RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+#RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.* 
+#RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/ontology.rdf [R=303,NE,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+#RewriteCond %{HTTP_ACCEPT} application/n-triples
+#RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+#RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+#RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/ontology.ttl [R=303,NE,L]
+
+#default response: html
+RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/baf/doc/index.html [R=303,NE,L]

--- a/baf/README.md
+++ b/baf/README.md
@@ -1,0 +1,23 @@
+# Building Automation Functions (BAF)
+
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the BAF (Building Automation Functions) ontology.
+
+## Uses
+
+The BAF (Building Automation Functions) model is a catalogue of generic control functions usually implemented by automation engineers 
+when designing and deploying BACS (Building Automation and Control Systems). It defines so called function blocks together with their 
+parameters, inputs / outputs (I/O), and additional functions. They describe the functional building blocks that BACS systems implement 
+to control and monitor HVAC systems (Heating, Ventilation and Air Conditioning).
+
+## Contact
+
+This space is administered by:
+
+**Hervé Pruvost**  
+_R&D Engineer_  
+[Fraunhofer IIS/EAS](hhttps://www.eas.iis.fraunhofer.de/)  
+Dresden, Germany  
+<herve.pruvost@eas.iis.fraunhofer.de>  
+GitHub: [HervePruvost](https://github.com/HervePruvost)
+Linkedin: [Hervé Pruvost](https://www.linkedin.com/in/hervepruvost/)
+ORCID: [0000-0001-7604-8543](https://orcid.org/0000-0001-7604-8543)


### PR DESCRIPTION
Hello,
I need one perma-id URL for my newly added folder ./baf.
README.md and .htaccess files are ready in both folders.
Everything seems valid.

Thank you in advance
BR
Hervé Pruvost
(Fraunhofer IIS/EAS)

P.S.: This is a new pull request that corrects and replaces the closed PR #3403