### PR TITLE
Add FEP prefix

### DIFF
--- a/fep/.htaccess
+++ b/fep/.htaccess
@@ -1,0 +1,17 @@
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
+Options +FollowSymLinks
+RewriteEngine on
+
+# catch FEP-specific context requests
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^([^/\.]*)/?(.*?)?/?$ https://codeberg.org/fediverse/fep/raw/branch/main/fep/$1/context.jsonld [R=302,L]
+
+# catch FEP-specific context requests without content negotiation
+RewriteRule ^([^/\.]*)/?(.*?)?.jsonld$ https://codeberg.org/fediverse/fep/raw/branch/main/fep/$1/context.jsonld [R=302,L]
+
+# catch FEP proposal documents
+RewriteRule ^([^/\.]*)/?(.*?)?/?$ https://codeberg.org/fediverse/fep/src/branch/main/fep/$1/fep-$1.md [R=302,L]
+
+# a generic catch-all rule
+RewriteRule ^(.*?)\/?$ https://codeberg.org/fediverse/fep/raw/branch/main/fep/$1 [R=302,L]

--- a/fep/README.md
+++ b/fep/README.md
@@ -1,0 +1,30 @@
+# FEP: Fediverse Enhancement Proposals
+
+A [Fediverse Enhancement Proposal](https://codeberg.org/fediverse/fep/src/branch/main/feps/fep-a4ed.md) (FEP) is a document that provides information to the Fediverse community. The goal of a FEP is to improve interoperability and well-being of diverse services, applications and communities that form the Fediverse.
+
+## See also
+
+FEP community links:
+
+- [SocialHub forum category](https://socialhub.activitypub.rocks/c/standards/fep/54)
+- [Current Codeberg repository](https://codeberg.org/fediverse/fep)
+
+FEP-888d is the proposal covering this usage of W3ID:
+
+- [SocialHub forum thread](https://socialhub.activitypub.rocks/t/fep-888d-using-w3id-org-fep-as-a-namespace-for-extension-terms-and-for-fep-documents/3098)
+- [The proposal as currently hosted on Codeberg](https://codeberg.org/fediverse/fep/src/branch/main/fep/888d/fep-888d.md)
+
+## Contact
+
+This prefix was submitted as a PR by a (a@trwnh.com, or @trwnh on GitHub). You may contact them directly for updates via the following methods:
+
+- mailto:a@trwnh.com
+- xmpp:a@trwnh.com
+- https://mastodon.social/@trwnh
+- https://github.com/trwnh/w3id.org/issues
+
+However, it may be a good idea to also or instead field your questions or concerns directly to the SocialHub forum or Codeberg organization, as that is where the community resides. Future PRs may come from other parties, but MUST be accompanied by a relevant community link.
+
+### Maintainers
+
+- @trwnh <https://github.com/trwnh>


### PR DESCRIPTION
# FEP: Fediverse Enhancement Proposals

A [Fediverse Enhancement Proposal](https://codeberg.org/fediverse/fep/src/branch/main/feps/fep-a4ed.md) (FEP) is a document that provides information to the Fediverse community. The goal of a FEP is to improve interoperability and well-being of diverse services, applications and communities that form the Fediverse.

## See also

FEP community links:

- [SocialHub forum category](https://socialhub.activitypub.rocks/c/standards/fep/54)
- [Current Codeberg repository](https://codeberg.org/fediverse/fep)

FEP-888d is the proposal covering this usage of W3ID:

- [SocialHub forum thread](https://socialhub.activitypub.rocks/t/fep-888d-using-w3id-org-fep-as-a-namespace-for-extension-terms-and-for-fep-documents/3098)
- [The proposal as currently hosted on Codeberg](https://codeberg.org/fediverse/fep/src/branch/main/fep/888d/fep-888d.md)