### PR TITLE
Rule #1a and Rule #3a have been removed since they make rule #2 and #4 ineffective.

### DIFF
--- a/emmo/.htaccess
+++ b/emmo/.htaccess
@@ -7,7 +7,7 @@
 # For example if you want to test how
 # https://w3id.org/emmo/domain/domain-battery is redirected, enter
 # https://w3id.org/domain/domain-battery as URL to test on
-# https://htaccess.madewithlove.com/
+# https://htaccess.madewithlove.com/.
 #
 ##########################################################################
 
@@ -21,67 +21,59 @@ RewriteEngine On
 ##  Redirections for domain ontologies
 ##########################################################################
 
+# THIS RULE HAS BEEN REMOVED SINCE IT MAKES RULE #2 INEFFECTIVE, WITH THE CONSEQUENCE OF MAKING IT IMPOSSIBLE TO RETRIEVE THE TTL FILE WHEN USING THE "https://w3id.org/emmo/domain/{DOMAIN}/" URL.
+# ONLY THE ALIASES WORK WITH RULE #1 ACTIVE.
+# FOR ACCESSING THE ONTOLOGY'S HTML DOCUMENTATION, A DIFFERENT MECHANISM NEEDS TO BE ESTABLISHED.
+# THIS NEEDS TO BE TAKEN CARE OF ALSO FOR THE RULES CONCERNING THE WHOLE EMMO, WHICH SUFFER FROM THE SAME ISSUES.
 # Rule 1a: https://w3id.org/emmo/domain/{DOMAIN}
-# Alias:   https://w3id.org/emmo/domain/{DOMAIN}/
-# Redirect to GitHub Pages
 # If the request appears coming from a browser, redirect to html documentation otherwise to squashed turtle file.
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
-RewriteRule ^domain/(domain-)?([^/]+)/?$ https://emmo-repo.github.io/domain-$2/$2.html [R=303,NE,L]
-RewriteRule ^domain/(domain-)?([^/]+)/?$ https://emmo-repo.github.io/domain-$2/$2.ttl [R=303,NE,L]
+# RewriteCond %{HTTP_ACCEPT} text/html [OR]
+# RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+# RewriteRule ^domain/(domain-)?([^/]+)$ https://emmo-repo.github.io/domain-$2/$2.html [R=303,NE,L]
+# RewriteRule ^domain/(domain-)?([^/]+)$ https://emmo-repo.github.io/domain-$2/$2.ttl [R=303,NE,L]
 
 # Rule 1b: https://w3id.org/emmo/domain/{DOMAIN}/inferred
-# Redirect to GitHub Pages
-# Inferred ontology (only turtle) on GitHub Pages
-RewriteRule ^domain/(domain-)?([^/]+)/inferred/?$ https://emmo-repo.github.io/domain-$2/$2-inferred.ttl [R=303,NE,L]
+# Redirect to inferred ontology (only turtle)
+RewriteRule ^domain/(domain-)?([^/]+)/inferred$ https://emmo-repo.github.io/domain-$2/$2-inferred.ttl [R=303,NE,L]
 
-# Rule 1c: https://w3id.org/emmo/domain/{DOMAIN}/context
-# Redirect to GitHub Pages
-RewriteRule ^domain/(domain-)?([^/]+)/context/?$ https://emmo-repo.github.io/domain-$2/context/context.json [R=303,NE,L]
 
-# Rule 1d: https://w3id.org/emmo/domain/{DOMAIN}/context/{CONTEXTNAME}
-# Redirect to GitHub Pages
-RewriteRule ^domain/(domain-)?([^/]+)/context/([^/]+)/?$ https://emmo-repo.github.io/domain-$2/context/$3.json [R=303,NE,L]
-
-# Rule 2: https://w3id.org/emmo/domain/{DOMAIN}/source
+# Rule 2: https://w3id.org/emmo/domain/{DOMAIN}/
 # Alias:  https://w3id.org/emmo/domain/{DOMAIN}/latest
-# Redirect to master branch
-# {DOMAIN}.ttl file
+# Alias:  https://w3id.org/emmo/domain/{DOMAIN}/source
+# {DOMAIN}.ttl file in the root of the master branch
+RewriteRule ^domain/(domain-)?([^/]+)$ https://raw.githubusercontent.com/emmo-repo/domain-$2/master/$2.ttl [R=303,NE,L]
 RewriteRule ^domain/(domain-)?([^/]+)/$ https://raw.githubusercontent.com/emmo-repo/domain-$2/master/$2.ttl [R=303,NE,L]
 RewriteRule ^domain/(domain-)?([^/]+)/latest/?$ https://raw.githubusercontent.com/emmo-repo/domain-$2/master/$2.ttl [R=303,NE,L]
 RewriteRule ^domain/(domain-)?([^/]+)/source/?$ https://raw.githubusercontent.com/emmo-repo/domain-$2/master/$2.ttl [R=303,NE,L]
 
-
+# SAME HERE...
 # Rule 3a: https://w3id.org/emmo/domain/{DOMAIN}/{VERSION}
-# Alias:   https://w3id.org/emmo/domain/{DOMAIN}/{VERSION}/
-# Redirect to GitHub Pages
 # If the request appears coming from a browser, redirect to the html documentation otherwise redirect to squashed ontology of given version
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
-RewriteRule ^domain/(domain-)?([^/]+)/([0-9][^/]*)/?$ https://emmo-repo.github.io/domain-$2/versions/$3/$2.html [R=303,NE,L]
-RewriteRule ^domain/(domain-)?([^/]+)/([0-9][^/]*)/?$ https://emmo-repo.github.io/domain-$2/versions/$3/$2.ttl [R=303,NE,L]
+# RewriteCond %{HTTP_ACCEPT} text/html [OR]
+# RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+# RewriteRule ^domain/(domain-)?([^/]+)/([0-9][^/]*)$ https://emmo-repo.github.io/$1$2/versions/$3/$2.html [R=303,NE,L]
+# RewriteRule ^domain/(domain-)?([^/]+)/([0-9][^/]*)$ https://emmo-repo.github.io/$1$2/versions/$3/$2.ttl [R=303,NE,L]
 
 # Rule 3b: https://w3id.org/emmo/domain/{DOMAIN}/{VERSION}/inferred
-# Redirect to GitHub Pages
-RewriteRule ^domain/(domain-)?([^/]+)/([0-9][^/]*)/inferred/?$ https://emmo-repo.github.io/domain-$2/versions/$3/$2-inferred.ttl [R=303,NE,L]
+RewriteRule ^domain/(domain-)?([^/]+)/([0-9][^/]*)/inferred$ https://emmo-repo.github.io/$1$2/versions/$3/$2-inferred.ttl [R=303,NE,L]
 
 
-# Rule 4: https://w3id.org/emmo/domain/{DOMAIN}/{VERSION}/source
-# Redirect to specified version branch
-# {DOMAIN}.ttl file
+# Rule 4: https://w3id.org/emmo/domain/{DOMAIN}/{VERSION}/
+# Alias:  https://w3id.org/emmo/domain/{DOMAIN}/{VERSION}/source
+# {DOMAIN}.ttl file in the root of branch for the given version
+RewriteRule ^domain/(domain-)?([^/]+)/([0-9][^/]*)$ https://raw.githubusercontent.com/emmo-repo/domain-$2/$3/$2.ttl [R=303,NE,L]
+RewriteRule ^domain/(domain-)?([^/]+)/([0-9][^/]*)/$ https://raw.githubusercontent.com/emmo-repo/domain-$2/$3/$2.ttl [R=303,NE,L]
 RewriteRule ^domain/(domain-)?([^/]+)/([0-9][^/]*)/source/?$ https://raw.githubusercontent.com/emmo-repo/domain-$2/$3/$2.ttl [R=303,NE,L]
 
 
 # Rule 5: https://w3id.org/emmo/domain/{DOMAIN}/{PATH}/{MODULE}
-# Redirect to master branch
 # {PATH}/{MODULE}.ttl file in master branch
-RewriteRule ^domain/(domain-)?([^/]+)/([^0-9].*[^/])/?$ https://raw.githubusercontent.com/emmo-repo/domain-$2/master/$3.ttl [R=303,NE,L]
+RewriteRule ^domain/(domain-)?([^/]+)/([^0-9].*)/?$ https://raw.githubusercontent.com/emmo-repo/domain-$2/master/$3.ttl [R=303,NE,L]
 
 
 # Rule 6: https://w3id.org/emmo/domain/{DOMAIN}/{VERSION}/{PATH}/{MODULE}
-# Redirect to specified version branch
 # {PATH}/{MODULE}.ttl file in branch {VERSION} ({PATH} may be empty if the module .ttl file is in the repository root)
-RewriteRule ^domain/(domain-)?([^/]+)/([0-9][^/]*)/([^0-9].*[^/])/?$ https://raw.githubusercontent.com/emmo-repo/domain-$2/$3/$4.ttl [R=303,NE,L]
+RewriteRule ^domain/(domain-)?([^/]+)/([0-9][^/]*)/([^0-9].*)/?$ https://raw.githubusercontent.com/emmo-repo/domain-$2/$3/$4.ttl [R=303,NE,L]
 
 
 
@@ -90,8 +82,6 @@ RewriteRule ^domain/(domain-)?([^/]+)/([0-9][^/]*)/([^0-9].*[^/])/?$ https://raw
 ##########################################################################
 
 # Rule 7a: https://w3id.org/emmo
-# Alias:   https://w3id.org/emmo/
-# Redirect to GitHub Pages
 # If the request appears coming from a browser, redirect to html documentation otherwise to squashed turtle file.
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
@@ -99,28 +89,23 @@ RewriteRule ^$ https://emmo-repo.github.io/emmo.html [R=303,NE,L]
 RewriteRule ^$ https://emmo-repo.github.io/emmo.ttl [R=303,NE,L]
 
 # Rule 7b: https://w3id.org/emmo/inferred
-# Redirect to GitHub Pages
-# Inferred ontology (only turtle) on GitHub Pages
-RewriteRule ^inferred/?$ https://emmo-repo.github.io/emmo-inferred.ttl [R=303,NE,L]
+# Redirect to inferred ontology (only turtle)
+RewriteRule ^inferred$ https://emmo-repo.github.io/emmo-inferred.ttl [R=303,NE,L]
 
 
-# Rule 8a: https://w3id.org/emmo/source
+# Rule 8a: https://w3id.org/emmo/
 # Alias:   https://w3id.org/emmo/latest
-# Redirect to master branch
+# Alias:   https://w3id.org/emmo/source
+# emmo.ttl file in the root of the master branch
 RewriteRule ^/$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/emmo.ttl [R=303,NE,L]
 RewriteRule ^latest/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/emmo.ttl [R=303,NE,L]
 RewriteRule ^source/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/emmo.ttl [R=303,NE,L]
 
-# Rule 8b: https://w3id.org/emmo/tlo
-# Rule 8c: https://w3id.org/emmo/mlo
-# Rule 8d: https://w3id.org/emmo/mereocausality
-# Rule 8e: https://w3id.org/emmo/perspectives
-# Rule 8f: https://w3id.org/emmo/multiperspective
-# Rule 8g: https://w3id.org/emmo/disciplines
-# Rule 8h: https://w3id.org/emmo/disciplines/units
-# Redirect to master branch
-RewriteRule ^tlo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/emmo-tlo.ttl [R=303,NE,L]
-RewriteRule ^mlo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/emmo-mlo.ttl [R=303,NE,L]
+# Rule 8b: https://w3id.org/emmo/mereocausality
+# Rule 8c: https://w3id.org/emmo/perspectives
+# Rule 8d: https://w3id.org/emmo/multiperspective
+# Rule 8e: https://w3id.org/emmo/disciplines
+# Rule 8f: https://w3id.org/emmo/disciplines/units
 RewriteRule ^mereocausality/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/mereocausality/mereocausality.ttl [R=303,NE,L]
 RewriteRule ^perspectives/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/perspectives/perspectives.ttl [R=303,NE,L]
 RewriteRule ^multiperspective/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/multiperspective/multiperspective.ttl [R=303,NE,L]
@@ -129,35 +114,27 @@ RewriteRule ^disciplines/units/?$ https://raw.githubusercontent.com/emmo-repo/EM
 
 
 # Rule 9a: https://w3id.org/emmo/{VERSION}
-# Alias:   https://w3id.org/emmo/{VERSION}/
-# Redirect to specified version branch
 # If the request appears coming from a browser, redirect to html documentation otherwise to squashed turtle file for given version.
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
-RewriteRule ^([0-9][^/]*)/?$ https://emmo-repo.github.io/versions/$1/emmo.html [R=303,NE,L]
-RewriteRule ^([0-9][^/]*)/?$ https://emmo-repo.github.io/versions/$1/emmo.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)$ https://emmo-repo.github.io/versions/$1/emmo.html [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)$ https://emmo-repo.github.io/versions/$1/emmo.ttl [R=303,NE,L]
 #
 # Rule 9b: https://w3id.org/emmo/{VERSION}/inferred
-# Redirect to GitHub Pages
-RewriteRule ^([0-9][^/]*)/inferred/?$ https://emmo-repo.github.io/versions/$1/emmo-inferred.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/inferred$ https://emmo-repo.github.io/versions/$1/emmo-inferred.ttl [R=303,NE,L]
 
 
-# Rule 10a: https://w3id.org/emmo/{VERSION}/source
-# Redirect to specified version branch
+# Rule 10a: https://w3id.org/emmo/{VERSION}/
+# Alias:    https://w3id.org/emmo/{VERSION}/source
 # emmo.ttl file in the root of branch for the given version
 RewriteRule ^([0-9][^/]*)/$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/emmo.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/source/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/emmo.ttl [R=303,NE,L]
-#
-# Rule 10b: https://w3id.org/emmo/{VERSION}/tlo
-# Rule 10c: https://w3id.org/emmo/{VERSION}/mlo
-# Rule 10d: https://w3id.org/emmo/{VERSION}/mereocausality
-# Rule 10e: https://w3id.org/emmo/{VERSION}/perspectives
-# Rule 10f: https://w3id.org/emmo/{VERSION}/multiperspective
-# Rule 10g: https://w3id.org/emmo/{VERSION}/disciplines
-# Rule 10h: https://w3id.org/emmo/{VERSION}/disciplines/units
-# Redirect to specified version branch
-RewriteRule ^([0-9][^/]*)/tlo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/emmo-tlo.ttl [R=303,NE,L]
-RewriteRule ^([0-9][^/]*)/mlo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/emmo-mlo.ttl [R=303,NE,L]
+
+# Rule 10b: https://w3id.org/emmo/mereocausality
+# Rule 10c: https://w3id.org/emmo/perspectives
+# Rule 10d: https://w3id.org/emmo/multiperspective
+# Rule 10e: https://w3id.org/emmo/disciplines
+# Rule 10f: https://w3id.org/emmo/disciplines/units
 RewriteRule ^([0-9][^/]*)/mereocausality/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/mereocausality/mereocausality.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/perspectives/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/perspectives/perspectives.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/multiperspective/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/multiperspective/multiperspective.ttl [R=303,NE,L]
@@ -166,12 +143,10 @@ RewriteRule ^([0-9][^/]*)/disciplines/units/?$ https://raw.githubusercontent.com
 
 
 # Rule 11: https://w3id.org/emmo/{PATH}/{MODULE}
-# Redirect to specified version branch
 # Turtle file for given module of EMMO
-RewriteRule ^([^0-9].*[^/])/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/$1.ttl [R=303,NE,L]
+RewriteRule ^([^0-9].*)/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/$1.ttl [R=303,NE,L]
 
 
 # Rule 12: https://w3id.org/emmo/{VERSION}/{PATH}/{MODULE}
-# Redirect to specified version branch
 # Turtle file for given version and module of EMMO
-RewriteRule ^([0-9][^/]*)/([^0-9].*[^/])/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/$2.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/([^0-9].*)/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/$2.ttl [R=303,NE,L]


### PR DESCRIPTION
Rule #1a and Rule #3a have been removed since they make rule https://github.com/perma-id/w3id.org/pull/2 and https://github.com/perma-id/w3id.org/pull/4 ineffective, with the consequence of making it impossible to retrieve the ttl file when using the "[https://w3id.org/emmo/domain/{DOMAIN}/](https://w3id.org/emmo/domain/%7BDOMAIN%7D/)" url or the [https://w3id.org/emmo/domain/{DOMAIN}{VERSION}/](https://w3id.org/emmo/domain/%7BDOMAIN%7D%7BVERSION%7D/) url. For accessing the ontology's html documentation, a different mechanism needs to be established. This needs to be taken care of also for the rules concerning the whole EMMO, which suffer from the same issues.