### PR TITLE
Add `/ksa/` - Kingdom of Saudi Arabia ontologies by the OGC

### DIFF
--- a/ksa/.htaccess
+++ b/ksa/.htaccess
@@ -1,0 +1,17 @@
+RewriteEngine on
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType text/n3 .n3
+AddType application/n-triples .nt
+AddType application/ld+json .jsonld
+
+# Homepage
+RewriteRule ^$ https://defs-dev.opengis.net/vocprez-ksa/ [R=302,L]
+
+## Feature Type Catalog
+RewriteRule ^feature-types(/.*|)?$ https://defs-dev.opengis.net/vocprez-ksa/object?uri=https://w3id.org/ksa/feature-types$1 [R=303,L]
+

--- a/ksa/README.md
+++ b/ksa/README.md
@@ -1,0 +1,10 @@
+# /ksa
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the Feature Type Catalog of the Kingdom of Saudi Arabia, developed
+by the [Open Geospatial Consortium (OGC)](https://www.ogc.org).
+
+## Contact
+This space is administered by:  
+
+**Alejandro Villar** 
+<avillar@ogc.org>
+


### PR DESCRIPTION
Add `/ksa/` as the base path for ontology and vocabulary identifiers for the Kingdom of Saudi Arabia, developed by the Open Geospatial Consortium.

For now, only a Feature Type Catalog is available.
