### PR TITLE
Use HTTPS for ILIAD JF property redirects

### DIFF
--- a/iliad/.htaccess
+++ b/iliad/.htaccess
@@ -202,5 +202,5 @@ RewriteRule ^jf/api/v1.0/ObservedProperties\((.*)\)/Datastreams$ https://grlc-dp
 RewriteRule ^jf/api/v1.0/ObservedProperties\((.*)\)/Datastreams$ https://grlc-dpi-enabler-demeter.apps.paas-dev.psnc.pl/api-git/ILIAD-ocean-twin/JF-API/ObservedProperty_Datastreams?obp=$1&limit=100 [R=302,L]
 
 ##EV
-RewriteRule ^jellyfish/property/(.*)$ http://defs-dev.opengis.net/vocprez-hosted/object?uri=http://w3id.org/iliad/jellyfish/property/$1 [R=302,L]
-RewriteRule ^jellyfish/property$ http://defs-dev.opengis.net/vocprez-hosted/object?uri=http://w3id.org/iliad/jellyfish/property [R=302,L]
+RewriteRule ^jellyfish/property/(.*)$ https://defs-dev.opengis.net/vocprez-hosted/object?uri=http://w3id.org/iliad/jellyfish/property/$1 [R=302,L]
+RewriteRule ^jellyfish/property$ https://defs-dev.opengis.net/vocprez-hosted/object?uri=http://w3id.org/iliad/jellyfish/property [R=302,L]

--- a/iliad/.htaccess
+++ b/iliad/.htaccess
@@ -202,5 +202,5 @@ RewriteRule ^jf/api/v1.0/ObservedProperties\((.*)\)/Datastreams$ https://grlc-dp
 RewriteRule ^jf/api/v1.0/ObservedProperties\((.*)\)/Datastreams$ https://grlc-dpi-enabler-demeter.apps.paas-dev.psnc.pl/api-git/ILIAD-ocean-twin/JF-API/ObservedProperty_Datastreams?obp=$1&limit=100 [R=302,L]
 
 ##EV
-RewriteRule ^jellyfish/property/(.*)$ https://defs-dev.opengis.net/vocprez-hosted/object?uri=http://w3id.org/iliad/jellyfish/property/$1 [R=302,L]
-RewriteRule ^jellyfish/property$ https://defs-dev.opengis.net/vocprez-hosted/object?uri=http://w3id.org/iliad/jellyfish/property [R=302,L]
+RewriteRule ^jellyfish/property/(.*)$ https://defs-dev.opengis.net/vocprez-hosted/object?uri=https://w3id.org/iliad/jellyfish/property/$1 [R=302,L]
+RewriteRule ^jellyfish/property$ https://defs-dev.opengis.net/vocprez-hosted/object?uri=https://w3id.org/iliad/jellyfish/property [R=302,L]


### PR DESCRIPTION
Use `https://defs-dev.opengis.net/...` URIs instead of `http://...` ones.

@rapw3k, as the official maintainer for `/iliad`, are you ok with this change?