### PR TITLE
nfdi4cat/voc4cat - Add redirects for xml/rdf

### DIFF
--- a/nfdi4cat/voc4cat/.htaccess
+++ b/nfdi4cat/voc4cat/.htaccess
@@ -24,7 +24,13 @@ RewriteRule "^v?([0-9]{4}\-[0-9]{2}\-[0-9]{2})\/voc4cat_([0-9]{7,})" "https://nf
 # TURTLE - single large file of version-tagged releases
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
-RewriteRule  "^v?([0-9]{4}\-[0-9]{2}\-[0-9]{2})" https://nfdi4cat.github.io/voc4cat/v$1/voc4cat.ttl [R=303,L,NE,NC]
+RewriteRule "^v?([0-9]{4}\-[0-9]{2}\-[0-9]{2})" https://nfdi4cat.github.io/voc4cat/v$1/voc4cat.ttl [R=303,L,NE,NC]
+
+# XML/RDF - single large file of version-tagged releases
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/xml
+RewriteRule "^v?([0-9]{4}\-[0-9]{2}\-[0-9]{2})" https://nfdi4cat.github.io/voc4cat/v$1/voc4cat.xml [R=303,L,NE,NC]
 
 # HTML - documentation
 RewriteCond %{HTTP_ACCEPT} text/html
@@ -46,6 +52,12 @@ RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
 RewriteRule  "^dev$" https://nfdi4cat.github.io/voc4cat/dev/voc4cat.ttl [R=303,L,NE,NC]
 
+# XML/RDF - single large file
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/xml
+RewriteRule  "^dev$" https://nfdi4cat.github.io/voc4cat/dev/voc4cat.xml [R=303,L,NE,NC]
+
 # HTML - documentation
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule "^dev$" https://nfdi4cat.github.io/voc4cat/dev/voc4cat/index.html [R=303,L,NE]
@@ -59,6 +71,12 @@ RewriteRule "^dev$" https://nfdi4cat.github.io/voc4cat/dev/voc4cat/index.html [R
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
 RewriteRule "^$" https://nfdi4cat.github.io/voc4cat/latest/voc4cat.ttl [R=303,L,NE]
+
+# XML/RDF - single large file
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/xml
+RewriteRule "^$" https://nfdi4cat.github.io/voc4cat/latest/voc4cat.xml [R=303,L,NE]
 
 # HTML - documentation
 RewriteCond %{HTTP_ACCEPT} text/html

--- a/nfdi4cat/voc4cat/README.md
+++ b/nfdi4cat/voc4cat/README.md
@@ -9,7 +9,7 @@ A SKOS vocabulary for catalysis maintained by NFDI4Cat & friends.
 
 Documentation / vocabulary as one large turtle file
 
--  https://w3id.org/nfdi4cat/voc4cat <BR>-(turtle)-> https://nfdi4cat.github.io/voc4cat/latest/voc4cat.ttl <BR>-(html)-> https://nfdi4cat.github.io/voc4cat/latest/voc4cat/index.html
+-  https://w3id.org/nfdi4cat/voc4cat <BR>-(turtle)-> https://nfdi4cat.github.io/voc4cat/latest/voc4cat.ttl <BR>-(xml/rdf)-> https://nfdi4cat.github.io/voc4cat/latest/voc4cat.xml <BR>-(html)-> https://nfdi4cat.github.io/voc4cat/latest/voc4cat/index.html
 
 Individual turtle files for concepts or collections
 
@@ -19,7 +19,7 @@ Individual turtle files for concepts or collections
 
 Documentation / vocabulary as one large turtle file
 
-- https://w3id.org/nfdi4cat/voc4cat/2023-08-17 <BR>-(turtle)-> https://nfdi4cat.github.io/voc4cat/v2023-08-17/voc4cat.ttl<BR>-(html)-> https://nfdi4cat.github.io/voc4cat/v2023-08-17/voc4cat/index.html
+- https://w3id.org/nfdi4cat/voc4cat/2023-08-17 <BR>-(turtle)-> https://nfdi4cat.github.io/voc4cat/v2023-08-17/voc4cat.ttl <BR>-(xml/rdf)-> https://nfdi4cat.github.io/voc4cat/v2023-08-17/voc4cat.xml <BR>-(html)-> https://nfdi4cat.github.io/voc4cat/v2023-08-17/voc4cat/index.html
 
 Individual turtle files for concepts or collections
 - https://w3id.org/nfdi4cat/voc4cat/2023-08-17/voc4cat_0000002 <BR>-(turtle)-> https://nfdi4cat.github.io/voc4cat/v2023-08-17/voc4cat/0000002.ttl
@@ -31,7 +31,7 @@ Individual turtle files for concepts or collections
 
 Documentation / vocabulary as one large turtle file
 
-- https://w3id.org/nfdi4cat/voc4cat/dev <BR>-(turtle)-> https://nfdi4cat.github.io/voc4cat/dev/voc4cat.ttl<BR>-(html)-> https://nfdi4cat.github.io/voc4cat/dev/voc4cat/index.html
+- https://w3id.org/nfdi4cat/voc4cat/dev <BR>-(turtle)-> https://nfdi4cat.github.io/voc4cat/dev/voc4cat.ttl  <BR>-(xml/rdf)-> https://nfdi4cat.github.io/voc4cat/dev/voc4cat.xml <BR>-(html)-> https://nfdi4cat.github.io/voc4cat/dev/voc4cat/index.html
 
 Individual turtle files for concepts or collections
 - https://w3id.org/nfdi4cat/voc4cat/dev/voc4cat_0000002 <BR>-(turtle)-> https://nfdi4cat.github.io/voc4cat/dev/voc4cat/0000002.ttl<BR>-(html)-> https://nfdi4cat.github.io/voc4cat/dev/voc4cat/index.html#https://w3id.org/nfdi4cat/voc4cat_0000002


### PR DESCRIPTION
Add redirects for content types for xml/rdf in addition to existing ones for turtle.

Closes: https://github.com/nfdi4cat/voc4cat/issues/26