### PR TITLE
Add two additional rewrite rules for Biopragmatics

### DIFF
--- a/biopragmatics/.htaccess
+++ b/biopragmatics/.htaccess
@@ -11,6 +11,12 @@ RewriteRule ^biomappings/sssom/(.+) https://raw.githubusercontent.com/biopragmat
 
 # Make Bioregistry artifacts available
 # Redirect registry objects
+# For example, we want https://w3id.org/biopragmatics/bioregistry.epm.json to redirect to https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/contexts/bioregistry.epm.json
+RewriteRule ^(.+).epm.json https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/contexts/$1.epm.json
+RewriteRule ^(.+).context.jsonld https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/contexts/$1.context.jsonld
+RewriteRule ^(.+).context.ttl https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/contexts/$1.context.ttl
+
+# Redirect registry objects
 # For example, we want https://w3id.org/biopragmatics/bioregistry/registry.json to redirect to https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/registry/registry.json
 RewriteRule ^bioregistry/registry\.(.+) https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/registry/registry.$1
 

--- a/biopragmatics/.htaccess
+++ b/biopragmatics/.htaccess
@@ -8,3 +8,12 @@ RewriteRule ^resources/(.+) https://github.com/biopragmatics/obo-db-ingest/raw/m
 # Make biomappings SSSOM artifacts available
 # For example, we want https://w3id.org/biopragmatics/biomappings/biomappings.sssom.tsv to redirect to https://raw.githubusercontent.com/biopragmatics/biomappings/master/docs/_data/sssom/biomappings.sssom.tsv
 RewriteRule ^biomappings/sssom/(.+) https://raw.githubusercontent.com/biopragmatics/biomappings/master/docs/_data/sssom/$1
+
+# Make Bioregistry artifacts available
+# Redirect registry objects
+# For example, we want https://w3id.org/biopragmatics/bioregistry/registry.json to redirect to https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/registry/registry.json
+RewriteRule ^bioregistry/registry\.(.+) https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/registry/registry.$1
+
+# Redirect Bioregistry contexts
+# For example, we want https://w3id.org/biopragmatics/bioregistry/context/bioregistry.rpm.json to redirect to https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/contexts/bioregistry.rpm.json
+RewriteRule ^bioregistry/context/(.+) https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/contexts/$1

--- a/biopragmatics/README.md
+++ b/biopragmatics/README.md
@@ -5,6 +5,8 @@ This [W3ID](https://w3id.org/) provides a persistent URI namespace for artifacts
 This initially includes:
 
 1. Making persistent URIs for ontologies created by converting various biomedical databases in the https://github.com/biopragmatics/obo-db-ingest repository.
+2. Make Biomappings resources available
+3. Make Bioregistry contexts available as top-level resources, like https://w3id.org/biopragmatics/bioregistry.epm.json
 
 ## Uses
 


### PR DESCRIPTION
This adds two new rewrite rules for the Biopragmatics namespace. These are specifically for artifacts in the Bioregistry project, which is a part of the Biopragmatics organization on GitHub. I'm the maintainer of both the projects and this redirect configuration on w3id