### PR TITLE
fix(tractusx): match from 0 additional chars instead one

### DIFF
--- a/tractusx/.htaccess
+++ b/tractusx/.htaccess
@@ -16,7 +16,7 @@ RewriteEngine On
 RewriteBase /
 
 # Rewrite rule to resolve policy context
-RewriteRule ^policy/v1.0.0(.+)$ https://eclipse-tractusx.github.io/tractusx-profiles/cx/context/policy.context.json [R=302,L]
+RewriteRule ^policy/v1.0.0(.*)$ https://eclipse-tractusx.github.io/tractusx-profiles/cx/context/policy.context.json [R=302,L]
 
 # Rewrite rule to default to the tx webpage
 RewriteRule ^(.*)$ https://eclipse-tractusx.github.io/ [R=303,L]


### PR DESCRIPTION
The behavior was such that `https://w3id.org/tractusx/policy/v1.0.0` didn't resolve correctly while `https://w3id.org/tractusx/policy/v1.0.0/` did. The fix should resolve this.