### PR TITLE
Patch 1

### DIFF
--- a/DOLCE/.htaccess
+++ b/DOLCE/.htaccess
@@ -4,14 +4,21 @@ Options -MultiViews
 
 RewriteEngine on
 
-# Match anything assuming to be a request to .owl file
-RewriteRule ^([^.]+)/?$ https://appliedontolab.github.io/DOLCE/$1.owl [R=303,L]
+# The "L" flag ensures that if the rule matches no further rules are processed
+# Match anything that does not contain "." and ends with "/" -- "/" excluded -- assuming to be a request to .owl file  e.g. www.w3id.org/DOLCE/OWL/DOLCEbasic/ --> https://appliedontolab.github.io/DOLCE/OWL/DOLCEbasic.owl
+RewriteRule ^([^.]+)\/$ https://appliedontolab.github.io/DOLCE/$1.owl [R=303,L]
 
-# Match anything that ends with .owl
+# Match anything that does not contain "." and does not end with "/" assuming to be a request to .owl file e.g. www.w3id.org/DOLCE/OWL/DOLCEbasic -->  https://appliedontolab.github.io/DOLCE/OWL/DOLCEbasic.owl
+RewriteRule ^([^.]+[^\/])$ https://appliedontolab.github.io/DOLCE/$1.owl [R=303,L]
+
+# Match anything that ends with .owl (including possibly strings containing dots and dashes) e.g. www.w3id.org/DOLCE/OWL/DOLCEbasic-0.1.owl --> https://appliedontolab.github.io/DOLCE/OWL/DOLCEbasic-0.1.owl
 RewriteRule ^(.+)\.owl$ https://appliedontolab.github.io/DOLCE/$1.owl [R=303,L]
 
-# Match anything that ends with .ttl
+# Match anything that ends with .ttl (including possibly strings containing dots and dashes) e.g. e.g. www.w3id.org/DOLCE/OWL/DOLCEbasic.ttl --> https://appliedontolab.github.io/DOLCE/OWL/DOLCEbasic.ttl
 RewriteRule ^(.+)\.ttl$ https://appliedontolab.github.io/DOLCE/$1.ttl [R=303,L]
 
-# Match anything that ends with .rdf
+# Match anything that ends with .rdf (including possibly strings containing dots and dashes) e.g. e.g. www.w3id.org/DOLCE/OWL/DOLCEbasic.rdf --> https://appliedontolab.github.io/DOLCE/OWL/DOLCEbasic.rdf
 RewriteRule ^(.+)\.rdf$ https://appliedontolab.github.io/DOLCE/$1.rdf [R=303,L]
+
+# Match anything that ends (after a "/") with "."s or numbers (e.g. /0.1 or /1.2.3 or /9.9.9.9) to an appropriate versioning file e.g. www.w3id.org/DOLCE/OWL/DOLCEbasic/0.1 --> https://appliedontolab.github.io/DOLCE/OWL/DOLCEbasic-0.1.owl
+RewriteRule ^(.*)\/([0-9\.]+)(?!.*\/)$ https://appliedontolab.github.io/DOLCE/$1-$2.owl [R=303,L]

--- a/DOLCE/.htaccess
+++ b/DOLCE/.htaccess
@@ -22,3 +22,7 @@ RewriteRule ^(.+)\.rdf$ https://appliedontolab.github.io/DOLCE/$1.rdf [R=303,L]
 
 # Match anything that ends (after a "/") with "."s or numbers (e.g. /0.1 or /1.2.3 or /9.9.9.9) to an appropriate versioning file e.g. www.w3id.org/DOLCE/OWL/DOLCEbasic/0.1 --> https://appliedontolab.github.io/DOLCE/OWL/DOLCEbasic-0.1.owl
 RewriteRule ^(.*)\/([0-9\.]+)(?!.*\/)$ https://appliedontolab.github.io/DOLCE/$1-$2.owl [R=303,L]
+
+# Match anything that ends (after a "/") with "."s or numbers followed by a "/" (e.g. /0.1/ or /1.2.3/ or /9.9.9.9/) to an appropriate versioning file e.g. www.w3id.org/DOLCE/OWL/DOLCEbasic/0.1/ --> https://appliedontolab.github.io/DOLCE/OWL/DOLCEbasic-0.1.owl
+RewriteRule ^(.*)\/([0-9\.]+)\/(?!.*\/)$ https://appliedontolab.github.io/DOLCE/$1-$2.owl [R=303,L]
+


### PR DESCRIPTION
corrected and expanded redirect rules.

For example, before https://www.w3id.org/DOLCE/OWL/DOLCEbasic/ is sent to https://appliedontolab.github.io/DOLCE/OWL/DOLCEbasic/.owl

also added versioning redirect
