### PR TITLE
Redirects for HEU research project DigiBatt

### DIFF
--- a/digibatt/.htaccess
+++ b/digibatt/.htaccess
@@ -1,7 +1,7 @@
 RewriteEngine On
 
 # Rule 1: point to index
-RewriteRule ^digibatt$ https://battmoteam.github.io/digibatt/index.html [R=301,L]
+RewriteRule ^digibatt$ https://digibatt.github.io/digibatt/index.html [R=301,L]
 
 # Rules 2-10: point to respective pages
-RewriteRule ^digibatt/(organization|deliverable|milestone|workpackage|task|publication|data|event|software)(|/public|#(.*))$ https://battmoteam.github.io/digibatt/$1.html$3 [R=301,L]
+RewriteRule ^digibatt/(organization|deliverable|milestone|workpackage|task|publication|data|event|software)(|/public|#(.*))$ https://digibatt.github.io/digibatt/$1.html$3 [R=301,L]

--- a/digibatt/.htaccess
+++ b/digibatt/.htaccess
@@ -1,0 +1,7 @@
+RewriteEngine On
+
+# Rule 1: point to index
+RewriteRule ^digibatt$ https://battmoteam.github.io/digibatt/index.html [R=301,L]
+
+# Rules 2-10: point to respective pages
+RewriteRule ^digibatt/(organization|deliverable|milestone|workpackage|task|publication|data|event|software)(|/public|#(.*))$ https://battmoteam.github.io/digibatt/$1.html$3 [R=301,L]

--- a/digibatt/readme.md
+++ b/digibatt/readme.md
@@ -1,0 +1,26 @@
+# DigiBatt Project PURLs
+
+This repository contains the .htaccess file to set up Persistent Uniform Resource Locators (PURLs) for the Horizon Europe research project **DigiBatt** (DIGITAL SOLUTIONS FOR ACCELERATED BATTERY TESTING).
+
+## Project Information
+
+- Project Title: DigiBatt - DIGITAL SOLUTIONS FOR ACCELERATED BATTERY TESTING
+- Grant Agreement No.: 101103997
+- Website: [DigiBatt Project](https://digibattproject.eu/)
+
+## Purpose
+
+The .htaccess file provided in this repository is intended to be used with the w3id.org Persistent URL (PURL) service. It redirects requests made to specific paths within the DigiBatt project to corresponding pages on the project website.
+
+## Redirect Rules
+
+The .htaccess file implements the following redirect rules:
+
+1. Redirects <https://w3id.org/digibatt> to the **index** page <https://battmoteam.github.io/digibatt/index.html>.
+2. Redirects paths related to **organizations**, **deliverables**, **milestones**, **work packages**, **tasks**, **publications**, **datasets**, **events**, and **software** to their respective pages on the project website.
+
+For detailed information about each redirect rule, please refer to the comments within the .htaccess file.
+
+---
+
+For any questions or issues, please contact [DigiBatt Project Team](mailto:francesca.watson@sintef.no).

--- a/digibatt/readme.md
+++ b/digibatt/readme.md
@@ -24,3 +24,5 @@ For detailed information about each redirect rule, please refer to the comments 
 ---
 
 For any questions or issues, please contact [DigiBatt Project Team](mailto:francesca.watson@sintef.no).
+
+DigiBatt W3ID Maintainer: [@jsimonclark](https://github.com/jsimonclark)

--- a/digibatt/readme.md
+++ b/digibatt/readme.md
@@ -16,7 +16,7 @@ The .htaccess file provided in this repository is intended to be used with the w
 
 The .htaccess file implements the following redirect rules:
 
-1. Redirects <https://w3id.org/digibatt> to the **index** page <https://battmoteam.github.io/digibatt/index.html>.
+1. Redirects <https://w3id.org/digibatt> to the **index** page <https://digibatt.github.io/digibatt/index.html>.
 2. Redirects paths related to **organizations**, **deliverables**, **milestones**, **work packages**, **tasks**, **publications**, **datasets**, **events**, and **software** to their respective pages on the project website.
 
 For detailed information about each redirect rule, please refer to the comments within the .htaccess file.


### PR DESCRIPTION
This pull request creates basic redirect rules to be used for the Horizon Europe research project DigiBatt. It is intended to support the creation of RDF linked data and knowledge graphs in the project. 

The .htaccess file contains two re-direct rules:

1. Point the base purl `https://w3id.org/digibatt` to the project documentation index file `https://battmoteam.github.io/digibatt/index.html`
2. Point sub-category purls to the respective html files in the project documentation, e.g. `https://w3id.org/digibatt/deliverable/public#D1` to `https://battmoteam.github.io/digibatt/deliverable.html#D1`

Project Website: [DigiBatt](https://digibattproject.eu/)
Cordis Entry: [DigiBatt on Cordis](https://cordis.europa.eu/project/id/101103997)
Contacts: [Simon Clark](mailto:simon.clark@sintef.no), [Francesca Watson](mailto:francesca.watson@sintef.no)