### PR TITLE
remove escape sequences, fixes to rules

### DIFF
--- a/isample/biology/biosampledfeature/.htaccess
+++ b/isample/biology/biosampledfeature/.htaccess
@@ -4,7 +4,7 @@ RewriteEngine on
 # set environmental variable for the current version
 SetEnvIf Request_URI "^.*" currentversion=1.0
 
-#https://vocabs.ardc.edu.au/repository/api/lda/isamples/biology-extension-basic-taxon-classes-for-biologic/1-0/resource?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fbiology%2Fbiosampledfeature%2F1.0%2Fbiologicentityvocabulary
+#https://vocabs.ardc.edu.au/repository/api/lda/isamples/biology-extension-basic-taxon-classes-for-biologic/1-0/resource?uri=https://w3id.org/isample/biology/biosampledfeature/1.0/biologicentityvocabulary
 
 # ../isample/biology/biosampledfeature get vocabulary ttl format with text/turtle accept header
 RewriteCond %{HTTP:Accept} text/turtle [NC]
@@ -17,11 +17,6 @@ RewriteRule       ^/?$   https://vocabs.ardc.edu.au/repository/api/lda/isamples/
 # just ../isample/biology/biosampledfeature  gets the html view of the current version of the vocab, from ARDC RVA
 RewriteRule       ^/?$   https://vocabs.ardc.edu.au/repository/api/lda/isamples/biology-extension-basic-taxon-classes-for-biologic/1-0/resource?uri=https://w3id.org/isample/biology/biosampledfeature/%{ENV:currentversion}/biologicentityvocabulary [R=303,L]
 
-#  Have to check if this is necessary. Currently only valid version is 1.0 
-#need condition to check if there is a version number
-# will need to update with new versions
-#RewriteCond ^\d+.\d+\/ "=0.9/"
-#RewriteRule       ^(^\d+.\d+\/.+)$    #https://vocabs.ardc.edu.au/repository/api/lda/isamples/biology-extension-basic-taxon-classes-for-biologic/1-0/resource?uri=https://w3id.org/isample/biology/biosampledfeature/$1/biologicentityvocabulary [R=303,L]
 
 # no version number gets ARDC vocabulary landing page
 RewriteRule       ^(.+)$   https://vocabs.ardc.edu.au/viewById/672  [R=303,L]

--- a/isample/biology/biosampledfeature/1.0/.htaccess
+++ b/isample/biology/biosampledfeature/1.0/.htaccess
@@ -2,25 +2,25 @@ Options +FollowSymLinks
 RewriteEngine on 
 
 #example:
-#https://vocabs.ardc.edu.au/repository/api/lda/isamples/biology-extension-basic-taxon-classes-for-biologic/1-0/resource?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fbiology%2Fbiosampledfeature%2F1.0%2Flichen
+#https://vocabs.ardc.edu.au/repository/api/lda/isamples/biology-extension-basic-taxon-classes-for-biologic/1-0/resource?uri=https://w3id.org/isample/biology/biosampledfeature/1.0/lichen
 
 
 #  uri to access individual term
 
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^(.+)$     https://vocabs.ardc.edu.au/repository/api/lda/isamples/biology-extension-basic-taxon-classes-for-biologic/1-0/resource?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fbiology%2Fbiosampledfeature%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$     https://vocabs.ardc.edu.au/repository/api/lda/isamples/biology-extension-basic-taxon-classes-for-biologic/1-0/resource?uri=https://w3id.org/isample/biology/biosampledfeature/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} application/json [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/biology-extension-basic-taxon-classes-for-biologic/1-0/resource.json?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fbiology%2Fbiosampledfeature%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/biology-extension-basic-taxon-classes-for-biologic/1-0/resource.json?uri=https://w3id.org/isample/biology/biosampledfeature/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} application/rdf+xml [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/biology-extension-basic-taxon-classes-for-biologic/1-0/resource.rdf?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fbiology%2Fbiosampledfeature%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/biology-extension-basic-taxon-classes-for-biologic/1-0/resource.rdf?uri=https://w3id.org/isample/biology/biosampledfeature/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} text/html [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/biology-extension-basic-taxon-classes-for-biologic/1-0/resource.html?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fbiology%2Fbiosampledfeature%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/biology-extension-basic-taxon-classes-for-biologic/1-0/resource.html?uri=https://w3id.org/isample/biology/biosampledfeature/1.0/$1 [R=303,L]
 
 # default format is html
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/biology-extension-basic-taxon-classes-for-biologic/1-0/resource?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fbiology%2Fbiosampledfeature%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/biology-extension-basic-taxon-classes-for-biologic/1-0/resource?uri=https://w3id.org/isample/biology/biosampledfeature/1.0/$1 [R=303,L]
 
 
 

--- a/isample/earthenv/esmaterialsample/1.0/.htaccess
+++ b/isample/earthenv/esmaterialsample/1.0/.htaccess
@@ -4,19 +4,19 @@ RewriteEngine on
 #  uri to access individual term
 
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^(.+)$     https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-material/1-0/resource.ttl?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fearthenv%2Fesmaterialsample%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$     https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-material/1-0/resource.ttl?uri=https://w3id.org/isample/earthenv/esmaterialsample/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} application/json [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-material/1-0/resource.json?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fearthenv%2Fesmaterialsample%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-material/1-0/resource.json?uri=https://w3id.org/isample/earthenv/esmaterialsample/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} application/rdf+xml [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-material/1-0/resource.rdf?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fearthenv%2Fesmaterialsample%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-material/1-0/resource.rdf?uri=https://w3id.org/isample/earthenv/esmaterialsample/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} text/html [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-material/1-0/resource.html?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fearthenv%2Fesmaterialsample%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-material/1-0/resource.html?uri=https://w3id.org/isample/earthenv/esmaterialsample/1.0/$1 [R=303,L]
 
 # default format is html
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-material/1-0/resource?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fearthenv%2Fesmaterialsample%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-material/1-0/resource?uri=https://w3id.org/isample/earthenv/esmaterialsample/1.0/$1 [R=303,L]
 
 
 

--- a/isample/earthenv/esmaterialsample/1.0/README.md
+++ b/isample/earthenv/esmaterialsample/1.0/README.md
@@ -8,7 +8,7 @@
 catches https://w3id.org/isample/vocabulary/specimentype/1.0/{term}
 
 Redirects to ARDC Research Vocabularies Australia (RVA)
-https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-type-vocabulary/2023-11-06/resource?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fvocabulary%2Fspecimentype%2F1.0%2F{term}
+https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-type-vocabulary/2023-11-06/resource?uri=https://w3id.org/isample/vocabulary/specimentype/1.0/{term}
 
 not3 that the RVA URLs include a revision date; if the vocabulary is updated without generating a new version in the term URI, the redirects will need to be modified.
 

--- a/isample/earthenv/essampledfeatrole/1.0/.htaccess
+++ b/isample/earthenv/essampledfeatrole/1.0/.htaccess
@@ -4,17 +4,17 @@ RewriteEngine on
 #  uri to access individual term
 
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^(.+)$     https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-sampled/1-0/resource?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fearthenv%2Fessampledfeatrole%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$     https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-sampled/1-0/resource?uri=https://w3id.org/isample/earthenv/essampledfeatrole/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} application/json [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-sampled/1-0/resource.json?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fearthenv%2Fessampledfeatrole%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-sampled/1-0/resource.json?uri=https://w3id.org/isample/earthenv/essampledfeatrole/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} application/rdf+xml [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-sampled/1-0/resource.rdf?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fearthenv%2Fessampledfeatrole%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-sampled/1-0/resource.rdf?uri=https://w3id.org/isample/earthenv/essampledfeatrole/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} text/html [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-sampled/1-0/resource.html?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fearthenv%2Fessampledfeatrole%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-sampled/1-0/resource.html?uri=https://w3id.org/isample/earthenv/essampledfeatrole/1.0/$1 [R=303,L]
 
 # default format is html
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-sampled/1-0/resource?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fearthenv%2Fessampledfeatrole%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-sampled/1-0/resource?uri=https://w3id.org/isample/earthenv/essampledfeatrole/1.0/$1 [R=303,L]
 

--- a/isample/earthenv/mingroup/1.0/.htaccess
+++ b/isample/earthenv/mingroup/1.0/.htaccess
@@ -1,24 +1,24 @@
 Options +FollowSymLinks
 RewriteEngine on 
 
-#https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-mineral-group-vocabulary/1-0/resource?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fearthenv%2Fmingroup%2F1.0%2Fcarbonatenitratemineral
+#https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-mineral-group-vocabulary/1-0/resource?uri=https://w3id.org/isample/earthenv/mingroup/1.0/carbonatenitratemineral
 
 #  uri to access individual term
 
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^(.+)$     https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-mineral-group-vocabulary/1-0/resource?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fearthenv%2Fmingroup%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$     https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-mineral-group-vocabulary/1-0/resource?uri=https://w3id.org/isample/earthenv/mingroup/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} application/json [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-mineral-group-vocabulary/1-0/resource.json?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fearthenv%2Fmingroup%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-mineral-group-vocabulary/1-0/resource.json?uri=https://w3id.org/isample/earthenv/mingroup/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} application/rdf+xml [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-mineral-group-vocabulary/1-0/resource.rdf?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fearthenv%2Fmingroup%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-mineral-group-vocabulary/1-0/resource.rdf?uri=https://w3id.org/isample/earthenv/mingroup/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} text/html [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-mineral-group-vocabulary/1-0/resource.html?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fearthenv%2Fmingroup%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-mineral-group-vocabulary/1-0/resource.html?uri=https://w3id.org/isample/earthenv/mingroup/1.0/$1 [R=303,L]
 
 # default format is html
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-mineral-group-vocabulary/1-0/resource?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fearthenv%2Fmingroup%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-mineral-group-vocabulary/1-0/resource?uri=https://w3id.org/isample/earthenv/mingroup/1.0/$1 [R=303,L]
 
 
 

--- a/isample/earthenv/rocksediment/1.0/.htaccess
+++ b/isample/earthenv/rocksediment/1.0/.htaccess
@@ -4,17 +4,17 @@ RewriteEngine on
 #  uri to access individual term
 
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^(.+)$     https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-rock-and/1-0/resource?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fearthenv%2Frocksediment%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$     https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-rock-and/1-0/resource?uri=https://w3id.org/isample/earthenv/rocksediment/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} application/json [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-rock-and/1-0/resource.json?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fearthenv%2Frocksediment%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-rock-and/1-0/resource.json?uri=https://w3id.org/isample/earthenv/rocksediment/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} application/rdf+xml [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-rock-and/1-0/resource.rdf?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fearthenv%2Frocksediment%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-rock-and/1-0/resource.rdf?uri=https://w3id.org/isample/earthenv/rocksediment/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} text/html [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-rock-and/1-0/resource.html?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fearthenv%2Frocksediment%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-rock-and/1-0/resource.html?uri=https://w3id.org/isample/earthenv/rocksediment/1.0/$1 [R=303,L]
 
 # default format is html
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-rock-and/1-0/resource?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fearthenv%2Frocksediment%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/earth-and-environmental-science-extension-rock-and/1-0/resource?uri=https://w3id.org/isample/earthenv/rocksediment/1.0/$1 [R=303,L]
 

--- a/isample/opencontext/material/0.1/.htaccess
+++ b/isample/opencontext/material/0.1/.htaccess
@@ -9,30 +9,30 @@ SetEnvIf Request_URI "^.*" currentversion=0.1
 
 # ...isample/opencontext/material/0.1/oc_materialsvocab  gets turtle serialization of oc_materialsvocab ConceptScheme
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^/oc_materialsvocab$    http://cor.esipfed.org/ont/api/v0/ont?format=ttl&iri=https://w3id.org/isample/opencontext/material/%{ENV:currentversion}/oc_materialsvocab [R=303,L]
+RewriteRule       ^oc_materialsvocab$    http://cor.esipfed.org/ont/api/v0/ont?format=ttl&iri=https://w3id.org/isample/opencontext/material/%{ENV:currentversion}/oc_materialsvocab [R=303,L]
 
 
 # ../isample/opencontext/material/0.1/{term},  gets turtle serialization of skos concept 
 #   format with text/turtle accept header
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^/(.+)$   http://cor.esipfed.org/ont/api/v0/ont?format=ttl&iri=https://w3id.org/isample/opencontext/material/%{ENV:currentversion}/$1 [R=303,L]
+RewriteRule       ^(.+)$   http://cor.esipfed.org/ont/api/v0/ont?format=ttl&iri=https://w3id.org/isample/opencontext/material/%{ENV:currentversion}/$1 [R=303,L]
 
 # ...isample/opencontext/material/0.1/oc_materialsvocab  gets rdf xml serialization of oc_materialsvocab ConceptScheme 
 RewriteCond %{HTTP:Accept} appplication/rdf+xml [NC]
-RewriteRule       ^/oc_materialsvocab$    http://cor.esipfed.org/ont/api/v0/ont?format=rdf&iri=https://w3id.org/isample/opencontext/material/%{ENV:currentversion}/oc_materialsvocab [R=303,L]
+RewriteRule       ^oc_materialsvocab$    http://cor.esipfed.org/ont/api/v0/ont?format=rdf&iri=https://w3id.org/isample/opencontext/material/%{ENV:currentversion}/oc_materialsvocab [R=303,L]
 
 
 # ../isample/opencontext/material/0.1/{term},  gets RDF xml serialization of skos concept 
 RewriteCond %{HTTP:Accept} appplication/rdf+xml [NC]
-RewriteRule       ^/(.+)$   http://cor.esipfed.org/ont/api/v0/ont?format=rdf&iri=https://w3id.org/isample/opencontext/material/%{ENV:currentversion}/$1 [R=303,L]
+RewriteRule       ^(.+)$   http://cor.esipfed.org/ont/api/v0/ont?format=rdf&iri=https://w3id.org/isample/opencontext/material/%{ENV:currentversion}/$1 [R=303,L]
 
 
 #any other accept header. ../isample/opencontext/material/0.1/{term}, returns CORS landing page for concept
 # will need to update with new versions
-RewriteRule       ^/(.+)$    http://cor.esipfed.org/ont/api/v0/ont?iri=https://w3id.org/isample/opencontext/material/%{ENV:currentversion}/$1 [R=303,L]
+RewriteRule       ^(.+)$    http://cor.esipfed.org/ont/api/v0/ont?iri=https://w3id.org/isample/opencontext/material/%{ENV:currentversion}/$1 [R=303,L]
 
 # any other accept header with no terminal string
 #   gets landing page for the version of the vocab, from ESIP COR.  
 #   Pylode doesn't currently seem to be working (2023-12-30).
-RewriteRule       ^/?$  http://cor.esipfed.org/ont?iri=https://w3id.org/isample/opencontext/specimentype/%{ENV:currentversion}/oc_spectypevocab [R=303,L]
+RewriteRule       ^/?$  http://cor.esipfed.org/ont?iri=https://w3id.org/isample/opencontext/material/%{ENV:currentversion}/oc_materialsvocab [R=303,L]
 

--- a/isample/opencontext/specimentype/0.1/.htaccess
+++ b/isample/opencontext/specimentype/0.1/.htaccess
@@ -9,31 +9,31 @@ SetEnvIf Request_URI "^.*" currentversion=0.1
 
 # ...isample/opencontext/specimenttype/0.1/oc_spectypevocab  gets turtle serialization of oc_spectypevocab ConceptScheme
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^/oc_spectypevocab$    http://cor.esipfed.org/ont/api/v0/ont?format=ttl&iri=https://w3id.org/isample/opencontext/specimenttype/%{ENV:currentversion}/oc_spectypevocab [R=303,L]
+RewriteRule       ^oc_spectypevocab$    http://cor.esipfed.org/ont/api/v0/ont?format=ttl&iri=https://w3id.org/isample/opencontext/specimenttype/%{ENV:currentversion}/oc_spectypevocab [R=303,L]
 
 
 # ../isample/opencontext/specimenttype/0.1/{term},  gets turtle serialization of skos concept 
 #   format with text/turtle accept header
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^/(.+)$   http://cor.esipfed.org/ont/api/v0/ont?format=ttl&iri=https://w3id.org/isample/opencontext/specimenttype/%{ENV:currentversion}/$1 [R=303,L]
+RewriteRule       ^(.+)$   http://cor.esipfed.org/ont/api/v0/ont?format=ttl&iri=https://w3id.org/isample/opencontext/specimenttype/%{ENV:currentversion}/$1 [R=303,L]
 
 # ...isample/opencontext/specimenttype/0.1/oc_spectypevocab  gets rdf xml serialization of oc_spectypevocab ConceptScheme 
 RewriteCond %{HTTP:Accept} appplication/rdf+xml [NC]
-RewriteRule       ^/oc_spectypevocab$    http://cor.esipfed.org/ont/api/v0/ont?format=rdf&iri=https://w3id.org/isample/opencontext/specimenttype/%{ENV:currentversion}/oc_spectypevocab [R=303,L]
+RewriteRule       ^oc_spectypevocab$    http://cor.esipfed.org/ont/api/v0/ont?format=rdf&iri=https://w3id.org/isample/opencontext/specimenttype/%{ENV:currentversion}/oc_spectypevocab [R=303,L]
 
 
 # ../isample/opencontext/specimenttype/0.1/{term},  gets RDF xml serialization of skos concept 
 RewriteCond %{HTTP:Accept} appplication/rdf+xml [NC]
-RewriteRule       ^/(.+)$   http://cor.esipfed.org/ont/api/v0/ont?format=rdf&iri=https://w3id.org/isample/opencontext/specimenttype/%{ENV:currentversion}/$1 [R=303,L]
+RewriteRule       ^(.+)$   http://cor.esipfed.org/ont/api/v0/ont?format=rdf&iri=https://w3id.org/isample/opencontext/specimenttype/%{ENV:currentversion}/$1 [R=303,L]
 
 
 #any other accept header. ../isample/opencontext/specimenttype/0.1/{term}, returns CORS landing page for concept
 # will need to update with new versions
-RewriteRule       ^/(.+)$    http://cor.esipfed.org/ont/api/v0/ont?iri=https://w3id.org/isample/opencontext/specimenttype/%{ENV:currentversion}/$1 [R=303,L]
+RewriteRule       ^(.+)$    http://cor.esipfed.org/ont/api/v0/ont?iri=https://w3id.org/isample/opencontext/specimenttype/%{ENV:currentversion}/$1 [R=303,L]
 
 # any other accept header with no terminal string
 #   gets landing page for the version of the vocab, from ESIP COR.  
 #   Pylode doesn't currently seem to be working (2023-12-30).
-RewriteRule       ^/?$   http://cor.esipfed.org/ont/api/v0/ont?iri=https://w3id.org/isample/opencontext/specimenttype/%{ENV:currentversion}/oc_spectypevocab [R=303,L]
+RewriteRule       ^$   http://cor.esipfed.org/ont/api/v0/ont?iri=https://w3id.org/isample/opencontext/specimenttype/%{ENV:currentversion}/oc_spectypevocab [R=303,L]
 
 

--- a/isample/opencontext/specimentype/0.1/README.md
+++ b/isample/opencontext/specimentype/0.1/README.md
@@ -8,7 +8,7 @@
 catches https://w3id.org/isample/vocabulary/specimentype/1.0/{term}
 
 Redirects to ARDC Research Vocabularies Australia (RVA)
-https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-type-vocabulary/2023-11-06/resource?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fvocabulary%2Fspecimentype%2F1.0%2F{term}
+https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-type-vocabulary/2023-11-06/resource?uri=https://w3id.org/isample/vocabulary/specimentype/1.0/{term}
 
 not that the RVA URLs include a revision date; if the vocabulary is updated without generating a new version in the term URI, the redirects will need to be modified.
 

--- a/isample/vocabulary/material/.htaccess
+++ b/isample/vocabulary/material/.htaccess
@@ -2,21 +2,17 @@ Options +FollowSymLinks
 RewriteEngine on 
 
 # set environmental variable for the current version
-SetEnvIf Request_URI "^.*" currentversion=1.0
+SetEnvIf Request_URI "^.*" currentversion=1-0
 # 
 
 # ../isample/vocabulary/material get vocabulary ttl format with text/turtle accept header
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^/?$   http://cor.esipfed.org/ont/api/v0/ont?format=ttl&iri=https://w3id.org/isample/vocabulary/material/%{ENV:currentversion}/materialsvocabulary [R=303,L]
+RewriteRule       ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/3190/isamples_isamples-materials-vocabulary_%{ENV:currentversion}.ttl [R=303,L]
 
-# just ../isample/vocabulary/material  gets the pylode view of the current version of the vocab, from ESIP COR
-RewriteRule       ^/?$   http://cor.esipfed.org/pylode?url=http://cor.esipfed.org/ont/api/v0/ont?iri=https://w3id.org/isample/vocabulary/material/%{ENV:currentversion}/materialsvocabulary [R=303,L]
+RewriteCond %{HTTP:Accept} application/rdf+xml [NC]
+RewriteRule       ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/3190/isamples_isamples-materials-vocabulary_%{ENV:currentversion}.rdf [R=303,L]
 
-#need condition to check if there is a version number
-# will need to update with new versions
-RewriteCond ^\d+.\d+\/ "=0.9/"
-RewriteRule       ^(^\d+.\d+\/.+)$    http://cor.esipfed.org/ont/api/v0/ont?iri=https://w3id.org/isample/vocabulary/material/$1 [R=303,L]
+RewriteCond %{HTTP:Accept} application/ld+json [NC]
+RewriteRule       ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/3190/isamples_isamples-materials-vocabulary_%{ENV:currentversion}.jsonld [R=303,L]
 
-# no version number gets currentversion
-RewriteRule       ^(.+)$    http://cor.esipfed.org/ont/api/v0/ont?iri=https://w3id.org/isample/vocabulary/material/%{ENV:currentversion}/$1 [R=303,L]
-
+RewriteRule       ^/?$     https://vocabs.ardc.edu.au/viewById/664 [R=303,L]

--- a/isample/vocabulary/material/0.9/.htaccess
+++ b/isample/vocabulary/material/0.9/.htaccess
@@ -9,30 +9,30 @@ SetEnvIf Request_URI "^.*" currentversion=0.9
 
 # ...isample/vocabulary/material/0.9/materialsvocabulary  gets turtle serialization of materialsvocabulary ConceptScheme
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^/?materialsvocabulary$    http://cor.esipfed.org/ont/api/v0/ont?format=ttl&iri=https://w3id.org/isample/vocabulary/material/%{ENV:currentversion}/materialsvocabulary [R=303,L]
+RewriteRule       ^materialsvocabulary$    http://cor.esipfed.org/ont/api/v0/ont?format=ttl&iri=https://w3id.org/isample/vocabulary/material/%{ENV:currentversion}/materialsvocabulary [R=303,L]
 
 
 # ../isample/vocabulary/material/0.9/{term},  gets turtle serialization of skos concept 
 #   format with text/turtle accept header
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^/?(.+)$   http://cor.esipfed.org/ont/api/v0/ont?format=ttl&iri=https://w3id.org/isample/vocabulary/material/%{ENV:currentversion}/$1 [R=303,L]
+RewriteRule       ^(.+)$   http://cor.esipfed.org/ont/api/v0/ont?format=ttl&iri=https://w3id.org/isample/vocabulary/material/%{ENV:currentversion}/$1 [R=303,L]
 
 # ...isample/vocabulary/material/0.9/materialsvocabulary  gets rdf xml serialization of materialsvocabulary ConceptScheme 
 RewriteCond %{HTTP:Accept} appplication/rdf+xml [NC]
-RewriteRule       ^/?materialsvocabulary$    http://cor.esipfed.org/ont/api/v0/ont?format=rdf&iri=https://w3id.org/isample/vocabulary/material/%{ENV:currentversion}/materialsvocabulary [R=303,L]
+RewriteRule       ^materialsvocabulary$    http://cor.esipfed.org/ont/api/v0/ont?format=rdf&iri=https://w3id.org/isample/vocabulary/material/%{ENV:currentversion}/materialsvocabulary [R=303,L]
 
 
 # ../isample/vocabulary/material/0.9/{term},  gets RDF xml serialization of skos concept 
 RewriteCond %{HTTP:Accept} appplication/rdf+xml [NC]
-RewriteRule       ^/?(.+)$   http://cor.esipfed.org/ont/api/v0/ont?format=rdf&iri=https://w3id.org/isample/vocabulary/material/%{ENV:currentversion}/$1 [R=303,L]
+RewriteRule       ^(.+)$   http://cor.esipfed.org/ont/api/v0/ont?format=rdf&iri=https://w3id.org/isample/vocabulary/material/%{ENV:currentversion}/$1 [R=303,L]
 
 
 #any other accept header. ../isample/vocabulary/material/0.9/{term}, returns CORS landing page for concept
 # will need to update with new versions
-RewriteRule       ^/?(.+)$    http://cor.esipfed.org/ont/api/v0/ont?iri=https://w3id.org/isample/vocabulary/material/%{ENV:currentversion}/$1 [R=303,L]
+RewriteRule       ^(.+)$    http://cor.esipfed.org/ont/api/v0/ont?iri=https://w3id.org/isample/vocabulary/material/%{ENV:currentversion}/$1 [R=303,L]
 
 # any other accept header with no terminal string
 #   gets landing page for the version of the vocab, from ESIP COR.  
 #   Pylode doesn't currently seem to be working (2023-12-30).
-RewriteRule       ^/?$  http://cor.esipfed.org/ont?iri=https://w3id.org/isample/vocabulary/material/%{ENV:currentversion}/materialsvocabulary [R=303,L]
+RewriteRule       ^$  http://cor.esipfed.org/ont?iri=https://w3id.org/isample/vocabulary/material/%{ENV:currentversion}/materialsvocabulary [R=303,L]
 

--- a/isample/vocabulary/material/1.0/.htaccess
+++ b/isample/vocabulary/material/1.0/.htaccess
@@ -4,17 +4,17 @@ RewriteEngine on
 #  uri to access individual term
 
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^(.+)$     https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-materials-vocabulary/1-0/resource.ttl?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fvocabulary%2Fmaterial%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$     https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-materials-vocabulary/1-0/resource.ttl?uri=https://w3id.org/isample/vocabulary/material/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} application/json [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-materials-vocabulary/1-0/resource.json?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fvocabulary%2Fmaterial%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-materials-vocabulary/1-0/resource.json?uri=https://w3id.org/isample/vocabulary/material/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} application/rdf+xml [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-materials-vocabulary/1-0/resource.rdf?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fvocabulary%2Fmaterial%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-materials-vocabulary/1-0/resource.rdf?uri=https://w3id.org/isample/vocabulary/material/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} text/html [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-materials-vocabulary/1-0/resource.html?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fvocabulary%2Fmaterial%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-materials-vocabulary/1-0/resource.html?uri=https://w3id.org/isample/vocabulary/material/1.0/$1 [R=303,L]
 
 # default format is html
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-materials-vocabulary/1-0/resource?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fvocabulary%2Fmaterial%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-materials-vocabulary/1-0/resource?uri=https://w3id.org/isample/vocabulary/material/1.0/$1 [R=303,L]
 

--- a/isample/vocabulary/sampledfeature/.htaccess
+++ b/isample/vocabulary/sampledfeature/.htaccess
@@ -1,22 +1,25 @@
 Options +FollowSymLinks
 RewriteEngine on 
 
+Options +FollowSymLinks
+RewriteEngine on
+
 # set environmental variable for the current version
-SetEnvIf Request_URI "^.*" currentversion=0.9
+SetEnvIf Request_URI "^.*" currentversion=1-0
 # 
 
 # ../isample/vocabulary/sampledfeature get vocabulary ttl format with text/turtle accept header
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^/?$   http://cor.esipfed.org/ont/api/v0/ont?format=ttl&iri=https://w3id.org/isample/vocabulary/sampledfeature/%{ENV:currentversion}/sampledfeaturevocabulary [R=303,L]
+RewriteRule       ^/?$   https://vocabs.ardc.edu.au/registry/api/resource/downloads/3199/isamples_isamples-sampled-feature-type-vocabulary_%{ENV:currentversion}.ttl [R=303,L]
 
-# just ../isample/vocabulary/sampledfeature  gets the pylode view of the current version of the vocab, from ESIP COR
-RewriteRule       ^/?$   http://cor.esipfed.org/pylode?url=http://cor.esipfed.org/ont/api/v0/ont?iri=https://w3id.org/isample/vocabulary/sampledfeature/%{ENV:currentversion}/sampledfeaturevocabulary [R=303,L]
+RewriteCond %{HTTP:Accept} application/rdf+xml [NC]
+RewriteRule       ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/3199/isamples_isamples-sampled-feature-type-vocabulary_%{ENV:currentversion}.rdf [R=303,L]
 
-#need condition to check if there is a version number
-# will need to update with new versions
-RewriteCond ^\d+.\d+\/ "=0.9/"
-RewriteRule       ^(^\d+.\d+\/.+)$    http://cor.esipfed.org/ont/api/v0/ont?iri=https://w3id.org/isample/vocabulary/sampledfeature/$1 [R=303,L]
+RewriteCond %{HTTP:Accept} application/ld+json [NC]
+RewriteRule       ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/3199/isamples_isamples-sampled-feature-type-vocabulary_%{ENV:currentversion}.jsonld [R=303,L]
 
-# no version number gets currentversion
-RewriteRule       ^(.+)$    http://cor.esipfed.org/ont/api/v0/ont?iri=https://w3id.org/isample/vocabulary/sampledfeature/%{ENV:currentversion}/$1 [R=303,L]
+RewriteRule       ^/?$     https://vocabs.ardc.edu.au/viewById/665 [R=303,L]
+
+
+
 

--- a/isample/vocabulary/sampledfeature/1.0/.htaccess
+++ b/isample/vocabulary/sampledfeature/1.0/.htaccess
@@ -2,22 +2,22 @@ Options +FollowSymLinks
 RewriteEngine on 
 
 #  uri to access individual term
-# https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-sampled-feature-type-vocabulary/1-0/resource?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fvocabulary%2Fsampledfeature%2F1.0%2Fatmosphere
+# https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-sampled-feature-type-vocabulary/1-0/resource?uri=https://w3id.org/isample/vocabulary/sampledfeature/1.0/atmosphere
 
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^(.+)$     https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-sampled-feature-type-vocabulary/1-0/resource.ttl?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fvocabulary%2Fsampledfeature%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$     https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-sampled-feature-type-vocabulary/1-0/resource.ttl?uri=https://w3id.org/isample/vocabulary/sampledfeature/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} application/json [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-sampled-feature-type-vocabulary/1-0/resource.json?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fvocabulary%2Fsampledfeature%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-sampled-feature-type-vocabulary/1-0/resource.json?uri=https://w3id.org/isample/vocabulary/sampledfeature/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} application/rdf+xml [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-sampled-feature-type-vocabulary/1-0/resource.rdf?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fvocabulary%2Fsampledfeature%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-sampled-feature-type-vocabulary/1-0/resource.rdf?uri=https://w3id.org/isample/vocabulary/sampledfeature/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} text/html [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-sampled-feature-type-vocabulary/1-0/resource.html?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fvocabulary%2Fsampledfeature%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-sampled-feature-type-vocabulary/1-0/resource.html?uri=https://w3id.org/isample/vocabulary/sampledfeature/1.0/$1 [R=303,L]
 
 # default format is html
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-sampled-feature-type-vocabulary/1-0/resource?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fvocabulary%2Fsampledfeature%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-sampled-feature-type-vocabulary/1-0/resource?uri=https://w3id.org/isample/vocabulary/sampledfeature/1.0/$1 [R=303,L]
 
 # no term, just the vocab
 RewriteRule       ^$

--- a/isample/vocabulary/specimentype/.htaccess
+++ b/isample/vocabulary/specimentype/.htaccess
@@ -2,24 +2,18 @@ Options +FollowSymLinks
 RewriteEngine on 
 
 # set environmental variable for the current version
-SetEnvIf Request_URI "^.*" currentversion=1.0
+SetEnvIf Request_URI "^.*" currentversion=1-0
 # 
 
 # ../isample/vocabulary/specimentype get vocabulary ttl format with text/turtle accept header
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^/?$   http://cor.esipfed.org/ont/api/v0/ont?format=ttl&iri=https://w3id.org/isample/vocabulary/specimentype/%{ENV:currentversion}/specimentypevocabulary [R=303,L]
+RewriteRule       ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/3196/isamples_isamples-material-sample-type-vocabulary_%{ENV:currentversion}.ttl [R=303,L]
 
-# just ../isample/vocabulary/specimentype  gets the pylode view of the current version of the vocab, from ESIP COR
-RewriteRule       ^/?$   http://cor.esipfed.org/pylode?url=http://cor.esipfed.org/ont/api/v0/ont?iri=https://w3id.org/isample/vocabulary/specimentype/%{ENV:currentversion}/specimentypevocabulary [R=303,L]
+RewriteCond %{HTTP:Accept} application/rdf+xml [NC]
+RewriteRule       ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/3196/isamples_isamples-material-sample-type-vocabulary_%{ENV:currentversion}.rdf [R=303,L]
 
-#need condition to check if there is a version number
-# will need to update with new versions
-RewriteCond ^\d+.\d+\/ "=0.9/"
-RewriteRule       ^(^\d+.\d+\/.+)$    http://cor.esipfed.org/ont/api/v0/ont?iri=https://w3id.org/isample/vocabulary/specimentype/$1 [R=303,L]
+RewriteCond %{HTTP:Accept} application/ld+json [NC]
+RewriteRule       ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/3190/3196/isamples_isamples-material-sample-type-vocabulary_%{ENV:currentversion}.jsonld [R=303,L]
 
-RewriteCond ^\d+.\d+\/ "=1.0/"
-RewriteRule       ^(^\d+.\d+\/.+)$    http://cor.esipfed.org/ont/api/v0/ont?iri=https://w3id.org/isample/vocabulary/specimentype/$1 [R=303,L]
-
-# no version number gets currentversion
-RewriteRule       ^(.+)$    http://cor.esipfed.org/ont/api/v0/ont?iri=https://w3id.org/isample/vocabulary/specimentype/%{ENV:currentversion}/$1 [R=303,L]
+RewriteRule       ^/?$     https://vocabs.ardc.edu.au/viewById/663 [R=303,L]
 

--- a/isample/vocabulary/specimentype/0.9/.htaccess
+++ b/isample/vocabulary/specimentype/0.9/.htaccess
@@ -12,30 +12,30 @@ SetEnvIf Request_URI "^.*" currentversion=0.9
 
 # ...isample/vocabulary/specimentype/0.9/specimentypevocabulary  gets turtle serialization of specimentypevocabulary ConceptScheme
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^/?specimentypevocabulary$    http://cor.esipfed.org/ont/api/v0/ont?format=ttl&iri=https://w3id.org/isample/vocabulary/specimentype/%{ENV:currentversion}/specimentypevocabulary [R=303,L]
+RewriteRule       ^specimentypevocabulary$    http://cor.esipfed.org/ont/api/v0/ont?format=ttl&iri=https://w3id.org/isample/vocabulary/specimentype/%{ENV:currentversion}/specimentypevocabulary [R=303,L]
 
 
 # ../isample/vocabulary/specimentype/0.9/{term},  gets turtle serialization of skos concept 
 #   format with text/turtle accept header
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^/?(.+)$   http://cor.esipfed.org/ont/api/v0/ont?format=ttl&iri=https://w3id.org/isample/vocabulary/specimentype/%{ENV:currentversion}/$1 [R=303,L]
+RewriteRule       ^(.+)$   http://cor.esipfed.org/ont/api/v0/ont?format=ttl&iri=https://w3id.org/isample/vocabulary/specimentype/%{ENV:currentversion}/$1 [R=303,L]
 
 # ...isample/vocabulary/specimentype/0.9/specimentypevocabulary  gets rdf xml serialization of specimentypevocabulary ConceptScheme 
 RewriteCond %{HTTP:Accept} appplication/rdf+xml [NC]
-RewriteRule       ^/?specimentypevocabulary$    http://cor.esipfed.org/ont/api/v0/ont?format=rdf&iri=https://w3id.org/isample/vocabulary/specimentype/%{ENV:currentversion}/specimentypevocabulary [R=303,L]
+RewriteRule       ^specimentypevocabulary$    http://cor.esipfed.org/ont/api/v0/ont?format=rdf&iri=https://w3id.org/isample/vocabulary/specimentype/%{ENV:currentversion}/specimentypevocabulary [R=303,L]
 
 
 # ../isample/vocabulary/specimentype/0.9/{term},  gets RDF xml serialization of skos concept 
 RewriteCond %{HTTP:Accept} appplication/rdf+xml [NC]
-RewriteRule       ^/?(.+)$   http://cor.esipfed.org/ont/api/v0/ont?format=rdf&iri=https://w3id.org/isample/vocabulary/specimentype/%{ENV:currentversion}/$1 [R=303,L]
+RewriteRule       ^(.+)$   http://cor.esipfed.org/ont/api/v0/ont?format=rdf&iri=https://w3id.org/isample/vocabulary/specimentype/%{ENV:currentversion}/$1 [R=303,L]
 
 
 #any other accept header. ../isample/vocabulary/specimentype/0.9/{term}, returns CORS landing page for concept
 # will need to update with new versions
-RewriteRule       ^/?(.+)$    http://cor.esipfed.org/ont/api/v0/ont?iri=https://w3id.org/isample/vocabulary/specimentype/%{ENV:currentversion}/$1 [R=303,L]
+RewriteRule       ^(.+)$    http://cor.esipfed.org/ont/api/v0/ont?iri=https://w3id.org/isample/vocabulary/specimentype/%{ENV:currentversion}/$1 [R=303,L]
 
 # any other accept header with no terminal string
 #   gets landing page for the version of the vocab, from ESIP COR.  
 #   Pylode doesn't currently seem to be working (2023-12-30).
-RewriteRule       ^/?$  http://cor.esipfed.org/ont?iri=https://w3id.org/isample/vocabulary/specimentype/%{ENV:currentversion}/specimentypevocabulary [R=303,L]
+RewriteRule       ^$  http://cor.esipfed.org/ont?iri=https://w3id.org/isample/vocabulary/specimentype/%{ENV:currentversion}/specimentypevocabulary [R=303,L]
 

--- a/isample/vocabulary/specimentype/1.0/.htaccess
+++ b/isample/vocabulary/specimentype/1.0/.htaccess
@@ -1,22 +1,22 @@
 Options +FollowSymLinks
 RewriteEngine on 
 
-#https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-type-vocabulary/1-0/resource?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fvocabulary%2Fspecimentype%2F1.0%2Ffluidincontainer
+#https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-type-vocabulary/1-0/resource?uri=https://w3id.org/isample/vocabulary/specimentype/1.0/fluidincontainer
 
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-type-vocabulary/1-0/resource.ttl?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fvocabulary%2Fspecimentype%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-type-vocabulary/1-0/resource.ttl?uri=https://w3id.org/isample/vocabulary/specimentype/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} application/jso [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-type-vocabulary/1-0/resource.json?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fvocabulary%2Fspecimentype%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-type-vocabulary/1-0/resource.json?uri=https://w3id.org/isample/vocabulary/specimentype/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} application/rdf+xml [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-type-vocabulary/1-0/resource.rdf?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fvocabulary%2Fspecimentype%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-type-vocabulary/1-0/resource.rdf?uri=https://w3id.org/isample/vocabulary/specimentype/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} text/html [NC]
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-type-vocabulary/1-0/resource.html?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fvocabulary%2Fspecimentype%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-type-vocabulary/1-0/resource.html?uri=https://w3id.org/isample/vocabulary/specimentype/1.0/$1 [R=303,L]
 
 # default format is html
-RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-type-vocabulary/1-0/resource?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fvocabulary%2Fspecimentype%2F1.0%2F$1 [R=303,L]
+RewriteRule       ^(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-type-vocabulary/1-0/resource?uri=https://w3id.org/isample/vocabulary/specimentype/1.0/$1 [R=303,L]
 
 
 

--- a/isample/vocabulary/specimentype/1.0/README.md
+++ b/isample/vocabulary/specimentype/1.0/README.md
@@ -8,7 +8,7 @@
 catches https://w3id.org/isample/vocabulary/specimentype/1.0/{term}
 
 Redirects to ARDC Research Vocabularies Australia (RVA)
-https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-type-vocabulary/2023-11-06/resource?uri=https%3A%2F%2Fw3id.org%2Fisample%2Fvocabulary%2Fspecimentype%2F1.0%2F{term}
+https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-type-vocabulary/2023-11-06/resource?uri=https://w3id.org/isample/vocabulary/specimentype/1.0/{term}
 
 not that the RVA URLs include a revision date; if the vocabulary is updated without generating a new version in the term URI, the redirects will need to be modified.
 


### PR DESCRIPTION
escaping :// in url query parameters seems to cause problems, remove escape sequences. Fix some redirect targets and remove leading '/' in rules.