### PR TITLE
Inrupt: Add .htaccess test scripts

### DIFF
--- a/inrupt/test/Dockerfile
+++ b/inrupt/test/Dockerfile
@@ -1,0 +1,16 @@
+FROM docker.io/library/httpd:2.4
+
+LABEL maintainer david.bowen@inrupt.com
+
+# Enable the rewrite module
+RUN sed -i '/LoadModule rewrite_module/s/^#//' /usr/local/apache2/conf/httpd.conf
+
+# Stop the log message about server name distracting us
+RUN echo "ServerName inrupt_httpd" >> /usr/local/apache2/conf/httpd.conf
+
+# Use debug because this service is run to diagnose problems
+RUN sed -i "/LogLevel/s/warn/debug/" /usr/local/apache2/conf/httpd.conf
+
+# This is needed to allow our local .htaccess file to override the configuration
+# Of course you wouldn't do this care-free replace on a live server's config
+RUN sed -i "/AllowOverride/s/None/All/" /usr/local/apache2/conf/httpd.conf

--- a/inrupt/test/README.md
+++ b/inrupt/test/README.md
@@ -1,0 +1,5 @@
+# Inrupt Vocabulary Developer Notes
+
+You should run (test.sh)[test.sh] before sending the PR to w3id.org so you are confident it's going to work as designed. Of course you want a `0` exit code to show it worked.
+
+You should add to test.sh if there are things you want to ensure keep happening.

--- a/inrupt/test/test.sh
+++ b/inrupt/test/test.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+pushd "$(dirname "$0")" > /dev/null
+
+echo "Assembling httpd service..."
+image_name="inrupt_httpd"
+podman build -t "${image_name}" . > /dev/null
+
+# Use a random port to avoid clashes with other services on the host running the test
+apache=$(podman run --rm --detach --publish "127.0.0.1::80" -v "$(pwd)/../":/usr/local/apache2/htdocs/inrupt/ "${image_name}")
+local_host_and_port=$(podman port "${apache}" 80)
+echo "httpd is running locally as ${local_host_and_port}"
+
+echo "Running actions to gather data..."
+readme_contents=$(curl --silent "http://${local_host_and_port}/inrupt/README.md")
+request_vocab=$(curl -H "Accept: text/turtle" --silent --verbose "http://${local_host_and_port}/inrupt/namespace/vocab/care_and_feed/" 2>&1)
+request_docs=$(curl -H "Accept: text/html" --silent --verbose "http://${local_host_and_port}/inrupt/namespace/vocab/care_and_feed/" 2>&1)
+
+logs=$(podman logs "${apache}" 2>&1)
+
+# Tidy up before possibly crashing out on bad assertions
+podman rm -fv "${apache}" > /dev/null
+
+echo "Running assertions..."
+
+# Un-comment this if you need help debugging
+# echo "${logs}"
+
+grep 'Inrupt Namespace for Public Resources' <<< "{$readme_contents}" > /dev/null
+grep "Location: https://storage.inrupt.com/ef6ef7d1-8fe0-4381-b87e-17b2bf0bb591/public/namespace/vocab/care_and_feed/care_and_feed" <<< "${request_vocab}" > /dev/null
+grep "Location: https://storage.inrupt.com/ef6ef7d1-8fe0-4381-b87e-17b2bf0bb591/public/namespace/vocab/care_and_feed/care_and_feed.html" <<< "${request_docs}" > /dev/null
+grep '"GET /inrupt/namespace/vocab/care_and_feed/ HTTP/1.1" 302'  <<< "${logs}" > /dev/null
+
+echo "Done"
+
+popd > /dev/null


### PR DESCRIPTION
Following on from my discussions with Daniel and Pat in email, these are the tests Inrupters can run to ensure our contribution to w3id.org will work as expected.