### PR TITLE
Remove documentation of link checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,22 +131,6 @@ mailing list. Make sure to include the URL that you want on w3id.org, the
 URL that you want to redirect to, and the HTTP code that you want to use 
 when redirecting. An administrator will then create the redirect for you.
 
-#### Link checking
-A simple [Travis-CI](https://travis-ci.org/perma-id/w3id.org) job
-(see [`.travis.yml`](.travis.yml)) will extract all https://w3id.org/
-URIs from `*/README.md` and check them with
-[`linkchecker`](https://wummel.github.io/linkchecker/).
-In theory, this will catch two kinds of errors:
-
-1. Following a redirection gives a `404 Not Found`
-2. An error in `.htaccess` causes a `500 Server Error`.
-
-Note that this only checks URIs that are listed in the `README.md` files.
-
-Travis might comment on your Pull Request if this test reveals an error.
-Check its output logs to ensure the errors are not caused by
-your modification.
-
 <a id="naming"></a>
 ### Naming Policy
 

--- a/index.html
+++ b/index.html
@@ -183,26 +183,6 @@ mailing list. Make sure to include the URL that you want on w3id.org, the
 URL that you want to redirect to, and the HTTP code that you want to use
 when redirecting. An administrator will then create the redirect for you.
         </p>
-        <h4>Link checking</h4>
-        <p>
-A simple <a herf="https://travis-ci.org/perma-id/w3id.org">Travis-CI</a> job
-(see <a href="https://github.com/perma-id/w3id.org/blob/master/.travis.yml">.travis.yml</a>) will extract all https://w3id.org/
-URIs from <code>*/README.md</code> and check them with
-<code><a href="https://wummel.github.io/linkchecker/">linkchecker</a></code>.
-In theory, this will catch two kinds of errors:
-        </p>
-        <ol>
-          <li>Following a redirection gives a <code>404 Not Found</code></li>
-          <li>An error in <code>.htaccess</code> causes a <code>500 Server Error</code>.</li>
-        </ol>
-        <p>
-Note that this only checks URIs that are listed in the `README.md` files.
-        </p>
-        <p>
-Travis might comment on your Pull Request if this test reveals an error.
-Check its output logs to ensure the errors are not caused by
-your modification.        
-        </p>
         <h3 id="naming-policy">Naming Policy</h3>
         <p>
 There is no official policy on identifier names. The current practice


### PR DESCRIPTION
The checking [was disabled some time ago](https://github.com/perma-id/w3id.org/commit/7636d95dff670b178ef2b4ac17196af64c2f4bf1) so it's probably best to remove references to that in the documentation.