### PR TITLE
Added redirect for the /cro (construction resource ontology) 

### DIFF
--- a/cro/.htaccess
+++ b/cro/.htaccess
@@ -1,0 +1,28 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+
+# If accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://ip.pages.rwth-aachen.de/ioc/iocressource/ontology.ttl
+
+# If accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://ip.pages.rwth-aachen.de/ioc/iocressource/ontology.xml
+
+# If suffix ttl, redirect to turtle 
+RewriteRule ^.ttl$ https://ip.pages.rwth-aachen.de/ioc/iocressource/ontology.ttl
+
+# If suffix html, redirect to html 
+RewriteRule ^.html$ https://ip.pages.rwth-aachen.de/ioc/iocressource/
+
+# If suffix rdf, redirect to rdf 
+RewriteRule ^.rdf$ https://ip.pages.rwth-aachen.de/ioc/iocressource/ontology.xml
+
+# Default response: html
+RewriteRule ^$ https://ip.pages.rwth-aachen.de/ioc/iocressource/

--- a/cro/README.md
+++ b/cro/README.md
@@ -1,0 +1,16 @@
+# /cro/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the Internet of Construction (IoC) - Construction Ressource Ontology (CRO) .
+
+## Uses
+Interconnecting Data in Construction Processes - focusing on construction resources and machinery.
+See http://www.internet-of-construction.com/index_en.html
+
+## Contact
+This space is administered by:  
+
+**Lukas Kirner**  
+  *Researcher*  
+Individualized Production, RWTH Aachen, Germany.  
+https://github.com/kirner-ip
+<kirner@ip.rwth-aachen.de>  
+ORCID: [0000-0001-9753-2422](https://orcid.org/0000-0001-9753-2422) 


### PR DESCRIPTION
The CRO was developed within the ioc project .htacces works in same fashion than for the main ioc ontology which is also redirected here.

I wish whoever manages this a Merry Christmas and a Happy New Year :)

**Lukas Kirner**
  *Researcher*  
Individualized Production, RWTH Aachen, Germany.  
https://github.com/kirner-ip
<kirner@ip.rwth-aachen.de>  
ORCID: [0000-0001-9753-2422](https://orcid.org/0000-0001-9753-2422) 