### PR TITLE
Add /busy/ for Building Systems Ontology

### DIFF
--- a/busy/.htaccess
+++ b/busy/.htaccess
@@ -1,0 +1,14 @@
+RewriteEngine on
+Options +FollowSymLinks
+Options -MultiViews
+
+AddType text/turtle .ttl
+
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://vijoc.github.io/busy/busy.ttl [R=303,NE,L]
+
+RewriteRule ^busy.ttl$ https://vijoc.github.io/busy/busy.ttl [R=302,NE,L]
+
+RewriteRule ^busy.html$ https://vijoc.github.io/busy [R=302,NE,L]
+
+RewriteRule ^$ https://vijoc.github.io/busy [R=303,NE,L]

--- a/busy/README.md
+++ b/busy/README.md
@@ -1,0 +1,9 @@
+# Building Systems Ontology (BuSy)
+
+This URI namespace is used for the Building Systems (BuSy) ontology.
+
+* [Ontology documentation](https://vijoc.github.io/busy)
+
+Contact
+
+* Ville Kukkonen <ville.kukkonen@aalto.fi>, ORCID [0000-0002-4482-5309](https://orcid.org/0000-0002-4482-5309)


### PR DESCRIPTION
Add new `/busy/` namespace for Building Systems Ontology.

Simple `.htaccess` modeled after the one from [OPM](https://github.com/perma-id/w3id.org/blob/128e7e51ad6f277608e3c16ffd0b1446d51872d8/opm/.htaccess).