### PR TITLE
New redirection domain for iaam/i40fd

### DIFF
--- a/iaam/i40fd/.htaccess
+++ b/iaam/i40fd/.htaccess
@@ -16,26 +16,26 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://iaam_embedded.pages.fh-aachen.de/semantics/i40fd-ontology/latest/index-en.html [R=303,L]
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/index-en.html [R=303,L]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^$ https://iaam_embedded.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.jsonld [R=303,L]
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.jsonld [R=303,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^$ https://iaam_embedded.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.owl [R=303,L]
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.owl [R=303,L]
 
 # Rewrite rule to serve N-Triples content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^$ https://iaam_embedded.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.nt [R=303,L]
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.nt [R=303,L]
 
 # Rewrite rule to serve TTL content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle
-RewriteRule ^$ https://iaam_embedded.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.ttl [R=303,L]
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.ttl [R=303,L]
 
 
 # Rewrite rules for any other version.
@@ -43,31 +43,31 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(.+)$ https://iaam_embedded.pages.fh-aachen.de/semantics/i40fd-ontology/$1/index-en.html [R=303,L]
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/index-en.html [R=303,L]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^(.+)$ https://iaam_embedded.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iontology.jsonld [R=303,L]
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iontology.jsonld [R=303,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^(.+)$ https://iaam_embedded.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iontology.owl [R=303,L]
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iontology.owl [R=303,L]
 
 # Rewrite rule to serve N-Triples content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^(.+)$ https://iaam_embedded.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iontology.nt [R=303,L]
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iontology.nt [R=303,L]
 
 # Rewrite rule to serve TTL content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle
-RewriteRule ^(.+)$ https://iaam_embedded.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iontology.ttl [R=303,L]
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iontology.ttl [R=303,L]
 
 
 RewriteCond %{HTTP_ACCEPT} .+
-RewriteRule ^(.*)$ https://iaam_embedded.pages.fh-aachen.de/semantics/i40fd-ontology/latest/406.html [R=406,L]
+RewriteRule ^(.*)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/406.html [R=406,L]
 # Default response
 # ---------------------------
 # Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
-RewriteRule ^$ https://iaam_embedded.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.owl [R=303,L]
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.owl [R=303,L]


### PR DESCRIPTION
When importing the ontology from iaam/i40fd in Protege 5.6.3 the error invalid domain appears due to
underscores. See https://stackoverflow.com/a/48444910 Removed underscore from domain to make domain
compatible with Protege.