### PR TITLE
Init PURL redirects for BIG-MAP

### DIFF
--- a/big-map/.htaccess
+++ b/big-map/.htaccess
@@ -1,0 +1,7 @@
+RewriteEngine On
+
+# Rule 1: Redirect base to index
+RewriteRule ^$ https://big-map.github.io/ProjectKnowledgeGraph/index.html [R=301,L]
+
+# Rule 2: Redirect /resource to a specific page, with or without a fragment
+RewriteRule ^resource(|#(.*))$ https://big-map.github.io/ProjectKnowledgeGraph/bigmap.html$2 [R=301,L]

--- a/big-map/readme.md
+++ b/big-map/readme.md
@@ -1,0 +1,28 @@
+# BIG-MAP Project PURLs
+
+This repository contains the .htaccess file to set up Persistent Uniform Resource Locators (PURLs) for the Horizon 2020 research project **BIG-MAP** (BATTERY INTERFACE GENOME - MATERIALS ACCELERATION PLATFORM).
+
+## Project Information
+
+- Project Title: BIG-MAP - BATTERY INTERFACE GENOME - MATERIALS ACCELERATION PLATFORM
+- Grant Agreement No.: 957189
+- Website: [BIG-MAP Project](https://www.big-map.eu/)
+
+## Purpose
+
+The .htaccess file provided in this repository is intended to be used with the w3id.org Persistent URL (PURL) service. It redirects requests made to specific paths within the BIG-MAP project to corresponding pages on the project website.
+
+## Redirect Rules
+
+The .htaccess file implements the following redirect rules:
+
+1. Redirects the base <https://w3id.org/big-map> to the **index** page <https://big-map.github.io/ProjectKnowledgeGraph/index.html>.
+2. Redirects URIs for specific resources at <https://w3id.org/big-map/resource#bigmap_{UUID}> to their respective pages on the project documentation <https://big-map.github.io/ProjectKnowledgeGraph/index.html#bigmap_{UUID}>.
+
+For detailed information about each redirect rule, please refer to the comments within the .htaccess file.
+
+---
+
+For any questions or issues, please contact [BIG-MAP Project Team](mailto:simon.clark@sintef.no).
+
+BIG-MAP W3ID Maintainer: [@jsimonclark](https://github.com/jsimonclark)

--- a/big-map/readme.md
+++ b/big-map/readme.md
@@ -17,7 +17,7 @@ The .htaccess file provided in this repository is intended to be used with the w
 The .htaccess file implements the following redirect rules:
 
 1. Redirects the base <https://w3id.org/big-map> to the **index** page <https://big-map.github.io/ProjectKnowledgeGraph/index.html>.
-2. Redirects URIs for specific resources at <https://w3id.org/big-map/resource#bigmap_{UUID}> to their respective pages on the project documentation <https://big-map.github.io/ProjectKnowledgeGraph/index.html#bigmap_{UUID}>.
+2. Redirects URIs for specific resources at <https://w3id.org/big-map/resource#{ID}> to their respective pages on the project resource documentation <https://big-map.github.io/ProjectKnowledgeGraph/bigmap.html#{ID}>.
 
 For detailed information about each redirect rule, please refer to the comments within the .htaccess file.
 


### PR DESCRIPTION
This pull request initializes PURL redirects for the EU research project BIG-MAP. The goal is to provide resolvable URIs within an RDF knowledge graph for the creation of linked data. 

.htaccess rules have been tested and confirmed with [madewithlove ](https://htaccess.madewithlove.com/)