### PR TITLE
feat(catenax): add rule for credential jsonld context

### DIFF
--- a/catenax/.htaccess
+++ b/catenax/.htaccess
@@ -91,7 +91,7 @@ RewriteRule ^taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/pr
 RewriteRule ^policy(/|.*)$ https://raw.githubusercontent.com/catenax-eV/cx-odrl-profile/main/profile.ttl [R=302,L]
 
 # Credential json-ld context resolution
-RewriteRule ^credentials/v1.0.0(.*)$ https://raw.githubusercontent.com/eclipse-tractusx/tractusx-profiles/8aad90cb9b9a83ce365f42e961dd6dd4ea0c926f/cx/credentials/schema/context/credentials.context.json [R=302,L]
+RewriteRule ^credentials/v1.0.0(.*)$ https://eclipse-tractusx.github.io/tractusx-profiles/cx/context/credentials.context.json [R=302,L]
 
 # Rewrite rule to serve the TTL content from the vocabulary URI by default
 RewriteRule ^(.*)$ https://catenax-ng.github.io/product-ontology [R=303,L]


### PR DESCRIPTION
The CX credentials require a resolvable context [1]. Its application can be seen in the examples [2].

[1] https://github.com/eclipse-tractusx/tractusx-profiles/blob/main/cx/credentials/schema/context/credentials.context.json
[2] https://github.com/eclipse-tractusx/tractusx-profiles/blob/main/cx/credentials/samples/bpn.credential.json