### PR TITLE
Update .htaccess for digibatt

### DIFF
--- a/digibatt/.htaccess
+++ b/digibatt/.htaccess
@@ -1,7 +1,7 @@
 RewriteEngine On
 
 # Rule 1: point to index
-RewriteRule ^digibatt$ https://digibatt.github.io/digibatt/index.html [R=301,L]
+RewriteRule ^$ https://digibatt.github.io/digibatt/index.html [R=301,L]
 
 # Rules 2-10: point to respective pages
-RewriteRule ^digibatt/(organization|deliverable|milestone|workpackage|task|publication|data|event|software)(|/public|#(.*))$ https://digibatt.github.io/digibatt/$1.html$3 [R=301,L]
+RewriteRule ^/(organization|deliverable|milestone|workpackage|task|publication|data|event|software)(|/public|#(.*))$ https://digibatt.github.io/digibatt/$1.html$3 [R=301,L]

--- a/digibatt/.htaccess
+++ b/digibatt/.htaccess
@@ -4,4 +4,4 @@ RewriteEngine On
 RewriteRule ^$ https://digibatt.github.io/digibatt/index.html [R=301,L]
 
 # Rules 2-10: point to respective pages
-RewriteRule ^/(organization|deliverable|milestone|workpackage|task|publication|data|event|software)(|/public|#(.*))$ https://digibatt.github.io/digibatt/$1.html$3 [R=301,L]
+RewriteRule ^(organization|deliverable|milestone|workpackage|task|publication|data|event|software)(|/public|#(.*))$ https://digibatt.github.io/digibatt/$1.html$3 [R=301,L]


### PR DESCRIPTION
This pull request modifies the .htaccess file for digibatt to remove the redundant "digibatt" string from the PURL, such that the following redirection is valid:

`https://w3id.org/digibatt` --> `https://digibatt.github.io/digibatt/index.html`