### PR TITLE
Add work-accident to w3id.org/italia

### DIFF
--- a/italia/work-accident/README.md
+++ b/italia/work-accident/README.md
@@ -1,0 +1,17 @@
+Repository (italy/work-accident) for redirecting to ontologies and open data of INAIL (the National Institute for Insurance against Accidents at Work) 
+===================
+
+We intend to use **w3id.org/italia/work-accident** for national persistent URIs for work accident information of the public sector.
+
+We initially plan to create:
++ `w3id.org/italia/work-accident/onto` for all the ontologies of the network mentioned above
++ `w3id.org/italia/work-accident/controlled-vocabulary` for all the controlled vocabularies
++ `w3id.org/italia/work-accident/data` for all the other types of data
+
+
+Some redirect rules will be to the [github repository of INAIL](https://github.com/InailUfficio5/inail-ndc) we are using as semantic assets repo, open to all.
+
+Contacts:
+
++ INAIL Ufficio V: github (https://github.com/InailUfficio5) - email (dcod@inail.it)
++ Anna Maria De Paoli: github (https://github.com/InailUfficio5) - email (a.depaoli@inail.it)

--- a/italia/work-accident/controlled-vocabulary/.htaccess
+++ b/italia/work-accident/controlled-vocabulary/.htaccess
@@ -1,0 +1,30 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+SetEnvIf Accept ^.*text/turtle.* SYNTAX=ttl
+SetEnvIf Accept ^.*application/json.* SYNTAX=json
+SetEnvIf Accept ^.*application/csv.* SYNTAX=csv
+SetEnvIf Accept ^.*text/csv.* SYNTAX=csv
+SetEnvIf Accept ^.*text/html.* SYNTAX=html
+SetEnvIf Request_URI ^.*$ ROOT_URL=https://github.com/InailUfficio5/inail-ndc/tree/main/assets/controlled-vocabularies/
+
+RewriteCond %{ENV:SYNTAX} ^(ttl|json|csv)$
+RewriteRule ^(icdx)(/?)$ %{ENV:ROOT_URL}icdx-classificazione-internazionale-malattie/latest/icdx.%{ENV:SYNTAX} [R=303,L]
+RewriteCond %{ENV:SYNTAX} ^(ttl|json|csv)$
+RewriteRule ^([a-zA-Z0-9]+)(\_)([a-zA-Z0-9]+)(\_)([a-zA-Z0-9]+)(\_)([a-zA-Z0-9]+)(\_)([a-zA-Z0-9]+)(\_)([a-zA-Z0-9]+)(/?)$ %{ENV:ROOT_URL}$1-$3-$5-$7-$9-$11/latest/$1_$3_$5_$7_$9_$11.%{ENV:SYNTAX} [R=303,L]
+RewriteCond %{ENV:SYNTAX} ^(ttl|json|csv)$
+RewriteRule ^([a-zA-Z0-9]+)(\_)([a-zA-Z0-9]+)(\_)([a-zA-Z0-9]+)(\_)([a-zA-Z0-9]+)(\_)([a-zA-Z0-9]+)(/?)$ %{ENV:ROOT_URL}$1-$3-$5-$7-$9/latest/$1_$3_$5_$7_$9.%{ENV:SYNTAX} [R=303,L]
+RewriteCond %{ENV:SYNTAX} ^(ttl|json|csv)$
+RewriteRule ^([a-zA-Z0-9]+)(\_)([a-zA-Z0-9]+)(\_)([a-zA-Z0-9]+)(\_)([a-zA-Z0-9]+)(/?)$ %{ENV:ROOT_URL}$1-$3-$5-$7/latest/$1_$3_$5_$7.%{ENV:SYNTAX} [R=303,L]
+RewriteCond %{ENV:SYNTAX} ^(ttl|json|csv)$
+RewriteRule ^([a-zA-Z0-9]+)(\_)([a-zA-Z0-9]+)(/?)$ %{ENV:ROOT_URL}$1-$3-$5/latest/$1_$3_$5.%{ENV:SYNTAX} [R=303,L]
+RewriteCond %{ENV:SYNTAX} ^(ttl|json|csv)$
+RewriteRule ^([a-zA-Z0-9]+)(\_)([a-zA-Z0-9]+)(/?)$ %{ENV:ROOT_URL}$1-$3/latest/$1_$3.%{ENV:SYNTAX} [R=303,L]
+RewriteCond %{ENV:SYNTAX} ^(ttl|json|csv)$
+RewriteRule ^([a-zA-Z-_0-9]+)(/?)$ %{ENV:ROOT_URL}$1/latest/$1.%{ENV:SYNTAX} [R=303,L]
+
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^(.+)$ https://schema.gov.it/lodview/controlled-vocabulary/$1 [R=303,L]
+
+RewriteRule ^(.+)/(.+)/(.+)$ https://schema.gov.it/lodview/controlled-vocabulary/$1/$2/$3 [R=303,L]

--- a/italia/work-accident/data/.htaccess
+++ b/italia/work-accident/data/.htaccess
@@ -1,0 +1,7 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+SetEnvIf Request_URI ^.*$ ROOT_URL=https://schema.gov.it/lodview/data/
+
+RewriteRule ^(.*)$ %{ENV:ROOT_URL}$1 [R=303,L]
+RewriteRule ^(.*)/$ %{ENV:ROOT_URL}$1 [R=303,L]

--- a/italia/work-accident/onto/.htaccess
+++ b/italia/work-accident/onto/.htaccess
@@ -1,0 +1,23 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+SetEnvIf Accept ^.*application/rdf\+xml.* SYNTAX=rdf
+SetEnvIf Accept ^.*application/rdf\+xml.* SYNTAX=owl
+SetEnvIf Accept ^.*application/n-triples.* SYNTAX=n3
+SetEnvIf Accept ^.*text/turtle.* SYNTAX=ttl
+SetEnvIf Accept ^.*text/html.* SYNTAX=html
+SetEnvIf Request_URI ^.*$ ROOT_URL=https://github.com/InailUfficio5/inail-ndc/tree/main/assets/ontologies/
+ 
+
+RewriteCond %{ENV:SYNTAX} ^(rdf|ttl|owl|n3)$
+RewriteRule ^([a-zA-Z-_0-9]+)(\_amministrative)(/?)$ %{ENV:ROOT_URL}$1/latest/$1$2.%{ENV:SYNTAX} [R=303,L]
+RewriteCond %{ENV:SYNTAX} ^(rdf|ttl|owl|n3)$
+RewriteRule ^([a-zA-Z-_0-9]+)(/?)$ %{ENV:ROOT_URL}$1/latest/$1.%{ENV:SYNTAX} [R=303,L]
+
+
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^(.+)(/.+)$ https://schema.gov.it/lodview/onto/$1$2 [R=303,L]
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^(.+)/$ https://schema.gov.it/lode/extract?url=https://w3id.org/italia/work-accident/onto/$1 [R=303,L]
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^(.+)$ https://schema.gov.it/lode/extract?url=https://w3id.org/italia/work-accident/onto/$1 [R=303,L]


### PR DESCRIPTION
Add work-accident to w3id.org/italia for redirecting to ontologies and open data of INAIL (the National Institute for Insurance against Accidents at Work)