### PR TITLE
feat(tractusx): register tractusx namespace

### DIFF
--- a/tractusx/.htaccess
+++ b/tractusx/.htaccess
@@ -18,5 +18,5 @@ RewriteBase /
 # Rewrite rule to resolve policy context
 RewriteRule ^policy/v1.0.0(.+)$ https://raw.githubusercontent.com/eclipse-tractusx/tractusx-profiles/09527f14c724b45f81a09e7adfbd066af8f2a92d/cx/credentials/schema/context/policy.context.json [R=302,L]
 
-# Rewrite rule to serve the TTL content from the vocabulary URI by default
+# Rewrite rule to default to the tx webpage
 RewriteRule ^(.*)$ https://eclipse-tractusx.github.io/ [R=303,L]

--- a/tractusx/.htaccess
+++ b/tractusx/.htaccess
@@ -16,7 +16,7 @@ RewriteEngine On
 RewriteBase /
 
 # Rewrite rule to resolve policy context
-RewriteRule ^policy/v1.0.0(.+)$ https://raw.githubusercontent.com/eclipse-tractusx/tractusx-profiles/09527f14c724b45f81a09e7adfbd066af8f2a92d/cx/credentials/schema/context/policy.context.json [R=302,L]
+RewriteRule ^policy/v1.0.0(.+)$ https://eclipse-tractusx.github.io/tractusx-profiles/cx/context/policy.context.json [R=302,L]
 
 # Rewrite rule to default to the tx webpage
 RewriteRule ^(.*)$ https://eclipse-tractusx.github.io/ [R=303,L]

--- a/tractusx/.htaccess
+++ b/tractusx/.htaccess
@@ -1,0 +1,22 @@
+#
+# Tractus-X Namespace Forwarding Rules
+# tested with https://htaccess.madewithlove.com/
+#
+
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.ttl and *.jsonld files served as appropriate content type,
+# if not present in main apache config
+AddType text/turtle .ttl
+AddType application/ld+json .jsonld
+# Rewrite engine setup
+RewriteEngine On
+#Change the path to the folder here
+RewriteBase /
+
+# Rewrite rule to resolve policy context
+RewriteRule ^policy/v1.0.0(.+)$ https://raw.githubusercontent.com/eclipse-tractusx/tractusx-profiles/09527f14c724b45f81a09e7adfbd066af8f2a92d/cx/credentials/schema/context/policy.context.json [R=302,L]
+
+# Rewrite rule to serve the TTL content from the vocabulary URI by default
+RewriteRule ^(.*)$ https://eclipse-tractusx.github.io/ [R=303,L]

--- a/tractusx/README.md
+++ b/tractusx/README.md
@@ -1,0 +1,10 @@
+# Tractus-X Namespace
+
+This namespace serves as redirection platform for multiple resources from the [Eclipse Tractus-X project](https://eclipse-tractusx.github.io/) - mostly stemming from the 
+[Tractus-X Profiles repository](https://github.com/eclipse-tractusx/tractusx-profiles).
+
+Contact: 
+
+- Stephan Bauer <stephan.bauer@catena-x.net> (https://github.com/HFocken)
+- James Marino <jim.marino@gmail.com> (https://github.com/jimmarino)
+- Arno Weiß <arno.weiss@sap.com> (https://github.com/arnoweiss)


### PR DESCRIPTION
Tractus-X is one of the most active projects in the Eclipse Foundation [1]. In different repositories, there's structures that are identified in the `https://w3id.org/tractusx` namespace. Reference implementations like tractusx-edc [2] use properties from this namespace. The spec can be found in tractusx-profiles [3]

[1]https://projects.eclipse.org/projects/automotive.tractusx
[2] https://github.com/eclipse-tractusx/tractusx-edc
[3] https://github.com/eclipse-tractusx/tractusx-profiles