### PR TITLE
Add resolution for gensc/terms endpoint.

### DIFF
--- a/gensc/.htaccess
+++ b/gensc/.htaccess
@@ -1,10 +1,12 @@
 Options +FollowSymLinks
 RewriteEngine on
 
-<!-- gensc/mixs ednpoint route -->
-RewriteRule ^mixs$ https://genomicsstandardsconsortium.github.io/mixs/$1 [R=302,L]
+# gensc/mixs endpoint route
+RewriteRule ^mixs$ https://genomicsstandardsconsortium.github.io/mixs/ [R=302,L]
 
-<!-- TODO: gensc/terms endpoint -->
+# gensc/terms endpoint route
+RewriteRule ^terms$ https://genomicsstandardsconsortium.github.io/mixs/ [R=302,L]
+RewriteRule ^terms/MIXS:(.*)$ https://genomicsstandardsconsortium.github.io/mixs/$1 [R=302,L]
 
-<!-- Rewrite Base URL -->
+# Rewrite Base URL
 RewriteRule ^(.*)$ https://gensc.org/$1 [R=302,L]


### PR DESCRIPTION
Identifiers of the form https://w3id.org/gensc/terms/MIXS:0000001 were proposed and used for the [Darwin Core extension](https://rs.gbif.org/extension/gbif/1.0/dna_derived_data_2022-02-23.xml) incorporating MIXS terms. These do not currently resolve.

This PR:

1. Replaces the `<!-- XML comment -->` with `# Apache comment`, which is the cause of the HTTP 500 errors for https://w3id.org/gensc/
2. Removes the spurious `$1` from the existing https://w3id.org/gensc/mixs 
3. Adds support for identifiers in the form https://w3id.org/gensc/terms/MIXS:0000001, redirecting them to https://genomicsstandardsconsortium.github.io/mixs/0000001/

Since I'm not sure of the status of the `gensc/terms` route I haven't added YAML/JSON/etc redirects, which exist for the [mixs route](https://github.com/perma-id/w3id.org/blob/master/mixs/.htaccess).

This is a draft PR; I am not part of the Genomics Standards Consortium.  It needs review and approval from @ramonawalls, @turbomam or @sujaypatil96.