### PR TITLE
Adds `/oseg/` - Open Source Ecology Germany e.V.

### DIFF
--- a/oseg/.htaccess
+++ b/oseg/.htaccess
@@ -1,0 +1,83 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# ## Ontologies
+
+# [Recommended IRI patterns for ontologies and their terms](
+# https://more.metadatacenter.org/recommended-iri-patterns-ontologies-and-their-terms)
+
+# ### OKH
+
+# latest
+RewriteRule \
+	^ont/osh/okh$ \
+	https://raw.githubusercontent.com/OPEN-NEXT/OKH-LOSH/master/OKH-LOSH.ttl \
+	[R=302,L]
+
+# versioned & other branches
+RewriteRule \
+	^ont/osh/([^/]+)/okh$ \
+	https://raw.githubusercontent.com/OPEN-NEXT/OKH-LOSH/$1/OKH-LOSH.ttl \
+	[R=302,L]
+
+# ### OTRL
+
+# latest
+RewriteRule \
+	^ont/osh/otrl$ \
+	https://raw.githubusercontent.com/OPEN-NEXT/OKH-LOSH/master/OTRL.ttl \
+	[R=302,L]
+
+# versioned & other branches
+RewriteRule \
+	^ont/osh/([^/]+)/otrl$ \
+	https://raw.githubusercontent.com/OPEN-NEXT/OKH-LOSH/$1/OTRL.ttl \
+	[R=302,L]
+
+# ### TsDC (core)
+
+# latest
+RewriteRule \
+	^ont/osh/tsdc/core$ \
+	https://gitlab.com/OSEGermany/oh-tsdc/-/raw/master/oh-tsdc.ttl \
+	[R=302,L]
+
+# versioned & other branches
+RewriteRule \
+	^ont/osh/([^/]+)/tsdc/core$ \
+	https://gitlab.com/OSEGermany/oh-tsdc/-/raw/$1/oh-tsdc.ttl \
+	[R=302,L]
+
+# ### TsDC requirements
+
+# latest
+RewriteRule \
+	^ont/osh/tsdc/req(uirements)?$ \
+	https://gitlab.com/OSEGermany/oh-tsdc/-/raw/master/tsdc-req.ttl \
+	[R=302,L]
+
+# versioned & other branches
+RewriteRule \
+	^ont/osh/([^/]+)/tsdc/req(uirements)?$ \
+	https://gitlab.com/OSEGermany/oh-tsdc/-/raw/$1/tsdc-req.ttl \
+	[R=302,L]
+
+# ### OSH Ontology
+
+# latest
+RewriteRule \
+	^ont/osh/oshont$ \
+	https://codeberg.org/oseg/osh-ont/raw/branch/master/src/ontology/osh.ttl \
+	[R=302,L]
+
+# other branches
+RewriteRule \
+	^ont/osh/([^/]+)/oshont$ \
+	https://codeberg.org/oseg/osh-ont/raw/branch/$1/src/ontology/osh.ttl \
+	[R=302,L]
+
+# versioned
+RewriteRule \
+	^ont/osh/([0-9][^/]*)/oshont$ \
+	https://codeberg.org/oseg/osh-ont/raw/tag/$1/src/ontology/osh.ttl \
+	[R=302,L]

--- a/oseg/README.md
+++ b/oseg/README.md
@@ -1,0 +1,37 @@
+# /oseg/
+
+This [W3ID](https://w3id.org) provides a persistent URI namespace
+for [Open Source Ecology Germany (OSEG)][OSEG-eV] resources.
+
+## Uses
+
+This namespace is broken down into different parts for [OSEG][OSEG-eV]s:
+
+- (RDF) ontologies
+- standards (TODO)
+- services (TODO)
+- maybe more in the future (TODO)
+
+## Contact
+
+This space is administered by:
+
+### OSEG
+
+A German non-profit association.
+
+[Open Source Ecology Germany e.V.][OSEG-eV] \
+<info@ose-germany.de> \
+Knobelsdorffstr. 22 \
+14059 Berlin, Germany
+
+In particular:
+
+#### Robin Vobruba
+
+*Software and Standards Architect/Dev* \
+<hoijui.quaero@gmail.com> \
+[hoijui@GitHub](https://github.com/hoijui)
+
+[OSEG-eV]: https://www.ose-germany.de
+[OSEG-community]: https://www.opensourceecology.de


### PR DESCRIPTION
For now, only RDF ontologies:

- OKH
- OTRL
- TsDC
- TsDC requirements
- OSH Ontology