### PR TITLE
[ad4gd] Add mappings for custom ad4gd properties

### DIFF
--- a/ad4gd/.htaccess
+++ b/ad4gd/.htaccess
@@ -66,3 +66,7 @@ RewriteRule ^model/(.*)$  https://raw.githubusercontent.com/AD4GD/GDIM/main/$1.t
 # Sensors and manufacturers in Hosted RAINBOW
 RewriteRule ^sensors/?$ https://defs-dev.opengis.net/vocprez-hosted/object?uri=https://w3id.org/ad4gd/sensors [R=302,L]
 RewriteRule ^sensors/(.+)$ https://defs-dev.opengis.net/vocprez-hosted/object?uri=https://w3id.org/ad4gd/sensors/$1 [R=303,L]
+
+# Properties in Hosted RAINBOW
+RewriteRule ^properties/?$ https://defs-dev.opengis.net/vocprez-hosted/object?uri=https://w3id.org/ad4gd/properties [R=302,L]
+RewriteRule ^properties/(.+)$ https://defs-dev.opengis.net/vocprez-hosted/object?uri=https://w3id.org/ad4gd/properties/$1 [R=303,L]


### PR DESCRIPTION
Add mappings for `https://w3id.org/ad4gd/properties/...` to hosted RAINBOW instance.

Please, @rapw3k confirm that the changes are ok.

Thank you.