### PR TITLE
Updates README for nfdi4ing/metadata4ing

### DIFF
--- a/nfdi4ing/metadata4ing/README.md
+++ b/nfdi4ing/metadata4ing/README.md
@@ -8,13 +8,12 @@ Redirections:
 * HTML: Visit documentation
   * https://w3id.org/nfdi4ing/metadata4ing
   * --> https://nfdi4ing.pages.rwth-aachen.de/metadata4ing/metadata4ing
-* Turtle/XML/nt/json-ld: Access respective ontology via content negotiation
-  * https://w3id.org/nfdi4ing/metadata4ing with HTTP-Header "Accept: text/turtle" for Turtle (.ttl) or "Accept: application/rdf+xml" for RDF (.xml), "Accept: text/n3" for N-triples (.nt), "Accept: application/ld+json" for JSON-LD (.jsonld) )
-rdf, json, ...)
-  * --> https://nfdi4ing.pages.rwth-aachen.de/metadata4ing/metadata4ing/ontology.ttl (or xml/nt/jsonld)
+* Turtle, RDF/XML, N-Triples, JSON-LD: Access respective ontology via content negotiation
+  * `https://w3id.org/nfdi4ing/metadata4ing` with HTTP-Header `Accept: text/turtle` for Turtle (`.ttl`), `Accept: application/rdf+xml` for RDF/XML (`.xml`), `Accept: text/n3` for N-Triples (`.nt`), `Accept: application/ld+json` for JSON-LD (`.jsonld`), or ...)
+  * --> `https://nfdi4ing.pages.rwth-aachen.de/metadata4ing/metadata4ing/ontology.ttl` (or `.xml`/`.nt`/`.jsonld`)
 * JSON-LD context file:
-  * https://w3id.org/nfdi4ing/metadata4ing/m4i_context.jsonld
-  * --> https://git.rwth-aachen.de/nfdi4ing/metadata4ing/metadata4ing/-/raw/master/m4i_context.jsonld
+  * `https://w3id.org/nfdi4ing/metadata4ing/m4i_context.jsonld`
+  * --> `https://git.rwth-aachen.de/nfdi4ing/metadata4ing/metadata4ing/-/raw/master/m4i_context.jsonld`
 
 
 Support:

--- a/nfdi4ing/metadata4ing/README.md
+++ b/nfdi4ing/metadata4ing/README.md
@@ -9,7 +9,7 @@ Redirections:
   * https://w3id.org/nfdi4ing/metadata4ing
   * --> https://nfdi4ing.pages.rwth-aachen.de/metadata4ing/metadata4ing
 * Turtle/XML/nt/json-ld: Access respective ontology via content negotiation
-  * https://w3id.org/nfdi4ing/metadata4ing with HTTP-Header "Accept: text/turtle" or "Accept: application/rdf+xml" for RDF, "Accept: text/n3" for N-triples, "Accept: application/ld+json" for JSON-LD)
+  * https://w3id.org/nfdi4ing/metadata4ing with HTTP-Header "Accept: text/turtle" for Turtle (.ttl) or "Accept: application/rdf+xml" for RDF (.xml), "Accept: text/n3" for N-triples (.nt), "Accept: application/ld+json" for JSON-LD (.jsonld) )
 rdf, json, ...)
   * --> https://nfdi4ing.pages.rwth-aachen.de/metadata4ing/metadata4ing/ontology.ttl (or xml/nt/jsonld)
 * JSON-LD context file:

--- a/nfdi4ing/metadata4ing/README.md
+++ b/nfdi4ing/metadata4ing/README.md
@@ -8,9 +8,13 @@ Redirections:
 * HTML: Visit documentation
   * https://w3id.org/nfdi4ing/metadata4ing
   * --> https://nfdi4ing.pages.rwth-aachen.de/metadata4ing/metadata4ing
-* Turtle/XML/nt/json-ld: Access respective ontology
-  * https://w3id.org/nfdi4ing/metadata4ing/metadata4ing.ttl (or rdf, json, ...)
+* Turtle/XML/nt/json-ld: Access respective ontology via content negotiation
+  * https://w3id.org/nfdi4ing/metadata4ing with HTTP-Header "Accept: text/turtle" or "Accept: application/rdf+xml" for RDF, "Accept: text/n3" for N-triples, "Accept: application/ld+json" for JSON-LD)
+rdf, json, ...)
   * --> https://nfdi4ing.pages.rwth-aachen.de/metadata4ing/metadata4ing/ontology.ttl (or xml/nt/jsonld)
+* JSON-LD context file:
+  * https://w3id.org/nfdi4ing/metadata4ing/m4i_context.jsonld
+  * --> https://git.rwth-aachen.de/nfdi4ing/metadata4ing/metadata4ing/-/raw/master/m4i_context.jsonld
 
 
 Support:

--- a/nfdi4ing/metadata4ing/README.md
+++ b/nfdi4ing/metadata4ing/README.md
@@ -9,7 +9,7 @@ Redirections:
   * https://w3id.org/nfdi4ing/metadata4ing
   * --> https://nfdi4ing.pages.rwth-aachen.de/metadata4ing/metadata4ing
 * Turtle, RDF/XML, N-Triples, JSON-LD: Access respective ontology via content negotiation
-  * `https://w3id.org/nfdi4ing/metadata4ing` with HTTP-Header `Accept: text/turtle` for Turtle (`.ttl`), `Accept: application/rdf+xml` for RDF/XML (`.xml`), `Accept: text/n3` for N-Triples (`.nt`), `Accept: application/ld+json` for JSON-LD (`.jsonld`), or ...)
+  * `https://w3id.org/nfdi4ing/metadata4ing` with HTTP-Header `Accept: text/turtle` for Turtle (`.ttl`), `Accept: application/rdf+xml` for RDF/XML (`.xml`), `Accept: text/n3` for N-Triples (`.nt`), `Accept: application/ld+json` for JSON-LD (`.jsonld`), or ...
   * --> `https://nfdi4ing.pages.rwth-aachen.de/metadata4ing/metadata4ing/ontology.ttl` (or `.xml`/`.nt`/`.jsonld`)
 * JSON-LD context file:
   * `https://w3id.org/nfdi4ing/metadata4ing/m4i_context.jsonld`


### PR DESCRIPTION
- adds a description of the content negotiation used, replacing the misleading and incorrect documentation of getting different serializations of the metadata4ing ontology
- adds a description of the direct link to the JSON-LD context file
