### PR TITLE
Remove superfluous directory name from .htaccess.

### DIFF
--- a/gensc/.htaccess
+++ b/gensc/.htaccess
@@ -1,5 +1,5 @@
 Options +FollowSymLinks
 RewriteEngine on
 
-RewriteRule ^gensc/terms/MIXS:(.*)$ https://w3id.org/mixs/$1 [R=302,L]
+RewriteRule ^terms/MIXS:(.*)$ https://w3id.org/mixs/$1 [R=302,L]
 RewriteRule ^(.*)$ https://www.gensc.org/ [R=302,L]


### PR DESCRIPTION
Sorry @dgarijo, I didn't notice this when I reviewed the patch.  The directory name should not be repeated in the .htaccess file.

(Fix for #4003.)