### PR TITLE
deletes incorrect line that got copied in there by accident

### DIFF
--- a/plattform-i40/css-effect/.htaccess
+++ b/plattform-i40/css-effect/.htaccess
@@ -6,8 +6,6 @@ RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
 RewriteRule ^(\d\.\d\.\d)/?$ https://raw.githubusercontent.com/aljoshakoecher/css-effect/v$1/css-effect.ttl [R=303,NC,L]
 
-https://raw.githubusercontent.com/aljoshakoecher/css-effect/main/css-effect.ttl
-
 # Redirect ontology IRI (withouth version) to the current main branch version
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]


### PR DESCRIPTION
Sorry to cause additional efforts. There was an incorrect line that got copied in between the rewrite rules by accident and it broke the redirects.