### PR TITLE
Update zpid redirects and Readme

### DIFF
--- a/zpid/.htaccess
+++ b/zpid/.htaccess
@@ -4,15 +4,17 @@ Options +FollowSymLinks
 RewriteEngine On
 
 # Redirect to our Skosmos homepage for the root URI w3id.org/zpid/
-RewriteRule	^$ https://skosmos.stg.zpid.org [R=302,L]
+RewriteRule	^$ https://vocabs.leibniz-psychology.org [R=302,L]
 
-# Redirect vocabulary concept uris (e.g. /vocabs/terms/5) to our Skosmos instance's concept page: 
-RewriteRule ^vocabs/(.+)/(.+)$	https://skosmos.stg.zpid.org/$1/page/$2 [R=302,L]
+# Redirect vocabulary concept uris (e.g. /vocabs/terms/5) to our Skosmos instance's concept page:
+RewriteRule ^vocabs/terms/(.+)$	https://skosmos.stg.zpid.org/terms/page/$1 [R=302,L]
+RewriteRule ^vocabs/(.+)/(.+)$	https://vocabs.leibniz-psychology.org/$1/page/$2 [R=302,L]
 
 # Redirect vocabulary scheme uris (e.g. /zpid/vocabs/terms/) to the vocabulary's/scheme's homepage on skosmos:
-RewriteRule ^vocabs/(.+)$	https://skosmos.stg.zpid.org/$1 [R=302,L]
+RewriteRule ^vocabs/terms$	https://skosmos.stg.zpid.org/terms [R=302,L]
+RewriteRule ^vocabs/(.+)$	https://vocabs.leibniz-psychology.org/$1 [R=302,L]
 
-# Note: We should probably add content negotiation some day, so people will be served JSON, Turtle, RDF/XML as desired, since Skosmos already offers it. 
+# Note: We should probably add content negotiation some day, so people will be served JSON, Turtle, RDF/XML as desired, since Skosmos already offers it.
 # Here are example api calls for json-ld and turtle:
-# - https://skosmos.stg.zpid.org/rest/v1/terms/data?uri=https%3A%2F%2Fpsyndex.de%2Fvocab%2Fterms%2F5&format=application/ld%2Bjson
-# - https://skosmos.stg.zpid.org/rest/v1/terms/data?uri=https%3A%2F%2Fpsyndex.de%2Fvocab%2Fterms%2F5&format=text/turtle
+# - https://vocabs.leibniz-psychology.org/rest/v1/class/data?uri=https%3A%2F%2Fw3id.org%2Fzpid%2Fvocabs%2Fclass%2F2100&format=application/ld%2Bjson
+# - https://vocabs.leibniz-psychology.org/rest/v1/class/data?uri=https%3A%2F%2Fw3id.org%2Fzpid%2Fvocabs%2Fclass%2F2100&format=text/turtle

--- a/zpid/README.md
+++ b/zpid/README.md
@@ -1,29 +1,31 @@
 # /zpid/
+
 This [W3ID](https://w3id.org) provides a persistent URI namespace for Leibniz Institute for Psychology (ZPID) resources.
 
 ## Uses
+
 We are a non-profit public organization provinding research infrastructures for psychology, with a main focus on the German-speaking world.
 The namespace will mainly be used to provide persistent identifiers for the controlled vocabularies we use to index records in our research databases (e.g. PSYNDEX).
 
 - Vocabulary concept uris that will be redirected to our Skosmos instance follow this format:
-https://w3id.org/zpid/vocabs/{vocid}/{Concept} will be redirected to https://skosmos.stg.zpid.org/{vocid}/page/{Concept}
-Example: https://w3id.org/zpid/vocabs/terms/5 -> https://skosmos.stg.zpid.org/terms/page/5
-- Uris of concept schemes (vocabularies) themselves go to the scheme'S homepage on Skosmos: https://w3id.org/zpid/vocabs/terms/ -> https://skosmos.stg.zpid.org/terms/
-- the root URL will redirect to our Skosmos instance's homepage: https://w3id.org/zpid/ -> https://skosmos.stg.zpid.org (may change when there is more linked open data available from us, for now there are just the vocabularies).
-
-**Note:** Any URLs to Skosmos are currently only accessible through our internal VPN, since Skosmos is still in testing for us. In the future, the redirects will be changed to an open Skosmos instance.
+  https://w3id.org/zpid/vocabs/{vocid}/{Concept} will be redirected to https://vocabs.leibniz-psychology.org/{vocid}/page/{Concept}
+  Example: https://w3id.org/zpid/vocabs/class/2100 -> https://vocabs.leibniz-psychology.org/class/page/2100
+- Uris of concept schemes (vocabularies) themselves go to the scheme's homepage on Skosmos: https://w3id.org/zpid/vocabs/class/ -> https://vocabs.leibniz-psychology.org/class/
+- For licensing reasons some vocabulary concept uris will be redirected to a url within our institute's vpn which is not publicly accessible.
+- the root URL will redirect to our Skosmos instance's homepage: https://w3id.org/zpid/ -> https://vocabs.leibniz-psychology.org (may change when there is more linked open data available from us, for now there are just the vocabularies).
 
 ## Contact
+
 This space is administered by:
 
-**Tina Trillitzsch**  
-email: ttr@leibniz-psychology.org  
+**Tina Trillitzsch**
+email: ttr@leibniz-psychology.org
 GitHub: [schlawiner](https://github.com/schlawiner)
 
-**Florian Grässle**  
-email: fg@@leibniz-psychology.org  
+**Florian Grässle**
+email: fg@leibniz-psychology.org
 GitHub: [holehan](https://github.com/holehan)
 
 both at:
-[Leibniz Institute for Psychology](https://leibniz-psychology.org/)  
+[Leibniz Institute for Psychology](https://leibniz-psychology.org/)
 Trier, Germany


### PR DESCRIPTION
This updates the redirects to point to our now openly accessible vocabulary browser at `https://vocabs.leibniz-psychology.org`. Some uris will still redirect to our private instance for licensing reasons.