### PR TITLE
Redirect /ksa/feature-types to homepage

### DIFF
--- a/ksa/.htaccess
+++ b/ksa/.htaccess
@@ -11,7 +11,8 @@ AddType application/ld+json .jsonld
 
 # Homepage
 RewriteRule ^$ https://defs-dev.opengis.net/vocprez-ksa/ [R=302,L]
+RewriteRule ^feature-types/?$ https://defs-dev.opengis.net/vocprez-ksa/ [R=302,L]
 
 ## Feature Type Catalog
-RewriteRule ^feature-types(/.*|)?$ https://defs-dev.opengis.net/vocprez-ksa/object?uri=https://w3id.org/ksa/feature-types$1 [R=303,L]
+RewriteRule ^feature-types/(.+)$ https://defs-dev.opengis.net/vocprez-ksa/object?uri=https://w3id.org/ksa/feature-types/$1 [R=303,L]
 


### PR DESCRIPTION
`^/feature-types/?$` path in remote no longer exists, so we need to remap it.