### PR TITLE
Fix /vc/status-list destination.

### DIFF
--- a/vc/status-list/.htaccess
+++ b/vc/status-list/.htaccess
@@ -2,4 +2,4 @@ Header set Access-Control-Allow-Origin *
 Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^$ https://w3c-ccg.github.io/vc-status-list-2021/ [R=302,L]
+RewriteRule ^$ https://w3c.github.io/vc-bitstring-status-list/ [R=302,L]

--- a/vc/status-list/README.md
+++ b/vc/status-list/README.md
@@ -1,6 +1,6 @@
-# VC Status List Vocabulary
+# VC Bitstring Status List Vocabulary
 
-- https://w3c-ccg.github.io/vc-status-list-2021/
+- https://w3c.github.io/vc-bitstring-status-list/
 
 ## Maintainers
 


### PR DESCRIPTION
The /vc/status-list/2021 path had been fixed, but references from other specs (VCDM and Bitstring Status List itself) do not use the 2021 path component, but only /vc/status-list

This solves for those references.