### PR TITLE
Add redirections for versioning and vocab "homepages".

### DIFF
--- a/mpilhlt/.htaccess
+++ b/mpilhlt/.htaccess
@@ -2,16 +2,81 @@ Options +FollowSymLinks
 RewriteEngine on
 # AllowEncodedSlashes NoDecode
 
+## =============================
+## Redirection rules.
+## Order is important, the "L" (last) flag means that no further rules will be processed.
+## Cf. <https://httpd.apache.org/docs/2.4/rewrite/flags.html>
+
+
+# ---------------
 # Vocabularies webpages
-RewriteRule ^polmat/(.*)                https://skohub.io/mpilhlt/vocabs-polmat/heads/main/w3id.org/mpilhlt/polmat/$1 [R=307,L]
-# RewriteRule ^worktime/(.*)              https://mpilhlt.github.io/vocabs-worktime/w3id.org/mpilhlt/worktime/$1 [R=307,L]
-RewriteRule ^worktime/(.*)              https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime/$1 [R=307,L]
-RewriteRule ^worktime_activity/(.*)     https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_activity/$1 [R=307,L]
-RewriteRule ^worktime_meta/(.*)         https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_meta/$1 [R=307,L]
-RewriteRule ^worktime_object/(.*)       https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_object/$1 [R=307,L]
-RewriteRule ^worktime_prescription/(.*) https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_prescription/$1 [R=307,L]
-RewriteRule ^worktime_role/(.*)         https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_role/$1 [R=307,L]
-RewriteRule ^worktime_term/(.*)         https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_term/$1 [R=307,L]
+
+RewriteRule ^polmat/(.*)                       https://skohub.io/mpilhlt/vocabs-polmat/heads/main/w3id.org/mpilhlt/polmat/$1 [R=307,L]
+
+# Worktime Project Vocabularies
+# Project homepage <https://www.lhlt.mpg.de/research-project/non-state-law-of-the-economy>
+# Vocabs homepage is at <https://w3id.org/mpilhlt/vocabs-worktime>
+# Latest versions of individual schemes and concepts are at <https://w3id.org/mpilhlt/worktime(_*)/*>
+# Older versions redirect to (correspondingly tagged) turtle files at <https://github.com/mpilhlt/vocabs-worktime/>
+
+# RewriteRule ^worktime/(.*)                   https://mpilhlt.github.io/vocabs-worktime/w3id.org/mpilhlt/worktime/$1 [R=307,L]
+RewriteRule ^vocabs-worktime/?$                https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/index.de.html [R=302,L]
+RewriteRule ^vocabs-worktime/index(.html?)?$   https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/index.de.html [R=302,L]
+RewriteRule ^vocabs-worktime/index.de.html?$   https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/index.de.html [R=302,L]
+RewriteRule ^vocabs-worktime/index.en.html?$   https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/index.en.html [R=302,L]
+
+RewriteRule ^worktime/latest/?$                https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime/scheme [R=307,L]
+RewriteRule ^worktime/latest/(.*)              https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime/$1 [R=307,L]
+RewriteRule ^worktime/0.0.4/(.*)               https://raw.githubusercontent.com/mpilhlt/vocabs-worktime/v0.0.4/work_time_regulation.ttl [R=307,L]
+RewriteRule ^worktime/0.0.3/(.*)               https://raw.githubusercontent.com/mpilhlt/vocabs-worktime/v0.0.3/work_time_regulation.ttl [R=307,L]
+RewriteRule ^worktime/?$                       https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime/scheme [R=307,L]
+RewriteRule ^worktime/(.*)                     https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime/$1 [R=307,L]
+
+RewriteRule ^worktime_activity/latest/?$       https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_activity/scheme [R=307,L]
+RewriteRule ^worktime_activity/latest/(.*)     https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_activity/$1 [R=307,L]
+RewriteRule ^worktime_activity/0.0.4/(.*)      https://raw.githubusercontent.com/mpilhlt/vocabs-worktime/v0.0.4/worktime_activity.ttl [R=307,L]
+RewriteRule ^worktime_activity/0.0.3/(.*)      https://raw.githubusercontent.com/mpilhlt/vocabs-worktime/v0.0.3/worktime_activity.ttl [R=307,L]
+RewriteRule ^worktime_activity/?$              https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_activity/scheme [R=307,L]
+RewriteRule ^worktime_activity/(.*)            https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_activity/$1 [R=307,L]
+
+RewriteRule ^worktime_meta/latest/?$           https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_meta/scheme [R=307,L]
+RewriteRule ^worktime_meta/latest/(.*)         https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_meta/$1 [R=307,L]
+RewriteRule ^worktime_meta/0.0.4/(.*)          https://raw.githubusercontent.com/mpilhlt/vocabs-worktime/v0.0.4/worktime_meta.ttl [R=307,L]
+RewriteRule ^worktime_meta/0.0.3/(.*)          https://raw.githubusercontent.com/mpilhlt/vocabs-worktime/v0.0.3/worktime_meta.ttl [R=307,L]
+RewriteRule ^worktime_meta/?$                  https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_meta/scheme [R=307,L]
+RewriteRule ^worktime_meta/(.*)                https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_meta/$1 [R=307,L]
+
+RewriteRule ^worktime_object/latest/?$         https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_object/scheme [R=307,L]
+RewriteRule ^worktime_object/latest/(.*)       https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_object/$1 [R=307,L]
+RewriteRule ^worktime_object/0.0.4/(.*)        https://raw.githubusercontent.com/mpilhlt/vocabs-worktime/v0.0.4/worktime_object.ttl [R=307,L]
+RewriteRule ^worktime_object/0.0.3/(.*)        https://raw.githubusercontent.com/mpilhlt/vocabs-worktime/v0.0.3/worktime_object.ttl [R=307,L]
+RewriteRule ^worktime_object/?$                https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_object/scheme [R=307,L]
+RewriteRule ^worktime_object/(.*)              https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_object/$1 [R=307,L]
+
+RewriteRule ^worktime_prescription/latest/?$   https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_prescription/scheme [R=307,L]
+RewriteRule ^worktime_prescription/latest/(.*) https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_prescription/$1 [R=307,L]
+RewriteRule ^worktime_prescription/0.0.4/(.*)  https://raw.githubusercontent.com/mpilhlt/vocabs-worktime/v0.0.4/worktime_prescription.ttl [R=307,L]
+RewriteRule ^worktime_prescription/0.0.3/(.*)  https://raw.githubusercontent.com/mpilhlt/vocabs-worktime/v0.0.3/worktime_prescription.ttl [R=307,L]
+RewriteRule ^worktime_prescription/?$          https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_prescription/scheme [R=307,L]
+RewriteRule ^worktime_prescription/(.*)        https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_prescription/$1 [R=307,L]
+
+RewriteRule ^worktime_role/latest/?$           https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_role/scheme [R=307,L]
+RewriteRule ^worktime_role/latest/(.*)         https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_role/$1 [R=307,L]
+RewriteRule ^worktime_role/0.0.4/(.*)          https://raw.githubusercontent.com/mpilhlt/vocabs-worktime/v0.0.4/worktime_role.ttl [R=307,L]
+RewriteRule ^worktime_role/0.0.3/(.*)          https://raw.githubusercontent.com/mpilhlt/vocabs-worktime/v0.0.3/worktime_role.ttl [R=307,L]
+RewriteRule ^worktime_role/?$                  https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_role/scheme [R=307,L]
+RewriteRule ^worktime_role/(.*)                https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_role/$1 [R=307,L]
+
+RewriteRule ^worktime_term/latest/?$           https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_term/scheme [R=307,L]
+RewriteRule ^worktime_term/latest/(.*)         https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_term/$1 [R=307,L]
+RewriteRule ^worktime_term/0.0.4/(.*)          https://raw.githubusercontent.com/mpilhlt/vocabs-worktime/v0.0.4/worktime_term.ttl [R=307,L]
+RewriteRule ^worktime_term/0.0.3/(.*)          https://raw.githubusercontent.com/mpilhlt/vocabs-worktime/v0.0.3/worktime_term.ttl [R=307,L]
+RewriteRule ^worktime_term/?$                  https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_term/scheme [R=307,L]
+RewriteRule ^worktime_term/(.*)                https://c111-064.cloud.gwdg.de/vocabs/mpilhlt/vocabs-worktime/heads/main/w3id.org/mpilhlt/worktime_term/$1 [R=307,L]
+
+
+# ----------------
+# Other redirections (APIs etc.)
 
 # Reconciliation API
 RewriteRule ^reconcile/(.*)             https://c111-064.cloud.gwdg.de/reconc/mpilhlt/$1 [R=307,NE,L]


### PR DESCRIPTION
The main purpose of our redirections is to host vocabularies. The repository itself now has a "homepage" that hadn't been accessible using the old redirections. And I have added versioned purls (and "latest") to redirect to (GitHub's tagged copy of) older vocabularies.

I've also added some comments for readability.