### PR TITLE
Fix wrong URIs in music-annotation-ontology

### DIFF
--- a/music-annotation/.htaccess
+++ b/music-annotation/.htaccess
@@ -16,23 +16,23 @@ RewriteEngine on
 
 # Rewrite rule to serve RDF/XML content if requested
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/v1/music-annotation-ontology.rdf [R=303,L]
+RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/1.0/music-annotation-ontology.rdf [R=303,L]
 
 # Rewrite rule to serve JSON-LD content if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/v1/music-annotation-ontology.jsonld [R=303,L]
+RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/1.0/music-annotation-ontology.jsonld [R=303,L]
 
 # Rewrite rule to serve N-Quads content if requested
 RewriteCond %{HTTP_ACCEPT} application/n-quads
-RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/v1/music-annotation-ontology.nq [R=303,L]
+RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/1.0/music-annotation-ontology.nq [R=303,L]
 
 # Rewrite rule to serve N-Triples content if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/v1/music-annotation-ontology.nt [R=303,L]
+RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/1.0/music-annotation-ontology.nt [R=303,L]
 
 # Rewrite rule to serve Turtle content if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/v1/music-annotation-ontology.ttl [R=303,L]
+RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/1.0/music-annotation-ontology.ttl [R=303,L]
 
 ## We assume that a path of the form [0-9]+.[0-9]+ is a version number and should be persisted
 


### PR DESCRIPTION
`/v1/` in URL path should have been `/1.0/`. (Not sure what I was thinking)