### PR TITLE
RiverBench: Add support for metadata dumps

### DIFF
--- a/riverbench/.htaccess
+++ b/riverbench/.htaccess
@@ -37,6 +37,9 @@ RewriteRule ^datasets/([a-z0-9-]+)(/dev)?\.(rdf|ttl|nt|jelly)([#?].*)?$ https://
 # Dataset metadata – explicit extension for tagged releases
 RewriteRule ^datasets/([a-z0-9-]+)/([a-z0-9.-]+)\.(rdf|ttl|nt|jelly)([#?].*)?$ https://github.com/RiverBench/dataset-$1/releases/download/v$2/metadata.$3 [R=302,L]
 
+# Metadata dumps – dev and tagged releases
+RewriteRule ^dumps/([a-z0-9.-]+)\.(rdf|ttl|nt|jelly)\.gz([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/$1/dump.$2.gz [R=302,L]
+
 ### SERVING HTML ###
 
 # Redirect /v/dev* to /

--- a/riverbench/README.md
+++ b/riverbench/README.md
@@ -13,6 +13,7 @@ Some test links that should always give a 200 response:
 - https://w3id.org/riverbench/v/dev.rdf
 - https://w3id.org/riverbench/v/dev.nt
 - https://w3id.org/riverbench/v/dev.ttl
+- https://w3id.org/riverbench/v/dev.jelly
 - https://w3id.org/riverbench/profiles/stream-triples
 - https://w3id.org/riverbench/profiles/stream-triples.rdf
 - https://w3id.org/riverbench/profiles/stream-triples.nt
@@ -21,6 +22,10 @@ Some test links that should always give a 200 response:
 - https://w3id.org/riverbench/profiles/stream-triples/dev.rdf
 - https://w3id.org/riverbench/profiles/stream-triples/dev.nt
 - https://w3id.org/riverbench/profiles/stream-triples/dev.ttl
+- https://w3id.org/riverbench/dumps/dev.rdf.gz
+- https://w3id.org/riverbench/dumps/dev.nt.gz
+- https://w3id.org/riverbench/dumps/dev.ttl.gz
+- https://w3id.org/riverbench/dumps/dev.jelly.gz
 
 ## Maintainers
 Piotr Sowiński \


### PR DESCRIPTION
This change adds support for downloading full metadata dumps of RiverBench. The change was tested locally with an Apache instance. Additional links for testing in CI were also added to the README.

Issue: https://github.com/RiverBench/RiverBench/issues/42