### PR TITLE
Add entries for IAW Glycerine instance

### DIFF
--- a/iaw/.htaccess
+++ b/iaw/.htaccess
@@ -1,10 +1,19 @@
 RewriteEngine On
 
-# IAW images.
+# IAW images (ARDC instance).
 RewriteRule ^images/(.*)$ https://iaw-image-server.ardc-hdcl-sia-iaw.cloud.edu.au/images/$1 [L]
 
-# IAW publication data.
+# IAW publication data (ARDC instance).
 RewriteRule ^data/publications/(.*)$ https://iaw-server.ardc-hdcl-sia-iaw.cloud.edu.au/api/publications/$1 [L]
 
-# IAW rendered publications.
+# IAW rendered publications (ARDC instance).
 RewriteRule ^publications/(.*)$ https://iaw.ardc-hdcl-sia-iaw.cloud.edu.au/publications/$1 [L]
+
+# IAW images (Glycerine instance).
+RewriteRule ^gly/images/(.*)$ https://image-server.glycerine.io/images/$1 [L]
+
+# IAW publication data (Glycerine instance).
+RewriteRule ^gly/data/publications/(.*)$ https://server.glycerine.io/api/publications/$1 [L]
+
+# IAW rendered publications (Glycerine instance).
+RewriteRule ^gly/publications/(.*)$ https://app.glycerine.io/publications/$1 [L]


### PR DESCRIPTION
Added persistent URL entries for publications hosted in the Glycerine instance.