### PR TITLE
Redirects for SPARQL-CDT spec

### DIFF
--- a/awslabs/neptune/SPARQL-CDTs/.htaccess
+++ b/awslabs/neptune/SPARQL-CDTs/.htaccess
@@ -1,0 +1,34 @@
+# This space is administered by:
+#
+# Olaf Hartig
+# ohartig@amazon.com
+# GitHub username: hartig
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# URIs of the datatypes
+RewriteRule "^List$" "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#list-datatype" [R=302,L]
+RewriteRule "^Map$"  "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#map-datatype" [R=302,L]
+
+# URIs of the functions
+RewriteRule "^concat$"      "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_concat" [R=302,L]
+RewriteRule "^contains$"    "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_contains" [R=302,L]
+RewriteRule "^containsKey$" "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_containsKey" [R=302,L]
+RewriteRule "^get$"         "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_get" [R=302,L]
+RewriteRule "^head$"        "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_head" [R=302,L]
+RewriteRule "^keys$"        "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_keys" [R=302,L]
+RewriteRule "^merge$"       "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_merge" [R=302,L]
+RewriteRule "^put$"         "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_put" [R=302,L]
+RewriteRule "^remove$"      "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_remove" [R=302,L]
+RewriteRule "^reverse$"     "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_reverse" [R=302,L]
+RewriteRule "^size$"        "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_size" [R=302,L]
+RewriteRule "^subseq$"      "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_subseq" [R=302,L]
+RewriteRule "^tail$"        "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_tail" [R=302,L]
+
+# URIs of the spec documents
+RewriteRule "^spec/editors_draft.html$" "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/editors_draft.html" [R=302,L]
+RewriteRule "^spec/latest.html$"        "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html" [R=302,L]
+
+# Default redirect for unmatched patterns to the latest version of the spec document
+RewriteRule "^(.*)$" "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html" [R=302,L]

--- a/awslabs/neptune/SPARQL-CDTs/README.md
+++ b/awslabs/neptune/SPARQL-CDTs/README.md
@@ -1,0 +1,41 @@
+# SPARQL-CDTs
+
+Specification of an extension to SPARQL for handling literals that capture composite values (lists, maps, etc.).
+
+
+## Redirects
+
+The following redirects are defined.
+
+### Redirects for the URIs of the datatypes
+* https://w3id.org/awslabs/neptune/SPARQL-CDTs/List
+* https://w3id.org/awslabs/neptune/SPARQL-CDTs/Map
+
+### Redirects for the URIs of the SPARQL functions
+* https://w3id.org/awslabs/neptune/SPARQL-CDTs/concat
+* https://w3id.org/awslabs/neptune/SPARQL-CDTs/contains
+* https://w3id.org/awslabs/neptune/SPARQL-CDTs/containsKey
+* https://w3id.org/awslabs/neptune/SPARQL-CDTs/get
+* https://w3id.org/awslabs/neptune/SPARQL-CDTs/head
+* https://w3id.org/awslabs/neptune/SPARQL-CDTs/keys
+* https://w3id.org/awslabs/neptune/SPARQL-CDTs/merge
+* https://w3id.org/awslabs/neptune/SPARQL-CDTs/put
+* https://w3id.org/awslabs/neptune/SPARQL-CDTs/remove
+* https://w3id.org/awslabs/neptune/SPARQL-CDTs/reverse
+* https://w3id.org/awslabs/neptune/SPARQL-CDTs/size
+* https://w3id.org/awslabs/neptune/SPARQL-CDTs/subseq
+* https://w3id.org/awslabs/neptune/SPARQL-CDTs/tail
+
+### Redirects for the URIs of the spec documents
+* https://w3id.org/awslabs/neptune/SPARQL-CDTs/spec/latest.html
+* https://w3id.org/awslabs/neptune/SPARQL-CDTs/spec/editors_draft.html
+
+
+## Contact
+
+* **Olaf Hartig** (Amazon)<br/>
+  &nbsp; &nbsp; Website: https://olafhartig.de/<br/>
+  &nbsp; &nbsp; GitHub username: [hartig](https://github.com/hartig)
+* **Gregory Todd Williams** (Amazon)<br/>
+  &nbsp; &nbsp; Website: https://kasei.us/<br/>
+  &nbsp; &nbsp; GitHub username: [kasei](https://github.com/kasei)


### PR DESCRIPTION
In the Amazon Neptune team at AWS we are working on a spec and corresponding artifacts (e.g., test suites) for an approach to capture and to query composite datatypes (lists and maps) as RDF literals. Our Github repo for this work is https://github.com/awslabs/SPARQL-CDTs

With this PR we want to introduce permanent identifiers for the new datatype IRIs and for the IRIs of the SPARQL functions defined in our spec, as well as for the spec document itself.

We are planning to publicly announce our proposal within the next couple of weeks. Until then, we would appreciate if pointers to it are not yet shared on mailing lists, etc.