### PR TITLE
trusted-wfrun-crate deprecated, now using 5s-crate

### DIFF
--- a/5s-crate/.htaccess
+++ b/5s-crate/.htaccess
@@ -1,0 +1,15 @@
+AddType application/ld+json .jsonld
+
+RewriteEngine on
+
+# Documentation/paper
+RewriteRule ^$ https://trefx.uk/5s-crate/ [R=303,L]
+
+
+# Crate profile (versioned)
+RewriteCond %{HTTP_ACCEPT} ^.*application/ld\+json.*
+# JSON-LD manifest
+RewriteRule ^(\d+\.\d+)$ https://trefx.uk/5s-crate/$1/ro-crate-metadata.jsonld [R=302,L]
+# HTML as default
+RewriteRule ^(\d+\.\d+)$ https://trefx.uk/5s-crate/$1/ [R=302,L]
+

--- a/5s-crate/README.md
+++ b/5s-crate/README.md
@@ -1,0 +1,14 @@
+# Five Saes RO-Crate profile
+
+Currently managed by the [TRE-FX](https://trefx.uk/) project.
+
+Primary contacts: 
+    - Stian Soiland-Reyes @stain
+    - Tom Giles @thomgiles
+
+Permalinks (examples):
+ * https://w3id.org/5s-crate
+ * https://w3id.org/5s-crate/0.4
+ 
+
+

--- a/5s-crate/README.md
+++ b/5s-crate/README.md
@@ -3,8 +3,8 @@
 Currently managed by the [TRE-FX](https://trefx.uk/) project.
 
 Primary contacts: 
-    - Stian Soiland-Reyes @stain
-    - Tom Giles @thomgiles
+- Stian Soiland-Reyes @stain
+- Tom Giles @thomgiles
 
 Permalinks (examples):
  * https://w3id.org/5s-crate

--- a/trusted-wfrun-crate/.htaccess
+++ b/trusted-wfrun-crate/.htaccess
@@ -2,14 +2,15 @@ AddType application/ld+json .jsonld
 
 RewriteEngine on
 
-# Documentation/paper
-RewriteRule ^$ https://trefx.uk/trusted-wfrun-crate/ [R=303,L]
+# Documentation (now called 5s-crate)
+RewriteRule ^$ https://trefx.uk/5s-crate/ [R=303,L]
 
 
 # Crate profile (versioned)
 RewriteCond %{HTTP_ACCEPT} ^.*application/ld\+json.*
-# JSON-LD manifest
-RewriteRule ^(\d+\.\d+)$ https://trefx.uk/trusted-wfrun-crate/$1/ro-crate-metadata.jsonld [R=302,L]
-# HTML as default
-RewriteRule ^(\d+\.\d+)$ https://trefx.uk/trusted-wfrun-crate/$1/ [R=302,L]
 
+# 0.3 was the only release
+RewriteRule ^0.3$ https://trefx.uk/trusted-wfrun-crate/0.3/ro-crate-metadata.jsonld [R=302,L]
+RewriteRule ^0.3$ https://trefx.uk/trusted-wfrun-crate/0.3/ [R=302,L]
+
+# Later versions use a different PID pattern https://w3id.org/5s-crate/

--- a/trusted-wfrun-crate/README.md
+++ b/trusted-wfrun-crate/README.md
@@ -3,8 +3,8 @@
 Currently managed by the [TRE-FX](https://trefx.uk/) project.
 
 Primary contacts: 
-    - Stian Soiland-Reyes @stain
-    - Tom Giles @thomgiles
+- Stian Soiland-Reyes @stain
+- Tom Giles @thomgiles
 
 Permalinks (**deprecated**):
  * https://w3id.org/trusted-wfrun-crate/0.3

--- a/trusted-wfrun-crate/README.md
+++ b/trusted-wfrun-crate/README.md
@@ -6,9 +6,11 @@ Primary contacts:
     - Stian Soiland-Reyes @stain
     - Tom Giles @thomgiles
 
-Permalinks (examples):
- * https://w3id.org/trusted-wfrun-crate
+Permalinks (**deprecated**):
  * https://w3id.org/trusted-wfrun-crate/0.3
  
+Deprecated:
+ * https://w3id.org/trusted-wfrun-crate
+   --> https://w3id.org/5s-crate
 
 


### PR DESCRIPTION
Old https://w3id.org/trusted-wfrun-crate/0.3 will remain, new PIDs will be under https://w3id.org/5s-crate
