### PR TITLE
/dpv update IRIs to new repo structure

### DIFF
--- a/dpv/.htaccess
+++ b/dpv/.htaccess
@@ -12,346 +12,246 @@ AddType application/rdf+xml .rdf .owl
 AddType text/turtle .ttl
 AddType application/n-triples .n3
 AddType application/ld+json .jsonld
+AddType text/owl-manchester .omn
 
 Header set Access-Control-Allow-Origin *
 Options +FollowSymLinks
 RewriteEngine on
 
-# DPV
+##### VOCAB: DPV #####
+RewriteRule ^$ https://w3c.github.io/dpv/dpv [R=302,L]
+
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
 RewriteRule ^$ https://w3c.github.io/dpv/dpv/dpv.rdf [R=302,L]
-
 RewriteCond %{HTTP_ACCEPT} text/turtle
 RewriteRule ^$ https://w3c.github.io/dpv/dpv/dpv.ttl [R=302,L]
-
 RewriteCond %{HTTP_ACCEPT} application/n\-triples
 RewriteRule ^$ https://w3c.github.io/dpv/dpv/dpv.n3 [R=302,L]
-
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
 RewriteRule ^$ https://w3c.github.io/dpv/dpv/dpv.jsonld [R=302,L]
 
-# DPV-GDPR
-# also covers /dpv/dpv-gdpr/dpia
+## DPV OWL Serialisation
+RewriteRule ^owl$ https://w3c.github.io/dpv/dpv-owl [R=302,L]
+
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^dpv-gdpr$ https://w3c.github.io/dpv/dpv-gdpr/dpv-gdpr.rdf [R=302,L]
-
+RewriteRule ^owl$ https://w3c.github.io/dpv/dpv/dpv-owl.owl [R=302,L]
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^dpv-gdpr$ https://w3c.github.io/dpv/dpv-gdpr/dpv-gdpr.ttl [R=302,L]
-
+RewriteRule ^owl$ https://w3c.github.io/dpv/dpv/dpv-owl.ttl [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^dpv-gdpr$ https://w3c.github.io/dpv/dpv-gdpr/dpv-gdpr.n3 [R=302,L]
-
+RewriteRule ^owl$ https://w3c.github.io/dpv/dpv/dpv-owl.n3 [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^dpv-gdpr$ https://w3c.github.io/dpv/dpv-gdpr/dpv-gdpr.jsonld [R=302,L]
+RewriteRule ^owl$ https://w3c.github.io/dpv/dpv/dpv-owl.jsonld [R=302,L]
+RewriteCond %{HTTP_ACCEPT} text/owl\-manchester
+RewriteRule ^owl$ https://w3c.github.io/dpv/dpv/dpv-owl.omn [R=302,L]
 
-# DPV-DGA
-# also covers /dpv/dpv-dga/dpia
+##### VOCAB: PD #####
+RewriteRule ^pd$ https://w3c.github.io/dpv/pd [R=302,L]
+
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^dpv-dga$ https://w3c.github.io/dpv/dpv-dga/dpv-dga.rdf [R=302,L]
-
+RewriteRule ^pd$ https://w3c.github.io/dpv/pd/pd.rdf [R=302,L]
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^dpv-dga$ https://w3c.github.io/dpv/dpv-dga/dpv-dga.ttl [R=302,L]
-
+RewriteRule ^pd$ https://w3c.github.io/dpv/pd/pd.ttl [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^dpv-dga$ https://w3c.github.io/dpv/dpv-dga/dpv-dga.n3 [R=302,L]
-
+RewriteRule ^pd$ https://w3c.github.io/dpv/pd/pd.n3 [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^dpv-dga$ https://w3c.github.io/dpv/dpv-dga/dpv-dga.jsonld [R=302,L]
+RewriteRule ^pd$ https://w3c.github.io/dpv/pd/pd.jsonld [R=302,L]
 
-# DPV-PD
+## PD OWL Serialisation
+RewriteRule ^pd/owl$ https://w3c.github.io/dpv/pd/pd-owl [R=302,L]
+
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^dpv-pd$ https://w3c.github.io/dpv/dpv-pd/dpv-pd.rdf [R=302,L]
-
+RewriteRule ^pd/owl$ https://w3c.github.io/dpv/pd/pd-owl.rdf [R=302,L]
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^dpv-pd$ https://w3c.github.io/dpv/dpv-pd/dpv-pd.ttl [R=302,L]
-
+RewriteRule ^pd/owl$ https://w3c.github.io/dpv/pd/pd-owl.ttl [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^dpv-pd$ https://w3c.github.io/dpv/dpv-pd/dpv-pd.n3 [R=302,L]
-
+RewriteRule ^pd/owl$ https://w3c.github.io/dpv/pd/pd-owl.n3 [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^dpv-pd$ https://w3c.github.io/dpv/dpv-pd/dpv-pd.jsonld [R=302,L]
+RewriteRule ^pd/owl$ https://w3c.github.io/dpv/pd/pd-owl.jsonld [R=302,L]
+RewriteCond %{HTTP_ACCEPT} text/owl\-manchester
+RewriteRule ^pd/owl$ https://w3c.github.io/dpv/pd/pd-owl.omn [R=302,L]
 
-# DPV-TECH
+##### VOCAB: LOC #####
+RewriteRule ^loc$ https://w3c.github.io/dpv/loc [R=302,L]
+
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^dpv-tech$ https://w3c.github.io/dpv/dpv-tech/dpv-tech.rdf [R=302,L]
-
+RewriteRule ^loc$ https://w3c.github.io/dpv/loc/loc.rdf [R=302,L]
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^dpv-tech$ https://w3c.github.io/dpv/dpv-tech/dpv-tech.ttl [R=302,L]
-
+RewriteRule ^loc$ https://w3c.github.io/dpv/loc/loc.ttl [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^dpv-tech$ https://w3c.github.io/dpv/dpv-tech/dpv-tech.n3 [R=302,L]
-
+RewriteRule ^loc$ https://w3c.github.io/dpv/loc/loc.n3 [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-rewriterule ^dpv-tech$ https://w3c.github.io/dpv/dpv-tech/dpv-tech.jsonld [r=302,l]
+RewriteRule ^loc$ https://w3c.github.io/dpv/loc/loc.jsonld [R=302,L]
 
-# DPV-legal
+## LOC OWL Serialisation
+RewriteRule ^loc/owl$ https://w3c.github.io/dpv/loc/loc-owl [R=302,L]
+
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^dpv-legal$ https://w3c.github.io/dpv/dpv-legal/dpv-legal.rdf [R=302,L]
-
+RewriteRule ^loc/owl$ https://w3c.github.io/dpv/loc/loc-owl.rdf [R=302,L]
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^dpv-legal$ https://w3c.github.io/dpv/dpv-legal/dpv-legal.ttl [R=302,L]
-
+RewriteRule ^loc/owl$ https://w3c.github.io/dpv/loc/loc-owl.ttl [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^dpv-legal$ https://w3c.github.io/dpv/dpv-legal/dpv-legal.n3 [R=302,L]
-
+RewriteRule ^loc/owl$ https://w3c.github.io/dpv/loc/loc-owl.n3 [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-rewriterule ^dpv-legal$ https://w3c.github.io/dpv/dpv-legal/dpv-legal.jsonld [r=302,l]
+RewriteRule ^loc/owl$ https://w3c.github.io/dpv/loc/loc-owl.jsonld [R=302,L]
+RewriteCond %{HTTP_ACCEPT} text/owl\-manchester
+RewriteRule ^loc/owl$ https://w3c.github.io/dpv/loc/loc-owl.omn [R=302,L]
 
-# risk
+##### VOCAB: RISK #####
+RewriteRule ^risk$ https://w3c.github.io/dpv/risk [R=302,L]
+
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
 RewriteRule ^risk$ https://w3c.github.io/dpv/risk/risk.rdf [R=302,L]
-
 RewriteCond %{HTTP_ACCEPT} text/turtle
 RewriteRule ^risk$ https://w3c.github.io/dpv/risk/risk.ttl [R=302,L]
-
 RewriteCond %{HTTP_ACCEPT} application/n\-triples
 RewriteRule ^risk$ https://w3c.github.io/dpv/risk/risk.n3 [R=302,L]
-
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-rewriterule ^risk$ https://w3c.github.io/dpv/risk/risk.jsonld [r=302,l]
+RewriteRule ^risk$ https://w3c.github.io/dpv/risk/risk.jsonld [R=302,L]
 
-# rights-eu
+## RISK OWL Serialisation
+RewriteRule ^risk/owl$ https://w3c.github.io/dpv/risk/risk-owl [R=302,L]
+
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^rights/eu$ https://w3c.github.io/dpv/rights/eu.rdf [R=302,L]
-
+RewriteRule ^risk/owl$ https://w3c.github.io/dpv/risk/risk-owl.rdf [R=302,L]
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^rights/eu$ https://w3c.github.io/dpv/rights/eu.ttl [R=302,L]
-
+RewriteRule ^risk/owl$ https://w3c.github.io/dpv/risk/risk-owl.ttl [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^rights/eu$ https://w3c.github.io/dpv/rights/eu.n3 [R=302,L]
-
+RewriteRule ^risk/owl$ https://w3c.github.io/dpv/risk/risk-owl.n3 [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-rewriterule ^rights/eu$ https://w3c.github.io/dpv/rights/eu.jsonld [r=302,l]
+RewriteRule ^risk/owl$ https://w3c.github.io/dpv/risk/risk-owl.jsonld [R=302,L]
+RewriteCond %{HTTP_ACCEPT} text/owl\-manchester
+RewriteRule ^risk/owl$ https://w3c.github.io/dpv/risk/risk-owl.omn [R=302,L]
 
-### DPV-SKOS ###
+##### VOCAB: TECH #####
+RewriteRule ^tech$ https://w3c.github.io/dpv/tech [R=302,L]
 
-# DPV-SKOS/DPV
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^dpv-skos$ https://w3c.github.io/dpv/dpv-skos/dpv.rdf [R=302,L]
-
+RewriteRule ^tech$ https://w3c.github.io/dpv/tech/tech.rdf [R=302,L]
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^dpv-skos$ https://w3c.github.io/dpv/dpv-skos/dpv.ttl [R=302,L]
-
+RewriteRule ^tech$ https://w3c.github.io/dpv/tech/tech.ttl [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^dpv-skos$ https://w3c.github.io/dpv/dpv-skos/dpv.n3 [R=302,L]
-
+RewriteRule ^tech$ https://w3c.github.io/dpv/tech/tech.n3 [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^dpv-skos$ https://w3c.github.io/dpv/dpv-skos/dpv.jsonld [R=302,L]
+RewriteRule ^tech$ https://w3c.github.io/dpv/tech/tech.jsonld [R=302,L]
 
-# DPV-SKOS/DPV-GDPR
-# also covers /dpv/dpv-skos/dpv-gdpr/dpia
+## TECH OWL Serialisation
+RewriteRule ^tech/owl$ https://w3c.github.io/dpv/tech/tech-owl [R=302,L]
+
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^dpv-skos/dpv-gdpr$ https://w3c.github.io/dpv/dpv-skos/dpv-gdpr/dpv-gdpr.rdf [R=302,L]
-
+RewriteRule ^tech/owl$ https://w3c.github.io/dpv/tech/tech-owl.rdf [R=302,L]
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^dpv-skos/dpv-gdpr$ https://w3c.github.io/dpv/dpv-skos/dpv-gdpr/dpv-gdpr.ttl [R=302,L]
-
+RewriteRule ^tech/owl$ https://w3c.github.io/dpv/tech/tech-owl.ttl [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^dpv-skos/dpv-gdpr$ https://w3c.github.io/dpv/dpv-skos/dpv-gdpr/dpv-gdpr.n3 [R=302,L]
-
+RewriteRule ^tech/owl$ https://w3c.github.io/dpv/tech/tech-owl.n3 [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^dpv-skos/dpv-gdpr$ https://w3c.github.io/dpv/dpv-skos/dpv-gdpr/dpv-gdpr.jsonld [R=302,L]
+RewriteRule ^tech/owl$ https://w3c.github.io/dpv/tech/tech-owl.jsonld [R=302,L]
+RewriteCond %{HTTP_ACCEPT} text/owl\-manchester
+RewriteRule ^tech/owl$ https://w3c.github.io/dpv/tech/tech-owl.omn [R=302,L]
 
-# DPV-SKOS/DPV-DGA
-# also covers /dpv/dpv-skos/dpv-dga/dpia
+##### VOCAB: LEGAL #####
+RewriteRule ^legal$ https://w3c.github.io/dpv/legal [R=302,L]
+
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^dpv-skos/dpv-dga$ https://w3c.github.io/dpv/dpv-skos/dpv-dga/dpv-dga.rdf [R=302,L]
-
+RewriteRule ^legal$ https://w3c.github.io/dpv/legal/legal.rdf [R=302,L]
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^dpv-skos/dpv-dga$ https://w3c.github.io/dpv/dpv-skos/dpv-dga/dpv-dga.ttl [R=302,L]
-
+RewriteRule ^legal$ https://w3c.github.io/dpv/legal/legal.ttl [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^dpv-skos/dpv-dga$ https://w3c.github.io/dpv/dpv-skos/dpv-dga/dpv-dga.n3 [R=302,L]
-
+RewriteRule ^legal$ https://w3c.github.io/dpv/legal/legal.n3 [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^dpv-skos/dpv-dga$ https://w3c.github.io/dpv/dpv-skos/dpv-dga/dpv-dga.jsonld [R=302,L]
+RewriteRule ^legal$ https://w3c.github.io/dpv/legal/legal.jsonld [R=302,L]
 
-# DPV-SKOS/DPV-PD
+## LEGAL OWL Serialisation
+RewriteRule ^legal/owl$ https://w3c.github.io/dpv/legal/legal-owl [R=302,L]
+
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^dpv-skos/dpv-pd$ https://w3c.github.io/dpv/dpv-skos/dpv-pd/dpv-pd.rdf [R=302,L]
-
+RewriteRule ^legal/owl$ https://w3c.github.io/dpv/legal/legal-owl.rdf [R=302,L]
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^dpv-skos/dpv-pd$ https://w3c.github.io/dpv/dpv-skos/dpv-pd/dpv-pd.ttl [R=302,L]
-
+RewriteRule ^legal/owl$ https://w3c.github.io/dpv/legal/legal-owl.ttl [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^dpv-skos/dpv-pd$ https://w3c.github.io/dpv/dpv-skos/dpv-pd/dpv-pd.n3 [R=302,L]
-
+RewriteRule ^legal/owl$ https://w3c.github.io/dpv/legal/legal-owl.n3 [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^dpv-skos/dpv-pd$ https://w3c.github.io/dpv/dpv-skos/dpv-pd/dpv-pd.jsonld [R=302,L]
+RewriteRule ^legal/owl$ https://w3c.github.io/dpv/legal/legal-owl.jsonld [R=302,L]
+RewriteCond %{HTTP_ACCEPT} text/owl\-manchester
+RewriteRule ^legal/owl$ https://w3c.github.io/dpv/legal/legal-owl.omn [R=302,L]
 
-# DPV-SKOS/DPV-TECH
+## LEGAL JURISDICTIONS ISO 3166-2
+# e.g. /legal/eu --> /legal/eu
+RewriteRule ^legal/([a-z]{2})$ https://w3c.github.io/dpv/legal/legal-$1 [R=302,L]
+
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^dpv-skos/dpv-tech$ https://w3c.github.io/dpv/dpv-skos/dpv-tech/dpv-tech.rdf [R=302,L]
-
+RewriteRule ^legal/([a-z]{2})$ https://w3c.github.io/dpv/legal/legal-$1.rdf [R=302,L]
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^dpv-skos/dpv-tech$ https://w3c.github.io/dpv/dpv-skos/dpv-tech/dpv-tech.ttl [R=302,L]
-
+RewriteRule ^legal/([a-z]{2})$ https://w3c.github.io/dpv/legal/legal-$1.ttl [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^dpv-skos/dpv-tech$ https://w3c.github.io/dpv/dpv-skos/dpv-tech/dpv-tech.n3 [R=302,L]
-
+RewriteRule ^legal/([a-z]{2})$ https://w3c.github.io/dpv/legal/legal-$1.n3 [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^dpv-skos/dpv-tech$ https://w3c.github.io/dpv/dpv-skos/dpv-tech/dpv-tech.jsonld [R=302,L]
+RewriteRule ^legal/([a-z]{2})$ https://w3c.github.io/dpv/legal/legal-$1.jsonld [R=302,L]
 
-# DPV-SKOS/DPV-legal
+# e.g. /legal/eu/gdpr --> /legal/eu/eu-gdpr
+RewriteRule ^legal/([a-z]{2})/(.*)$ https://w3c.github.io/dpv/legal/$1/$1-$2 [R=302,L]
+
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^dpv-skos/dpv-legal$ https://w3c.github.io/dpv/dpv-skos/dpv-legal/dpv-legal.rdf [R=302,L]
-
+RewriteRule ^legal/([a-z]{2})/(.*)$ https://w3c.github.io/dpv/legal/$1/$1-$2.rdf [R=302,L]
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^dpv-skos/dpv-legal$ https://w3c.github.io/dpv/dpv-skos/dpv-legal/dpv-legal.ttl [R=302,L]
-
+RewriteRule ^legal/([a-z]{2})/(.*)$ https://w3c.github.io/dpv/legal/$1/$1-$2.ttl [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^dpv-skos/dpv-legal$ https://w3c.github.io/dpv/dpv-skos/dpv-legal/dpv-legal.n3 [R=302,L]
-
+RewriteRule ^legal/([a-z]{2})/(.*)$ https://w3c.github.io/dpv/legal/$1/$1-$2.n3 [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^dpv-skos/dpv-legal$ https://w3c.github.io/dpv/dpv-skos/dpv-legal/dpv-legal.jsonld [R=302,L]
+RewriteRule ^legal/([a-z]{2})/(.*)$ https://w3c.github.io/dpv/legal/$1/$1-$2.jsonld [R=302,L]
 
-# dpv-skos/risk
+# e.g. /legal/eu/owl --> /legal/eu/legal-eu-owl
+RewriteRule ^legal/([a-z]{2})/owl$ https://w3c.github.io/dpv/legal/$1/legal-$1-owl [R=302,L]
+
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^dpv-skos/risk$ https://w3c.github.io/dpv/dpv-skos/risk/risk.rdf [R=302,L]
-
+RewriteRule ^legal/([a-z]{2})/owl$ https://w3c.github.io/dpv/legal/legal-$1-owl.rdf [R=302,L]
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^dpv-skos/risk$ https://w3c.github.io/dpv/dpv-skos/risk/risk.ttl [R=302,L]
-
+RewriteRule ^legal/([a-z]{2})/owl$ https://w3c.github.io/dpv/legal/legal-$1-owl.ttl [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^dpv-skos/risk$ https://w3c.github.io/dpv/dpv-skos/risk/risk.n3 [R=302,L]
-
+RewriteRule ^legal/([a-z]{2})/owl$ https://w3c.github.io/dpv/legal/legal-$1-owl.n3 [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-rewriterule ^dpv-skos/risk$ https://w3c.github.io/dpv/dpv-skos/risk/risk.jsonld [r=302,l]
+RewriteRule ^legal/([a-z]{2})/owl$ https://w3c.github.io/dpv/legal/legal-$1-owl.jsonld [R=302,L]
+RewriteCond %{HTTP_ACCEPT} text/owl\-manchester
+RewriteRule ^legal/([a-z]{2})/owl$ https://w3c.github.io/dpv/legal/legal-$1-owl.omn [R=302,L]
 
-# rights-eu
+# e.g. /legal/eu/gdpr/owl --> /legal/eu/gdpr/eu-gdpr-owl
+RewriteRule ^legal/([a-z]{2})/(.*)/owl$ https://w3c.github.io/dpv/legal/$1/$2/$1-$2-owl [R=302,L]
+
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^dpv-skos/rights/eu$ https://w3c.github.io/dpv/dpv-skos/rights/eu.rdf [R=302,L]
-
+RewriteRule ^legal/([a-z]{2})/(.*)/owl$ https://w3c.github.io/dpv/legal/$1/$1-$2-owl.rdf [R=302,L]
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^dpv-skos/rights/eu$ https://w3c.github.io/dpv/dpv-skos/rights/eu.ttl [R=302,L]
-
+RewriteRule ^legal/([a-z]{2})/(.*)/owl$ https://w3c.github.io/dpv/legal/$1/$1-$2-owl.ttl [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^dpv-skos/rights/eu$ https://w3c.github.io/dpv/dpv-skos/rights/eu.n3 [R=302,L]
-
+RewriteRule ^legal/([a-z]{2})/(.*)/owl$ https://w3c.github.io/dpv/legal/$1/$1-$2-owl.n3 [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-rewriterule ^dpv-skos/rights/eu$ https://w3c.github.io/dpv/dpv-skos/rights/eu.jsonld [r=302,l]
+RewriteRule ^legal/([a-z]{2})/(.*)/owl$ https://w3c.github.io/dpv/legal/$1/$1-$2-owl.jsonld [R=302,L]
 
-### DPV-OWL ###
+########## DEPRECATED URLS ARE REDIRECTED
 
-# DPV-OWL/DPV
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^dpv-owl$ https://w3c.github.io/dpv/dpv-owl/dpv.rdf [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^dpv-owl$ https://w3c.github.io/dpv/dpv-owl/dpv.ttl [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^dpv-owl$ https://w3c.github.io/dpv/dpv-owl/dpv.n3 [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^dpv-owl$ https://w3c.github.io/dpv/dpv-owl/dpv.jsonld [R=302,L]
-
-# DPV-OWL/DPV-GDPR
-# also covers /dpv/dpv-owl/dpv-gdpr/dpia
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^dpv-owl/dpv-gdpr$ https://w3c.github.io/dpv/dpv-owl/dpv-gdpr/dpv-gdpr.rdf [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^dpv-owl/dpv-gdpr$ https://w3c.github.io/dpv/dpv-owl/dpv-gdpr/dpv-gdpr.ttl [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^dpv-owl/dpv-gdpr$ https://w3c.github.io/dpv/dpv-owl/dpv-gdpr/dpv-gdpr.n3 [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^dpv-owl/dpv-gdpr$ https://w3c.github.io/dpv/dpv-owl/dpv-gdpr/dpv-gdpr.jsonld [R=302,L]
-
-# DPV-OWL/DPV-DGA
-# also covers /dpv/dpv-owl/dpv-dga/dpia
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^dpv-owl/dpv-dga$ https://w3c.github.io/dpv/dpv-owl/dpv-dga/dpv-dga.rdf [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^dpv-owl/dpv-dga$ https://w3c.github.io/dpv/dpv-owl/dpv-dga/dpv-dga.ttl [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^dpv-owl/dpv-dga$ https://w3c.github.io/dpv/dpv-owl/dpv-dga/dpv-dga.n3 [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^dpv-owl/dpv-dga$ https://w3c.github.io/dpv/dpv-owl/dpv-dga/dpv-dga.jsonld [R=302,L]
-
-# DPV-OWL/DPV-PD
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^dpv-owl/dpv-pd$ https://w3c.github.io/dpv/dpv-owl/dpv-pd/dpv-pd.rdf [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^dpv-owl/dpv-pd$ https://w3c.github.io/dpv/dpv-owl/dpv-pd/dpv-pd.ttl [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^dpv-owl/dpv-pd$ https://w3c.github.io/dpv/dpv-owl/dpv-pd/dpv-pd.n3 [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^dpv-owl/dpv-pd$ https://w3c.github.io/dpv/dpv-owl/dpv-pd/dpv-pd.jsonld [R=302,L]
-
-# DPV-OWL/DPV-TECH
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^dpv-owl/dpv-tech$ https://w3c.github.io/dpv/dpv-owl/dpv-tech/dpv-tech.rdf [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^dpv-owl/dpv-tech$ https://w3c.github.io/dpv/dpv-owl/dpv-tech/dpv-tech.ttl [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^dpv-owl/dpv-tech$ https://w3c.github.io/dpv/dpv-owl/dpv-tech/dpv-tech.n3 [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^dpv-owl/dpv-tech$ https://w3c.github.io/dpv/dpv-owl/dpv-tech/dpv-tech.jsonld [R=302,L]
-
-# DPV-OWL/DPV-legal
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^dpv-owl/dpv-legal$ https://w3c.github.io/dpv/dpv-owl/dpv-legal/dpv-legal.rdf [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^dpv-owl/dpv-legal$ https://w3c.github.io/dpv/dpv-owl/dpv-legal/dpv-legal.ttl [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^dpv-owl/dpv-legal$ https://w3c.github.io/dpv/dpv-owl/dpv-legal/dpv-legal.n3 [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^dpv-owl/dpv-legal$ https://w3c.github.io/dpv/dpv-owl/dpv-legal/dpv-legal.jsonld [R=302,L]
-
-# dpv-owl/risk
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^dpv-owl/risk$ https://w3c.github.io/dpv/dpv-owl/risk/risk.rdf [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^dpv-owl/risk$ https://w3c.github.io/dpv/dpv-owl/risk/risk.ttl [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^dpv-owl/risk$ https://w3c.github.io/dpv/dpv-owl/risk/risk.n3 [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-rewriterule ^dpv-owl/risk$ https://w3c.github.io/dpv/dpv-owl/risk/risk.jsonld [r=302,l]
-
-# rights-eu
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^dpv-owl/rights/eu$ https://w3c.github.io/dpv/dpv-owl/rights/eu.rdf [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^dpv-owl/rights/eu$ https://w3c.github.io/dpv/dpv-owl/rights/eu.ttl [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} application/n\-triples
-RewriteRule ^dpv-owl/rights/eu$ https://w3c.github.io/dpv/dpv-owl/rights/eu.n3 [R=302,L]
-
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-rewriterule ^dpv-owl/rights/eu$ https://w3c.github.io/dpv/dpv-owl/rights/eu.jsonld [r=302,l]
+RewriteRule ^dpv-skos$ https://w3id.org/dpv [R=302,L]
+RewriteRule ^dpv-skos/dpv-pd$ https://w3id.org/dpv/pd [R=302,L]
+RewriteRule ^dpv-skos/dpv-gdpr$ https://w3id.org/dpv/legal/eu/gdpr [R=302,L]
+RewriteRule ^dpv-skos/dpv-dga$ https://w3id.org/dpv/legal/eu/dga [R=302,L]
+RewriteRule ^dpv-skos/dpv-tech$ https://w3id.org/dpv/tech [R=302,L]
+RewriteRule ^dpv-skos/dpv-legal$ https://w3id.org/dpv/loc [R=302,L]
+RewriteRule ^dpv-owl$ https://w3id.org/dpv/owl [R=302,L]
+RewriteRule ^dpv-owl/dpv-pd$ https://w3id.org/dpv/pd/owl [R=302,L]
+RewriteRule ^dpv-owl/dpv-gdpr$ https://w3id.org/dpv/legal/eu/gdpr/owl [R=302,L]
+RewriteRule ^dpv-owl/dpv-dga$ https://w3id.org/dpv/legal/eu/dga/owl [R=302,L]
+RewriteRule ^dpv-owl/dpv-tech$ https://w3id.org/dpv/tech/owl [R=302,L]
+RewriteRule ^dpv-owl/dpv-legal$ https://w3id.org/dpv/loc/owl [R=302,L]
 
 # --- #
 # Default content type paths
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
 RewriteRule ^(.*)$ https://w3c.github.io/dpv/$1.rdf [R=302,L]
-
 RewriteCond %{HTTP_ACCEPT} text/turtle
 RewriteRule ^(.*)$ https://w3c.github.io/dpv/$1.ttl [R=302,L]
-
 RewriteCond %{HTTP_ACCEPT} application/n\-triples
 RewriteRule ^(.*)$ https://w3c.github.io/dpv/$1.n3 [R=302,L]
-
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
 RewriteRule ^(.*)$ https://w3c.github.io/dpv/$1.ldjson [R=302,L]
+RewriteCond %{HTTP_ACCEPT} text/owl\-manchester
+RewriteRule ^(.*)$ https://w3c.github.io/dpv/$1.omn [R=302,L]
 
 # Default
 # w3id.org/dpv
@@ -360,40 +260,47 @@ RewriteRule ^$ https://w3c.github.io/dpv/dpv [R=302,L]
 RewriteRule ^(.*)$ https://w3c.github.io/dpv/$1 [R=302,L]
 
 # --- Paths to test --- #
-#|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
-#| prefix                 | w3id                                        | HTML                                             | RDF                                                        |
-#|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
-#| dpv                    | https://w3id.org/dpv/dpv                    | https://w3c.github.io/dpv/dpv                    | https://w3c.github.io/dpv/dpv.rdf                          |
-#| dpv-skos               | https://w3id.org/dpv/dpv-skos               | https://w3c.github.io/dpv/dpv-skos               | https://w3c.github.io/dpv/dpv-skos/dpv.rdf                 |
-#| dpv-owl                | https://w3id.org/dpv/dpv-owl                | https://w3c.github.io/dpv/dpv-owl                | https://w3c.github.io/dpv/dpv-owl/dpv.rdf                  |
-#|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
-#| dpv-pd                 | https://w3id.org/dpv/dpv-pd                 | https://w3c.github.io/dpv/dpv-pd                 | https://w3c.github.io/dpv/dpv-pd/dpv-pd.rdf                |
-#| dpv-skos/dpv-pd        | https://w3id.org/dpv/dpv-skos/dpv-pd        | https://w3c.github.io/dpv/dpv-skos/dpv-pd        | https://w3c.github.io/dpv/dpv-skos/dpv-pd/dpv-pd.rdf       |
-#| dpv-owl/dpv-pd         | https://w3id.org/dpv/dpv-owl/dpv-pd         | https://w3c.github.io/dpv/dpv-owl/dpv-pd         | https://w3c.github.io/dpv/dpv-owl/dpv-pd/dpv-pd.rdf        |
-#|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
-#| dpv-gdpr               | https://w3id.org/dpv/dpv-gdpr               | https://w3c.github.io/dpv/dpv-gdpr               | https://w3c.github.io/dpv/dpv-gdpr/dpv-gdpr.rdf            |
-#| dpv-skos/dpv-gdpr      | https://w3id.org/dpv/dpv-skos/dpv-gdpr      | https://w3c.github.io/dpv/dpv-skos/dpv-gdpr      | https://w3c.github.io/dpv/dpv-skos/dpv-gdpr/dpv-gdpr.rdf   |
-#| dpv-owl/dpv-gdpr       | https://w3id.org/dpv/dpv-owl/dpv-gdpr       | https://w3c.github.io/dpv/dpv-owl/dpv-gdpr       | https://w3c.github.io/dpv/dpv-owl/dpv-gdpr/dpv-gdpr.rdf    |
-#|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
-#| dpv-gdpr/dpia          | https://w3id.org/dpv/dpv-gdpr/dpia          | https://w3c.github.io/dpv/dpv-gdpr/dpia          | NIL                                                        |
-#| dpv-skos/dpv-gdpr/dpia | https://w3id.org/dpv/dpv-skos/dpv-gdpr/dpia | https://w3c.github.io/dpv/dpv-skos/dpv-gdpr/dpia | NIL                                                        |
-#| dpv-owl/dpv-gdpr/dpia  | https://w3id.org/dpv/dpv-owl/dpv-gdpr/dpia  | https://w3c.github.io/dpv/dpv-owl/dpv-gdpr/dpia  | NIL                                                        |
-#|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
-#| dpv-tech               | https://w3id.org/dpv/dpv-tech               | https://w3c.github.io/dpv/dpv-tech               | https://w3c.github.io/dpv/dpv-tech/dpv-tech.rdf            |
-#| dpv-skos/dpv-tech      | https://w3id.org/dpv/dpv-skos/dpv-tech      | https://w3c.github.io/dpv/dpv-skos/dpv-tech      | https://w3c.github.io/dpv/dpv-skos/dpv-tech/dpv-tech.rdf   |
-#| dpv-owl/dpv-tech       | https://w3id.org/dpv/dpv-owl/dpv-tech       | https://w3c.github.io/dpv/dpv-owl/dpv-tech       | https://w3c.github.io/dpv/dpv-owl/dpv-tech/dpv-tech.rdf    |
-#|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
-#| dpv-legal              | https://w3id.org/dpv/dpv-legal              | https://w3c.github.io/dpv/dpv-legal              | https://w3c.github.io/dpv/dpv-legal/dpv-legal.rdf          |
-#| dpv-skos/dpv-legal     | https://w3id.org/dpv/dpv-skos/dpv-legal     | https://w3c.github.io/dpv/dpv-skos/dpv-legal     | https://w3c.github.io/dpv/dpv-skos/dpv-legal/dpv-legal.rdf |
-#| dpv-owl/dpv-legal      | https://w3id.org/dpv/dpv-owl/dpv-legal      | https://w3c.github.io/dpv/dpv-owl/dpv-legal      | https://w3c.github.io/dpv/dpv-owl/dpv-legal/dpv-legal.rdf  |
-#|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
-#| rights                 | https://w3id.org/dpv/rights                 | https://w3c.github.io/dpv/rights                 | NIL                                                        |
-#| rights-eu              | https://w3id.org/dpv/rights/eu              | https://w3c.github.io/dpv/rights/eu              | https://w3c.github.io/dpv/rights/eu.rdf                    |
-#|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
-#| risk                   | https://w3id.org/dpv/risk                   | https://w3c.github.io/dpv/risk                   | https://w3c.github.io/dpv/risk/risk.rdf                    |
-#|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
-#| primer                 | https://w3id.org/dpv/primer                 | https://w3c.github.io/dpv/primer                 | NIL                                                        |
-#| guides                 | https://w3id.org/dpv/guides                 | https://w3c.github.io/dpv/guides                 | NIL                                                        |
-#| examples               | https://w3id.org/dpv/examples               | https://w3c.github.io/dpv/examples               | https://w3c.github.io/dpv/examples/.*X.rdf                 |
-#| use-cases              | https://w3id.org/dpv/use-cases              | https://w3c.github.io/dpv/use-cases              | https://w3c.github.io/dpv/use-cases/.*X.rdf                |
-#|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
+# |--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+# | prefix             | w3id                                     | HTML                                                        | RDF                                                             |
+# |--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+# | dpv                | https://w3id.org/dpv                     | https://w3c.github.io/dpv/dpv                               | https://w3c.github.io/dpv/dpv/dpv.rdf                           |
+# | dpv-owl            | https://w3id.org/dpv/owl                 | https://w3c.github.io/dpv/dpv/dpv-owl                       | https://w3c.github.io/dpv/dpv/dpv-owlrdf                        |
+# |--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+# | pd                 | https://w3id.org/dpv/pd                  | https://w3c.github.io/dpv/pd                                | https://w3c.github.io/dpv/pd/pd.rdf                             |
+# | pd-owl             | https://w3id.org/dpv/pd/owl              | https://w3c.github.io/dpv/pd/pd-owl                         | https://w3c.github.io/dpv/pd/pd-owl.rdf                         |
+# |--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+# | tech               | https://w3id.org/dpv/tech                | https://w3c.github.io/dpv/tech                              | https://w3c.github.io/dpv/tech/tech.rdf                         |
+# | tech-owl           | https://w3id.org/dpv/tech/owl            | https://w3c.github.io/dpv/tech/tech-owl                     | https://w3c.github.io/dpv/tech/tech-owl.rdf                     |
+# |--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+# | loc                | https://w3id.org/dpv/loc                 | https://w3c.github.io/dpv/loc                               | https://w3c.github.io/dpv/loc/loc.rdf                           |
+# | loc-owl            | https://w3id.org/dpv/loc/owl             | https://w3c.github.io/dpv/loc/loc-owl                       | https://w3c.github.io/dpv/loc/loc-owl.rdf                       |
+# |--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+# | risk               | https://w3id.org/dpv/risk                | https://w3c.github.io/dpv/risk                              | https://w3c.github.io/dpv/risk/risk.rdf                         |
+# | risk-owl           | https://w3id.org/dpv/risk/owl            | https://w3c.github.io/dpv/risk/risk-owl                     | https://w3c.github.io/dpv/risk/risk-owl.rdf                     |
+# |--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+# | tech               | https://w3id.org/dpv/tech                | https://w3c.github.io/dpv/tech                              | https://w3c.github.io/dpv/tech/tech.rdf                         |
+# | tech-owl           | https://w3id.org/dpv/tech/owl            | https://w3c.github.io/dpv/tech/tech-owl                     | https://w3c.github.io/dpv/tech/tech-owl.rdf                     |
+# |--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+# | legal              | https://w3id.org/dpv/legal               | https://w3c.github.io/dpv/legal                             | https://w3c.github.io/dpv/legal/legal.rdf                       |
+# | legal-owl          | https://w3id.org/dpv/legal/owl           | https://w3c.github.io/dpv/legal/legal-owl                   | https://w3c.github.io/dpv/legal/legal-owl.rdf                   |
+# |--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+# | legal-[a-z]{2}     | https://w3id.org/dpv/legal/[a-z]{2}      | https://w3c.github.io/dpv/legal/[a-z]{2}                    | https://w3c.github.io/dpv/legal/[a-z]{2}/legal-[a-z]{2}.rdf     |
+# | legal-[a-z]{2}-owl | https://w3id.org/dpv/legal/[a-z]{2}/owl  | https://w3c.github.io/dpv/legal/[a-z]{2}/legal-[a-z]{2}-owl | https://w3c.github.io/dpv/legal/[a-z]{2}/legal-[a-z]{2}-owl.rdf |
+# |--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+# | eu-gdpr            | https://w3id.org/dpv/legal/eu/gdpr       | https://w3c.github.io/dpv/legal/eu/gdpr                     | https://w3c.github.io/dpv/legal/eu/gdpr/eu-gdpr.rdf             |
+# | eu-gdpr-owl        | https://w3id.org/dpv/legal/eu/gdpr/owl   | https://w3c.github.io/dpv/legal/eu/gdpr/eu-gdpr-owl         | https://w3c.github.io/dpv/legal/eu/gdpr/eu-gdpr-owl.rdf         |
+# |--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+# | eu-dga             | https://w3id.org/dpv/legal/eu/dga        | https://w3c.github.io/dpv/legal/eu/dga                      | https://w3c.github.io/dpv/legal/eu/dga/eu-dga.rdf               |
+# | eu-dga-owl         | https://w3id.org/dpv/legal/eu/dga/owl    | https://w3c.github.io/dpv/legal/eu/dga-owl                  | https://w3c.github.io/dpv/legal/eu/dga/eu-dga-owl.rdf           |
+# |--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+# | eu-aiact           | https://w3id.org/dpv/legal/eu/aiact      | https://w3c.github.io/dpv/legal/eu/aiact                    | https://w3c.github.io/dpv/legal/eu/aiact/eu-aiact.rdf           |
+# | eu-aiact-owl       | https://w3id.org/dpv/legal/eu/aiact/owl  | https://w3c.github.io/dpv/legal/eu/aiact-owl                | https://w3c.github.io/dpv/legal/eu/aiact/eu-aiact-owl.rdf       |
+# |--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+# | eu-rights          | https://w3id.org/dpv/legal/eu/rights     | https://w3c.github.io/dpv/legal/eu/rights                   | https://w3c.github.io/dpv/legal/eu/rights/eu-rights.rdf         |
+# | eu-rights-owl      | https://w3id.org/dpv/legal/eu/rights/owl | https://w3c.github.io/dpv/legal/eu/rights-owl               | https://w3c.github.io/dpv/legal/eu/rights/eu-rights-owl.rdf     |
+# |--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+# | primer             | https://w3id.org/dpv/primer              | https://w3c.github.io/dpv/primer                            | NIL                                                             |
+# | guides             | https://w3id.org/dpv/guides              | https://w3c.github.io/dpv/guides                            | NIL                                                             |
+# | examples           | https://w3id.org/dpv/examples            | https://w3c.github.io/dpv/examples                          | https://w3c.github.io/dpv/examples/.*X.rdf                      |
+# | use-cases          | https://w3id.org/dpv/use-cases           | https://w3c.github.io/dpv/use-cases                         | https://w3c.github.io/dpv/use-cases/.*X.rdf                     |
+# |--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|

--- a/dpv/README.md
+++ b/dpv/README.md
@@ -5,47 +5,67 @@ This [w3id](https://w3id.org/) provides a persistent URI namespace for Data Priv
 ## Uses
 
 ```
-|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
-| prefix                 | w3id                                        | HTML                                             | RDF                                                        |
-|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
-| dpv                    | https://w3id.org/dpv/dpv                    | https://w3c.github.io/dpv/dpv                    | https://w3c.github.io/dpv/dpv.rdf                          |
-| dpv-skos               | https://w3id.org/dpv/dpv-skos               | https://w3c.github.io/dpv/dpv-skos               | https://w3c.github.io/dpv/dpv-skos/dpv.rdf                 |
-| dpv-owl                | https://w3id.org/dpv/dpv-owl                | https://w3c.github.io/dpv/dpv-owl                | https://w3c.github.io/dpv/dpv-owl/dpv.rdf                  |
-|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
-| dpv-pd                 | https://w3id.org/dpv/dpv-pd                 | https://w3c.github.io/dpv/dpv-pd                 | https://w3c.github.io/dpv/dpv-pd/dpv-pd.rdf                |
-| dpv-skos/dpv-pd        | https://w3id.org/dpv/dpv-skos/dpv-pd        | https://w3c.github.io/dpv/dpv-skos/dpv-pd        | https://w3c.github.io/dpv/dpv-skos/dpv-pd/dpv-pd.rdf       |
-| dpv-owl/dpv-pd         | https://w3id.org/dpv/dpv-owl/dpv-pd         | https://w3c.github.io/dpv/dpv-owl/dpv-pd         | https://w3c.github.io/dpv/dpv-owl/dpv-pd/dpv-pd.rdf        |
-|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
-| dpv-gdpr               | https://w3id.org/dpv/dpv-gdpr               | https://w3c.github.io/dpv/dpv-gdpr               | https://w3c.github.io/dpv/dpv-gdpr/dpv-gdpr.rdf            |
-| dpv-skos/dpv-gdpr      | https://w3id.org/dpv/dpv-skos/dpv-gdpr      | https://w3c.github.io/dpv/dpv-skos/dpv-gdpr      | https://w3c.github.io/dpv/dpv-skos/dpv-gdpr/dpv-gdpr.rdf   |
-| dpv-owl/dpv-gdpr       | https://w3id.org/dpv/dpv-owl/dpv-gdpr       | https://w3c.github.io/dpv/dpv-owl/dpv-gdpr       | https://w3c.github.io/dpv/dpv-owl/dpv-gdpr/dpv-gdpr.rdf    |
-|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
-| dpv-dga                | https://w3id.org/dpv/dpv-dga                | https://w3c.github.io/dpv/dpv-dga                | https://w3c.github.io/dpv/dpv-dga/dpv-dga.rdf              |
-| dpv-skos/dpv-dga       | https://w3id.org/dpv/dpv-skos/dpv-dga       | https://w3c.github.io/dpv/dpv-skos/dpv-dga       | https://w3c.github.io/dpv/dpv-skos/dpv-dga/dpv-dga.rdf     |
-| dpv-owl/dpv-dga        | https://w3id.org/dpv/dpv-owl/dpv-dga        | https://w3c.github.io/dpv/dpv-owl/dpv-dga        | https://w3c.github.io/dpv/dpv-owl/dpv-dga/dpv-dga.rdf      |
-|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
-| dpv-gdpr/dpia          | https://w3id.org/dpv/dpv-gdpr/dpia          | https://w3c.github.io/dpv/dpv-gdpr/dpia          | NIL                                                        |
-| dpv-skos/dpv-gdpr/dpia | https://w3id.org/dpv/dpv-skos/dpv-gdpr/dpia | https://w3c.github.io/dpv/dpv-skos/dpv-gdpr/dpia | NIL                                                        |
-| dpv-owl/dpv-gdpr/dpia  | https://w3id.org/dpv/dpv-owl/dpv-gdpr/dpia  | https://w3c.github.io/dpv/dpv-owl/dpv-gdpr/dpia  | NIL                                                        |
-|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
-| dpv-tech               | https://w3id.org/dpv/dpv-tech               | https://w3c.github.io/dpv/dpv-tech               | https://w3c.github.io/dpv/dpv-tech/dpv-tech.rdf            |
-| dpv-skos/dpv-tech      | https://w3id.org/dpv/dpv-skos/dpv-tech      | https://w3c.github.io/dpv/dpv-skos/dpv-tech      | https://w3c.github.io/dpv/dpv-skos/dpv-tech/dpv-tech.rdf   |
-| dpv-owl/dpv-tech       | https://w3id.org/dpv/dpv-owl/dpv-tech       | https://w3c.github.io/dpv/dpv-owl/dpv-tech       | https://w3c.github.io/dpv/dpv-owl/dpv-tech/dpv-tech.rdf    |
-|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
-| dpv-legal              | https://w3id.org/dpv/dpv-legal              | https://w3c.github.io/dpv/dpv-legal              | https://w3c.github.io/dpv/dpv-legal/dpv-legal.rdf          |
-| dpv-skos/dpv-legal     | https://w3id.org/dpv/dpv-skos/dpv-legal     | https://w3c.github.io/dpv/dpv-skos/dpv-legal     | https://w3c.github.io/dpv/dpv-skos/dpv-legal/dpv-legal.rdf |
-| dpv-owl/dpv-legal      | https://w3id.org/dpv/dpv-owl/dpv-legal      | https://w3c.github.io/dpv/dpv-owl/dpv-legal      | https://w3c.github.io/dpv/dpv-owl/dpv-legal/dpv-legal.rdf  |
-|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
-| rights                 | https://w3id.org/dpv/rights                 | https://w3c.github.io/dpv/rights                 |                                                            |
-| rights-eu              | https://w3id.org/dpv/rights/eu              | https://w3c.github.io/dpv/rights/eu              | https://w3c.github.io/dpv/rights/eu.rdf                    |
-|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
-| risk                   | https://w3id.org/dpv/risk                   | https://w3c.github.io/dpv/risk                   | https://w3c.github.io/dpv/risk/risk.rdf                    |
-|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
-| primer                 | https://w3id.org/dpv/primer                 | https://w3c.github.io/dpv/primer                 | NIL                                                        |
-| guides                 | https://w3id.org/dpv/guides                 | https://w3c.github.io/dpv/guides                 | NIL                                                        |
-| examples               | https://w3id.org/dpv/examples               | https://w3c.github.io/dpv/examples               | https://w3c.github.io/dpv/examples/.*X.rdf                 |
-| use-cases              | https://w3id.org/dpv/use-cases              | https://w3c.github.io/dpv/use-cases              | https://w3c.github.io/dpv/use-cases/.*X.rdf                |
-|------------------------+---------------------------------------------+--------------------------------------------------+------------------------------------------------------------|
+|--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+| prefix             | w3id                                     | HTML                                                        | RDF                                                             |
+|--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+| dpv                | https://w3id.org/dpv                     | https://w3c.github.io/dpv/dpv                               | https://w3c.github.io/dpv/dpv/dpv.rdf                           |
+| dpv-owl            | https://w3id.org/dpv/owl                 | https://w3c.github.io/dpv/dpv/dpv-owl                       | https://w3c.github.io/dpv/dpv/dpv-owlrdf                        |
+|--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+| pd                 | https://w3id.org/dpv/pd                  | https://w3c.github.io/dpv/pd                                | https://w3c.github.io/dpv/pd/pd.rdf                             |
+| pd-owl             | https://w3id.org/dpv/pd/owl              | https://w3c.github.io/dpv/pd/pd-owl                         | https://w3c.github.io/dpv/pd/pd-owl.rdf                         |
+|--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+| tech               | https://w3id.org/dpv/tech                | https://w3c.github.io/dpv/tech                              | https://w3c.github.io/dpv/tech/tech.rdf                         |
+| tech-owl           | https://w3id.org/dpv/tech/owl            | https://w3c.github.io/dpv/tech/tech-owl                     | https://w3c.github.io/dpv/tech/tech-owl.rdf                     |
+|--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+| loc                | https://w3id.org/dpv/loc                 | https://w3c.github.io/dpv/loc                               | https://w3c.github.io/dpv/loc/loc.rdf                           |
+| loc-owl            | https://w3id.org/dpv/loc/owl             | https://w3c.github.io/dpv/loc/loc-owl                       | https://w3c.github.io/dpv/loc/loc-owl.rdf                       |
+|--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+| risk               | https://w3id.org/dpv/risk                | https://w3c.github.io/dpv/risk                              | https://w3c.github.io/dpv/risk/risk.rdf                         |
+| risk-owl           | https://w3id.org/dpv/risk/owl            | https://w3c.github.io/dpv/risk/risk-owl                     | https://w3c.github.io/dpv/risk/risk-owl.rdf                     |
+|--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+| tech               | https://w3id.org/dpv/tech                | https://w3c.github.io/dpv/tech                              | https://w3c.github.io/dpv/tech/tech.rdf                         |
+| tech-owl           | https://w3id.org/dpv/tech/owl            | https://w3c.github.io/dpv/tech/tech-owl                     | https://w3c.github.io/dpv/tech/tech-owl.rdf                     |
+|--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+| legal              | https://w3id.org/dpv/legal               | https://w3c.github.io/dpv/legal                             | https://w3c.github.io/dpv/legal/legal.rdf                       |
+| legal-owl          | https://w3id.org/dpv/legal/owl           | https://w3c.github.io/dpv/legal/legal-owl                   | https://w3c.github.io/dpv/legal/legal-owl.rdf                   |
+|--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+| legal-[a-z]{2}     | https://w3id.org/dpv/legal/[a-z]{2}      | https://w3c.github.io/dpv/legal/[a-z]{2}                    | https://w3c.github.io/dpv/legal/[a-z]{2}/legal-[a-z]{2}.rdf     |
+| legal-[a-z]{2}-owl | https://w3id.org/dpv/legal/[a-z]{2}/owl  | https://w3c.github.io/dpv/legal/[a-z]{2}/legal-[a-z]{2}-owl | https://w3c.github.io/dpv/legal/[a-z]{2}/legal-[a-z]{2}-owl.rdf |
+|--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+| eu-gdpr            | https://w3id.org/dpv/legal/eu/gdpr       | https://w3c.github.io/dpv/legal/eu/gdpr                     | https://w3c.github.io/dpv/legal/eu/gdpr/eu-gdpr.rdf             |
+| eu-gdpr-owl        | https://w3id.org/dpv/legal/eu/gdpr/owl   | https://w3c.github.io/dpv/legal/eu/gdpr/eu-gdpr-owl         | https://w3c.github.io/dpv/legal/eu/gdpr/eu-gdpr-owl.rdf         |
+|--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+| eu-dga             | https://w3id.org/dpv/legal/eu/dga        | https://w3c.github.io/dpv/legal/eu/dga                      | https://w3c.github.io/dpv/legal/eu/dga/eu-dga.rdf               |
+| eu-dga-owl         | https://w3id.org/dpv/legal/eu/dga/owl    | https://w3c.github.io/dpv/legal/eu/dga-owl                  | https://w3c.github.io/dpv/legal/eu/dga/eu-dga-owl.rdf           |
+|--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+| eu-aiact           | https://w3id.org/dpv/legal/eu/aiact      | https://w3c.github.io/dpv/legal/eu/aiact                    | https://w3c.github.io/dpv/legal/eu/aiact/eu-aiact.rdf           |
+| eu-aiact-owl       | https://w3id.org/dpv/legal/eu/aiact/owl  | https://w3c.github.io/dpv/legal/eu/aiact-owl                | https://w3c.github.io/dpv/legal/eu/aiact/eu-aiact-owl.rdf       |
+|--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+| eu-rights          | https://w3id.org/dpv/legal/eu/rights     | https://w3c.github.io/dpv/legal/eu/rights                   | https://w3c.github.io/dpv/legal/eu/rights/eu-rights.rdf         |
+| eu-rights-owl      | https://w3id.org/dpv/legal/eu/rights/owl | https://w3c.github.io/dpv/legal/eu/rights-owl               | https://w3c.github.io/dpv/legal/eu/rights/eu-rights-owl.rdf     |
+|--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+| primer             | https://w3id.org/dpv/primer              | https://w3c.github.io/dpv/primer                            | NIL                                                             |
+| guides             | https://w3id.org/dpv/guides              | https://w3c.github.io/dpv/guides                            | NIL                                                             |
+| examples           | https://w3id.org/dpv/examples            | https://w3c.github.io/dpv/examples                          | https://w3c.github.io/dpv/examples/.*X.rdf                      |
+| use-cases          | https://w3id.org/dpv/use-cases           | https://w3c.github.io/dpv/use-cases                         | https://w3c.github.io/dpv/use-cases/.*X.rdf                     |
+|--------------------+------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------|
+
+|-----------------------------------------+----------------------------------------|
+| old url                                 | redirect url                           |
+|-----------------------------------------+----------------------------------------|
+| https://w3id.org/dpv/dpv-skos           | https://w3id.org/dpv                   |
+| https://w3id.org/dpv/dpv-skos/dpv-pd    | https://w3id.org/dpv/pd                |
+| https://w3id.org/dpv/dpv-skos/dpv-gdpr  | https://w3id.org/dpv/legal/eu/gdpr     |
+| https://w3id.org/dpv/dpv-skos/dpv-dga   | https://w3id.org/dpv/legal/eu/dga      |
+| https://w3id.org/dpv/dpv-skos/dpv-tech  | https://w3id.org/dpv/tech              |
+| https://w3id.org/dpv/dpv-skos/dpv-legal | https://w3id.org/dpv/loc               |
+| https://w3id.org/dpv/dpv-owl            | https://w3id.org/dpv/owl               |
+| https://w3id.org/dpv/dpv-owl/dpv-pd     | https://w3id.org/dpv/pd/owl            |
+| https://w3id.org/dpv/dpv-owl/dpv-gdpr   | https://w3id.org/dpv/legal/eu/gdpr/owl |
+| https://w3id.org/dpv/dpv-owl/dpv-dga    | https://w3id.org/dpv/legal/eu/dga/owl  |
+| https://w3id.org/dpv/dpv-owl/dpv-tech   | https://w3id.org/dpv/tech/owl          |
+| https://w3id.org/dpv/dpv-owl/dpv-legal  | https://w3id.org/dpv/loc/owl           |
+|-----------------------------------------+----------------------------------------|
 ```
 
 # Contacts


### PR DESCRIPTION
- suffixes and prefixes are changed e.g. /dpv-pd --> /pd
- serialisation are changed e.g. /dpv-owl/dpv-pd --> /pd/owl
- deprecated IRIs are redirected e.g. /dpv-owl/dpv-pd --> /pd/owl