### PR TITLE
permanent URL

### DIFF
--- a/GVTPDOntology/.htaccess
+++ b/GVTPDOntology/.htaccess
@@ -1,0 +1,74 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
+
+RewriteEngine on
+
+# Rewrite rule for latest version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://gvt2023.github.io/GVTPDOnto/Documentation/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://gvt2023.github.io/GVTPDOnto/Documentation/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://gvt2023.github.io/GVTPDOnto/Documentation/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://gvt2023.github.io/GVTPDOnto/Documentation/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle 
+RewriteRule ^$ https://gvt2023.github.io/GVTPDOnto/Documentation/ontology.ttl [R=303,L]
+
+
+# Rewrite rules for any other version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(.+)$ https://gvt2023.github.io/GVTPDOnto/Documentation/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(.+)$ https://gvt2023.github.io/GVTPDOnto/Documentation/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(.+)$ https://gvt2023.github.io/GVTPDOnto/Documentation/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(.+)$ https://gvt2023.github.io/GVTPDOnto/Documentation/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle 
+RewriteRule ^(.+)$ https://gvt2023.github.io/GVTPDOnto/Documentation/ontology.ttl [R=303,L]
+
+
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^(.*)$ https://gvt2023.github.io/GVTPDOnto/Documentation/406.html [R=406,L]
+# Default response
+# ---------------------------
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^$ https://ahmedreyadh1985sh.github.io/GVTPDonto/OntoDoc/GVTPDOnt/ontology.rdf [R=303,L]

--- a/GVTPDOntology/README.md
+++ b/GVTPDOntology/README.md
@@ -1,0 +1,8 @@
+
+Documentation is available at: https://gvt2023.github.io/GVTPDOnto/Documentation/index-en.html
+
+I need this URI https://w3id.org/GVTPDOntology  redirects to https://gvt2023.github.io/GVTPDOnto/Documentation/index-en.html
+
+Contact: https://github.com/GVT2023
+         gvtpdo@gmail.com
+


### PR DESCRIPTION
Please, I need a permanent URL that is (https://w3id.org/GVTPDOntology) that points to the Ontology Documentation page(https://gvt2023.github.io/GVTPDOnto/Documentation/index-en.html) , noting that I have created a new account. with respect.