### PR TITLE
fix(catenax): cater for explicit turtle file suffixes.

### DIFF
--- a/catenax/.htaccess
+++ b/catenax/.htaccess
@@ -34,13 +34,13 @@ RewriteRule ^next/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/pr
 RewriteRule ^ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned complete ontology
-RewriteRule ^v23.09/ontology(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology.ttl [R=302,L]
+RewriteRule ^v23.09/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned complete ontology
-RewriteRule ^next/ontology(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology.ttl [R=302,L]
+RewriteRule ^next/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve complete ontology
-RewriteRule ^ontology(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology.ttl [R=302,L]
+RewriteRule ^ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned use case ontology links
 RewriteRule ^v23.09/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
@@ -49,7 +49,7 @@ RewriteRule ^v23.09/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax
 RewriteRule ^next/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve use case ontology links
-RewriteRule ^usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
+RewriteRule ^usecase/(.+)?#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned use case ontologies
 RewriteRule ^v23.09/usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
@@ -58,16 +58,16 @@ RewriteRule ^v23.09/usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/p
 RewriteRule ^next/usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve use case ontologies
-RewriteRule ^usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
+RewriteRule ^usecase/(.+)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned taxonomy
-RewriteRule ^v23.09/taxonomy(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/taxonomy.ttl [R=302,L]
+RewriteRule ^v23.09/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve complete taxonomy
-RewriteRule ^next/taxonomy(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/taxonomy.ttl [R=302,L]
+RewriteRule ^next/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve complete taxonomy
-RewriteRule ^taxonomy(/)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/taxonomy.ttl [R=302,L]
+RewriteRule ^taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve the TTL content from the vocabulary URI by default
 RewriteRule ^(.*)$ https://catenax-ng.github.io/product-ontology [R=303,L]


### PR DESCRIPTION
# What

extensions to rules which capture for explicit turtle file suffixes

# Why

there are quite some references to the previous file rules themselves.

Thx very much for your help!