### PR TITLE
Add override for mediatype/.

### DIFF
--- a/mediatype/.htaccess
+++ b/mediatype/.htaccess
@@ -1,5 +1,10 @@
 RewriteEngine On
 
+#################
+# 2024-04-26: w3id.org administrative override due to problematic content at target domain
+RewriteRule ^.*$ https://github.com/nicholascar/mediatypes-service [R=302,L]
+#################
+
 # one-off redirect for the DCAT Dataset identifier for this Media Types dataset
 RewriteCond %{QUERY_STRING} ^_format=text/turtle$ [OR]
 RewriteCond %{HTTP:Accept} text/turtle [NC]


### PR DESCRIPTION
The current content at `conneg.info` is problematic. It appears the domain control was lost. Overriding to the source of what likely was there before and leaving to the maintainer (@nicholascar) to fix as needed.

More info: https://github.com/perma-id/w3id.org/issues/3625