### PR TITLE
add redirect ontology classes view by default

### DIFF
--- a/radx/.htaccess
+++ b/radx/.htaccess
@@ -7,7 +7,9 @@ RewriteEngine on
 RewriteRule ^$ https://radxdatahub.bioportal.bioontology.org/ontologies
 
 # Rewrite for GDMT
+RewriteRule ^gdmt$ https://radxdatahub.bioportal.bioontology.org/ontologies/GDMT/?p=classes
 RewriteRule ^gdmt/(.+)$ https://radxdatahub.bioportal.bioontology.org/ontologies/GDMT/?p=classes&conceptid=https://w3id.org/gdmt/$1
 
 # Rewrite for RADx Missing Values Reasons vocab
+RewriteRule ^RADXTT-MVREASONS$ https://radxdatahub.bioportal.bioontology.org/ontologies/RADXTT-MVREASONS/?p=classes
 RewriteRule ^RADXTT-MVREASONS/(.+)$ https://radxdatahub.bioportal.bioontology.org/ontologies/RADXTT-MVREASONS/?p=classes&conceptid=https://radx.orgx/vocs/missing-value-reason/$1


### PR DESCRIPTION
add a default redirect to the ontology classes view when no terms are specified 