### PR TITLE
Add RDF-STaX

### DIFF
--- a/stax/.htaccess
+++ b/stax/.htaccess
@@ -1,0 +1,126 @@
+Options -MultiViews
+
+AddType application/rdf+xml .rdf
+AddType text/turtle .ttl
+AddType application/n-triples .nt
+AddType application/ld+json .jsonld
+
+RewriteEngine on
+
+### EXPLICIT EXTENSIONS ###
+
+# Explicit extension for dev release
+RewriteRule ^(dev/)?ontology/?\.(rdf|ttl|nt|jsonld)([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/dev/stax.$2 [R=302,L]
+
+# Explicit extension for tagged releases
+RewriteRule ^([a-z0-9.-]+)/ontology/?\.(rdf|ttl|nt|jsonld)([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/v$1/stax.$2 [R=302,L]
+
+# Explicit extension for dev release – OWL 2 DL variant
+RewriteRule ^(dev/)?ontology/dl/?\.(rdf|ttl|nt|jsonld)([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/dev/dl.$2 [R=302,L]
+
+# Explicit extension for tagged releases – OWL 2 DL variant
+RewriteRule ^([a-z0-9.-]+)/ontology/dl/?\.(rdf|ttl|nt|jsonld)([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/v$1/dl.$2 [R=302,L]
+
+### SERVING HTML ###
+
+# Redirect the DL variant to documentation (dev release)
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(dev/)?ontology/dl/?([#?].*)?$ https://rdf-stax.github.io/dev/ontology$2 [R=302,L]
+
+# Redirect the DL variant to documentation (tagged releases)
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^([a-z0-9.-]+)/ontology/dl/?([#?].*)?$ https://rdf-stax.github.io/$1/ontology$2 [R=302,L]
+
+# Serve HTML if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(.*)$ https://rdf-stax.github.io/$1 [R=302,L]
+
+### ONTOLOGY WITH CONTENT NEGOTIATION ###
+
+# RDF/XML for dev release
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(dev/)?ontology/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/dev/stax.rdf [R=302,L]
+
+# RDF/XML for tagged releases
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^([a-z0-9.-]+)/ontology/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/v$1/stax.rdf [R=302,L]
+
+# N-Triples for dev release
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(dev/)?ontology/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/dev/stax.nt [R=302,L]
+
+# N-Triples for tagged releases
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^([a-z0-9.-]+)/ontology/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/v$1/stax.nt [R=302,L]
+
+# Turtle for dev release
+RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^(dev/)?ontology/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/dev/stax.ttl [R=302,L]
+
+# Turtle for tagged releases
+RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^([a-z0-9.-]+)/ontology/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/v$1/stax.ttl [R=302,L]
+
+# JSON-LD for dev release
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(dev/)?ontology/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/dev/stax.jsonld [R=302,L]
+
+# JSON-LD for tagged releases
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^([a-z0-9.-]+)/ontology/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/v$1/stax.jsonld [R=302,L]
+
+### ONTOLOGY IN OWL 2 DL VARIANT WITH CONTENT NEGOTIATION ###
+
+# RDF/XML for dev release
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(dev/)?ontology/dl/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/dev/dl.rdf [R=302,L]
+
+# RDF/XML for tagged releases
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^([a-z0-9.-]+)/ontology/dl/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/v$1/dl.rdf [R=302,L]
+
+# N-Triples for dev release
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(dev/)?ontology/dl/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/dev/dl.nt [R=302,L]
+
+# N-Triples for tagged releases
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^([a-z0-9.-]+)/ontology/dl/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/v$1/dl.nt [R=302,L]
+
+# Turtle for dev release
+RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^(dev/)?ontology/dl/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/dev/dl.ttl [R=302,L]
+
+# Turtle for tagged releases
+RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^([a-z0-9.-]+)/ontology/dl/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/v$1/dl.ttl [R=302,L]
+
+# JSON-LD for dev release
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(dev/)?ontology/dl/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/dev/dl.jsonld [R=302,L]
+
+# JSON-LD for tagged releases
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^([a-z0-9.-]+)/ontology/dl/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/v$1/dl.jsonld [R=302,L]
+
+### SERVING DOCUMENTATION ###
+
+# Default response – redirect to documentation
+RewriteRule ^(.*)$ https://rdf-stax.github.io/$1 [R=302,L]

--- a/stax/README.md
+++ b/stax/README.md
@@ -1,0 +1,35 @@
+# RDF Stream Taxonomy (RDF-STaX)
+
+[RDF-STaX](https://github.com/RDF-STaX/rdf-stax.github.io) is a taxonomy of RDF stream types. It can be used to describe RDF streams used on the Web, in software tools, or in scientific publications.
+
+## Contents
+
+The .htaccess handles serving the RDF-STaX ontology in various formats and versions. It also handles redirects to the documentation pages.
+
+The docs are hosted on GitHub Pages, and the ontology files are stored as releases on GitHub.
+
+## Test links
+
+Some test links that should always give a 200 response:
+
+- https://w3id.org/stax/ontology
+- https://w3id.org/stax/ontology/#test
+- https://w3id.org/stax/ontology.rdf
+- https://w3id.org/stax/ontology.nt
+- https://w3id.org/stax/ontology.ttl
+- https://w3id.org/stax/ontology.jsonld
+- https://w3id.org/stax/ontology/dl
+- https://w3id.org/stax/ontology/dl.rdf
+- https://w3id.org/stax/dev/ontology
+- https://w3id.org/stax/dev/ontology/dl
+- https://w3id.org/stax/dev/ontology/dl.jsonld
+- https://w3id.org/stax/dev/ontology.ttl
+- https://w3id.org/stax/0.3.0/ontology
+- https://w3id.org/stax/0.3.0/ontology/dl
+- https://w3id.org/stax/0.3.0/ontology.nt
+- https://w3id.org/stax/0.3.0/ontology/dl.jsonld#test
+
+## Maintainers
+Piotr Sowiński \
+GitHub: https://github.com/Ostrzyciel \
+ORCID: https://orcid.org/0000-0002-2543-9461

--- a/stax/README.md
+++ b/stax/README.md
@@ -1,6 +1,6 @@
 # RDF Stream Taxonomy (RDF-STaX)
 
-[RDF-STaX](https://github.com/RDF-STaX/rdf-stax.github.io) is a taxonomy of RDF stream types. It can be used to describe RDF streams used on the Web, in software tools, or in scientific publications.
+[RDF-STaX](https://github.com/RDF-STaX/rdf-stax.github.io) is a taxonomy of RDF stream types. It can be used to describe published RDF streams, datasets, software tools, or scientific publications.
 
 ## Contents
 


### PR DESCRIPTION
RDF Stream Taxonomy (RDF-STaX, prefix `stax`) is an OWL 2 DL ontology that models types of RDF streams. It is intended to be used to describe published streams, datasets, software, and scientific publications.

The ontology files are hosted as GitHub releases. The documentation is hosted on GitHub pages. The .htaccess file covers a few different cases with support for content negotiation, explicit file extensions, and different ontology versions.

I have tested this on a local Apache instance. There are also links in the README to be used as test cases by the CI.