### PR TITLE
Fix order of redirect rules to get html (not xml)

### DIFF
--- a/nfdi4cat/voc4cat/.htaccess
+++ b/nfdi4cat/voc4cat/.htaccess
@@ -26,14 +26,17 @@ RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
 RewriteRule "^v?([0-9]{4}\-[0-9]{2}\-[0-9]{2})" https://nfdi4cat.github.io/voc4cat/v$1/voc4cat.ttl [R=303,L,NE,NC]
 
+# HTML - documentation
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule "^v?([0-9]{4}\-[0-9]{2}\-[0-9]{2})" https://nfdi4cat.github.io/voc4cat/v$1/voc4cat/index.html [R=303,L,NE,NC]
+
 # XML/RDF - single large file of version-tagged releases
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} application/xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/xml
 RewriteRule "^v?([0-9]{4}\-[0-9]{2}\-[0-9]{2})" https://nfdi4cat.github.io/voc4cat/v$1/voc4cat.xml [R=303,L,NE,NC]
 
-# HTML - documentation
-RewriteCond %{HTTP_ACCEPT} text/html
+# No content-negotiation at all: Fallback to HTML
 RewriteRule "^v?([0-9]{4}\-[0-9]{2}\-[0-9]{2})" https://nfdi4cat.github.io/voc4cat/v$1/voc4cat/index.html [R=303,L,NE,NC]
 
 # === "in development" version (last commit to main) ===
@@ -52,14 +55,17 @@ RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
 RewriteRule  "^dev$" https://nfdi4cat.github.io/voc4cat/dev/voc4cat.ttl [R=303,L,NE,NC]
 
+# HTML - documentation
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule "^dev$" https://nfdi4cat.github.io/voc4cat/dev/voc4cat/index.html [R=303,L,NE]
+
 # XML/RDF - single large file
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} application/xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/xml
 RewriteRule  "^dev$" https://nfdi4cat.github.io/voc4cat/dev/voc4cat.xml [R=303,L,NE,NC]
 
-# HTML - documentation
-RewriteCond %{HTTP_ACCEPT} text/html
+# No content-negotiation at all: Fallback to HTML
 RewriteRule "^dev$" https://nfdi4cat.github.io/voc4cat/dev/voc4cat/index.html [R=303,L,NE]
 
 # === latest release ===
@@ -72,14 +78,17 @@ RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
 RewriteRule "^$" https://nfdi4cat.github.io/voc4cat/latest/voc4cat.ttl [R=303,L,NE]
 
+# HTML - documentation
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule "^$" https://nfdi4cat.github.io/voc4cat/latest/voc4cat/index.html [R=303,L,NE]
+
 # XML/RDF - single large file
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} application/xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/xml
 RewriteRule "^$" https://nfdi4cat.github.io/voc4cat/latest/voc4cat.xml [R=303,L,NE]
 
-# HTML - documentation
-RewriteCond %{HTTP_ACCEPT} text/html
+# No content-negotiation at all: Fallback to HTML for both versioned and non-versioned
 RewriteRule "^$" https://nfdi4cat.github.io/voc4cat/latest/voc4cat/index.html [R=303,L,NE]
 
 # === No content-negotiation at all (or HTML) ===


### PR DESCRIPTION
Some rules were not prioritizing text/html oder application/xml.

Related https://github.com/nfdi4cat/voc4cat/issues/44