### PR TITLE
New perma-id for new ontology "ESIM"

### DIFF
--- a/esim/.htaccess
+++ b/esim/.htaccess
@@ -1,0 +1,41 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
+
+### Rewrite rules
+
+#RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/baf/doc/index.html [R=302,L]
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*|\*/\*)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml 
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/esim/doc/index.html  [R=303,NE,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+#RewriteCond %{HTTP_ACCEPT} application/ld\+json
+#RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/esim/doc/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+#RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.* 
+#RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/esim/doc/ontology.rdf [R=303,NE,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+#RewriteCond %{HTTP_ACCEPT} application/n-triples
+#RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/esim/doc/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+#RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+#RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/esim/doc/ontology.ttl [R=303,NE,L]
+
+#default response: html
+RewriteRule ^$ https://hpruvost.pages.fraunhofer.de/semantic-models/esim/doc/index.html [R=303,NE,L]

--- a/esim/README.md
+++ b/esim/README.md
@@ -4,9 +4,9 @@ This [W3ID](https://w3id.org) provides a persistent URI namespace for the ESIM (
 
 ## Uses
 
-ESIM (Energy System Information Model) is a domain-specific metadata model that is represented as an RDF graph 
-and that describes information about energy systems at building and urban levels including their automation and
-control systems. It comprises functional, structural and physical descriptions of the
+ESIM (Energy System Information Model) is a domain-specific metadata model, is represented as an RDF graph,
+that describes information about energy systems at building and urban levels including their automation and
+control systems. It comprises functional, structural, and physical descriptions of the
 systems as master metadata and additional operational metadata.
 
 ## Contact

--- a/esim/README.md
+++ b/esim/README.md
@@ -1,0 +1,23 @@
+# Energy System Information Model (ESIM)
+
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the ESIM (Energy System Information Model) ontology.
+
+## Uses
+
+ESIM (Energy System Information Model) is a domain-specific metadata model that is represented as an RDF graph 
+and that describes information about energy systems at building and urban levels including their automation and
+control systems. It comprises functional, structural and physical descriptions of the
+systems as master metadata and additional operational metadata.
+
+## Contact
+
+This space is administered by:
+
+**Hervé Pruvost**  
+_R&D Engineer_  
+[Fraunhofer IIS/EAS](hhttps://www.eas.iis.fraunhofer.de/)  
+Dresden, Germany  
+<herve.pruvost@eas.iis.fraunhofer.de>  
+GitHub: [HervePruvost](https://github.com/HervePruvost)
+Linkedin: [Hervé Pruvost](https://www.linkedin.com/in/hervepruvost/)
+ORCID: [0000-0001-7604-8543](https://orcid.org/0000-0001-7604-8543)

--- a/esim/README.md
+++ b/esim/README.md
@@ -18,6 +18,6 @@ _R&D Engineer_
 [Fraunhofer IIS/EAS](hhttps://www.eas.iis.fraunhofer.de/)  
 Dresden, Germany  
 <herve.pruvost@eas.iis.fraunhofer.de>  
-GitHub: [HervePruvost](https://github.com/HervePruvost)
-Linkedin: [Hervé Pruvost](https://www.linkedin.com/in/hervepruvost/)
+GitHub: [HervePruvost](https://github.com/HervePruvost)  
+Linkedin: [Hervé Pruvost](https://www.linkedin.com/in/hervepruvost/)  
 ORCID: [0000-0001-7604-8543](https://orcid.org/0000-0001-7604-8543)


### PR DESCRIPTION
Hello,
I would like to register a new perma-id URL for my newly added folder ./esim.
README.md and .htaccess files are ready and included in the esim folder.
Everything seems valid.

Thank you in advance
BR
Hervé Pruvost
(Fraunhofer IIS/EAS)