### PR TITLE
Inrupt: Add opentelemetry vocab

### DIFF
--- a/inrupt/.htaccess
+++ b/inrupt/.htaccess
@@ -20,6 +20,12 @@ RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
 RewriteRule namespace/vocab/care_and_feed/ https://storage.inrupt.com/ef6ef7d1-8fe0-4381-b87e-17b2bf0bb591/public/namespace/vocab/care_and_feed/care_and_feed.html [R=302,L,QSA]
 
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule namespace/vocab/opentelemetry/ https://storage.inrupt.com/ef6ef7d1-8fe0-4381-b87e-17b2bf0bb591/public/namespace/vocab/opentelemetry/opentelemetry [R=302,L,QSA]
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteRule namespace/vocab/opentelemetry/ https://storage.inrupt.com/ef6ef7d1-8fe0-4381-b87e-17b2bf0bb591/public/namespace/vocab/opentelemetry/opentelemetry.html [R=302,L,QSA]
 
 #
 # Wildcard handler for all other URLs...


### PR DESCRIPTION
This is used by our tooling so we want to make it public. It's not endorsed by https://opentelemetry.io/