### PR TITLE
adds directory for Plattform Industrie 4.0 and redirects for CSSE ontology

### DIFF
--- a/plattform-i40/css-effect/.htaccess
+++ b/plattform-i40/css-effect/.htaccess
@@ -1,0 +1,23 @@
+RewriteEngine on
+
+# Redirect ontology version IRI to the given version
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^(\d\.\d\.\d)/?$ https://raw.githubusercontent.com/aljoshakoecher/css-effect/v$1/css-effect.ttl [R=303,NC,L]
+
+https://raw.githubusercontent.com/aljoshakoecher/css-effect/main/css-effect.ttl
+
+# Redirect ontology IRI (withouth version) to the current main branch version
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^/?$ https://raw.githubusercontent.com/aljoshakoecher/css-effect/main/css-effect.ttl [R=303,NC,L]
+
+# Redirect HTML requests to the main repository page
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(\d\.\d\.\d)?/?$ https://github.com/aljoshakoecher/css-effect [R=302,NC,L]
+

--- a/plattform-i40/readme.md
+++ b/plattform-i40/readme.md
@@ -1,0 +1,16 @@
+# Plattform Industrie 4.0
+Redirects for ontologies developed in working groups of Plattform Industrie 4.0.
+
+## Overview
+Working groups of Plattform Industrie 4.0 develop information models that are sometimes implemented as OWL ontologies. The .htaccess files in the subdirectories of this directory set up redirects for such ontologies so that ontology IRIs can be resolved to proper URLs.
+Content-Negotiation is supported which means:
+- If you try to open ontology IRIs with a browser (i.e. request an HTML document), the request is redirected to the corresponding Github repository page / readme.
+- If you request a ttl or rdf-xml version (e.g. when importing an ontology through a tool like Protege), the request will be redirected to the actual ontology file. Versions are also taken into account so that you may import an ontology with a specific version IRI.
+
+List of ontologies that are currently redirected:
+- CSSE: Lightweight ontology module to formally represent effects of manufacturing operations in the context of capabilities, skills and services (see [whitepaper](https://www.plattform-i40.de/IP/Redaktion/EN/Downloads/Publikation/CapabilitiesSkillsServices.html) for more info)
+
+## Maintainers
+- Aljosha Köcher (@aljoshakoecher)
+- Tobias Klausmann (@tobijk2)
+- Michael Winter (@winterIAT)


### PR DESCRIPTION
Adds a new parent directory for ontologies created by working groups of Plattform Industrie 4.0.
This parent folder contains a directory structure with redirects for ontologies. Every directory contains an .htaccess file that takes care of redirecting requests to that particular ontology. This PR also adds the first ontology called "css-effect". 