### PR TITLE
Create the identifier for Image Annotation Workbench (IAW)

### DIFF
--- a/iaw/.htaccess
+++ b/iaw/.htaccess
@@ -1,0 +1,10 @@
+RewriteEngine On
+
+# IAW images.
+RewriteRule ^images/(.*)$ https://iaw-image-server.ardc-hdcl-sia-iaw.cloud.edu.au/images/$1 [L]
+
+# IAW publication data.
+RewriteRule ^data/publications/(.*)$ https://iaw-server.ardc-hdcl-sia-iaw.cloud.edu.au/api/publications/$1 [L]
+
+# IAW rendered publications.
+RewriteRule ^publications/(.*)$ https://iaw.ardc-hdcl-sia-iaw.cloud.edu.au/publications/$1 [L]

--- a/iaw/README.md
+++ b/iaw/README.md
@@ -1,0 +1,19 @@
+# /iaw/
+
+This [W3ID](https://w3id.org) provides a persistent URI namespace for Image Annotation Workbench (IAW) resources.
+
+## Uses
+
+- Subpath `/images` provides the namespace for images hosted in the IAW image server.
+- Subpath `/data/publications` provides the namespace for publication data in raw format (JSON).
+- Subpath `/publications` provides the namespace for rendered IAW publications.
+
+## Contact
+This space is administered by:
+
+**Yang Li**  
+*Technical Lead*  
+[Systemik Solutions](https://systemiksolutions.com/)  
+Sydney, NSW Australia  
+<yangli@systemiksolutions.com>  
+GitHub: [yangli0516](https://github.com/yangli0516)


### PR DESCRIPTION
Create the identifier for Image Annotation Workbench (IAW) to provide persistent URLs for IIIF images, publications, and IIIF manifests.