### PR TITLE
update neio .htaccess

### DIFF
--- a/neural-electronic-interface-ontology/.htaccess
+++ b/neural-electronic-interface-ontology/.htaccess
@@ -1,3 +1,7 @@
+Options +FollowSymLinks
+Options -MultiViews
+
+RewriteEngine on
 # Directive to ensure *.rdf *.owl *.jsonld *.ttl files served as appropriate content type,
 # if not present in main apache config
 AddType application/rdf+xml .rdf .owl

--- a/neural-electronic-interface-ontology/.htaccess
+++ b/neural-electronic-interface-ontology/.htaccess
@@ -1,0 +1,41 @@
+# Directive to ensure *.rdf *.owl *.jsonld *.ttl files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf .owl
+AddType text/turtle .ttl
+AddType application/ld+json .jsonld
+
+# redirect terms to bioportal
+RewriteRule ^(.*/NEIO_)(.+)$ https://bioportal.bioontology.org/ontologies/NEIO/?p=classes&conceptid=https%3A%2F%2Fw3id.org%2Fneural-electronic-interface-ontology%2FNEIO_$2 [R=302,L] 
+
+# redirect ontology files to github repo
+# owl files
+RewriteRule ^(.*/neio.owl) https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio.owl
+RewriteRule ^(.*/NEIO.owl) https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio.owl
+
+RewriteRule ^(.*/neio-full.owl) https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio-full.owl
+RewriteRule ^(.*/NEIO-full.owl) https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio-full.owl
+
+RewriteRule ^(.*/neio-base.owl) https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio-base.owl
+RewriteRule ^(.*/NEIO-base.owl) https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio-base.owl
+
+RewriteRule ^(.*/neio-non-classified.owl) https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio-non-classified.owl
+RewriteRule ^(.*/NEIO-non-classified.owl) https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio-non-classified.owl
+
+RewriteRule ^(.*/neio-simple.owl) https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio-simple.owl
+RewriteRule ^(.*/NEIO-simple.owl) https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio-simple.owl
+
+# obo files
+RewriteRule ^(.*/neio.obo) https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio.obo
+RewriteRule ^(.*/NEIO.obo) https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio.obo
+
+RewriteRule ^(.*/neio-full.obo) https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio-full.obo
+RewriteRule ^(.*/NEIO-full.obo) https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio-full.obo
+
+RewriteRule ^(.*/neio-base.obo) https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio-base.obo
+RewriteRule ^(.*/NEIO-base.obo) https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio-base.obo
+
+RewriteRule ^(.*/neio-non-classified.obo) https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio-non-classified.bo
+RewriteRule ^(.*/NEIO-non-classified.obo) https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio-non-classified.obo
+
+RewriteRule ^(.*/neio-simple.obo) https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio-simple.obo
+RewriteRule ^(.*/NEIO-simple.obo) https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio-simple.obo

--- a/neural-electronic-interface-ontology/README.md
+++ b/neural-electronic-interface-ontology/README.md
@@ -1,0 +1,11 @@
+# Neural Electronic Interface Ontology
+The Neural Electronic Interface Ontology represents the types of devices used to interface with the central nervous system to enhance (or augment) stimuli from a subject's external environment, the conditions under which these devices should be employed, the assessment of a subject's sensory ability, and the metrics for evaluating the performance.
+
+## Ontology IRI
+https://w3id.org/neural-electronic-interface-ontology/neio.owl
+
+## Namespace
+https://w3id.org/neural-electronic-interface-ontology/NEIO_
+
+## Contacts
+* Bill Duncan <wdduncan@gmail.com> ([@wdduncan](https://github.com/wdduncan))


### PR DESCRIPTION
Trying to fix .htacess. My rewrites don't seem be working.   

`https://w3id.org/neural-electronic-interface-ontology/neio.owl` should redirect to [https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio.owl](https://raw.githubusercontent.com/uflcod/neural-electronic-interface-ontology/main/neio.owl)

And `https://w3id.org/neural-electronic-interface-ontology/NEIO_0000101` should redirect to [https://bioportal.bioontology.org/ontologies/NEIO/?p=classes&conceptid=https%3A%2F%2Fw3id.org%2Fneural-electronic-interface-ontology%2FNEIO_0000101](https://bioportal.bioontology.org/ontologies/NEIO/?p=classes&conceptid=https%3A%2F%2Fw3id.org%2Fneural-electronic-interface-ontology%2FNEIO_0000101).

I tested my rewrite rule on [https://htaccess.madewithlove.com/](https://htaccess.madewithlove.com/). Is there a better way to debug?