### PR TITLE
iaam/i40fd: Added canopen and device vocab paths

### DIFF
--- a/iaam/i40fd/protocol/canopen/.htaccess
+++ b/iaam/i40fd/protocol/canopen/.htaccess
@@ -1,0 +1,73 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
+
+RewriteEngine on
+
+# Rewrite rule for latest version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/canopen/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/canopen/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/canopen/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/canopen/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/canopen/ontology.ttl [R=303,L]
+
+
+# Rewrite rules for any other version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/canopen/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/canopen/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/canopen/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/canopen/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/canopen/ontology.ttl [R=303,L]
+
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^(.*)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/canopen/406.html [R=406,L]
+# Default response
+# ---------------------------
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/canopen/ontology.owl [R=303,L]

--- a/iaam/i40fd/protocol/canopen/README.md
+++ b/iaam/i40fd/protocol/canopen/README.md
@@ -1,0 +1,10 @@
+# Industry 4.0 Field Device IO-Link Ontology
+
+This ontology provides CANOpen concepts for integration with the [Industry 4.0 Field device](http://w3id.org/iaam/i40fd/) ontology.
+
+This is a research project of the [Institute for Applied Automation and Mechatronics](https://www.iaam.fh-aachen.de) (IaaM).
+
+## Contact 
+| Maintainer | Institute    | Email| ORCID| Github-ID |
+|----------- |--------------|------|------|------------|
+Victor Chavez |  University of Applied Sciences FH Aachen| chavez-bermudez@fh-aachen.de|   https://orcid.org/0000-0001-6419-1641 | [vChavezB](https://github.com/vChavezB)

--- a/iaam/i40fd/vocab/device/.htaccess
+++ b/iaam/i40fd/vocab/device/.htaccess
@@ -1,0 +1,73 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
+
+RewriteEngine on
+
+# Rewrite rule for latest version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/vocab-device/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/vocab-device/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/vocab-device/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/vocab-device/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/vocab-device/ontology.ttl [R=303,L]
+
+
+# Rewrite rules for any other version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/vocab-device/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/vocab-device/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/vocab-device/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/vocab-device/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/vocab-device/ontology.ttl [R=303,L]
+
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^(.*)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/vocab-device/406.html [R=406,L]
+# Default response
+# ---------------------------
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/vocab-device/ontology.owl [R=303,L]

--- a/iaam/i40fd/vocab/device/README.md
+++ b/iaam/i40fd/vocab/device/README.md
@@ -1,0 +1,10 @@
+# Industry 4.0 Field Device IO-Link Ontology
+
+This ontology provides a generalized device vocabulary for integration with the [Industry 4.0 Field device](http://w3id.org/iaam/i40fd/) ontology.
+
+This is a research project of the [Institute for Applied Automation and Mechatronics](https://www.iaam.fh-aachen.de) (IaaM).
+
+## Contact 
+| Maintainer | Institute    | Email| ORCID| Github-ID |
+|----------- |--------------|------|------|------------|
+Victor Chavez |  University of Applied Sciences FH Aachen| chavez-bermudez@fh-aachen.de|   https://orcid.org/0000-0001-6419-1641 | [vChavezB](https://github.com/vChavezB)


### PR DESCRIPTION
In namespace iaam/i40fd new paths have been added to integrate the canopen protocol ontology and the
generic device vocabulary.