### PR TITLE
Clean Aviation ODE4HERA project (2024-2026): added readme and htaccess file to redirect the biblio ontology

### DIFF
--- a/CA-ODE4HERA/BiblioOnto/.htaccess
+++ b/CA-ODE4HERA/BiblioOnto/.htaccess
@@ -1,0 +1,36 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+
+# Rewrite engine setup
+RewriteEngine on
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^ode4herabibonto$ https://github.com/FrancescoTorrigiani/BiblioOntology/blob/main/ode4hera_biblio_onto.html [R=303]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^ode4herabibonto$ https://github.com/FrancescoTorrigiani/BiblioOntology/blob/main/ode4hera_biblio_onto.owl [R=303]
+
+# Rewrite rule to serve TURTLE content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^ode4herabibonto$ https://github.com/FrancescoTorrigiani/BiblioOntology/blob/main/ode4hera_biblio_onto.ttl [R=303]
+
+# Choose the default response
+# ---------------------------
+
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^ode4herabibonto$ https://github.com/FrancescoTorrigiani/BiblioOntology/blob/main/ode4hera_biblio_onto.ttl [R=303]
+
+# Rewrite rule to serve HTML content from the vocabulary URI by default (disabled)
+# (To enable this option, uncomment the rewrite rule below, and comment out the rewrite rule directly above)
+# RewriteRule ^ode4herabibonto$ https://github.com/FrancescoTorrigiani/BiblioOntology/blob/main/ode4hera_biblio_onto.html [R=303]

--- a/CA-ODE4HERA/BiblioOnto/README.md
+++ b/CA-ODE4HERA/BiblioOnto/README.md
@@ -7,4 +7,7 @@ Repository created to store the redirections of the ODE4HERA bibliography ontolo
 * RDF/XML: https://github.com/FrancescoTorrigiani/BiblioOntology/blob/main/ode4hera_biblio_onto.owl
 * TTL: https://github.com/FrancescoTorrigiani/BiblioOntology/blob/main/ode4hera_biblio_onto.ttl
 
+[w3id-ode4hera-onto](https://github.com/FrancescoTorrigiani/w3id-ode4hera-onto/tree/master) mantainers:
+* [Francesco Torrigiani](https://github.com/FrancescoTorrigiani)
+
 ODE4HERA is a Clean Aviation project (2024-01-01 – 2026-12-31) developing an Open Digital Environment for the development of Hybrid-Electric Regional Aircrafts.

--- a/CA-ODE4HERA/BiblioOnto/README.md
+++ b/CA-ODE4HERA/BiblioOnto/README.md
@@ -1,9 +1,10 @@
 # ODE4HERA BiblioOntology
 Repository created to store the redirections of the ODE4HERA bibliography ontology.
 
-/CA-ODE4HERA/BiblioOnto
-HTML: https://github.com/FrancescoTorrigiani/BiblioOntology/blob/main/ode4hera_biblio_onto.html
-RDF/XML: https://github.com/FrancescoTorrigiani/BiblioOntology/blob/main/ode4hera_biblio_onto.owl
-TTL: https://github.com/FrancescoTorrigiani/BiblioOntology/blob/main/ode4hera_biblio_onto.ttl
+## `/CA-ODE4HERA/BiblioOnto`
+
+* HTML: https://github.com/FrancescoTorrigiani/BiblioOntology/blob/main/ode4hera_biblio_onto.html
+* RDF/XML: https://github.com/FrancescoTorrigiani/BiblioOntology/blob/main/ode4hera_biblio_onto.owl
+* TTL: https://github.com/FrancescoTorrigiani/BiblioOntology/blob/main/ode4hera_biblio_onto.ttl
 
 ODE4HERA is a Clean Aviation project (2024-01-01 – 2026-12-31) developing an Open Digital Environment for the development of Hybrid-Electric Regional Aircrafts.

--- a/CA-ODE4HERA/BiblioOnto/README.md
+++ b/CA-ODE4HERA/BiblioOnto/README.md
@@ -1,0 +1,9 @@
+# ODE4HERA BiblioOntology
+Repository created to store the redirections of the ODE4HERA bibliography ontology.
+
+/CA-ODE4HERA/BiblioOnto
+HTML: https://github.com/FrancescoTorrigiani/BiblioOntology/blob/main/ode4hera_biblio_onto.html
+RDF/XML: https://github.com/FrancescoTorrigiani/BiblioOntology/blob/main/ode4hera_biblio_onto.owl
+TTL: https://github.com/FrancescoTorrigiani/BiblioOntology/blob/main/ode4hera_biblio_onto.ttl
+
+ODE4HERA is a Clean Aviation project (01 Jan. 2024 - 31 Dec. 2026) developing an Open Digital Environement for the development of Hybrid-Electric Regional Aircrafts.

--- a/CA-ODE4HERA/BiblioOnto/README.md
+++ b/CA-ODE4HERA/BiblioOnto/README.md
@@ -6,4 +6,4 @@ HTML: https://github.com/FrancescoTorrigiani/BiblioOntology/blob/main/ode4hera_b
 RDF/XML: https://github.com/FrancescoTorrigiani/BiblioOntology/blob/main/ode4hera_biblio_onto.owl
 TTL: https://github.com/FrancescoTorrigiani/BiblioOntology/blob/main/ode4hera_biblio_onto.ttl
 
-ODE4HERA is a Clean Aviation project (01 Jan. 2024 - 31 Dec. 2026) developing an Open Digital Environement for the development of Hybrid-Electric Regional Aircrafts.
+ODE4HERA is a Clean Aviation project (2024-01-01 – 2026-12-31) developing an Open Digital Environment for the development of Hybrid-Electric Regional Aircrafts.


### PR DESCRIPTION
In the Clean Aviation project ODE4HERA, we build several linked models concerning the development for hybrid-electric aircraft. We are looking at different methods to share the models. This is the first step towards sharing the entire set of models, for the moment the redirection only involves the bibliography ontology.

My starting point was the blog [post](https://linkingresearch.wordpress.com/2016/01/17/permanent-identifiers-and-vocabulary-publication-purl-org-and-w3id/) by [Daniel Garijo](http://www.dgarijo.com/). The html documentation for the ontology is generated with [pyLODE](https://github.com/RDFLib/pyLODE).