### PR TITLE
Add Music Annotation ontology in /music-annotation

### DIFF
--- a/music-annotation/.htaccess
+++ b/music-annotation/.htaccess
@@ -1,0 +1,57 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+
+AddType application/rdf+xml .rdf
+AddType application/ld+json .jsonld
+AddType application/n-quads .nq
+AddType application/n-triples .nt
+AddType text/turtle .ttl
+
+RewriteEngine on
+
+# This is a single ontology (The Music Annotation Ontology) served
+# in different RDF serialisations on request
+
+## If the base directory or /latest is used, we'll go to the current version (which is 1.0, the only version)
+
+# Rewrite rule to serve RDF/XML content if requested
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/v1/music-annotation-ontology.rdf [R=303,L]
+
+# Rewrite rule to serve JSON-LD content if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/v1/music-annotation-ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve N-Quads content if requested
+RewriteCond %{HTTP_ACCEPT} application/n-quads
+RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/v1/music-annotation-ontology.nq [R=303,L]
+
+# Rewrite rule to serve N-Triples content if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/v1/music-annotation-ontology.nt [R=303,L]
+
+# Rewrite rule to serve Turtle content if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/v1/music-annotation-ontology.ttl [R=303,L]
+
+## We assume that a path of the form [0-9]+.[0-9]+ is a version number and should be persisted
+
+# Rewrite rule to serve RDF/XML content if requested
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^([0-9]+[.][0-9]+)/?$ https://domestic-beethoven.eu/ontology/$1/music-annotation-ontology.rdf [R=303,L]
+
+# Rewrite rule to serve JSON-LD content if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^([0-9]+[.][0-9]+)/?$ https://domestic-beethoven.eu/ontology/$1/music-annotation-ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve N-Quads content if requested
+RewriteCond %{HTTP_ACCEPT} application/n-quads
+RewriteRule ^([0-9]+[.][0-9]+)/?$ https://domestic-beethoven.eu/ontology/$1/music-annotation-ontology.nq [R=303,L]
+
+# Rewrite rule to serve N-Triples content if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^([0-9]+[.][0-9]+)/?$ https://domestic-beethoven.eu/ontology/$1/music-annotation-ontology.nt [R=303,L]
+
+# Rewrite rule to serve Turtle content if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^([0-9]+[.][0-9]+)/?$ https://domestic-beethoven.eu/ontology/$1/music-annotation-ontology.ttl [R=303,L]

--- a/music-annotation/README.md
+++ b/music-annotation/README.md
@@ -1,0 +1,22 @@
+# /music-annotation/
+This [W3ID](https://w3id.rg) provides a persistent URI namespace for the Music Annotation Ontology.
+
+## Uses
+
+This namespace is used solely for the **Music Annotation Ontology** set out in [Lewis et al (2023)](https://dl.acm.org/doi/10.1145/3543882.3543891) and documented on the [Beethoven in the House project website](https://domestic-beethoven.eu/assets/docs/BitHModelDocumentation_v0.2.1.pdf) and [Hankinson et al (2022)](https://hcommons.org/deposits/item/hc:59295/).
+
+The path on its own, or with the suffix /latest, will always point to the latest version of the ontology. Specific versions can be specified in the path (e.g. https://w3id.org/1.0/). 
+
+Content negotiation is used to choose a suitable RDF serialisation format.
+
+## Contact
+
+This space is administered by:  
+
+**David Lewis**, University of Oxford & Goldsmiths, University of London (david.lewis@oerc.ox.ac.uk | d.lewis@gold.ac.uk)  
+GitHub: [DILewis](https://github.com/DILewis)  
+ORCID: [0000-0003-4151-0499](https://orcid.org/0000-0003-4151-0499)
+
+**Mark Saccomano**, Universität Paderborn (mark.saccomano@uni-paderborn.de)  
+GitHub: [mss2221](https://github.com/mss2221)  
+ORCID: [0000-0002-4635-7684](https://orcid.org/0000-0002-4635-7684)

--- a/music-annotation/README.md
+++ b/music-annotation/README.md
@@ -1,5 +1,5 @@
 # /music-annotation/
-This [W3ID](https://w3id.rg) provides a persistent URI namespace for the Music Annotation Ontology.
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the Music Annotation Ontology.
 
 ## Uses
 

--- a/music-annotation/README.md
+++ b/music-annotation/README.md
@@ -5,7 +5,7 @@ This [W3ID](https://w3id.rg) provides a persistent URI namespace for the Music A
 
 This namespace is used solely for the **Music Annotation Ontology** set out in [Lewis et al (2023)](https://dl.acm.org/doi/10.1145/3543882.3543891) and documented on the [Beethoven in the House project website](https://domestic-beethoven.eu/assets/docs/BitHModelDocumentation_v0.2.1.pdf) and [Hankinson et al (2022)](https://hcommons.org/deposits/item/hc:59295/).
 
-The path on its own, or with the suffix /latest, will always point to the latest version of the ontology. Specific versions can be specified in the path (e.g. https://w3id.org/1.0/). 
+The path on its own, or with the suffix `/latest`, will always point to the latest version of the ontology. Specific versions can be specified in the path (e.g., `https://w3id.org/music-annotation/1.0/`).
 
 Content negotiation is used to choose a suitable RDF serialisation format.
 


### PR DESCRIPTION
The Music Annotation Ontology has been defined and described as part of the [Beethoven in the House project](https://domestic-beethoven.eu) and now needs a persistent URL. 

This PR proposes https://w3id.org/music-annotation