### PR TITLE
Update of brot, bridge, brcomp, brstr and bmat

### DIFF
--- a/bmat/.htaccess
+++ b/bmat/.htaccess
@@ -11,30 +11,30 @@ AddType application/rdf+xml .rdf
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://wisib.de/ontologie/bmat/ [R=302,NE,L]
+RewriteRule ^$ https://alhakam.github.io/bmat/ [R=302,NE,L]
 
 # In case of accept header <text/turtle>
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
-RewriteRule ^$ https://wisib.de/ontologie/bmat/ontology.ttl [R=303,NE,L]
+RewriteRule ^$ https://alhakam.github.io/bmat/ontology.ttl [R=303,NE,L]
 
 # In case of accept header <application/rdf+xml>
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^$ https://wisib.de/ontologie/bmat/ontology.xml [R=302,NE,L]
+RewriteRule ^$ https://alhakam.github.io/bmat/ontology.xml [R=302,NE,L]
 
 # If suffix ttl, redirect to turtle version
-RewriteRule ^bmat.ttl$ https://wisib.de/ontologie/bmat/ontology.ttl [R=302,NE,L]
+RewriteRule ^bmat.ttl$ https://alhakam.github.io/bmat/ontology.ttl [R=302,NE,L]
 
 # If suffix html, redirect to html version
-RewriteRule ^bmat.html$ https://wisib.de/ontologie/bmat/ [R=302,NE,L]
+RewriteRule ^bmat.html$ https://alhakam.github.io/bmat/ [R=302,NE,L]
 
 # If suffix rdf, redirect to rdf version
-RewriteRule ^bmat.rdf$ https://wisib.de/ontologie/bmat/ontology.xml [R=302,NE,L]
+RewriteRule ^bmat.rdf$ https://alhakam.github.io/bmat/ontology.xml [R=302,NE,L]
 
 # If suffix jsonld, redirect to jsonld version
-RewriteRule ^bmat.jsonld$ https://wisib.de/ontologie/bmat/ontology.json [R=302,NE,L]
+RewriteRule ^bmat.jsonld$ https://alhakam.github.io/bmat/ontology.json [R=302,NE,L]
 
 # If suffix nt, redirect to nt version
-RewriteRule ^bmat.nt$ https://wisib.de/ontologie/bmat/ontology.nt [R=302,NE,L]
+RewriteRule ^bmat.nt$ https://alhakam.github.io/bmat/ontology.nt [R=302,NE,L]
 
 # Default response: html
-RewriteRule ^$ https://wisib.de/ontologie/bmat/ [R=303,NE,L]
+RewriteRule ^$ https://alhakam.github.io/bmat/ [R=303,NE,L]

--- a/bmat/readme.md
+++ b/bmat/readme.md
@@ -2,8 +2,8 @@
 
 Ontology
 
-* Doc      https://wisib.de/ontologie/bmat/
-* Turtle   https://wisib.de/ontologie/bmat/ontology.ttl
+* Doc      https://alhakam.github.io/bmat/
+* Turtle   https://alhakam.github.io/bmat/ontology.ttl
 
 
 Contacts

--- a/brcomp/.htaccess
+++ b/brcomp/.htaccess
@@ -11,30 +11,30 @@ AddType application/rdf+xml .rdf
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://wisib.de/ontologie/brcomp/ [R=302,NE,L]
+RewriteRule ^$ https://alhakam.github.io/brcomp/ [R=302,NE,L]
 
 # In case of accept header <text/turtle>
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
-RewriteRule ^$ https://wisib.de/ontologie/brcomp/ontology.ttl [R=303,NE,L]
+RewriteRule ^$ https://alhakam.github.io/brcomp/ontology.ttl [R=303,NE,L]
 
 # In case of accept header <application/rdf+xml>
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^$ https://wisib.de/ontologie/brcomp/ontology.xml [R=302,NE,L]
+RewriteRule ^$ https://alhakam.github.io/brcomp/ontology.xml [R=302,NE,L]
 
 # If suffix ttl, redirect to turtle version
-RewriteRule ^brcomp.ttl$ https://wisib.de/ontologie/brcomp/ontology.ttl [R=302,NE,L]
+RewriteRule ^brcomp.ttl$ https://alhakam.github.io/brcomp/ontology.ttl [R=302,NE,L]
 
 # If suffix html, redirect to html version
-RewriteRule ^brcomp.html$ https://wisib.de/ontologie/brcomp/ [R=302,NE,L]
+RewriteRule ^brcomp.html$ https://alhakam.github.io/brcomp/ [R=302,NE,L]
 
 # If suffix rdf, redirect to rdf version
-RewriteRule ^brcomp.rdf$ https://wisib.de/ontologie/brcomp/ontology.xml [R=302,NE,L]
+RewriteRule ^brcomp.rdf$ https://alhakam.github.io/brcomp/ontology.xml [R=302,NE,L]
 
 # If suffix jsonld, redirect to jsonld version
-RewriteRule ^brcomp.jsonld$ https://wisib.de/ontologie/brcomp/ontology.json [R=302,NE,L]
+RewriteRule ^brcomp.jsonld$ https://alhakam.github.io/brcomp/ontology.json [R=302,NE,L]
 
 # If suffix nt, redirect to nt version
-RewriteRule ^brcomp.nt$ https://wisib.de/ontologie/brcomp/ontology.nt [R=302,NE,L]
+RewriteRule ^brcomp.nt$ https://alhakam.github.io/brcomp/ontology.nt [R=302,NE,L]
 
 # Default response: html
-RewriteRule ^$ https://wisib.de/ontologie/brcomp/ [R=303,NE,L]
+RewriteRule ^$ https://alhakam.github.io/brcomp/ [R=303,NE,L]

--- a/brcomp/readme.md
+++ b/brcomp/readme.md
@@ -2,8 +2,8 @@
 
 Ontology
 
-* Doc      https://wisib.de/ontologie/brcomp/
-* Turtle   https://wisib.de/ontologie/brcomp/ontology.ttl
+* Doc      https://alhakam.github.io/brcomp/
+* Turtle   https://alhakam.github.io/brcomp/ontology.ttl
 
 
 Contacts

--- a/bridge/.htaccess
+++ b/bridge/.htaccess
@@ -11,30 +11,30 @@ AddType application/rdf+xml .rdf
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://wisib.de/ontologie/bridge/ [R=302,NE,L]
+RewriteRule ^$ https://alhakam.github.io/bridge/ [R=302,NE,L]
 
 # In case of accept header <text/turtle>
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
-RewriteRule ^$ https://wisib.de/ontologie/bridge/ontology.ttl [R=303,NE,L]
+RewriteRule ^$ https://alhakam.github.io/bridge/ontology.ttl [R=303,NE,L]
 
 # In case of accept header <application/rdf+xml>
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^$ https://wisib.de/ontologie/bridge/ontology.xml [R=302,NE,L]
+RewriteRule ^$ https://alhakam.github.io/bridge/ontology.xml [R=302,NE,L]
 
 # If suffix ttl, redirect to turtle version
-RewriteRule ^bridge.ttl$ https://wisib.de/ontologie/bridge/ontology.ttl [R=302,NE,L]
+RewriteRule ^bridge.ttl$ https://alhakam.github.io/bridge/ontology.ttl [R=302,NE,L]
 
 # If suffix html, redirect to html version
-RewriteRule ^bridge.html$ https://wisib.de/ontologie/bridge/ [R=302,NE,L]
+RewriteRule ^bridge.html$ https://alhakam.github.io/bridge/ [R=302,NE,L]
 
 # If suffix rdf, redirect to rdf version
-RewriteRule ^bridge.rdf$ https://wisib.de/ontologie/bridge/ontology.xml [R=302,NE,L]
+RewriteRule ^bridge.rdf$ https://alhakam.github.io/bridge/ontology.xml [R=302,NE,L]
 
 # If suffix jsonld, redirect to jsonld version
-RewriteRule ^bridge.jsonld$ https://wisib.de/ontologie/bridge/ontology.json [R=302,NE,L]
+RewriteRule ^bridge.jsonld$ https://alhakam.github.io/bridge/ontology.json [R=302,NE,L]
 
 # If suffix nt, redirect to nt version
-RewriteRule ^bridge.nt$ https://wisib.de/ontologie/bridge/ontology.nt [R=302,NE,L]
+RewriteRule ^bridge.nt$ https://alhakam.github.io/bridge/ontology.nt [R=302,NE,L]
 
 # Default response: html
-RewriteRule ^$ https://wisib.de/ontologie/bridge/ [R=303,NE,L]
+RewriteRule ^$ https://alhakam.github.io/bridge/ [R=303,NE,L]

--- a/bridge/readme.md
+++ b/bridge/readme.md
@@ -2,8 +2,8 @@
 
 Ontology
 
-* Doc      https://wisib.de/ontologie/bridge/
-* Turtle   https://wisib.de/ontologie/bridge/ontology.ttl
+* Doc      https://alhakam.github.io/bridge/
+* Turtle   https://alhakam.github.io/bridge/ontology.ttl
 
 
 Contacts

--- a/brot/.htaccess
+++ b/brot/.htaccess
@@ -11,30 +11,30 @@ AddType application/rdf+xml .rdf
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://wisib.de/ontologie/brot/ [R=302,NE,L]
+RewriteRule ^$ https://alhakam.github.io/brot/ [R=302,NE,L]
 
 # In case of accept header <text/turtle>
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
-RewriteRule ^$ https://wisib.de/ontologie/brot/ontology.ttl [R=303,NE,L]
+RewriteRule ^$ https://alhakam.github.io/brot/ontology.ttl [R=303,NE,L]
 
 # In case of accept header <application/rdf+xml>
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^$ https://wisib.de/ontologie/brot/ontology.xml [R=302,NE,L]
+RewriteRule ^$ https://alhakam.github.io/brot/ontology.xml [R=302,NE,L]
 
 # If suffix ttl, redirect to turtle version
-RewriteRule ^brot.ttl$ https://wisib.de/ontologie/brot/ontology.ttl [R=302,NE,L]
+RewriteRule ^brot.ttl$ https://alhakam.github.io/brot/ontology.ttl [R=302,NE,L]
 
 # If suffix html, redirect to html version
-RewriteRule ^brot.html$ https://wisib.de/ontologie/brot/ [R=302,NE,L]
+RewriteRule ^brot.html$ https://alhakam.github.io/brot/ [R=302,NE,L]
 
 # If suffix rdf, redirect to rdf version
-RewriteRule ^brot.rdf$ https://wisib.de/ontologie/brot/ontology.xml [R=302,NE,L]
+RewriteRule ^brot.rdf$ https://alhakam.github.io/brot/ontology.xml [R=302,NE,L]
 
 # If suffix jsonld, redirect to jsonld version
-RewriteRule ^brot.jsonld$ https://wisib.de/ontologie/brot/ontology.json [R=302,NE,L]
+RewriteRule ^brot.jsonld$ https://alhakam.github.io/brot/ontology.json [R=302,NE,L]
 
 # If suffix nt, redirect to nt version
-RewriteRule ^brot.nt$ https://wisib.de/ontologie/brot/ontology.nt [R=302,NE,L]
+RewriteRule ^brot.nt$ https://alhakam.github.io/brot/ontology.nt [R=302,NE,L]
 
 # Default response: html
-RewriteRule ^$ https://wisib.de/ontologie/brot/ [R=303,NE,L]
+RewriteRule ^$ https://alhakam.github.io/brot/ [R=303,NE,L]

--- a/brot/readme.md
+++ b/brot/readme.md
@@ -2,8 +2,8 @@
 
 Ontology
 
-* Doc      https://wisib.de/ontologie/brot/
-* Turtle   https://wisib.de/ontologie/brot/ontology.ttl
+* Doc      https://alhakam.github.io/brot/
+* Turtle   https://alhakam.github.io/brot/ontology.ttl
 
 
 Contacts

--- a/brstr/.htaccess
+++ b/brstr/.htaccess
@@ -11,30 +11,30 @@ AddType application/rdf+xml .rdf
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://wisib.de/ontologie/brstr/ [R=302,NE,L]
+RewriteRule ^$ https://alhakam.github.io/brstr/ [R=302,NE,L]
 
 # In case of accept header <text/turtle>
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
-RewriteRule ^$ https://wisib.de/ontologie/brstr/ontology.ttl [R=303,NE,L]
+RewriteRule ^$ https://alhakam.github.io/brstr/ontology.ttl [R=303,NE,L]
 
 # In case of accept header <application/rdf+xml>
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^$ https://wisib.de/ontologie/brstr/ontology.xml [R=302,NE,L]
+RewriteRule ^$ https://alhakam.github.io/brstr/ontology.xml [R=302,NE,L]
 
 # If suffix ttl, redirect to turtle version
-RewriteRule ^brstr.ttl$ https://wisib.de/ontologie/brstr/ontology.ttl [R=302,NE,L]
+RewriteRule ^brstr.ttl$ https://alhakam.github.io/brstr/ontology.ttl [R=302,NE,L]
 
 # If suffix html, redirect to html version
-RewriteRule ^brstr.html$ https://wisib.de/ontologie/brstr/ [R=302,NE,L]
+RewriteRule ^brstr.html$ https://alhakam.github.io/brstr/ [R=302,NE,L]
 
 # If suffix rdf, redirect to rdf version
-RewriteRule ^brstr.rdf$ https://wisib.de/ontologie/brstr/ontology.xml [R=302,NE,L]
+RewriteRule ^brstr.rdf$ https://alhakam.github.io/brstr/ontology.xml [R=302,NE,L]
 
 # If suffix jsonld, redirect to jsonld version
-RewriteRule ^brstr.jsonld$ https://wisib.de/ontologie/brstr/ontology.json [R=302,NE,L]
+RewriteRule ^brstr.jsonld$ https://alhakam.github.io/brstr/ontology.json [R=302,NE,L]
 
 # If suffix nt, redirect to nt version
-RewriteRule ^brstr.nt$ https://wisib.de/ontologie/brstr/ontology.nt [R=302,NE,L]
+RewriteRule ^brstr.nt$ https://alhakam.github.io/brstr/ontology.nt [R=302,NE,L]
 
 # Default response: html
-RewriteRule ^$ https://wisib.de/ontologie/brstr/ [R=303,NE,L]
+RewriteRule ^$ https://alhakam.github.io/brstr/ [R=303,NE,L]

--- a/brstr/readme.md
+++ b/brstr/readme.md
@@ -2,8 +2,8 @@
 
 Ontology
 
-* Doc      https://wisib.de/ontologie/brstr/
-* Turtle   https://wisib.de/ontologie/brstr/ontology.ttl
+* Doc      https://alhakam.github.io/brstr/
+* Turtle   https://alhakam.github.io/brstr/ontology.ttl
 
 
 Contacts


### PR DESCRIPTION
Updated the urls of the following ontologies (all of them were part of the research project "wiSIB"):

- brot
- bridge
- brcomp
- brstr
- bmat 

the original url https://wisib.de/ontologie under which the ontologies were stored does not exist anymore.