### PR TITLE
nfdi4cat: fix match pattern; fix examples in README

### DIFF
--- a/nfdi4cat/voc4cat/.htaccess
+++ b/nfdi4cat/voc4cat/.htaccess
@@ -41,7 +41,7 @@ RewriteRule  "^dev$" https://nfdi4cat.github.io/voc4cat/dev/voc4cat.ttl [R=303,L
 # TURTLE - individual concept or collection turtle files of version-tagged releases
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
-RewriteRule "^v?([0-9]{4}\-[0-9]{2}\-[0-9]{2})/voc4cat_([0-9]{7,})" https://nfdi4cat.github.io/voc4cat/v$1/voc4cat/$2.ttl [R=303,L,NE,NC]
+RewriteRule "^v?([0-9]{4}\-[0-9]{2}\-[0-9]{2})\/voc4cat_([0-9]{7,})" https://nfdi4cat.github.io/voc4cat/v$1/voc4cat/$2.ttl [R=303,L,NE,NC]
 
 # TURTLE - individual concept or collection turtle files of "in development" version (last commit to main)
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]

--- a/nfdi4cat/voc4cat/README.md
+++ b/nfdi4cat/voc4cat/README.md
@@ -21,9 +21,9 @@ A SKOS vocabulary for catalysis maintained by NFDI4Cat & friends.
 - Documentation
   - https://w3id.org/nfdi4cat/voc4cat/2023-08-17 <BR>--> https://nfdi4cat.github.io/voc4cat/v2023-08-17/voc4cat/
 - Vocabulary as one large turtle file
-  - https://w3id.org/nfdi4cat/voc4cat/2023-08-17/voc4cat.ttl <BR>--> https://nfdi4cat.github.io/voc4cat/v2023-08-17/voc4cat/voc4cat.ttl
+  - https://w3id.org/nfdi4cat/voc4cat/2023-08-17/voc4cat.ttl <BR>--> https://nfdi4cat.github.io/voc4cat/v2023-08-17/voc4cat.ttl
 - Individual turtle files for concepts or collections
-  - https://w3id.org/nfdi4cat/voc4cat/2023-08-17/voc4cat_0000002 <BR>--> https://nfdi4cat.github.io/voc4cat/2023-08-17/voc4cat/0000002.ttl
+  - https://w3id.org/nfdi4cat/voc4cat/2023-08-17/voc4cat_0000002 <BR>--> https://nfdi4cat.github.io/voc4cat/v2023-08-17/voc4cat/0000002.ttl
 
 ### Redirects for "in-development" version
 
@@ -32,7 +32,7 @@ The files are built from most recent commit.
 - Documentation
   - https://w3id.org/nfdi4cat/voc4cat/dev <BR>--> https://nfdi4cat.github.io/voc4cat/dev/voc4cat/
 - Vocabulary as one large turtle file
-  - https://w3id.org/nfdi4cat/voc4cat/dev/voc4cat.ttl <BR>--> https://nfdi4cat.github.io/voc4cat/dev/voc4cat/voc4cat.ttl
+  - https://w3id.org/nfdi4cat/voc4cat/dev/voc4cat.ttl <BR>--> https://nfdi4cat.github.io/voc4cat/dev/voc4cat.ttl
 - Individual turtle files for concepts or collections
   - https://w3id.org/nfdi4cat/voc4cat/dev/voc4cat_0000002 <BR>--> https://nfdi4cat.github.io/voc4cat/dev/voc4cat/0000002.ttl
 


### PR DESCRIPTION
After testing the first live version, we found that one pattern missed an escape.

Thanks a lot for merging #3541 so quickly. We highly appreciate your work.