### PR TITLE
iadopt: redirect ontology to fragment identifiers

### DIFF
--- a/iadopt/ont/.htaccess
+++ b/iadopt/ont/.htaccess
@@ -20,6 +20,7 @@ RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 RewriteCond %{REQUEST_URI} /ont/(\d+)\.(\d+)\.(\d+)
+RewriteRule /(.+)$ https://i-adopt.github.io/archive/%1.%2.%3/index.html#/$1 [NE,R=303,L]
 RewriteRule ^ https://i-adopt.github.io/archive/%1.%2.%3/index.html [R=303,L]
 
 # Rewrite rule to serve JSON-LD
@@ -52,6 +53,7 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(.+)$ https://i-adopt.github.io/index.html#/$1 [NE,R=303,L]
 RewriteRule ^$ https://i-adopt.github.io/index.html [R=303,L]
 
 # Rewrite rule to serve JSON-LD


### PR DESCRIPTION
this adds a redirect to fragment identifiers of the IAdopt ontology.

fixes #3444 