### PR TITLE
Initial mixs 6 2 rc req fixed

### DIFF
--- a/mixs-6-2-rc/.htaccess
+++ b/mixs-6-2-rc/.htaccess
@@ -1,3 +1,6 @@
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^(.*) https://github.com/microbiomedata/ [R=307,L]
+
+RewriteRule ^(.*).yaml$ https://github.com/microbiomedata/mixs-6-2-release-candidate/tree/main/generated-schema/$1.yaml [R=302,L]
+
+RewriteRule ^(.*)$      https://microbiomedata.github.io/mixs-6-2-release-candidate/$1 [R=302,L]

--- a/mixs-6-2-rc/.htaccess
+++ b/mixs-6-2-rc/.htaccess
@@ -1,0 +1,3 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^(.*) https://github.com/microbiomedata/ [R=307,L]

--- a/mixs-6-2-rc/README.md
+++ b/mixs-6-2-rc/README.md
@@ -1,0 +1,17 @@
+For access to schema files and per-term help pages for the [National Microbiome Data Collaborative](https://microbiomedata.org/)
+
+See also https://github.com/microbiomedata/nmdc-schema
+
+Intended to redirect soemthing like https://w3id/nmdc/nmdc.yaml
+
+to https://raw.githubusercontent.com/microbiomedata/nmdc-schema/main/src/schema/nmdc.yaml
+
+[LinkML](https://linkml.io/) prefix `nmdc` would be expanded to https://w3id/nmdc/
+
+So `nmdc:nmdc.yaml` would also expand/redirect to https://raw.githubusercontent.com/microbiomedata/nmdc-schema/main/src/schema/nmdc.yaml
+
+
+## Contact people:
+- Mark A. Miller, MAM@lbl.gov
+- Donny Winston, donny@polyneme.xyz
+- Chris Mungal: CJMungall@lbl.gov

--- a/mixs-6-2-rc/README.md
+++ b/mixs-6-2-rc/README.md
@@ -1,17 +1,7 @@
-For access to schema files and per-term help pages for the [National Microbiome Data Collaborative](https://microbiomedata.org/)
+NMDC is proposing a redesign of the MIxS standard at the governing body's (GSC) annual meeting in August 2023
 
-See also https://github.com/microbiomedata/nmdc-schema
-
-Intended to redirect soemthing like https://w3id/nmdc/nmdc.yaml
-
-to https://raw.githubusercontent.com/microbiomedata/nmdc-schema/main/src/schema/nmdc.yaml
-
-[LinkML](https://linkml.io/) prefix `nmdc` would be expanded to https://w3id/nmdc/
-
-So `nmdc:nmdc.yaml` would also expand/redirect to https://raw.githubusercontent.com/microbiomedata/nmdc-schema/main/src/schema/nmdc.yaml
-
+We're requesting a namespace from w3id that is distinct from NMDC or MIxS during the evaluation period
 
 ## Contact people:
 - Mark A. Miller, MAM@lbl.gov
-- Donny Winston, donny@polyneme.xyz
-- Chris Mungal: CJMungall@lbl.gov
+- Chris Mungall: CJMungall@lbl.gov


### PR DESCRIPTION
NMDC is proposing a redesign of the MIxS standard at the governing body's (GSC) annual meeting in August 2023

We're requesting a namespace from w3id that is distinct from NMDC or MIxS during the evaluation period

## Contact people:
- Mark A. Miller, MAM@lbl.gov
- Chris Mungall: CJMungall@lbl.gov