### PR TITLE
Adding versioning to the permanent URI of icon ontology

### DIFF
--- a/icon/.htaccess
+++ b/icon/.htaccess
@@ -5,8 +5,11 @@ RewriteEngine on
 
 RewriteRule ^$ https://br0ast.github.io/ICON/ [R=301]
 
-RewriteRule ^ontology/$ https://raw.githubusercontent.com/br0ast/ICON/main/Ontology/rdfversion.owl [R=303,L]
-RewriteRule ^ontology(.*)$ https://raw.githubusercontent.com/br0ast/ICON/main/Ontology/rdfversion.owl [R=303,L]
+RewriteRule ^ontology/1\.0\.0$ https://raw.githubusercontent.com/br0ast/ICON/main/Ontology/1.0/icon.owl [R=303,L]
+RewriteRule ^ontology/1\.1\.0$ https://github.com/br0ast/ICON/blob/main/Ontology/1.1/icon.owl [R=303,L]
+RewriteRule ^ontology/current(.*)$ https://raw.githubusercontent.com/br0ast/ICON/main/Ontology/current/icon.rdf [R=303,L]
+RewriteRule ^ontology/2\.0\.0(.*)$ https://raw.githubusercontent.com/br0ast/ICON/main/Ontology/current/icon.rdf [R=303,L]
+RewriteRule ^ontology(.*)$ https://raw.githubusercontent.com/br0ast/ICON/main/Ontology/current/icon.rdf [R=303,L]
 RewriteRule ^docs(.*)$ https://br0ast.github.io/ICON/ICONOntologyDocumentation/index-en.html [R=303,L]
 RewriteRule ^development(.*)$ https://github.com/br0ast/ICON/tree/main/Development [R=303,L]
 

--- a/icon/README.md
+++ b/icon/README.md
@@ -4,7 +4,7 @@ This [W3ID](https://w3id.org) provides a persistent URI namespace for the icon o
 ## Uses
 This namespace is broken down into different different parts:
 * [https://w3id.org/icon/docs/](https://w3id.org/icon/docs/) leads to a [widoco](https://github.com/dgarijo/Widoco) visualization of the ontology.
-* [https://w3id.org/icon/ontology/](https://w3id.org/icon/ontology/) leads to a raw owl file of the ontology (useful for imports)
+* [https://w3id.org/icon/ontology/](https://w3id.org/icon/ontology/) leads to a raw owl file of the current version ontology (useful for imports). Different versions of the ontology are available (add 1.0.0 or 1.1.0 to the url for previous versions).
 * [https://w3id.org/icon/development/](https://w3id.org/icon/development/) leads to a github repository that contains the development documentation of the ontology.
 * [https://w3id.org/icon/data/](https://w3id.org/icon/data/) leads to a RDF dataset of iconological interpretations described with the ICON ontology.
 


### PR DESCRIPTION
The .htaccess files has been modified to include permanent uris for the different versions of the ontology. The readme file has been updated to include this new option