### PR TITLE
rml: fix zip resources

### DIFF
--- a/rml/.htaccess
+++ b/rml/.htaccess
@@ -76,7 +76,7 @@ RewriteCond %{REQUEST_URI} io/shapes
 RewriteRule io/shapes/?$ https://kg-construct.github.io/rml-io/shapes/io.ttl [NE,R,L]
 RewriteCond %{REQUEST_URI} io/bc
 RewriteRule io/bc/?$ https://kg-construct.github.io/rml-io/ontology/rml-io-bc.ttl [NE,R,L]
-RewriteCond %{REQUEST_URI} (source|target|encoding|compression|serialization|null|referenceFormulation|iterator|namespacePrefix|namespaceURL|namespace|LogicalSource|LogicalTarget|ReferenceFormulation|Source|Target|Namespace|Encoding|Compression|JSONPath|XPath|XPathReferenceFormulation|CSV|SQL2008Table|SQL2008Query|UTF-8|UTF-16|none|gzip|zip|tarxz|targzip)$
+RewriteCond %{REQUEST_URI} (source|target|encoding|compression|serialization|null|referenceFormulation|iterator|namespacePrefix|namespaceURL|namespace|LogicalSource|LogicalTarget|ReferenceFormulation|Source|Target|Namespace|Encoding|Compression|JSONPath|XPath|XPathReferenceFormulation|CSV|SQL2008Table|SQL2008Query|UTF-8|UTF-16|none|gzip|\/zip|tarxz|targzip)$
 RewriteRule ^(.*)$ https://%{SERVER_NAME}/rml/$1.io.conneg [NE,R,L]
 
 


### PR DESCRIPTION
Resources compressed as zip were redirected to ontology instead of resource since they also contain 'zip'