### PR TITLE
Bugfix in redirect for APD namespace

### DIFF
--- a/APD/.htaccess
+++ b/APD/.htaccess
@@ -19,7 +19,7 @@ RewriteCond %{HTTP_ACCEPT} application/ld\+json
 RewriteRule ^release/(\d+)\.(\d+)\.(\d+)(.+)?$ https://traitecoevo.github.io/APD/release/$1.$2.$3/APD.json [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^(.+)$ https://traitecoevo.github.io/APD/APD.json [R=303,L]
+RewriteRule ^ https://traitecoevo.github.io/APD/APD.json [R=303,L]
 
 # ------------------------------------------------------------------------------
 # Rewrite rule to serve N-Triples
@@ -27,7 +27,7 @@ RewriteCond %{HTTP_ACCEPT} application/n-triples
 RewriteRule ^release/(\d+)\.(\d+)\.(\d+)(.+)?$ https://traitecoevo.github.io/APD/release/$1.$2.$3/APD.nt [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^(.+)$ https://traitecoevo.github.io/APD/APD.nt [R=303,L]
+RewriteRule ^ https://traitecoevo.github.io/APD/APD.nt [R=303,L]
 
 # ------------------------------------------------------------------------------
 # Rewrite rule to serve N-Quads
@@ -35,7 +35,7 @@ RewriteCond %{HTTP_ACCEPT} application/n-quads
 RewriteRule ^release/(\d+)\.(\d+)\.(\d+)(.+)?$ https://traitecoevo.github.io/APD/release/$1.$2.$3/APD.nq [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/n-quads
-RewriteRule ^(.+)$ https://traitecoevo.github.io/APD/APD.nq [R=303,L]
+RewriteRule ^ https://traitecoevo.github.io/APD/APD.nq [R=303,L]
 
 # ------------------------------------------------------------------------------
 # Rewrite rule to serve TTL
@@ -47,7 +47,7 @@ RewriteRule ^release/(\d+)\.(\d+)\.(\d+)(.+)?$ https://traitecoevo.github.io/APD
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle
-RewriteRule ^(.+)$ https://traitecoevo.github.io/APD/APD.ttl [R=303,L]
+RewriteRule ^ https://traitecoevo.github.io/APD/APD.ttl [R=303,L]
 
 # ------------------------------------------------------------------------------
 # Rewrite rule to serve HTML
@@ -60,4 +60,4 @@ RewriteRule ^glossary/glossary_(.+)/?$ https://traitecoevo.github.io/APD/index.h
 RewriteRule ^glossary/?$ https://traitecoevo.github.io/APD/index.html#glossary [R=303,NE,L]
 
 ## Final call should catch all remaining calls that haven't been matched above 
-RewriteRule ^(.+)$ https://traitecoevo.github.io/APD/index.html [R=303,L]
+RewriteRule ^ https://traitecoevo.github.io/APD/index.html [R=303,L]

--- a/APD/README.md
+++ b/APD/README.md
@@ -29,6 +29,9 @@ Suggestions for changes are welcome and can be posted at https://github.com/trai
   - `[R=303]` — A redirect. When a server responds with a `303` status code, it provides a `Location` pointing to a different URI. The client, upon receiving a `303` response, automatically makes a `GET` request to the URI specified in the `Location` header.  
   - `[L]` — If the previous conditions pass, this rule is executed, and no more evaluation is done. 
   - `[NE]` — (noescape) Prevents conversion of special characters to their hexcode equivalent; needed for links including a `#`.
+- the following matches are used
+  - `RewriteRule ^traits/trait_(.+)$ https://...` - the `(.+)` captures the 1 or more characters after `trait_` in the URL
+  - `RewriteRule ^ https://...` - captures any URL that hasn't been matched by the previous rules. Same behaviour as `RewriteRule ^(.*)$ https://...`. Note behaves differently to `RewriteRule ^$ https://...` which would only match the root URL. 
 
 ## Usage
 


### PR DESCRIPTION
Hi Team,

I recently update the .htaccess file for the APD namespace (https://github.com/perma-id/w3id.org/pull/3963). Unfortunately I made an error (should have used `^ ` instead of `^(.+)$` as general catch-all rule, breaking many redirects. This PR corrects the issue. Apologies for the extra load. 

Thanks,
Daniel
