### PR TITLE
fix(catenax): specific rules did not fire because of a leading slash in the pattern

### DIFF
--- a/catenax/.htaccess
+++ b/catenax/.htaccess
@@ -16,58 +16,58 @@ RewriteEngine On
 RewriteBase /
 
 # Rewrite rule to serve versioned domain ontology links
-RewriteRule ^(.*)v23.09/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$2_ontology.ttl [R=302,L]
+RewriteRule ^v23.09/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain ontology links
-RewriteRule ^(.*)next/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology/$2_ontology.ttl [R=302,L]
+RewriteRule ^next/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve domain ontology links
-RewriteRule ^(.*)ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$2_ontology.ttl [R=302,L]
+RewriteRule ^ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain ontologies
-RewriteRule ^(.*)v23.09/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$2_ontology.ttl [R=302,L]
+RewriteRule ^v23.09/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioined domain ontologies
-RewriteRule ^(.*)next/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology/$2_ontology.ttl [R=302,L]
+RewriteRule ^next/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve domain ontologies
-RewriteRule ^(.*)ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$2_ontology.ttl [R=302,L]
+RewriteRule ^ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned complete ontology
-RewriteRule ^(.*)v23.09/ontology(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology.ttl [R=302,L]
+RewriteRule ^v23.09/ontology(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned complete ontology
-RewriteRule ^(.*)next/ontology(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology.ttl [R=302,L]
+RewriteRule ^next/ontology(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve complete ontology
-RewriteRule ^(.*)ontology(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology.ttl [R=302,L]
+RewriteRule ^ontology(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned use case ontology links
-RewriteRule ^(.*)v23.09/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$2_use_case_ontology.ttl [R=302,L]
+RewriteRule ^v23.09/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned use case ontology links
-RewriteRule ^(.*)next/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology_use_case/$2_use_case_ontology.ttl [R=302,L]
+RewriteRule ^next/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve use case ontology links
-RewriteRule ^(.*)usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$2_use_case_ontology.ttl [R=302,L]
+RewriteRule ^usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned use case ontologies
-RewriteRule ^(.*)v23.09/usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$2_use_case_ontology.ttl [R=302,L]
+RewriteRule ^v23.09/usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned use case ontologies
-RewriteRule ^(.*)next/usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology_use_case/$2_use_case_ontology.ttl [R=302,L]
+RewriteRule ^next/usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve use case ontologies
-RewriteRule ^(.*)usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$2_use_case_ontology.ttl [R=302,L]
+RewriteRule ^usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned taxonomy
-RewriteRule ^(.*)v23.09/taxonomy(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/taxonomy.ttl [R=302,L]
+RewriteRule ^v23.09/taxonomy(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve complete taxonomy
-RewriteRule ^(.*)next/taxonomy(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/taxonomy.ttl [R=302,L]
+RewriteRule ^next/taxonomy(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve complete taxonomy
-RewriteRule ^(.*)taxonomy(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/taxonomy.ttl [R=302,L]
+RewriteRule ^taxonomy(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve the TTL content from the vocabulary URI by default
 RewriteRule ^(.*)$ https://catenax-ng.github.io/product-ontology [R=303,L]

--- a/catenax/.htaccess
+++ b/catenax/.htaccess
@@ -16,58 +16,58 @@ RewriteEngine On
 RewriteBase /
 
 # Rewrite rule to serve versioned domain ontology links
-RewriteRule ^(.*)/v23.09/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$2_ontology.ttl [R=302,L]
+RewriteRule ^(.*)v23.09/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$2_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain ontology links
-RewriteRule ^(.*)/next/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology/$2_ontology.ttl [R=302,L]
+RewriteRule ^(.*)next/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology/$2_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve domain ontology links
-RewriteRule ^(.*)/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$2_ontology.ttl [R=302,L]
+RewriteRule ^(.*)ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$2_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain ontologies
-RewriteRule ^(.*)/v23.09/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$2_ontology.ttl [R=302,L]
+RewriteRule ^(.*)v23.09/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$2_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioined domain ontologies
-RewriteRule ^(.*)/next/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology/$2_ontology.ttl [R=302,L]
+RewriteRule ^(.*)next/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology/$2_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve domain ontologies
-RewriteRule ^(.*)/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$2_ontology.ttl [R=302,L]
+RewriteRule ^(.*)ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$2_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned complete ontology
-RewriteRule ^(.*)/v23.09/ontology(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology.ttl [R=302,L]
+RewriteRule ^(.*)v23.09/ontology(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned complete ontology
-RewriteRule ^(.*)/next/ontology(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology.ttl [R=302,L]
+RewriteRule ^(.*)next/ontology(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve complete ontology
-RewriteRule ^(.*)/ontology(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology.ttl [R=302,L]
+RewriteRule ^(.*)ontology(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned use case ontology links
-RewriteRule ^(.*)/v23.09/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$2_use_case_ontology.ttl [R=302,L]
+RewriteRule ^(.*)v23.09/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$2_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned use case ontology links
-RewriteRule ^(.*)/next/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology_use_case/$2_use_case_ontology.ttl [R=302,L]
+RewriteRule ^(.*)next/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology_use_case/$2_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve use case ontology links
-RewriteRule ^(.*)/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$2_use_case_ontology.ttl [R=302,L]
+RewriteRule ^(.*)usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$2_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned use case ontologies
-RewriteRule ^(.*)/v23.09/usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$2_use_case_ontology.ttl [R=302,L]
+RewriteRule ^(.*)v23.09/usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$2_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned use case ontologies
-RewriteRule ^(.*)/next/usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology_use_case/$2_use_case_ontology.ttl [R=302,L]
+RewriteRule ^(.*)next/usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology_use_case/$2_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve use case ontologies
-RewriteRule ^(.*)/usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$2_use_case_ontology.ttl [R=302,L]
+RewriteRule ^(.*)usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$2_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned taxonomy
-RewriteRule ^(.*)/v23.09/taxonomy(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/taxonomy.ttl [R=302,L]
+RewriteRule ^(.*)v23.09/taxonomy(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve complete taxonomy
-RewriteRule ^(.*)/next/taxonomy(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/taxonomy.ttl [R=302,L]
+RewriteRule ^(.*)next/taxonomy(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve complete taxonomy
-RewriteRule ^(.*)/taxonomy(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/taxonomy.ttl [R=302,L]
+RewriteRule ^(.*)taxonomy(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve the TTL content from the vocabulary URI by default
 RewriteRule ^(.*)$ https://catenax-ng.github.io/product-ontology [R=303,L]


### PR DESCRIPTION
apache removes the first slash after the virtual dir folder w3id.org, so most specific rules did not fire.

this has been resolved and tested using a local apache (see https://github.com/perma-id/w3id.org/issues/2258)

sorry for the inconvenience.