### PR TITLE
examples: Add Examples 5 & 6 and maintainer info request

### DIFF
--- a/examples/.htaccess
+++ b/examples/.htaccess
@@ -1,0 +1,15 @@
+# # /examples/
+#
+# A collection of URL redirection examples.
+#
+# https://w3id.org/examples/ redirects to
+# https://github.com/perma-id/w3id.org/tree/master/examples
+#
+# ## Contact
+# This space is administered by:  
+#
+# Arthit Suriyawongkul
+# GitHub username: bact
+
+RewriteEngine on
+RewriteRule ^ https://github.com/perma-id/w3id.org/tree/master/examples [R=302,L]

--- a/examples/README.md
+++ b/examples/README.md
@@ -119,8 +119,8 @@ When the *Substitution* `https://fairsharing.github.io/mircat/$1` is evaluated, 
 A single resource, located by the same URL, can have multiple representations.
 For example, an image can can be represented in both GIF and PNG formats.
 
-A web server can be configured to return different media type or file format
-depends on the client's request or capability. We call this mechanism a
+A web server can be configured to return a different media type or file format
+depending on the client's request or capability. We call this mechanism
 "[content negotiation](https://en.wikipedia.org/wiki/Content_negotiation)".
 
 [/ppop/.htaccess](https://github.com/perma-id/w3id.org/blob/master/ppop/.htaccess) demonstrates the use of `RewriteCond %{HTTP_ACCEPT}` to check which [media types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_Types) the client accepts or expects to be returned by the server.
@@ -159,7 +159,7 @@ RewriteCond TestString CondPattern [Flags]
 
 Where *CondPattern* is a regular expresssion to match pattern in *TestString*.
 
-In this case, *TestString* is `%{HTTP_ACCEPT}` which its value is taken from
+In this case, *TestString* is `%{HTTP_ACCEPT}` which value is taken from
 an `Accept` field in the HTTP request header. The `Accept` field can be a
 string like this:
 
@@ -167,8 +167,8 @@ string like this:
 Accept: text/html, application/xhtml+xml, application/xml, image/webp
 ```
 
-Each media type will be presented, separated by a comma. With that, we can use
-*CondPattern* to matches media types in this string.
+Each media type will be presented, separated by a comma. We can then use
+*CondPattern* to match media types in this string.
 
 
 ### Example 3: Dealing with query string
@@ -182,10 +182,10 @@ the query string is `title=Web`.
 As the query string is not included in the string that the *Pattern* of
 *RewriteRule* will compared against, you cannot use *Pattern* to match them.
 
-To find pattern in the query string, use `%{QUERY_STRING}` as a *TestString*
+To find a pattern in the query string, use `%{QUERY_STRING}` as a *TestString*
 in *RewriteCond*.
 
-As an example, if you like to redirect the URL
+As an example, if you would like to redirect the URL
 `https://w3id.org/examples?a=1&b=2` to
 `https://example.com/path/file.php?a=1&b=2`, you can use this set of rules:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -220,10 +220,10 @@ See [`/OWLunit/.htaccess`](https://github.com/perma-id/w3id.org/blob/master/OWLu
 
 ### Example 6: Redirection based on a file extension in the URL
 
-Check for pattern of a file extension (like `.json`, `.png`, `.rdf`, `.html`)
+Check for the pattern of a file extension (like `.json`, `.png`, `.rdf`, `.html`)
 in the requested URL, and rewrite the URL accordingly.
 
-This technique can compliments `RewriteCond %{HTTP_ACCEPT}` rules (explained
+This technique can complement `RewriteCond %{HTTP_ACCEPT}` rules (explained
 in [Example 2](#example-2-supporting-multiple-media-types-mime-types)).
 
 See [`/SocDOnt/.htaccess`](https://github.com/perma-id/w3id.org/blob/master/SocDOnt/.htaccess).

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,4 +1,4 @@
-# Examples
+# /examples/
 
 This permanent W3ID is meant to be a place to host examples for publishing things on w3id.org.
 
@@ -9,12 +9,15 @@ This permanent W3ID is meant to be a place to host examples for publishing thing
   * [Example 1: Minimalist (grouping)](#example-1-minimalist-grouping)
   * [Example 2: Supporting multiple media types (MIME types)](#example-2-supporting-multiple-media-types-mime-types)
   * [Example 3: Dealing with query string](#example-3-dealing-with-query-string)
+  * [Example 4: Publish vocabularies with W3ID](#example-4-publish-vocabularies-with-w3id)
+  * [Example 5: Version-aware URIs of ontologies](#example-5-version-aware-uris-of-ontologies)
 * [README.md](#readmemd)
-* [Publish vocabularies with W3ID](#publish-vocabularies-with-w3id)
+
 
 ## .htaccess
 
-`.htaccess` file is the key for the working of URL redirection service of W3ID. Without it, redirection cannot be done.
+`.htaccess` file is the key for the working of URL redirection service of W3ID.
+Without it, redirection cannot be done.
 
 ### What is `.htaccess?`
 
@@ -25,13 +28,17 @@ issues, such as URL redirection, URL shortening, access control (for different
 web pages and files), and more. The 'dot' (period or full stop) before the
 file name makes it a hidden file in Unix-based environments. 
 
-In W3ID context, it is used primarily for URL redirection. The `.htaccess` file is where you can put URL rewriting rules in. A set of URL rewriting rules will work together and effectively made URL
-redirection happen.
+In W3ID context, it is used primarily for URL redirection. The `.htaccess`
+file is where you can put URL rewriting rules in. A set of URL rewriting rules
+will work together and effectively made URL redirection happen.
 
 ### Put ID info and maintainer info inside .htaccess
 
-You are encouraged to put a breif ID info and a maintainer info in the comment
-(lines staring with `#` character) of a `.htaccess` file.
+Maintainers of an ID are required to put a breif ID info and a maintainer info
+in the comment (lines staring with `#` character) of a `.htaccess` file.
+
+Having contact info and GitHub username help the overall maintainance process
+easier.
 
 ```ApacheConf
 # Example
@@ -148,7 +155,7 @@ Accept: text/html, application/xhtml+xml, application/xml, image/webp
 Each media type will be presented, separated by a comma. With that, we can use *CondPattern* to matches media types in this string.
 
 
-#### Example 3: Dealing with query string
+### Example 3: Dealing with query string
 
 Everything after the question mark (`?`) in the URL, but not that `?` itself, is a query string.
 
@@ -167,25 +174,35 @@ RewriteRule ^ https://example.com/path/file.php?%1? [R=302,L]
 
 In this example, the *CondPattern* `(.*)` in *RewriteCond* will match every characters in the query string (`a=1&b=2`) and put it in group one. This group one (`%1`) is later used in the *Substitution* of *RewriteRule*.
 
-
-
 Note that the special character to recall groups from *CondPattern* of *RewriteCond* is `%` (unlike the special character to recall groups from *Pattern* of *RewriteRule*, which is `$`).
 
 The character `?` at the end of the *Substitution* of *RewriteRule* tells the server not to pass the query string to the final URL after rewrite.
 
 
-## README.md
-
-Each ID hosted on W3ID is expected to have a file named `README.md` containing an information about the ID itself and an information about the maintainer(s). This can be more elaborate than the information inside `.htaccess`.
-
-The `.md` file extension at the end of the file name indicates that the file uses Markdown markup language for text formatting. You can have tables and images as well, if needed.
-
-GitHub will automatically display the content of a `README.md` to repository visitors.
-
-An example of a good README file: [w3id.org/dggs/README.md](https://github.com/perma-id/w3id.org/blob/master/dggs/README.md)
-
-
-## Publish vocabularies with W3ID
+### Example 4: Publish vocabularies with W3ID
 
 If you plan to publish a vocabulary/ontology with W3ID,
-see https://w3id.org/example/.
+see [/example/.htaccess](https://github.com/perma-id/w3id.org/blob/master/example/.htaccess)
+and https://w3id.org/example/.
+
+
+### Example 5: Version-aware URIs of ontologies
+
+See [/OWLunit/.htaccess](https://github.com/perma-id/w3id.org/blob/master/OWLunit/.htaccess).
+
+
+## README.md
+
+Each ID hosted on W3ID is required to have a file named `README.md` containing
+an information about the ID itself and an information about the maintainer(s).
+This can be more elaborate than the information inside `.htaccess`.
+
+The `.md` file extension at the end of the file name indicates that the file
+uses Markdown markup language for text formatting. You can have tables and
+images as well, if needed.
+
+GitHub will automatically display the content of a `README.md` to repository
+visitors.
+
+An example of a good README file:
+[w3id.org/dggs/README.md](https://github.com/perma-id/w3id.org/blob/master/dggs/README.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,10 +16,10 @@ This permanent W3ID is meant to be a place to host examples for publishing thing
 
 ## .htaccess
 
-`.htaccess` file is the key for the working of URL redirection service of W3ID.
+`.htaccess` file is the key to the working of URL redirection service of W3ID.
 Without it, redirection cannot be done.
 
-### What is `.htaccess?`
+### What is `.htaccess`?
 
 From [Wikipedia](https://en.wikipedia.org/wiki/.htaccess):
 > An .htaccess (hypertext access) file is a directory-level configuration file
@@ -28,17 +28,17 @@ issues, such as URL redirection, URL shortening, access control (for different
 web pages and files), and more. The 'dot' (period or full stop) before the
 file name makes it a hidden file in Unix-based environments. 
 
-In W3ID context, it is used primarily for URL redirection. The `.htaccess`
-file is where you can put URL rewriting rules in. A set of URL rewriting rules
-will work together and effectively made URL redirection happen.
+In the W3ID context, `.htaccess` is used primarily for URL redirection. This
+file is where you can put URL rewriting rules. A set of URL rewriting rules
+will work together and effectively make URL redirection happen.
 
 ### Put ID info and maintainer info inside .htaccess
 
-Maintainers of an ID are required to put a breif ID info and a maintainer info
-in the comment (lines staring with `#` character) of a `.htaccess` file.
+Maintainers of an ID are requested to put brief ID info and maintainer info
+in the comments (lines staring with `#` character) of an `.htaccess` file.
 
-Having contact info and GitHub username help the overall maintainance process
-easier.
+Including contact info and GitHub usernames helps ease the overall
+maintenance process.
 
 ```ApacheConf
 # Example
@@ -172,7 +172,7 @@ RewriteCond %{QUERY_STRING} (.*)
 RewriteRule ^ https://example.com/path/file.php?%1? [R=302,L]
 ```
 
-In this example, the *CondPattern* `(.*)` in *RewriteCond* will match every characters in the query string (`a=1&b=2`) and put it in group one. This group one (`%1`) is later used in the *Substitution* of *RewriteRule*.
+In this example, the *CondPattern* `(.*)` in *RewriteCond* will match every character in the query string (`a=1&b=2`) and put it in group one. This group one (`%1`) is used later in the *Substitution* of *RewriteRule*.
 
 Note that the special character to recall groups from *CondPattern* of *RewriteCond* is `%` (unlike the special character to recall groups from *Pattern* of *RewriteRule*, which is `$`).
 
@@ -182,19 +182,19 @@ The character `?` at the end of the *Substitution* of *RewriteRule* tells the se
 ### Example 4: Publish vocabularies with W3ID
 
 If you plan to publish a vocabulary/ontology with W3ID,
-see [/example/.htaccess](https://github.com/perma-id/w3id.org/blob/master/example/.htaccess)
+see [`/example/.htaccess`](https://github.com/perma-id/w3id.org/blob/master/example/.htaccess)
 and https://w3id.org/example/.
 
 
 ### Example 5: Version-aware URIs of ontologies
 
-See [/OWLunit/.htaccess](https://github.com/perma-id/w3id.org/blob/master/OWLunit/.htaccess).
+See [`/OWLunit/.htaccess`](https://github.com/perma-id/w3id.org/blob/master/OWLunit/.htaccess).
 
 
 ## README.md
 
 Each ID hosted on W3ID is required to have a file named `README.md` containing
-an information about the ID itself and an information about the maintainer(s).
+information about the ID itself and information about the maintainer(s).
 This can be more elaborate than the information inside `.htaccess`.
 
 The `.md` file extension at the end of the file name indicates that the file
@@ -205,4 +205,4 @@ GitHub will automatically display the content of a `README.md` to repository
 visitors.
 
 An example of a good README file:
-[w3id.org/dggs/README.md](https://github.com/perma-id/w3id.org/blob/master/dggs/README.md)
+[`w3id.org/dggs/README.md`](https://github.com/perma-id/w3id.org/blob/master/dggs/README.md)

--- a/examples/simple/.htaccess
+++ b/examples/simple/.htaccess
@@ -1,4 +1,6 @@
-# Example
+# # /examples/simple/
+#
+# A simple URL redirect example
 #
 # https://w3id.org/examples/simple/ redirects to https://example.com/
 #

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -2,7 +2,7 @@
 
 A simple URL redirection example.
 
-https://w3id.org/examples/simple/ redirects to https://example.com/
+[`https://w3id.org/examples/simple/`](https://w3id.org/examples/simple/) redirects to [`https://example.com/`](https://example.com/).
 
 ## Contact
 This space is administered by:  

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -1,6 +1,6 @@
-## /examples/simple/
+# /examples/simple/
 
-An example simple redirection.
+A simple URL redirection example.
 
 https://w3id.org/examples/simple/ redirects to https://example.com/
 


### PR DESCRIPTION
* Add Example 5: Version-aware URIs of ontologies
* Add Example 6: Redirection based on a file extension in the URL
* Add .htaccess file for /examples/, redirecting it to https://github.com/perma-id/w3id.org/tree/master/examples
* In README.md, states that having a maintainer info and GitHub username are requested, per reasons gave in #1673 