### PR TITLE
renamed ISA 88 to PackML

### DIFF
--- a/hsu-aut/PackML/.htaccess
+++ b/hsu-aut/PackML/.htaccess
@@ -4,18 +4,18 @@ RewriteEngine on
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
-RewriteRule ^(\d\.\d\.\d)/?$ https://raw.githubusercontent.com/hsu-aut/IndustrialStandard-ODP-ISA88/v$1/ISA88.owl [R=303,NC,L]
+RewriteRule ^(\d\.\d\.\d)/?$ https://raw.githubusercontent.com/hsu-aut/IndustrialStandard-ODP-PackML/v$1/PackML.owl [R=303,NC,L]
 
 # Redirect ontology IRI (without version) to the current main branch version
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
-RewriteRule ^/?$ https://raw.githubusercontent.com/hsu-aut/IndustrialStandard-ODP-ISA88/master/ISA88.owl [R=303,NC,L]
+RewriteRule ^/?$ https://raw.githubusercontent.com/hsu-aut/IndustrialStandard-ODP-PackML/master/PackML.owl [R=303,NC,L]
 
 # Redirect HTML requests to the main repository page
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(\d\.\d\.\d)?/?$ https://github.com/hsu-aut/IndustrialStandard-ODP-ISA88 [R=302,NC,L]
+RewriteRule ^(\d\.\d\.\d)?/?$ https://github.com/hsu-aut/IndustrialStandard-ODP-PackML [R=302,NC,L]
 


### PR DESCRIPTION
Simple renaming from ISA88 to PackML as the use of ISA88 was incorrect. The underlying resource is an ontology covering only the state machine according to PackML, but not the whole ISA88 information model.