### PR TITLE
Create entry for eventnotifications

### DIFF
--- a/eventnotifications/.htaccess
+++ b/eventnotifications/.htaccess
@@ -1,0 +1,5 @@
+Options +FollowSymLinks
+
+RewriteEngine on
+RewriteRule ^$ https://www.eventnotifications.net/ [R=302,L]
+RewriteRule ^labs(/.*)?$ https://labs.eventnotifications.net$1 [R=302,L]

--- a/eventnotifications/README.md
+++ b/eventnotifications/README.md
@@ -1,0 +1,26 @@
+# Event Notifications in Value-Adding Networks
+
+This [W3ID](https://w3id.org) provides a persistent URI namespace Event Notifications ontologies, and and artifacts from our labs.
+
+[Event Notifications in Value-Adding Networks](https://www.eventnotifications.net) is a profile for using [Linked Data Notifications](https://linkedresearch.org/ldn/) with [ActivityStreams2](https://www.w3.org/TR/activitystreams-core/) payloads in value-adding networks.
+
+The specification provides an interoperable fabric that can be used in scholarly communication to exchange messages among data nodes that make scholarly artifacts available to the network and service nodes that add value to these artifacts. 
+
+Other domain usage cover updating of search indexes, (web) archival systems, institutional repositories, and object registries.
+
+## Homepage
+
+https://www.eventnotifications.net
+
+## Laboratory
+
+https://labs.eventnotifications.net
+
+## Contacts
+
+* Patrick Hochtenbach, @phochste, patrick.hochstenbach@ugent.be
+* Miel Vander Sande, miel.vandersande@meemoo.be
+* Ruben Dedecker, ruben.dedecker@ugent.be
+* Paul Walk, paul@paulwalk.net
+* Martin Klein, mklein@lanl.gov
+* Herbert Van de Sompel, herbert.vandesompel@ugent.be


### PR DESCRIPTION
This pull request contains a redirect for the `eventnotifications` W3ID.

Event Notfications in Value-Adding networks is a specifications used in scholarly communication , musuem and archiving communities for a push based exchange notifications using a profile of Linked Data Notifications with ActivityStreams2 payloads.