### PR TITLE
nfdi4cat: Add redirects for voc4cat

### DIFF
--- a/nfdi4cat/.htaccess
+++ b/nfdi4cat/.htaccess
@@ -1,7 +1,11 @@
 Header set Access-Control-Allow-Origin *
-
 Options +FollowSymLinks
 RewriteEngine on
 
 # BASE: Visit homepage
 RewriteRule ^$ https://nfdi4cat.org/ [R=303,L]
+
+# VOC4CAT:TURTLE - individual concept or collection turtle files of latest release
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule "^voc4cat_([0-9]{7,})" https://nfdi4cat.github.io/voc4cat/latest/voc4cat/$1.ttl [R=303,L,NE]

--- a/nfdi4cat/README.md
+++ b/nfdi4cat/README.md
@@ -1,15 +1,20 @@
 NFDI4Cat
-==============================
+========
 
 NFDI4Cat is a community-driven and user-oriented initiative to secure the digital future of catalysis.
 We develop terminologies and ontologies as base for FAIR data management in catalysis.
 
-Homepage:
-* https://nfdi4cat.org/
+### Homepage
 
-Contacts:
+* [nfdi4cat.org](https://nfdi4cat.org/)
+
+### Resources that use w3id.org for permanent URIs
+
+* [voc4cat](https://github.com/nfdi4cat/voc4cat) - A SKOS vocabulary for catalysis maintained by NFDI4Cat & friends.
+
+### Contacts
 
 * General contact: [info@nfdi4cat.org](mailto:info@nfdi4cat.org)
 * GitHub w3id management:
-  * [David Linke](https://github.com/dalito) <david.linke@catalysis.de>
-  * [Sara Espinoza](https://github.com/SaraEspinoza) <sara.espinoza@dechema.de>
+  * David Linke (GitHub: [dalito](https://github.com/dalito), email: <david.linke@catalysis.de>)
+  * Sara Espinoza (GitHub: [SaraEspinoza](https://github.com/SaraEspinoza), email: <sara.espinoza@dechema.de>)

--- a/nfdi4cat/voc4cat/.htaccess
+++ b/nfdi4cat/voc4cat/.htaccess
@@ -1,0 +1,54 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+# Notes on used flags:
+# NC - sets case-insensitive matching
+# NE - noescape, prevents that special characters, such as & and ?, will be converted to their hexcode equivalent for rules that result in external redirects.
+# L - last, tells mod_rewrite to stop processing further rules sets.
+# R=303 - status code for "See Other". It indicates that the redirects don't link to the requested resource itself, but to another page.
+
+# HTML - documentation of latest release
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule "^$" https://nfdi4cat.github.io/voc4cat/latest/voc4cat/index.html [R=303,L,NE]
+
+# HTML - documentation of version-tagged releases
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule "^v?([0-9]{4}\-[0-9]{2}\-[0-9]{2})" https://nfdi4cat.github.io/voc4cat/v$1/voc4cat/index.html [R=303,L,NE,NC]
+
+# HTML - documentation of "in development" version (last commit to main)
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule "^dev$" https://nfdi4cat.github.io/voc4cat/dev/voc4cat/index.html [R=303,L,NE]
+
+# TURTLE - single large file of latest release
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule "^$" https://nfdi4cat.github.io/voc4cat/latest/voc4cat.ttl [R=303,L,NE]
+
+# TURTLE - single large file of version-tagged releases
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule  "^v?([0-9]{4}\-[0-9]{2}\-[0-9]{2})" https://nfdi4cat.github.io/voc4cat/v$1/voc4cat.ttl [R=303,L,NE,NC]
+
+# TURTLE - single large file of "in development" version (last commit to main)
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule  "^dev$" https://nfdi4cat.github.io/voc4cat/dev/voc4cat.ttl [R=303,L,NE,NC]
+
+# TURTLE - individual concept or collection turtle files of latest release
+# see .htaccess file one level up
+
+# TURTLE - individual concept or collection turtle files of version-tagged releases
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule "^v?([0-9]{4}\-[0-9]{2}\-[0-9]{2})/voc4cat_([0-9]{7,})" https://nfdi4cat.github.io/voc4cat/v$1/voc4cat/$2.ttl [R=303,L,NE,NC]
+
+# TURTLE - individual concept or collection turtle files of "in development" version (last commit to main)
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule "^dev/voc4cat_([0-9]{7,})" https://nfdi4cat.github.io/voc4cat/dev/voc4cat/$1.ttl [R=303,L,NE,NC]
+
+# No content-negotiation at all (or HTML): Fallback to HTML for both versioned and non-versioned
+RewriteRule "^$" https://nfdi4cat.github.io/voc4cat/latest/voc4cat/index.html [R=303,L,NE]
+RewriteRule "^v?([0-9]{4}\-[0-9]{2}\-[0-9]{2})$" https://nfdi4cat.github.io/voc4cat/v$1/voc4cat/index.html [R=303,L,NE,NC]
+RewriteRule "^dev$" https://nfdi4cat.github.io/voc4cat/dev/voc4cat/index.html [R=303,L,NE,NC]

--- a/nfdi4cat/voc4cat/README.md
+++ b/nfdi4cat/voc4cat/README.md
@@ -1,0 +1,42 @@
+Voc4Cat
+=======
+
+A SKOS vocabulary for catalysis maintained by NFDI4Cat & friends.
+
+- GitHub-repository [https://github.com/nfdi4cat/voc4cat](https://github.com/nfdi4cat/voc4cat)
+
+### Redirects to the latest release
+
+- Documentation
+  - https://w3id.org/nfdi4cat/voc4cat <BR>--> https://nfdi4cat.github.io/voc4cat/latest/voc4cat
+
+- Vocabulary as one large turtle file
+  -  https://w3id.org/nfdi4cat/voc4cat/voc4cat.ttl <BR>--> https://nfdi4cat.github.io/voc4cat/latest/voc4cat.ttl
+
+- Individual turtle files for concepts or collections
+  -  https://w3id.org/nfdi4cat/voc4cat_0000002 <BR>--> https://nfdi4cat.github.io/voc4cat/latest/voc4cat/0000002.ttl
+
+### Redirects to latest and earlier releases based on release tag
+
+- Documentation
+  - https://w3id.org/nfdi4cat/voc4cat/2023-08-17 <BR>--> https://nfdi4cat.github.io/voc4cat/v2023-08-17/voc4cat/
+- Vocabulary as one large turtle file
+  - https://w3id.org/nfdi4cat/voc4cat/2023-08-17/voc4cat.ttl <BR>--> https://nfdi4cat.github.io/voc4cat/v2023-08-17/voc4cat/voc4cat.ttl
+- Individual turtle files for concepts or collections
+  - https://w3id.org/nfdi4cat/voc4cat/2023-08-17/voc4cat_0000002 <BR>--> https://nfdi4cat.github.io/voc4cat/2023-08-17/voc4cat/0000002.ttl
+
+### Redirects for "in-development" version
+
+The files are built from most recent commit.
+
+- Documentation
+  - https://w3id.org/nfdi4cat/voc4cat/dev <BR>--> https://nfdi4cat.github.io/voc4cat/dev/voc4cat/
+- Vocabulary as one large turtle file
+  - https://w3id.org/nfdi4cat/voc4cat/dev/voc4cat.ttl <BR>--> https://nfdi4cat.github.io/voc4cat/dev/voc4cat/voc4cat.ttl
+- Individual turtle files for concepts or collections
+  - https://w3id.org/nfdi4cat/voc4cat/dev/voc4cat_0000002 <BR>--> https://nfdi4cat.github.io/voc4cat/dev/voc4cat/0000002.ttl
+
+### Contacts
+
+- David Linke (GitHub: [dalito](https://github.com/dalito), email: <david.linke@catalysis.de>)
+- Nikolaos Moustakas (GitHub: [nmoust](https://github.com/nmoust), email: <nikolaos.moustakas@catalysis.de>)


### PR DESCRIPTION
This adds redirects for a SKOS vocabulary for terms used in catalysis that we are developing within [NFDI4Cat](https://nfdi4cat.org).

The IRIs are following the [OBO policy for identifiers](https://obofoundry.org/id-policy.html) except that version-strings may have an optional "v" at the start.