### PR TITLE
Update Gaia-X redirections & README for latest version

### DIFF
--- a/gaia-x/.htaccess
+++ b/gaia-x/.htaccess
@@ -16,5 +16,14 @@ RewriteEngine on
 # Redirect to ODRL Verifiable Credential Profile
 RewriteRule ^ovc/* https://gitlab.com/gaia-x/lab/policy-reasoning/odrl-vc-profile/-/raw/main/ovc-1.ttl [R=303,L]
 
-# BASE: Visit homepage
-RewriteRule /?(.*) https://registry.gaia-x.eu/$1 [R=303]
+# Redirect to Shacl shapes
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule /?(.*) https://registry.gaia-x.eu/main/shapes/$1 [R=303]
+
+# Redirect to JSON-LD context
+RewriteCond %{HTTP_ACCEPT} application/ld+json
+RewriteRule /?(.*) https://registry.gaia-x.eu/main/schemas/$1 [R=303]
+
+# Redirect to OWL ontology
+RewriteCond %{HTTP_ACCEPT} application/rdf+xml
+RewriteRule /?(.*) https://registry.gaia-x.eu/main/owl/$1 [R=303]

--- a/gaia-x/README.md
+++ b/gaia-x/README.md
@@ -5,17 +5,11 @@ Homepage:
 * https://gaia-x.eu/
 
 Redirections:
-* Base URL: Visit homepage
-  * https://w3id.org/gaia-x
-  * --> https://gaia-x.eu/
-* Direct ontology access: Access respective ontology
-  * https://w3id.org/gaia-x/[core|resource|...].ttl (or rdf, json, ...)
-* HTML: Visit documentation
-  * https://w3id.org/gaia-x/[core|resource|...]
-  * ...and...
-  * https://w3id.org/gaia-x/[core|resource|...]/Class
-* Accept [ttl/rdf/xml/json-ld/json/nt]: Access respective ontology as whole
-  * https://w3id.org/gaia-x/[core|resource|...] or https://w3id.org/gaia-x/[core|resource|...]/Class
+* `ovlc/*` ODRL profile Turtle file
+* `<version>` (e.g. `development` or `2404`)
+  * with `Accept: text/turtle` returns the Gaia-X Shacl shapes
+  * with `Accept: application/ld+json` returns the Gaia-X JSON-LD context (or schema)
+  * with `Accept: application/rdf+xml` returns the Gaia-X OWL ontology
 
 Support:
 * GAIA-X Specifications and components and their [GitLab Repository](https://gitlab.com/gaia-x/)
@@ -26,3 +20,4 @@ Contacts:
 * [Pierre Gronlier](https://github.com/ticapix)
 * [Yassir SELLAMI](https://github.com/YassirSellami)
 * [Ewann Gavard](https://github.com/egavard)
+* [Vincent Kelleher](https://github.com/vincentkelleher)


### PR DESCRIPTION
This introduces the new redirection strategy for the latest Gaia-X Clearing House Registry version.

The README file also has been updated as it was outdated.