### PR TITLE
NEIO redirect to bioportal (attempt 1)

### DIFF
--- a/neural-electronic-interface-ontology/.htaccess
+++ b/neural-electronic-interface-ontology/.htaccess
@@ -3,7 +3,8 @@ Options -MultiViews
 RewriteEngine on
 
 # redirect terms to bioportal
-# RewriteRule ^(.*/NEIO_)(.+)$ https://bioportal.bioontology.org/ontologies/NEIO/?p=classes&conceptid=https%3A%2F%2Fw3id.org%2Fneural-electronic-interface-ontology%2FNEIO_$2 [R=302,L] 
+# test using https://w3id.org/neural-electronic-interface-ontology/NEIO_0000101
+RewriteRule ^neio_([a-zA-Z0-9]+)$ https://bioportal.bioontology.org/ontologies/NEIO/?p=classes&conceptid=https\%3A\%2F\%2Fw3id.org\%2Fneural-electronic-interface-ontology\%2FNEIO_$1 [R=302,NC,NE,L]
 
 # redirect ontology files to github repo
 # owl files


### PR DESCRIPTION
I added the rewrite rule:
```
RewriteRule ^neio_([a-zA-Z0-9]+)$ https://bioportal.bioontology.org/ontologies/NEIO/?p=classes&conceptid=https\%3A\%2F\%2Fw3id.org\%2Fneural-electronic-interface-ontology\%2FNEIO_$1 [R=302,NC,NE,L]
```
This works on my local server.

It can be tested using https://w3id.org/neural-electronic-interface-ontology/NEIO_0000101.