### PR TITLE
Addition of the dataspaces-policies namespace for the data spaces policies ontology

### DIFF
--- a/dataspaces-policies/.htaccess
+++ b/dataspaces-policies/.htaccess
@@ -1,0 +1,43 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
+# Rewrite engine setup
+RewriteEngine On
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://fhstp.github.io/dataspaces-policies/index.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://fhstp.github.io/dataspaces-policies/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://fhstp.github.io/dataspaces-policies/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://fhstp.github.io/dataspaces-policies/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle 
+RewriteRule ^$ https://fhstp.github.io/dataspaces-policies/ontology.ttl [R=303,L]
+
+# Default response
+# ---------------------------
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^$ https://fhstp.github.io/dataspaces-policies/ontology.ttl [R=303,L]

--- a/dataspaces-policies/README.md
+++ b/dataspaces-policies/README.md
@@ -1,0 +1,12 @@
+# /dataspaces-policies/
+Provides a persistent URI namespace for data space usage and access policies.
+
+Vocabulary:
+* https://w3id.org/dataspaces-policies/
+
+## Contact
+This space is administered by:  
+
+* Tobias Dam tobias.dam@fhstp.ac.at
+* Sebastian Neumaier sebastian.neumaier@fhstp.ac.at
+


### PR DESCRIPTION
Addition of the dataspaces-policies namespace.

Based on https://github.com/perma-id/w3id.org/blob/master/survey-ontology/.htaccess