### PR TITLE
RDF-STaX: add support for nanopub dumps

### DIFF
--- a/stax/.htaccess
+++ b/stax/.htaccess
@@ -4,6 +4,8 @@ AddType application/rdf+xml .rdf
 AddType text/turtle .ttl
 AddType application/n-triples .nt
 AddType application/ld+json .jsonld
+AddType application/trig .trig
+AddType application/n-quads .nq
 
 RewriteEngine on
 
@@ -21,7 +23,20 @@ RewriteRule ^(dev/)?ontology/dl/?\.(rdf|ttl|nt|jsonld)([#?].*)?$ https://github.
 # Explicit extension for tagged releases – OWL 2 DL variant
 RewriteRule ^([a-z0-9.-]+)/ontology/dl/?\.(rdf|ttl|nt|jsonld)([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/v$1/dl.$2 [R=302,L]
 
+# Explicit extension for nanopubs dev release
+RewriteRule ^(dev/)?nanopubs/?\.(trig|nq)([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/dev/nanopubs.$2 [R=302,L]
+
+# Explicit extension for nanopubs tagged releases
+RewriteRule ^([a-z0-9.-]+)/nanopubs/?\.(trig|nq)([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/v$1/nanopubs.$2 [R=302,L]
+
 ### SERVING HTML ###
+
+# Redirect the default version to docs (dev release)
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(ontology|nanopubs)/?([#?].*)?$ https://rdf-stax.github.io/dev/$1$2 [R=302,L]
 
 # Redirect the DL variant to documentation (dev release)
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
@@ -120,7 +135,29 @@ RewriteRule ^(dev/)?ontology/dl/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
 RewriteRule ^([a-z0-9.-]+)/ontology/dl/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/v$1/dl.jsonld [R=302,L]
 
+
+### NANOPUBS WITH CONTENT NEGOTIATION ###
+
+# TriG for dev release
+RewriteCond %{HTTP_ACCEPT} application/trig
+RewriteRule ^(dev/)?nanopubs/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/dev/nanopubs.trig [R=302,L]
+
+# TriG for tagged releases
+RewriteCond %{HTTP_ACCEPT} application/trig
+RewriteRule ^([a-z0-9.-]+)/nanopubs/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/v$1/nanopubs.trig [R=302,L]
+
+# N-Quads for dev release
+RewriteCond %{HTTP_ACCEPT} application/n-quads
+RewriteRule ^(dev/)?nanopubs/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/dev/nanopubs.nq [R=302,L]
+
+# N-Quads for tagged releases
+RewriteCond %{HTTP_ACCEPT} application/n-quads
+RewriteRule ^([a-z0-9.-]+)/nanopubs/?([#?].*)?$ https://github.com/RDF-STaX/rdf-stax.github.io/releases/download/v$1/nanopubs.nq [R=302,L]
+
 ### SERVING DOCUMENTATION ###
+
+# Redirect no version to dev version of the docs
+RewriteRule ^(ontology|nanopubs)/?([#?].*)?$ https://rdf-stax.github.io/dev/$1$2 [R=302,L]
 
 # Default response – redirect to documentation
 RewriteRule ^(.*)$ https://rdf-stax.github.io/$1 [R=302,L]

--- a/stax/README.md
+++ b/stax/README.md
@@ -29,6 +29,18 @@ Some test links that should always give a 200 response:
 - https://w3id.org/stax/0.3.0/ontology.nt
 - https://w3id.org/stax/0.3.0/ontology/dl.jsonld#test
 
+Nanopubs:
+
+- https://w3id.org/stax/nanopub
+- https://w3id.org/stax/nanopub.trig
+- https://w3id.org/stax/nanopub.nq
+- https://w3id.org/stax/dev/nanopub
+- https://w3id.org/stax/dev/nanopub.trig
+- https://w3id.org/stax/dev/nanopub.nq
+- https://w3id.org/stax/0.4.0/nanopub
+- https://w3id.org/stax/0.4.0/nanopub.trig
+- https://w3id.org/stax/0.4.0/nanopub.nq
+
 ## Maintainers
 Piotr Sowiński \
 GitHub: https://github.com/Ostrzyciel \


### PR DESCRIPTION
This PR adds support for downloading nanopublication dumps from the RDF-STaX website. See more details here: https://rdf-stax.github.io/dev/nanopubs/

The changes were tested with a local Apache instance. I have also added test URLs to the README.