### PR TITLE
Introduce w3id.org/cmd for measure description

### DIFF
--- a/cmd/.htaccess
+++ b/cmd/.htaccess
@@ -1,0 +1,22 @@
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+
+RewriteEngine on
+
+#Rewrite rules to serve HTML content, TTL...
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*|\*/\*)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://jendersen.github.io/TSoR-vocab/  [R=303,NE,L]
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.* 
+RewriteRule ^$ https://jendersen.github.io/TSoR-vocab/cmd.owl [R=303,NE,L]
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://jendersen.github.io/TSoR-vocab/cmd.ttl [R=303,NE,L]
+#default response: owl
+RewriteRule ^$ https://jendersen.github.io/TSoR-vocab/cmd.owl [R=303,NE,L]

--- a/cmd/readme.md
+++ b/cmd/readme.md
@@ -1,0 +1,12 @@
+
+Repository for redirecting to Compound Measure Description vocabulary
+===================
+
+Repository created to store the redirections of the CMD vocabulary. The vocabulary enables the description of compound measures, i.e. measures with several metrics or items organized along several dimensions.
+
+## Homepage:
+* https://jendersen.github.io/TSoR-vocab/
+
+## Contacts:
+* [Jennie Andersen](https://liris.cnrs.fr/page-membre/jennie-andersen) ([0000-0001-6907-0136](https://orcid.org/0000-0001-6907-0136))
+

--- a/cmd/readme.md
+++ b/cmd/readme.md
@@ -8,5 +8,5 @@ Repository created to store the redirections of the CMD vocabulary. The vocabula
 * https://jendersen.github.io/TSoR-vocab/
 
 ## Contacts:
-* [Jennie Andersen](https://liris.cnrs.fr/page-membre/jennie-andersen) ([0000-0001-6907-0136](https://orcid.org/0000-0001-6907-0136))
+* [Jennie Andersen](https://liris.cnrs.fr/page-membre/jennie-andersen) (GitHub: [Jendersen](https://github.com/Jendersen), ORCID: [0000-0001-6907-0136](https://orcid.org/0000-0001-6907-0136))
 


### PR DESCRIPTION
Add new folder with redirection rules to the Compound Measure Description vocabulary.