### PR TITLE
Added secondary ontology to iaam/i40fd

### DIFF
--- a/iaam/i40fd/.htaccess
+++ b/iaam/i40fd/.htaccess
@@ -16,26 +16,26 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/index-en.html [R=303,L]
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/iolink/index-en.html [R=303,L]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.jsonld [R=303,L]
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/iolink/ontology.jsonld [R=303,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.owl [R=303,L]
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/iolink/ontology.owl [R=303,L]
 
 # Rewrite rule to serve N-Triples content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.nt [R=303,L]
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/iolink/ontology.nt [R=303,L]
 
 # Rewrite rule to serve TTL content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle
-RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.ttl [R=303,L]
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/iolink/ontology.ttl [R=303,L]
 
 
 # Rewrite rules for any other version.
@@ -43,31 +43,31 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/index-en.html [R=303,L]
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iolink/index-en.html [R=303,L]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iontology.jsonld [R=303,L]
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iolink/ontology.jsonld [R=303,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iontology.owl [R=303,L]
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iolink/ontology.owl [R=303,L]
 
 # Rewrite rule to serve N-Triples content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iontology.nt [R=303,L]
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iolink/ontology.nt [R=303,L]
 
 # Rewrite rule to serve TTL content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle
-RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iontology.ttl [R=303,L]
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iolink/ontology.ttl [R=303,L]
 
 
 RewriteCond %{HTTP_ACCEPT} .+
-RewriteRule ^(.*)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/406.html [R=406,L]
+RewriteRule ^(.*)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/iolink/406.html [R=406,L]
 # Default response
 # ---------------------------
 # Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
-RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.owl [R=303,L]
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/iolink/ontology.owl [R=303,L]

--- a/iaam/i40fd/protocol/iolink/.htaccess
+++ b/iaam/i40fd/protocol/iolink/.htaccess
@@ -16,26 +16,26 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/index-en.html [R=303,L]
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/iolink/index-en.html [R=303,L]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.jsonld [R=303,L]
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/iolink/ontology.jsonld [R=303,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.owl [R=303,L]
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/iolink/ontology.owl [R=303,L]
 
 # Rewrite rule to serve N-Triples content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.nt [R=303,L]
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/iolink/ontology.nt [R=303,L]
 
 # Rewrite rule to serve TTL content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle
-RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.ttl [R=303,L]
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/iolink/ontology.ttl [R=303,L]
 
 
 # Rewrite rules for any other version.
@@ -43,31 +43,31 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/index-en.html [R=303,L]
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iolink/index-en.html [R=303,L]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/ontology.jsonld [R=303,L]
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iolink/ontology.jsonld [R=303,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/ontology.owl [R=303,L]
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iolink/ontology.owl [R=303,L]
 
 # Rewrite rule to serve N-Triples content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/ontology.nt [R=303,L]
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iolink/ontology.nt [R=303,L]
 
 # Rewrite rule to serve TTL content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle
-RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/ontology.ttl [R=303,L]
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/iolink/ontology.ttl [R=303,L]
 
 
 RewriteCond %{HTTP_ACCEPT} .+
-RewriteRule ^(.*)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/406.html [R=406,L]
+RewriteRule ^(.*)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/iolink/406.html [R=406,L]
 # Default response
 # ---------------------------
 # Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
-RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/ontology.owl [R=303,L]
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/iolink/ontology.owl [R=303,L]

--- a/iaam/i40fd/protocol/iolink/README.md
+++ b/iaam/i40fd/protocol/iolink/README.md
@@ -1,0 +1,10 @@
+# Industry 4.0 Field Device IO-Link Ontology
+
+This ontology provides IO-Link concepts for integration with the [Industry 4.0 Field device](https://w3id.org/iaam/i40fd/) ontology.
+
+This is a research project of the [Institute for Applied Automation and Mechatronics](https://www.iaam.fh-aachen.de) (IaaM).
+
+## Contact 
+| Maintainer | Institute    | Email| ORCID| Github-ID |
+|----------- |--------------|------|------|------------|
+Victor Chavez |  University of Applied Sciences FH Aachen| chavez-bermudez@fh-aachen.de|   https://orcid.org/0000-0001-6419-1641 | [vChavezB](https://github.com/vChavezB)


### PR DESCRIPTION
Expanded iaam/i40fd to include protocol/iolink which describes the IO-Link protocol
in the context of the i40fd ontology.