### PR TITLE
Added redirect for the PhyDit ontology

### DIFF
--- a/phydit/.htaccess
+++ b/phydit/.htaccess
@@ -1,0 +1,18 @@
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
+Options +FollowSymLinks
+RewriteEngine on
+
+#Rewrite rules for PhyDiT  ontology  
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*|\*/\*)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://autononous-buildings.github.io/phydit/phydit.html [R=302,L]
+RewriteRule ^doc$ https://autononous-buildings.github.io/phydit/readme.html [R=302,L]
+# Check if the requested MIME type is application/rdf+xml
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+# Redirect to www.blah.com/x.rdf
+RewriteRule ^(.*)$ https://autononous-buildings.github.io/phydit/phydit.owl.xml [L,R=301]

--- a/phydit/README.md
+++ b/phydit/README.md
@@ -1,0 +1,13 @@
+# PhyDiT: An ontology for creating physics-infused digital twins
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the ontologies in the Autonomous Building project.
+
+
+## Contact
+This space is administered by:  
+
+**Ganesh Ramanathan**  
+*Doctoral Researcher*  
+[University of St. Gallen](https://unisg.ch)  
+Switzerland  
+<ganesh.ramanathan@student.unisg.ch>  
+GitHub username: codepasta


### PR DESCRIPTION
Redirects to the Physics-infused Digital Twin ontology (PhyDiT ) and its documentation. Thank you!