### PR TITLE
Minor typos and default rule if not found 406 for iaam/i40fd

### DIFF
--- a/iaam/i40fd/.htaccess
+++ b/iaam/i40fd/.htaccess
@@ -16,11 +16,11 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://iaam_embedded.pages.fh-aachen.de/semantics/i40fd-ontology/latest/index-en.html[R=303,L]
+RewriteRule ^$ https://iaam_embedded.pages.fh-aachen.de/semantics/i40fd-ontology/latest/index-en.html [R=303,L]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^$ https://iaam_embedded.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.json [R=303,L]
+RewriteRule ^$ https://iaam_embedded.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.jsonld [R=303,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
@@ -47,7 +47,7 @@ RewriteRule ^(.+)$ https://iaam_embedded.pages.fh-aachen.de/semantics/i40fd-onto
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^(.+)$ https://iaam_embedded.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iontology.json [R=303,L]
+RewriteRule ^(.+)$ https://iaam_embedded.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iontology.jsonld [R=303,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
@@ -65,7 +65,8 @@ RewriteCond %{HTTP_ACCEPT} \*/turtle
 RewriteRule ^(.+)$ https://iaam_embedded.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iontology.ttl [R=303,L]
 
 
-
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^(.*)$ https://iaam_embedded.pages.fh-aachen.de/semantics/i40fd-ontology/latest/406.html [R=406,L]
 # Default response
 # ---------------------------
 # Rewrite rule to serve the RDF/XML content from the vocabulary URI by default


### PR DESCRIPTION
Fixed access for text/html due to a typo and acess to json version of the ontology.
In addition added a 406 response in case the format is not acceptable.