### PR TITLE
Add signposting-tutorial namespace

### DIFF
--- a/signposting-tutorial/.htaccess
+++ b/signposting-tutorial/.htaccess
@@ -1,3 +1,4 @@
 RewriteRule ^$ https://github.com/stain/signposting-tutorial [R,L]
 
+RewriteRule ^([^.]*)$ https://$1.github.io/signposting-tutorial/ [R,L]
 RewriteRule ^([^.]*)\.(\d+)$ https://$1.github.io/signposting-tutorial/$2/ [R,L]

--- a/signposting-tutorial/.htaccess
+++ b/signposting-tutorial/.htaccess
@@ -1,0 +1,3 @@
+RewriteRule ^$ https://github.com/stain/signposting-tutorial [R,L]
+
+RewriteRule ^([^.]*)\.(\d+)$ https://$1.github.io/signposting-tutorial/$2/ [R,L]

--- a/signposting-tutorial/README.md
+++ b/signposting-tutorial/README.md
@@ -5,8 +5,10 @@ tutorial](https://github.com/stain/signposting-tutorial) as example persistent
 identifiers for `cite-as` link relations. The tutorial involves cloning to a
 user's GitHub repository, e.g. 
 
+* https://w3id.org/signposting-tutorial/stain redirects to https://stain.github.io/signposting-tutorial/
 * https://w3id.org/signposting-tutorial/stain.7338056 redirects to https://stain.github.io/signposting-tutorial/7338056/
 
+The actual tutorial is linked to as <https://w3id.org/signposting-tutorial> 
 
 Maintainers:
 

--- a/signposting-tutorial/README.md
+++ b/signposting-tutorial/README.md
@@ -1,0 +1,18 @@
+## Signposting tutorial 
+
+This namespace is meant to be used for the [Signposting
+tutorial](https://github.com/stain/signposting-tutorial) as example persistent
+identifiers for `cite-as` link relations. The tutorial involves cloning to a
+user's GitHub repository, e.g. 
+
+* https://w3id.org/signposting-tutorial/stain.7338056 redirects to https://stain.github.io/signposting-tutorial/7338056/
+
+
+Maintainers:
+
+* Stian Soiland-Reyes (@stain)
+* Leyla Jael Garcia (@ljgarcia)
+* Claus Weiland (@cp-weiland)
+* Herbert van de Sompel (@hvdsomp)
+
+


### PR DESCRIPTION
This namespace is meant to be used for the [Signposting tutorial](https://github.com/stain/signposting-tutorial) as example persistent identifiers for `cite-as` link relations. The tutorial involves cloning to a user's GitHub repository, so the username is part of the (example) PID.