### PR TITLE
Added documentation and rewrite rules for /usgs/geokb/

### DIFF
--- a/usgs/README.md
+++ b/usgs/README.md
@@ -1,24 +1,19 @@
 # /usgs/
-
 Multiple rewrite cases for assets of the U.S. Geological Survey
 
 ## Geographic Names Information System (GNIS) Linked Open Data
-
 GNIS-LD was created by the UCSB STKO Lab in collaboration with the USGS Center for Excellence in Geospatial Information Science (CEGIS).
 
 ### Uses
-
 Handles dereferencing logic, redirection, and SPARQL query proxying for the GNIS-LD implementation.
 
 ### Links
-
 With "$1" being a unique identifier from the GNIS-LD implementation of the GNIS ontology...
 
 Links in the form `https://w3id.org/usgs/$1`
 * Redirect to `http://gnis-ld.org/lod/$1`
 
 ### Contacts
-
 * [About the GNIS-LD project](https://gnis-ld.org/about)
 
 ## GeoArchive collection of NI 43-101 Technical Reports (/4530692/)
@@ -36,7 +31,54 @@ Links in the form `https://w3id.org/z/$1/$2`
 * Using `Accept` header `application/atom+xml` -> `https://api.zotero.org/groups/$1/items/$2?format=atom`
 
 ### Contacts
+* Sky Bristol
+  * sbristol@usgs.gov
+  * Github: [https://github.com/skybristol](skybristol)
+  * ORCID: [https://orcid.org/0000-0003-1682-4031](0000-0003-1682-4031)
 
+## ScienceBase
+ScienceBase uses a UUID form of identifier that is reasonably permanent as long as ScienceBase continues to exist and operate with its domain and path. Given the possibility of future architecture changes in ScienceBase, the w3id.org rewrite rule can allow for some degree of flexibility in continuing to use the UUID identifiers for an item but redirecting to another infrastructure domain and path in future.
+
+### Uses
+This namespace simply includes the UUID identifier under the `/usgs/sb/` path and redirects to the item in ScienceBase under `/catalog/item/`. It was set up for cases where ScienceBase is being used as a long-term archive for items that do not have a DOI and the URLs will be used in and referenced from other third party systems.
+
+### Links
+With `$1` being the ScienceBase UUID for a Catalog item...
+
+Links in the form `https://w3id.org/usgs/sb/$1`
+* No `Accept` header or `text/html` -> `https://www.sciencebase.gov/catalog/item/$1`
+* Using `Accept` header `application/json` -> `https://www.sciencebase.gov/catalog/item/$1?format=json`
+
+### Contacts
+* Sky Bristol
+  * sbristol@usgs.gov
+  * Github: [https://github.com/skybristol](skybristol)
+  * ORCID: [https://orcid.org/0000-0003-1682-4031](0000-0003-1682-4031)
+
+## Geoscience Knowledgebase (GeoKB)
+USGS is building a working knowledge graph where we are currently partnering on the wikibase.cloud project to instantiate the "Geoscience Knowledgebase" in a Wikibase instance. Over time, we expect original entities in this instantiation to be linked to from many other locations using their QID and PID identifiers. We leverage the w3id.org rewrite space at a `/usgs/geokb/` path resolving to the `/entity/` path in the Wikibase instance. This is a general resolver for Wikibase instances that takes "Q" identifiers for items and "P" identifiers for properties and resolves them as appropriate. This includes calling the entities via "file extension" paths for JSON, TTL, and other encodings (see below for options).
+
+### Uses
+This namespace includes the Wikibase identifier under the `/usgs/geokb/` path and redirects to the item in the GeoKB Wikibase instance under `/entity/`. It is set up to support more persistent linking to entities which may be housed under alternate infrastructure at some point.
+
+We are also making extensive use of the wiki page functionality for "item talk" pages associated with entities in the Wikibase instance to provide specific documentation and additional details about an item that are not otherwise available as linked data in statements/claims. To help sustain this entity-specific functionality into the future, we also include the `/usgs/geokb/doc/` path rewrite rule.
+
+### Links
+With `$1` being the QID or PID for a Wikibase item...
+
+Links in the form `https://w3id.org/usgs/geokb/$1`
+* No `Accept` header or `text/html` -> `https://geokb.wikibase.cloud/entity/$1`
+* Using `Accept` header `application/json` -> `https://geokb.wikibase.cloud/entity/$1.json`
+* Using `Accept` header `application/ld+json` -> `https://geokb.wikibase.cloud/entity/$1.jsonld`
+* Using `Accept` header `application/n-triples` -> `https://geokb.wikibase.cloud/entity/$1.nt`
+* Using `Accept` header `text/ttl` -> `https://geokb.wikibase.cloud/entity/$1.ttl`
+* Using `Accept` header `text/n3` -> `https://geokb.wikibase.cloud/entity/$1.n3`
+
+Links in the form `https://w3id.org/usgs/geokb/doc/$1`
+* No `Accept` header or `text/html` -> `https://geokb.wikibase.cloud/wiki/Item_talk:$1`
+* Using `Accept` header `application/json` -> `https://geokb.wikibase.cloud/w/api.php?action=query&format=json&prop=revisions&rvprop=ids%7Ctimestamp%7Cflags%7Ccomment%7Cuser%7Ccontent&rvslots=*&rvlimit=1&titles=Item_talk%3A$1`
+
+### Contacts
 * Sky Bristol
   * sbristol@usgs.gov
   * Github: [https://github.com/skybristol](skybristol)

--- a/usgs/geokb/.htaccess
+++ b/usgs/geokb/.htaccess
@@ -1,0 +1,32 @@
+# Rewrite engine setup
+RewriteEngine on
+
+# JSON (Wikibase-specific) response from Wikibase "special pages" interface
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^(.*)$ https://geokb.wikibase.cloud/entity/$1.json [R=302,L]
+
+# JSON-LD response from Wikibase "special pages" interface
+RewriteCond %{HTTP_ACCEPT} application/ld+json
+RewriteRule ^(.*)$ https://geokb.wikibase.cloud/entity/$1.jsonld [R=302,L]
+
+# N-Triples response from Wikibase "special pages" interface
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(.*)$ https://geokb.wikibase.cloud/entity/$1.nt [R=302,L]
+
+# TTL (Turtle) text response from Wikibase "special pages" interface
+RewriteCond %{HTTP_ACCEPT} text/ttl
+RewriteRule ^(.*)$ https://geokb.wikibase.cloud/entity/$1.ttl [R=302,L]
+
+# Notation3 (N3) text response from Wikibase "special pages" interface
+RewriteCond %{HTTP_ACCEPT} text/n3
+RewriteRule ^(.*)$ https://geokb.wikibase.cloud/entity/$1.n3 [R=302,L]
+
+# HTML resolver for entity documentation
+RewriteRule ^doc/(.*)$ https://geokb.wikibase.cloud/wiki/Item_talk:$1 [R=302,L]
+
+# JSON (Wikibase-specific) response from the Wikibase API for an "item talk" page
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^doc/(.*)$ https://geokb.wikibase.cloud/w/api.php?action=query&format=json&prop=revisions&rvprop=ids%7Ctimestamp%7Cflags%7Ccomment%7Cuser%7Ccontent&rvslots=*&rvlimit=1&titles=Item_talk%3A$1 [R=302,L]
+
+# HTML resolver for /entity/ calls to the Wikibase instance
+RewriteRule ^(.*)$ https://geokb.wikibase.cloud/entity/$1 [R=302,L]


### PR DESCRIPTION
This rewrite rule resolves entities (properties and items) to the Wikibase instance we are using to develop a knowledge graph for all things USGS geoscience. It will support future mobility into other platforms for entities that are unique to this knowledge graph. I also followed some previous suggestions on formatting readme text.