### PR TITLE
Fix redirection for the np namespace (nanopublications)

### DIFF
--- a/np/.htaccess
+++ b/np/.htaccess
@@ -2,5 +2,5 @@ Header set Access-Control-Allow-Origin *
 Options +FollowSymLinks
 RewriteEngine on
 
-RewriteRule ^$ https://nanopub.net/ [R=302,L]
-RewriteRule ^(RA[A-Za-z0-9_\-]{43})$ https://np.petapico.org/$1 [R=302,L]
+RewriteRule ^$ https://nanopub.net/ [R=307,L]
+RewriteRule ^(RA[A-Za-z0-9_\-]{43}(\.trig)?)$ https://np.petapico.org/$1 [R=307,L]


### PR DESCRIPTION
This PR improve the redirection of the `/np/` namespace  (used for nanopublications)

* Fix redirection status from 302 to 307 for the np namespace to enable passing POST requests
* Enable redirection for URLs ending with `.trig`

@tkuhn please confirm you agree to integrate these changes since you are the owner of the namespace