### PR TITLE
Moved the redirect from University GitLab to a public Github

### DIFF
--- a/ioc/.htaccess
+++ b/ioc/.htaccess
@@ -9,20 +9,20 @@ AddType application/rdf+xml .rdf
 
 # If accept header <text/turtle>
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
-RewriteRule ^$ https://ip.pages.rwth-aachen.de/ioc/core/ontology.ttl
+RewriteRule ^$ https://internet-of-construction.github.io/IoC-Process-Ontology/ontology.ttl
 
 # If accept header <application/rdf+xml>
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^$ https://ip.pages.rwth-aachen.de/ioc/core/ontology.xml
+RewriteRule ^$ https://internet-of-construction.github.io/IoC-Process-Ontology/ontology.xml
 
 # If suffix ttl, redirect to turtle 
-RewriteRule ^.ttl$ https://ip.pages.rwth-aachen.de/ioc/core/ontology.ttl
+RewriteRule ^.ttl$ https://internet-of-construction.github.io/IoC-Process-Ontology/ontology.ttl
 
 # If suffix html, redirect to html 
-RewriteRule ^.html$ https://ip.pages.rwth-aachen.de/ioc/core/
+RewriteRule ^.html$ https://internet-of-construction.github.io/IoC-Process-Ontology/
 
 # If suffix rdf, redirect to rdf 
-RewriteRule ^.rdf$ https://ip.pages.rwth-aachen.de/ioc/core/ontology.xml
+RewriteRule ^.rdf$ https://internet-of-construction.github.io/IoC-Process-Ontology/ontology.xml
 
 # Default response: html
-RewriteRule ^$ https://ip.pages.rwth-aachen.de/ioc/core/
+RewriteRule ^$ https://internet-of-construction.github.io/IoC-Process-Ontology/


### PR DESCRIPTION
Hi dear folks at w3id,
I was able to finally move the Internet of Construction (IoC) Process Ontology to its new home.
Therefore changed the URLs.
Greetings,
Lukas
