### PR TITLE
fix: fix file extension for RDF/XML

### DIFF
--- a/sri/.htaccess
+++ b/sri/.htaccess
@@ -28,7 +28,7 @@ RewriteRule ^([^/]+)$ https://www.stefanbischof.at/sri/OnToology/sri.$1.ttl/docu
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^([^/]+)$ https://www.stefanbischof.at/sri/OnToology/sri.$1.ttl/documentation/ontology.rdf [R=303,L]
+RewriteRule ^([^/]+)$ https://www.stefanbischof.at/sri/OnToology/sri.$1.ttl/documentation/ontology.owl [R=303,L]
 
 # Rewrite rule to serve N-Triples content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
@@ -47,4 +47,4 @@ RewriteRule ^([^/]+)$ https://www.stefanbischof.at/sri/OnToology/sri.$1.ttl/docu
 # Default response
 # ---------------------------
 # Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
-RewriteRule ^([^/]+)$ https://www.stefanbischof.at/sri/OnToology/sri.$1.ttl/documentation/ontology.rdf [R=303,L]
+RewriteRule ^([^/]+)$ https://www.stefanbischof.at/sri/OnToology/sri.$1.ttl/documentation/ontology.owl [R=303,L]


### PR DESCRIPTION
widoco/ontoology changed the file extension for the RDF/XML output from .rdf to .owl. This commit fixes the corresponding redirection rules. 