### PR TITLE
RO-Crate for https://doi.org/10.5281/zenodo.8075229

### DIFF
--- a/ro/doi/.htaccess
+++ b/ro/doi/.htaccess
@@ -6,4 +6,8 @@ RewriteCond %{HTTP_ACCEPT} ^.*application/ld\+json.*
 RewriteRule ^10.5281/zenodo.5146227$ https://www.researchobject.org/2021-packaging-research-artefacts-with-ro-crate/ro-crate-metadata.jsonld [R=303,L]
 RewriteRule ^10.5281/zenodo.5146227$ https://www.researchobject.org/2021-packaging-research-artefacts-with-ro-crate/ [R=303,L]
 
-
+# Comparison tables for evaluating FAIR Digital Object and Linked Data, Zenodo
+# https://doi.org/10.5281/zenodo.8075229
+RewriteCond %{HTTP_ACCEPT} ^.*application/ld\+json.*
+RewriteRule ^10.5281/zenodo.8075229$ https://s11.no/2023/phd/evaluating-fdo/ro-crate-metadata.json [R=303,L]
+RewriteRule ^10.5281/zenodo.8075229$ https://s11.no/2023/phd/evaluating-fdo/ro-crate-preview.html [R=303,L]


### PR DESCRIPTION
Adds redirect for https://w3id.org/ro/doi/10.5281/zenodo.8075229 to RO-Crate at https://s11.no/2023/phd/evaluating-fdo/ro-crate-preview.html etc corresponding to https://doi.org/10.5281/zenodo.8075229 (to be minted)