### PR TITLE
feat: add new `sri` namespace

### DIFF
--- a/sri/.htaccess
+++ b/sri/.htaccess
@@ -1,0 +1,47 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .jsonld
+# Rewrite engine setup
+RewriteEngine On
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^([^/]+)$ https://www.stefanbischof.at/sri/OnToology/sri.ttl/documentation/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^([^/]+)$ https://www.stefanbischof.at/sri/OnToology/sri.ttl/documentation/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^([^/]+)$ https://www.stefanbischof.at/sri/OnToology/sri.ttl/documentation/ontology.rdf [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^([^/]+)$ https://www.stefanbischof.at/sri/OnToology/sri.ttl/documentation/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^([^/]+)$ https://www.stefanbischof.at/sri/OnToology/sri.ttl/documentation/ontology.ttl [R=303,L]
+
+# 406 Not Acceptable
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^([^/]+)$ https://www.stefanbischof.at/sri/OnToology/sri.ttl/documentation/406.html [R=406,L]
+
+# Default response
+# ---------------------------
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^([^/]+)$ https://www.stefanbischof.at/sri/OnToology/sri.ttl/documentation/ontology.rdf [R=303,L]

--- a/sri/README.md
+++ b/sri/README.md
@@ -1,0 +1,5 @@
+# /sri/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for semantic Smart Readiness Indicator resources.
+
+## Contact
+This space is administered by: Stefan Bischof [stefanbischof](https://github.com/stefanbischof/) ORCID: [0000-0001-9521-8907](https://orcid.org/0000-0001-9521-8907)


### PR DESCRIPTION
Please add the new namespace `sri` to the w3id repository.
It will contain semantic resources (an ontology and reference datasets) for the smart readiness indicator.

A local test of the `.htaccess` file worked.