### PR TITLE
Add `vdl/aamva/v1` redirect.

### DIFF
--- a/vdl/.htaccess
+++ b/vdl/.htaccess
@@ -11,4 +11,5 @@ Options +FollowSymLinks
 RewriteEngine on
 RewriteRule ^$ https://w3c-ccg.github.io/vdl-vocab/ [R=302,L]
 RewriteRule ^v1$ https://w3c-ccg.github.io/vdl-vocab/context/v1.jsonld [R=302,L]
+RewriteRule ^aamva/v1$ https://w3c-ccg.github.io/vdl-vocab/context/aamva/v1.jsonld [R=302,L]
 RewriteRule ^interop-reports$ https://w3c-ccg.github.io/vdl-test-suite/


### PR DESCRIPTION
This corresponds to the existing context here: https://github.com/w3c-ccg/vdl-vocab/tree/main/context/aamva.

@msporny @tplooker @clehner: Can one of you please approve.  Thanks.