### PR TITLE
Inrupt: Add opentelemetry vocab

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,22 +131,6 @@ mailing list. Make sure to include the URL that you want on w3id.org, the
 URL that you want to redirect to, and the HTTP code that you want to use 
 when redirecting. An administrator will then create the redirect for you.
 
-#### Link checking
-A simple [Travis-CI](https://travis-ci.org/perma-id/w3id.org) job
-(see [`.travis.yml`](.travis.yml)) will extract all https://w3id.org/
-URIs from `*/README.md` and check them with
-[`linkchecker`](https://wummel.github.io/linkchecker/).
-In theory, this will catch two kinds of errors:
-
-1. Following a redirection gives a `404 Not Found`
-2. An error in `.htaccess` causes a `500 Server Error`.
-
-Note that this only checks URIs that are listed in the `README.md` files.
-
-Travis might comment on your Pull Request if this test reveals an error.
-Check its output logs to ensure the errors are not caused by
-your modification.
-
 <a id="naming"></a>
 ### Naming Policy
 

--- a/index.html
+++ b/index.html
@@ -183,26 +183,6 @@ mailing list. Make sure to include the URL that you want on w3id.org, the
 URL that you want to redirect to, and the HTTP code that you want to use
 when redirecting. An administrator will then create the redirect for you.
         </p>
-        <h4>Link checking</h4>
-        <p>
-A simple <a herf="https://travis-ci.org/perma-id/w3id.org">Travis-CI</a> job
-(see <a href="https://github.com/perma-id/w3id.org/blob/master/.travis.yml">.travis.yml</a>) will extract all https://w3id.org/
-URIs from <code>*/README.md</code> and check them with
-<code><a href="https://wummel.github.io/linkchecker/">linkchecker</a></code>.
-In theory, this will catch two kinds of errors:
-        </p>
-        <ol>
-          <li>Following a redirection gives a <code>404 Not Found</code></li>
-          <li>An error in <code>.htaccess</code> causes a <code>500 Server Error</code>.</li>
-        </ol>
-        <p>
-Note that this only checks URIs that are listed in the `README.md` files.
-        </p>
-        <p>
-Travis might comment on your Pull Request if this test reveals an error.
-Check its output logs to ensure the errors are not caused by
-your modification.        
-        </p>
         <h3 id="naming-policy">Naming Policy</h3>
         <p>
 There is no official policy on identifier names. The current practice

--- a/inrupt/.htaccess
+++ b/inrupt/.htaccess
@@ -20,6 +20,12 @@ RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
 RewriteRule namespace/vocab/care_and_feed/ https://storage.inrupt.com/ef6ef7d1-8fe0-4381-b87e-17b2bf0bb591/public/namespace/vocab/care_and_feed/care_and_feed.html [R=302,L,QSA]
 
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule namespace/vocab/opentelemetry/ https://storage.inrupt.com/ef6ef7d1-8fe0-4381-b87e-17b2bf0bb591/public/namespace/vocab/opentelemetry/opentelemetry [R=302,L,QSA]
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteRule namespace/vocab/opentelemetry/ https://storage.inrupt.com/ef6ef7d1-8fe0-4381-b87e-17b2bf0bb591/public/namespace/vocab/opentelemetry/opentelemetry.html [R=302,L,QSA]
 
 #
 # Wildcard handler for all other URLs...


### PR DESCRIPTION
This is used by our tooling so we want to make it public. It's not endorsed by https://opentelemetry.io/