### PR TITLE
Fixes encoding of hash URLs in redirects for SPARQL-CDTs

### DIFF
--- a/awslabs/neptune/SPARQL-CDTs/.htaccess
+++ b/awslabs/neptune/SPARQL-CDTs/.htaccess
@@ -8,23 +8,23 @@ Options +FollowSymLinks
 RewriteEngine on
 
 # URIs of the datatypes
-RewriteRule "^List$" "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#list-datatype" [R=302,L]
-RewriteRule "^Map$"  "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#map-datatype" [R=302,L]
+RewriteRule "^List$" "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#list-datatype" [R=302,NE,L]
+RewriteRule "^Map$"  "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#map-datatype" [R=302,NE,L]
 
 # URIs of the functions
-RewriteRule "^concat$"      "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_concat" [R=302,L]
-RewriteRule "^contains$"    "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_contains" [R=302,L]
-RewriteRule "^containsKey$" "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_containsKey" [R=302,L]
-RewriteRule "^get$"         "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_get" [R=302,L]
-RewriteRule "^head$"        "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_head" [R=302,L]
-RewriteRule "^keys$"        "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_keys" [R=302,L]
-RewriteRule "^merge$"       "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_merge" [R=302,L]
-RewriteRule "^put$"         "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_put" [R=302,L]
-RewriteRule "^remove$"      "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_remove" [R=302,L]
-RewriteRule "^reverse$"     "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_reverse" [R=302,L]
-RewriteRule "^size$"        "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_size" [R=302,L]
-RewriteRule "^subseq$"      "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_subseq" [R=302,L]
-RewriteRule "^tail$"        "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_tail" [R=302,L]
+RewriteRule "^concat$"      "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_concat" [R=302,NE,L]
+RewriteRule "^contains$"    "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_contains" [R=302,NE,L]
+RewriteRule "^containsKey$" "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_containsKey" [R=302,NE,L]
+RewriteRule "^get$"         "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_get" [R=302,NE,L]
+RewriteRule "^head$"        "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_head" [R=302,NE,L]
+RewriteRule "^keys$"        "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_keys" [R=302,NE,L]
+RewriteRule "^merge$"       "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_merge" [R=302,NE,L]
+RewriteRule "^put$"         "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_put" [R=302,NE,L]
+RewriteRule "^remove$"      "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_remove" [R=302,NE,L]
+RewriteRule "^reverse$"     "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_reverse" [R=302,NE,L]
+RewriteRule "^size$"        "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_size" [R=302,NE,L]
+RewriteRule "^subseq$"      "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_subseq" [R=302,NE,L]
+RewriteRule "^tail$"        "https://awslabs.github.io/SPARQL-CDTs/spec/latest.html#func_tail" [R=302,NE,L]
 
 # URIs of the spec documents
 RewriteRule "^spec/editors_draft.html$" "https://raw.githack.com/awslabs/SPARQL-CDTs/main/spec/editors_draft.html" [R=302,L]


### PR DESCRIPTION
Daniel, I am terribly sorry that I have to bother you again. I just noticed that the target URLs that contain a hash character (`#`) are URL encoded, which turns them into the from URLs. The change in this PR should fix this issue (I hope!)