### PR TITLE
setting default to html

### DIFF
--- a/303/.htaccess
+++ b/303/.htaccess
@@ -3,16 +3,16 @@ RewriteEngine On
 DirectorySlash Off
 RewriteOptions AllowNoSlash
 
-# The HTML representation is very different from the machine readable representations --> direct 303, no link via generic document
-RewriteCond %{HTTP:Accept} text/html [NC]
-RewriteCond %{REQUEST_FILENAME} -d
-RewriteRule . https://github.com/athalhammer/303voc/ [R=303,L]
-
-# All machine-readable versions should be referred by a generic document
+# All machine-readable versions should be referred to by a generic document
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteCond %{HTTP:Accept} text/turtle [NC,OR]
 RewriteCond %{HTTP:Accept} application/ld\+json [NC]
 RewriteRule . https://w3id.org/303/doc [R=303,L]
+
+# Default to the HTML representation. 
+# As it is very different from the machine readable representations --> direct 303, no link via generic document
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule . https://github.com/athalhammer/303voc/ [R=303,L]
 
 # Turtle version of generic doc
 RewriteCond %{HTTP:Accept} text/turtle [NC]


### PR DESCRIPTION
Apparently there seems to be sth off with `text/html` requests from Firefox (Chrome just did fine)...