### PR TITLE
Use ;-based PIDs for RO-Crate instead of #

### DIFF
--- a/ro/doi/.htaccess
+++ b/ro/doi/.htaccess
@@ -18,10 +18,19 @@ RewriteCond %{HTTP_ACCEPT} ^.*application/ld\+json.*
 RewriteRule ^10.5281/zenodo.7782262$ https://s11.no/2023/phd/evaluating-fdo/PR-RequirementSpec-3.0/ro-crate-metadata.json [R=303,L]
 RewriteRule ^10.5281/zenodo.7782262$ https://s11.no/2023/phd/evaluating-fdo/PR-RequirementSpec-3.0/ [R=303,L]
 
+RewriteCond %{HTTP_ACCEPT} ^.*application/ld\+json.*
+RewriteRule ^10.5281/zenodo.7782262;([A-Za-z0-9-]*)$ https://s11.no/2023/phd/evaluating-fdo/PR-RequirementSpec-3.0/ [R=303,L]
+# PIDs within the RO-Crate -- but HTML has different anchors
+RewriteRule ^10.5281/zenodo.7782262;([A-Za-z0-9-]*)$ https://s11.no/2023/phd/evaluating-fdo/PR-RequirementSpec-3.0/#https%%03A//w3id.org/ro/doi/10.5281/zenodo.7782262;$1  [R=303,L,NE]
+
 #  https://w3id.org/ro/doi/10.5281/zenodo.7781926
 RewriteCond %{HTTP_ACCEPT} ^.*application/ld\+json.*
 RewriteRule ^10.5281/zenodo.7781926$ https://s11.no/2023/phd/evaluating-fdo/PR-RequirementSpec-2.1/ro-crate-metadata.json [R=303,L]
 RewriteRule ^10.5281/zenodo.7781926$ https://s11.no/2023/phd/evaluating-fdo/PR-RequirementSpec-2.1/ [R=303,L]
+# PIDs
+RewriteRule ^10.5281/zenodo.7781926;([A-Za-z0-9-]*)$ https://s11.no/2023/phd/evaluating-fdo/PR-RequirementSpec-3.0/ [R=303,L]
+# PIDs within the RO-Crate -- but HTML has different anchors
+RewriteRule ^10.5281/zenodo.7781926;([A-Za-z0-9-]*)$ https://s11.no/2023/phd/evaluating-fdo/PR-RequirementSpec-3.0/#https%%03A//w3id.org/ro/doi/10.5281/zenodo.7781926;$1  [R=303,L,NE]
 
 
 # BY-COVID - WP5 - Baseline Use Case: SARS-CoV-2 vaccine effectiveness assessment - Common Data Model Specification


### PR DESCRIPTION
The problem is that `#`-based URIs can't redirect per term, but the HTML had different anchors than in the intended PIDs as they were defined with full URIs inside the crate.

So we'll use `;` instead -- e.g. <https://w3id.org/ro/doi/10.5281/zenodo.7782262;FDO-GR1> redirects browsers to <https://s11.no/2023/phd/evaluating-fdo/PR-RequirementSpec-3.0/#https%3A//w3id.org/ro/doi/10.5281/zenodo.7782262%3BFDO-GR1>

tested locally -- some dubious `%%0` escaping there to make sure `#` passed along to browser using `[NE]` flag!