### PR TITLE
Added /usgs/sb/ rewrite rules and usgs namespace readme changes

### DIFF
--- a/usgs/README.md
+++ b/usgs/README.md
@@ -30,10 +30,30 @@ This namespace starts with the unique identifier for the Zotero Group Library co
 ### Links
 With `$1` being a unique Zotero library identifier and `$2` being a unique item identifier within that library...
 
-Links in the form `https://w3id.org/z/$1/$2`
+Links in the form `https://w3id.org/usgs/z/$1/$2`
 * No `Accept` header or `text/html` -> `https://www.zotero.org/groups/$1/usgs_ni_43-101_reports/items/$2`
-* Using `Accept` header `application/json` -> `https://api.zotero.org/groups/$1/items/$2?format=atom`
+* Using `Accept` header `application/json` -> `https://api.zotero.org/groups/$1/items/$2?format=json`
 * Using `Accept` header `application/atom+xml` -> `https://api.zotero.org/groups/$1/items/$2?format=atom`
+
+### Contacts
+
+* Sky Bristol
+  * sbristol@usgs.gov
+  * Github: [https://github.com/skybristol](skybristol)
+  * ORCID: [https://orcid.org/0000-0003-1682-4031](0000-0003-1682-4031)
+
+## ScienceBase
+ScienceBase uses a UUID form of identifier that is reasonably permanent as long as ScienceBase continues to exist and operate with its domain and path. Given the possibility of future architecture changes in ScienceBase, the w3id.org rewrite rule can allow for some degree of flexibility in continuing to use the UUID identifiers for an item but redirecting to another infrastructure domain and path in future.
+
+### Uses
+This namespace simply includes the UUID identifier under the /usgs/sb/ path and redirects to the item in ScienceBase under /catalog/item/. It was set up for cases where ScienceBase is being used as a long-term archive for items that do not have a DOI and the URLs will be used in and referenced from other third party systems.
+
+### Links
+With `$1` being the ScienceBase UUID for a Catalog item...
+
+Links in the form `https://w3id.org/usgs/sb/$1`
+* No `Accept` header or `text/html` -> `https://www.sciencebase.gov/catalog/item/$1`
+* Using `Accept` header `application/json` -> `https://www.sciencebase.gov/catalog/item/$1?format=json`
 
 ### Contacts
 

--- a/usgs/sb/.htaccess
+++ b/usgs/sb/.htaccess
@@ -1,0 +1,9 @@
+# Rewrite engine setup
+RewriteEngine on
+
+# JSON response from ScienceBase API
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^(.*)$ https://www.sciencebase.gov/catalog/item/$1?format=json [R=302,L]
+
+# HTML response from ScienceBase API
+RewriteRule ^(.*)$ https://www.sciencebase.gov/catalog/item/$1 [R=302,L]


### PR DESCRIPTION
I added a new "sub-namespace" for the /usgs/ identifier space to handle cases where we are using ScienceBase as a long-term archive and need an abstraction to safeguard URLs proliferated onto third party infrastructure for the eventual move of the archive items onto a ScienceBase successor.