### PR TITLE
Add new rewrite rule for biopragmatics

### DIFF
--- a/biopragmatics/.htaccess
+++ b/biopragmatics/.htaccess
@@ -4,3 +4,7 @@ RewriteEngine on
 # Make ontology artifacts in the "export" folder (https://github.com/biopragmatics/obo-db-ingest/tree/main/export) resolvable.
 # For example, we want https://w3id.org/biopragmatics/resources/interpro/92.0/interpro.obo to redirect to https://github.com/biopragmatics/obo-db-ingest/raw/main/export/interpro/92.0/interpro.obo
 RewriteRule ^resources/(.+) https://github.com/biopragmatics/obo-db-ingest/raw/main/export/$1
+
+# Make biomappings SSSOM artifacts available
+# For example, we want https://w3id.org/biopragmatics/biomappings/biomappings.sssom.tsv to redirect to https://raw.githubusercontent.com/biopragmatics/biomappings/master/docs/_data/sssom/biomappings.sssom.tsv
+RewriteRule ^biomappings/sssom/(.+) https://raw.githubusercontent.com/biopragmatics/biomappings/master/docs/_data/sssom/$1


### PR DESCRIPTION
Redo of #3508

This PR adds a rewrite rule to expose files in https://github.com/biopragmatics/biomappings (this is a repository I own) through the biopragmatics namespace (which I also own)

For example, we want https://w3id.org/biopragmatics/biomappings/biomappings.sssom.tsv to redirect to https://raw.githubusercontent.com/biopragmatics/biomappings/master/docs/_data/sssom/biomappings.sssom.tsv