### PR TITLE
Move /iiif to subspace; update contact details

### DIFF
--- a/locolligo/.htaccess
+++ b/locolligo/.htaccess
@@ -4,8 +4,6 @@ RewriteEngine on
 RewriteRule ^schemas/(.*)$ https://docuracy.github.io/Locolligo/schemas/$1 [NE,R=302,L]
 RewriteRule ^contexts/(.*)$ https://docuracy.github.io/Locolligo/contexts/$1 [NE,R=302,L]
 
-RewriteRule ^iiif/(.*)$ https://iiif.docuracy.co.uk/iiif/3/$1 [NE,R=302,L]
-
 # Dataset features: https://w3id.org/locolligo/name/id -> https://docuracy.github.io/Locolligo/datasets/#name/id
 # (Dataset names may include a '.', but feature ids may not, generally)
 RewriteRule ^([^/]+)/([^/\.]+)$ https://docuracy.github.io/Locolligo/datasets/#$1/$2 [NE,R=302,L]

--- a/locolligo/CAMPOP-Places/README.md
+++ b/locolligo/CAMPOP-Places/README.md
@@ -7,7 +7,7 @@ Example: https://w3id.org/locolligo/CAMPOP-Places/AGY.Llanerchymedd -> https://d
 
 **[Stephen Gadd](https://www.wikidata.org/wiki/Q7609282)**<br/>
 [Docuracy Ltd](https://docuracy.co.uk)<br/>
-[Woking, UK](https://www.wikidata.org/wiki/Q646225)<br/>
+[Rotherhithe, UK](https://www.wikidata.org/wiki/Q2886632)<br/>
 <locolligo@docuracy.co.uk>  <br/>
 GitHub: [docuracy](https://github.com/docuracy)<br/>
 ORCID: [0000-0003-3060-0181](https://orcid.org/0000-0003-3060-0181)<br/>

--- a/locolligo/README.md
+++ b/locolligo/README.md
@@ -10,9 +10,6 @@ https://w3id.org/locolligo/schemas/LP.json -> https://docuracy.github.io/Locolli
 https://w3id.org/locolligo/contexts/linkedplaces.jsonld -> https://docuracy.github.io/Locolligo/contexts/linkedplaces.jsonld
 
 
-### IIIF Images
-https://w3id.org/locolligo/iiif/miscellaneous%2FHollar_1660.jpg/info.json -> https://iiif.docuracy.co.uk/iiif/3/miscellaneous%2FHollar_1660.jpg/info.json
-
 ### Datasets
 Any URL not matching the above patterns is assumed to be a Linked Places (filename.lp.json) dataset. If the path includes another component after the name of the dataset, then the URL is assumed to be a reference to a feature within the dataset.
 

--- a/locolligo/iiif/.htaccess
+++ b/locolligo/iiif/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine on
+RewriteRule ^(.*)$ https://iiif.docuracy.co.uk/iiif/3/$1 [NE,R=302,L]

--- a/locolligo/iiif/README.md
+++ b/locolligo/iiif/README.md
@@ -1,0 +1,13 @@
+# /locolligo/iiif/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for IIIF images referenced by [Locolligo](https://github.com/docuracy/Locolligo/blob/main/README.md) datasets.
+<br/><br/>
+Example: https://w3id.org/locolligo/iiif/miscellaneous%2FHollar_1660.jpg/info.json -> https://iiif.docuracy.co.uk/iiif/3/miscellaneous%2FHollar_1660.jpg/info.json
+
+## Contact
+
+**[Stephen Gadd](https://www.wikidata.org/wiki/Q7609282)**<br/>
+[Docuracy Ltd](https://docuracy.co.uk)<br/>
+[Rotherhithe, UK](https://www.wikidata.org/wiki/Q2886632)<br/>
+<locolligo@docuracy.co.uk>  <br/>
+GitHub: [docuracy](https://github.com/docuracy)<br/>
+ORCID: [0000-0003-3060-0181](https://orcid.org/0000-0003-3060-0181)<br/>


### PR DESCRIPTION
Sorry, in the previous two Pull Requests I hadn't appreciated that my /iiif references require a subspace in order for the redirections to work properly.