### PR TITLE
chore: introduce new Catena-X release and move current pointer.

### DIFF
--- a/catenax/.htaccess
+++ b/catenax/.htaccess
@@ -16,13 +16,19 @@ RewriteEngine On
 RewriteBase /
 
 # Rewrite rule to serve versioned domain ontology links
+RewriteRule ^v23.12/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology/$1_ontology.ttl [R=302,L]
+
+# Rewrite rule to serve versioned domain ontology links
 RewriteRule ^v23.09/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain ontology links
 RewriteRule ^next/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve domain ontology links
-RewriteRule ^ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$1_ontology.ttl [R=302,L]
+RewriteRule ^ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology/$1_ontology.ttl [R=302,L]
+
+# Rewrite rule to serve versioned domain ontologies
+RewriteRule ^v23.12/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain ontologies
 RewriteRule ^v23.09/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$1_ontology.ttl [R=302,L]
@@ -31,7 +37,10 @@ RewriteRule ^v23.09/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/
 RewriteRule ^next/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve domain ontologies
-RewriteRule ^ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$1_ontology.ttl [R=302,L]
+RewriteRule ^ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology/$1_ontology.ttl [R=302,L]
+
+# Rewrite rule to serve versioned complete ontology
+RewriteRule ^v23.12/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned complete ontology
 RewriteRule ^v23.09/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology.ttl [R=302,L]
@@ -40,7 +49,10 @@ RewriteRule ^v23.09/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catena
 RewriteRule ^next/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve complete ontology
-RewriteRule ^ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology.ttl [R=302,L]
+RewriteRule ^ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology.ttl [R=302,L]
+
+# Rewrite rule to serve versioned use case ontology links
+RewriteRule ^v23.12/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned use case ontology links
 RewriteRule ^v23.09/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
@@ -49,7 +61,10 @@ RewriteRule ^v23.09/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax
 RewriteRule ^next/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve use case ontology links
-RewriteRule ^usecase/(.+)?#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
+RewriteRule ^usecase/(.+)?#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
+
+# Rewrite rule to serve versioned use case ontologies
+RewriteRule ^v23.12/usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned use case ontologies
 RewriteRule ^v23.09/usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
@@ -58,7 +73,10 @@ RewriteRule ^v23.09/usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/p
 RewriteRule ^next/usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve use case ontologies
-RewriteRule ^usecase/(.+)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
+RewriteRule ^usecase/(.+)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
+
+# Rewrite rule to serve versioned taxonomy
+RewriteRule ^v23.12/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve versioned taxonomy
 RewriteRule ^v23.09/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/taxonomy.ttl [R=302,L]
@@ -67,7 +85,7 @@ RewriteRule ^v23.09/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catena
 RewriteRule ^next/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve complete taxonomy
-RewriteRule ^taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/taxonomy.ttl [R=302,L]
+RewriteRule ^taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve the TTL content from the vocabulary URI by default
 RewriteRule ^(.*)$ https://catenax-ng.github.io/product-ontology [R=303,L]

--- a/catenax/README.md
+++ b/catenax/README.md
@@ -4,18 +4,21 @@ Documentation is available at: https://catena-x.net/, https://catenax-ng.github.
 
 The complete ontology is available as:
 
-TTL: https://github.com/catenax-ng/product-ontology/blob/v23.09/ontology.ttl (current)
+TTL: https://github.com/catenax-ng/product-ontology/blob/v23.12/ontology.ttl (current)
 TTL: https://github.com/catenax-ng/product-ontology/blob/main/ontology.ttl (next)
+TTL: https://github.com/catenax-ng/product-ontology/blob/v23.09/ontology.ttl (previous)
 
 The complete taxonomy is available as:
 
-TTL: https://github.com/catenax-ng/product-ontology/blob/v23.09/taxonomy.ttl (current)
+TTL: https://github.com/catenax-ng/product-ontology/blob/v23.12/taxonomy.ttl (current)
 TTL: https://github.com/catenax-ng/product-ontology/blob/main/taxonomy.ttl (next)
+TTL: https://github.com/catenax-ng/product-ontology/blob/v23.09/taxonomy.ttl (previous)
 
 Individual domain ontologies can be found under:
 
-https://github.com/catenax-ng/product-ontology/tree/v23.09/ontology (current)
+https://github.com/catenax-ng/product-ontology/tree/v23.12/ontology (current)
 https://github.com/catenax-ng/product-ontology/tree/main/ontology (next)
+https://github.com/catenax-ng/product-ontology/tree/v23.09/ontology (previous)
 
 Contact: 
 


### PR DESCRIPTION
Catena-X just published its new release https://eclipse-tractusx.github.io/blog/new-release-2312

these are the adaptions of the namespace to introduce the version and to move the "current" redirections.