### PR TITLE
Add project - rdfqar

### DIFF
--- a/rdfqar/.htaccess
+++ b/rdfqar/.htaccess
@@ -1,0 +1,6 @@
+# Basic redirect for the project page
+RewriteEngine On
+RewriteRule ^$ https://raw.githubusercontent.com/sxzhang1201/assess-rdf-resource/master/output/report.ttl [R=302,L]
+
+
+

--- a/rdfqar/README.md
+++ b/rdfqar/README.md
@@ -1,0 +1,13 @@
+## Repository of Quality Assessment Report for RDF Resources
+
+This repository hosts the foundational quality assessment on RDF resources (in the rare-disease field so far).
+
+### Source: 
+https://raw.githubusercontent.com/sxzhang1201/assess-rdf-resource/master/output/report.ttl 
+
+
+### Contact
+**Shuxin Zhang**   
+GitHub: [sxzhang1201](https://github.com/sxzhang1201)
+ORCID: [0000-0003-4715-9070](https://orcid.org/0000-0003-4715-9070)  
+Email: [s.x.zhang@amsterdamumc.nl](mailto:s.x.zhang@amsterdamumc.nl)


### PR DESCRIPTION
Dear maintainers, 

I am applying for a w3id for my project and hope that every URI starting with `https://w3id.org/rdfqar/` can be redirected to `https://raw.githubusercontent.com/sxzhang1201/assess-rdf-resource/master/output/report.ttl'.

I am not familiar with the `.htaccess` file so unsure if I write it correctly. Could you please help me check it out?

Much thanks in advance!

Regards,
Shuxin Zhang