### PR TITLE
Change awslabs/neptune/SPARQL-CDTs redirects to point to Github pages

### DIFF
--- a/awslabs/neptune/SPARQL-CDTs/.htaccess
+++ b/awslabs/neptune/SPARQL-CDTs/.htaccess
@@ -8,27 +8,27 @@ Options +FollowSymLinks
 RewriteEngine on
 
 # URIs of the datatypes
-RewriteRule "^List$" "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#list-datatype" [R=302,L]
-RewriteRule "^Map$"  "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#map-datatype" [R=302,L]
+RewriteRule "^List$" "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#list-datatype" [R=302,L]
+RewriteRule "^Map$"  "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#map-datatype" [R=302,L]
 
 # URIs of the functions
-RewriteRule "^concat$"      "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_concat" [R=302,L]
-RewriteRule "^contains$"    "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_contains" [R=302,L]
-RewriteRule "^containsKey$" "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_containsKey" [R=302,L]
-RewriteRule "^get$"         "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_get" [R=302,L]
-RewriteRule "^head$"        "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_head" [R=302,L]
-RewriteRule "^keys$"        "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_keys" [R=302,L]
-RewriteRule "^merge$"       "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_merge" [R=302,L]
-RewriteRule "^put$"         "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_put" [R=302,L]
-RewriteRule "^remove$"      "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_remove" [R=302,L]
-RewriteRule "^reverse$"     "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_reverse" [R=302,L]
-RewriteRule "^size$"        "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_size" [R=302,L]
-RewriteRule "^subseq$"      "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_subseq" [R=302,L]
-RewriteRule "^tail$"        "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html#func_tail" [R=302,L]
+RewriteRule "^concat$"      "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_concat" [R=302,L]
+RewriteRule "^contains$"    "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_contains" [R=302,L]
+RewriteRule "^containsKey$" "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_containsKey" [R=302,L]
+RewriteRule "^get$"         "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_get" [R=302,L]
+RewriteRule "^head$"        "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_head" [R=302,L]
+RewriteRule "^keys$"        "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_keys" [R=302,L]
+RewriteRule "^merge$"       "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_merge" [R=302,L]
+RewriteRule "^put$"         "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_put" [R=302,L]
+RewriteRule "^remove$"      "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_remove" [R=302,L]
+RewriteRule "^reverse$"     "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_reverse" [R=302,L]
+RewriteRule "^size$"        "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_size" [R=302,L]
+RewriteRule "^subseq$"      "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_subseq" [R=302,L]
+RewriteRule "^tail$"        "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_tail" [R=302,L]
 
 # URIs of the spec documents
 RewriteRule "^spec/editors_draft.html$" "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/editors_draft.html" [R=302,L]
-RewriteRule "^spec/latest.html$"        "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html" [R=302,L]
+RewriteRule "^spec/(.*)$"        "https://awslabs.github.io/SPARQL-CDTs/spec/$1" [R=302,L]
 
 # Default redirect for unmatched patterns to the latest version of the spec document
-RewriteRule "^(.*)$" "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/latest.html" [R=302,L]
+RewriteRule "^(.*)$" "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html" [R=302,L]


### PR DESCRIPTION
As per https://github.com/perma-id/w3id.org/pull/3928#issuecomment-1976296199, I have created Github pages for https://github.com/awslabs/SPARQL-CDTs and modified the redirects to point to these pages.