### PR TITLE
RiverBench: restructure PURLs for 2.0.0 release

### DIFF
--- a/riverbench/.htaccess
+++ b/riverbench/.htaccess
@@ -7,16 +7,21 @@ AddType application/x-jelly-rdf .jelly
 
 RewriteEngine on
 
-# Dataset releases
+
+
+### DATASET RELEASES ###
+
 RewriteRule ^datasets/([a-z0-9-]+)/dev/files/(.+)$ https://github.com/RiverBench/dataset-$1/releases/download/dev/$2 [R=302,L]
 RewriteRule ^datasets/([a-z0-9-]+)/([a-z0-9.-]+)/files/(.+)$ https://github.com/RiverBench/dataset-$1/releases/download/v$2/$3 [R=302,L]
 
-### EXPLICIT EXTENSIONS ###
 
-# Schema – explicit extension for dev release
+
+### METADATA -- EXPLICIT FILE EXTENSIONS ###
+
+# Schemas – explicit extension for dev release
 RewriteRule ^schema/([a-z0-9-]+)(/dev)?\.(rdf|ttl|nt|jelly)([#?].*)?$ https://github.com/RiverBench/schema/releases/download/dev/$1.$3 [R=302,L]
 
-# Schema – explicit extension for tagged releases
+# Schemas – explicit extension for tagged releases
 RewriteRule ^schema/([a-z0-9-]+)/([a-z0-9.-]+)\.(rdf|ttl|nt|jelly)([#?].*)?$ https://github.com/RiverBench/schema/releases/download/v$2/$1.$3 [R=302,L]
 
 # Main metadata – explicit extension for dev release
@@ -25,11 +30,14 @@ RewriteRule ^(v/dev)?\.(rdf|ttl|nt|jelly)([#?].*)?$ https://github.com/RiverBenc
 # Main metadata – explicit extension for tagged releases
 RewriteRule ^v/([a-z0-9.-]+)\.(rdf|ttl|nt|jelly)([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/v$1/metadata.$2 [R=302,L]
 
-# Profile metadata – explicit extension for dev release
-RewriteRule ^profiles/([a-z0-9-]+)(/dev)?\.(rdf|ttl|nt|jelly)([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/dev/profile-$1.$3 [R=302,L]
+# Profile metadata (1.0.x scheme, back-compat) – explicit extension for tagged releases
+RewriteRule ^profiles/([a-z0-9-]+)/(1\.0\.\d)\.(rdf|ttl|nt|jelly)([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/v$2/profile-$1.$3 [R=302,L]
+
+# Profile metadata – explicit extension for dev release (with back-compat for 1.0.x URL scheme)
+RewriteRule ^(v/dev/)?profiles/([a-z]+)-([a-z0-9-]+)(/dev)?\.(rdf|ttl|nt|jelly)([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/dev/profile-$2-$3.$5 [R=302,L]
 
 # Profile metadata – explicit extension for tagged releases
-RewriteRule ^profiles/([a-z0-9-]+)/([a-z0-9.-]+)\.(rdf|ttl|nt|jelly)([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/v$2/profile-$1.$3 [R=302,L]
+RewriteRule ^v/([a-z0-9.-]+)/profiles/([a-z]+)-([a-z0-9-]+)\.(rdf|ttl|nt|jelly)([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/v$1/profile-$2-$3.$4 [R=302,L]
 
 # Dataset metadata – explicit extension for dev release
 RewriteRule ^datasets/([a-z0-9-]+)(/dev)?\.(rdf|ttl|nt|jelly)([#?].*)?$ https://github.com/RiverBench/dataset-$1/releases/download/dev/metadata.$3 [R=302,L]
@@ -37,38 +45,87 @@ RewriteRule ^datasets/([a-z0-9-]+)(/dev)?\.(rdf|ttl|nt|jelly)([#?].*)?$ https://
 # Dataset metadata – explicit extension for tagged releases
 RewriteRule ^datasets/([a-z0-9-]+)/([a-z0-9.-]+)\.(rdf|ttl|nt|jelly)([#?].*)?$ https://github.com/RiverBench/dataset-$1/releases/download/v$2/metadata.$3 [R=302,L]
 
+# Task metadata – explicit extension for dev release
+RewriteRule ^(v/dev/)?tasks/([a-z]+)-([a-z0-9-]+)\.(rdf|ttl|nt|jelly)([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/dev/task-$2-$3.$4 [R=302,L]
+
+# Task metadata – explicit extension for tagged releases
+RewriteRule ^v/([a-z0-9.-]+)/tasks/([a-z]+)-([a-z0-9-]+)\.(rdf|ttl|nt|jelly)([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/v$1/task-$2-$3.$4 [R=302,L]
+
+# Category metadata – explicit extension for dev release
+RewriteRule ^(v/dev/)?categories/([a-z]+)\.(rdf|ttl|nt|jelly)([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/dev/metadata.$3 [R=302,L]
+
+# Category metadata – explicit extension for tagged releases
+RewriteRule ^v/([a-z0-9.-]+)/categories/([a-z]+)\.(rdf|ttl|nt|jelly)([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/v$1/metadata.$3 [R=302,L]
+
 # Metadata dumps – dev and tagged releases
 RewriteRule ^dumps/([a-z0-9.-]+)\.(rdf|ttl|nt|jelly)\.gz([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/$1/dump.$2.gz [R=302,L]
 
-### SERVING HTML ###
 
-# Redirect /v/dev* to /
+
+### HTML DOCUMENTATION PAGES ###
+
+# Redirect /schema/{name} to /v/dev/schema/{name}
+# Tagged releases are handled via redirects set up in the gh-pages branch of the documentation repo.
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^v/dev(.*)$ https://riverbench.github.io$1 [R=302,L]
+RewriteRule ^schema/([a-z0-9-]+)/?$ https://riverbench.github.io/v/dev/schema/$1 [R=302,L]
 
-# Redirect /schema/{name} to /schema/{name}/dev
+# Redirect /datasets/{name} to /v/dev/datasets/{name}
+# Tagged releases are handled via redirects set up in the gh-pages branch of the documentation repo.
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^schema/([a-z0-9-]+)/?$ https://riverbench.github.io/schema/$1/dev [R=302,L]
+RewriteRule ^datasets/([a-z0-9-]+)/?$ https://riverbench.github.io/v/dev/datasets/$1 [R=302,L]
 
-# Redirect /datasets/{name} to /datasets/{name}/dev
+# Redirect /profiles/{name} to /v/dev/profiles/{name}
+# This is an old URL scheme (1.0.x), kept for back-compatibility.
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^datasets/([a-z0-9-]+)/?$ https://riverbench.github.io/datasets/$1/dev [R=302,L]
+RewriteRule ^profiles/([a-z0-9-]+)/?$ https://riverbench.github.io/v/dev/profiles/$1 [R=302,L]
 
-# Redirect /profiles/{name} to /profiles/{name}/dev
+# Redirect /profiles/{name}/1.0.x to /v/1.0.x/profiles/{name}/1.0.x
+# This is an old URL scheme (1.0.x), kept for back-compatibility.
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^profiles/([a-z0-9-]+)/?$ https://riverbench.github.io/profiles/$1/dev [R=302,L]
+RewriteRule ^profiles/([a-z0-9-]+)/(1\.0\.\d)/?$ https://riverbench.github.io/v/$2/profiles/$1/$2 [R=302,L]
+
+# Redirect /profiles/{name}/{version} to /v/{version}/profiles/{name}
+# This is an old URL scheme (1.0.x), kept for back-compatibility and convenience.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^profiles/([a-z0-9-]+)/([a-z0-9.-]+)/?$ https://riverbench.github.io/v/$2/profiles/$1 [R=302,L]
+
+# Redirect /tasks/* to /v/dev/tasks/*
+# This URL should not be used really, but we add it here for convenience.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^tasks/(.+)$ https://riverbench.github.io/v/dev/tasks/$1 [R=302,L]
+
+# Redirect /categories/* to /v/dev/categories/*
+# This URL should not be used really, but we add it here for convenience.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^categories/(.+)$ https://riverbench.github.io/v/dev/categories/$1 [R=302,L]
+
+# Redirect several top-level important pages to /v/dev/
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(|documentation.*|datasets|schema)/?([#?].*)?$ https://riverbench.github.io/v/dev/$1$2 [R=302,L]
 
 # Serve HTML if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
@@ -77,7 +134,9 @@ RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 RewriteRule ^(.+)$ https://riverbench.github.io/$1 [R=302,L]
 
-### SERVING SCHEMAS (ONTOLOGIES) ###
+
+
+### SCHEMAS (ONTOLOGIES) -- CONTENT NEGOTIATION ###
 
 # Schema – RDF/XML for dev release
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
@@ -115,7 +174,9 @@ RewriteRule ^schema/([a-z0-9-]+)(/dev)?/?([#?].*)?$ https://github.com/RiverBenc
 RewriteCond %{HTTP_ACCEPT} application/x-jelly-rdf
 RewriteRule ^schema/([a-z0-9-]+)/([a-z0-9.-]+)/?([#?].*)?$ https://github.com/RiverBench/schema/releases/download/v$2/$1.jelly [R=302,L]
 
-### SERVING MAIN METADATA ###
+
+
+### MAIN METADATA -- CONTENT NEGOTIATION ###
 
 # Main metadata – RDF/XML for dev release
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
@@ -153,29 +214,57 @@ RewriteRule ^(v/dev)?/?([#?].*)?$ https://github.com/RiverBench/RiverBench/relea
 RewriteCond %{HTTP_ACCEPT} application/x-jelly-rdf
 RewriteRule ^v/([a-z0-9.-]+)/?([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/v$1/metadata.jelly [R=302,L]
 
-### SERVING PROFILES ###
 
-# Profile metadata – RDF/XML for dev release
+
+### PROFILE METADATA -- CONTENT NEGOTIATION ###
+
+# Profile metadata – RDF/XML for dev release (with back-compat for 1.0.x URL scheme)
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^profiles/([a-z0-9-]+)(/dev)?/?([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/dev/profile-$1.rdf [R=302,L]
+RewriteRule ^(v/dev/)?profiles/([a-z]+)-([a-z0-9-]+)(/dev)?/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/dev/profile-$2-$3.rdf [R=302,L]
+
+# Profile metadata – RDF/XML for tagged releases
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^v/([a-z0-9.-]+)/profiles/([a-z]+)-([a-z0-9-]+)/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/v$1/profile-$2-$3.rdf [R=302,L]
+
+# Profile metadata – N-Triples for dev release (with back-compat for 1.0.x URL scheme)
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(v/dev/)?profiles/([a-z]+)-([a-z0-9-]+)(/dev)?/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/dev/profile-$2-$3.nt [R=302,L]
+
+# Profile metadata – N-Triples for tagged releases
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^v/([a-z0-9.-]+)/profiles/([a-z]+)-([a-z0-9-]+)/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/v$1/profile-$2-$3.nt [R=302,L]
+
+# Profile metadata – Turtle for dev release (with back-compat for 1.0.x URL scheme)
+RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^(v/dev/)?profiles/([a-z]+)-([a-z0-9-]+)(/dev)?/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/dev/profile-$2-$3.ttl [R=302,L]
+
+# Profile metadata – Turtle for tagged releases
+RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^v/([a-z0-9.-]+)/profiles/([a-z]+)-([a-z0-9-]+)/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/v$1/profile-$2-$3.ttl [R=302,L]
+
+# Profile metadata – Jelly for dev release (with back-compat for 1.0.x URL scheme)
+RewriteCond %{HTTP_ACCEPT} application/x-jelly-rdf
+RewriteRule ^(v/dev/)?profiles/([a-z]+)-([a-z0-9-]+)(/dev)?/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/dev/profile-$2-$3.jelly [R=302,L]
+
+# Profile metadata – Jelly for tagged releases
+RewriteCond %{HTTP_ACCEPT} application/x-jelly-rdf
+RewriteRule ^v/([a-z0-9.-]+)/profiles/([a-z]+)-([a-z0-9-]+)/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/v$1/profile-$2-$3.jelly [R=302,L]
+
+
+
+### PROFILE METADATA -- CONTENT NEGOTIATION (1.0.x back-compat) ###
 
 # Profile metadata – RDF/XML for tagged releases
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
 RewriteRule ^profiles/([a-z0-9-]+)/([a-z0-9.-]+)/?([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/v$2/profile-$1.rdf [R=302,L]
 
-# Profile metadata – N-Triples for dev release
-RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^profiles/([a-z0-9-]+)(/dev)?/?([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/dev/profile-$1.nt [R=302,L]
-
 # Profile metadata – N-Triples for tagged releases
 RewriteCond %{HTTP_ACCEPT} application/n-triples
 RewriteRule ^profiles/([a-z0-9-]+)/([a-z0-9.-]+)/?([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/v$2/profile-$1.nt [R=302,L]
-
-# Profile metadata – Turtle for dev release
-RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
-RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
-RewriteCond %{HTTP_ACCEPT} \*/turtle
-RewriteRule ^profiles/([a-z0-9-]+)(/dev)?/?([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/dev/profile-$1.ttl [R=302,L]
 
 # Profile metadata – Turtle for tagged releases
 RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
@@ -183,15 +272,13 @@ RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle
 RewriteRule ^profiles/([a-z0-9-]+)/([a-z0-9.-]+)/?([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/v$2/profile-$1.ttl [R=302,L]
 
-# Profile metadata – Jelly for dev release
-RewriteCond %{HTTP_ACCEPT} application/x-jelly-rdf
-RewriteRule ^profiles/([a-z0-9-]+)(/dev)?/?([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/dev/profile-$1.jelly [R=302,L]
-
 # Profile metadata – Jelly for tagged releases
 RewriteCond %{HTTP_ACCEPT} application/x-jelly-rdf
 RewriteRule ^profiles/([a-z0-9-]+)/([a-z0-9.-]+)/?([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/v$2/profile-$1.jelly [R=302,L]
 
-### SERVING DATASET METADATA ###
+
+
+### DATASET METADATA -- CONTENT NEGOTIATION ###
 
 # Dataset metadata – RDF/XML for dev release
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
@@ -229,7 +316,89 @@ RewriteRule ^datasets/([a-z0-9-]+)(/dev)?/?([#?].*)?$ https://github.com/RiverBe
 RewriteCond %{HTTP_ACCEPT} application/x-jelly-rdf
 RewriteRule ^datasets/([a-z0-9-]+)/([a-z0-9.-]+)/?([#?].*)?$ https://github.com/RiverBench/dataset-$1/releases/download/v$2/metadata.jelly [R=302,L]
 
-### SERVING DOCUMENTATION ###
+
+
+### TASK METADATA -- CONTENT NEGOTIATION ###
+
+# Task metadata – RDF/XML for dev release
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(v/dev/)?tasks/([a-z]+)-([a-z0-9-]+)/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/dev/task-$2-$3.rdf [R=302,L]
+
+# Task metadata – RDF/XML for tagged releases
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^v/([a-z0-9.-]+)/tasks/([a-z]+)-([a-z0-9-]+)/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/v$1/task-$2-$3.rdf [R=302,L]
+
+# Task metadata – N-Triples for dev release
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(v/dev/)?tasks/([a-z]+)-([a-z0-9-]+)/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/dev/task-$2-$3.nt [R=302,L]
+
+# Task metadata – N-Triples for tagged releases
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^v/([a-z0-9.-]+)/tasks/([a-z]+)-([a-z0-9-]+)/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/v$1/task-$2-$3.nt [R=302,L]
+
+# Task metadata – Turtle for dev release
+RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^(v/dev/)?tasks/([a-z]+)-([a-z0-9-]+)/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/dev/task-$2-$3.ttl [R=302,L]
+
+# Task metadata – Turtle for tagged releases
+RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^v/([a-z0-9.-]+)/tasks/([a-z]+)-([a-z0-9-]+)/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/v$1/task-$2-$3.ttl [R=302,L]
+
+# Task metadata – Jelly for dev release
+RewriteCond %{HTTP_ACCEPT} application/x-jelly-rdf
+RewriteRule ^(v/dev/)?tasks/([a-z]+)-([a-z0-9-]+)/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/dev/task-$2-$3.jelly [R=302,L]
+
+# Task metadata – Jelly for tagged releases
+RewriteCond %{HTTP_ACCEPT} application/x-jelly-rdf
+RewriteRule ^v/([a-z0-9.-]+)/tasks/([a-z]+)-([a-z0-9-]+)/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/v$1/task-$2-$3.jelly [R=302,L]
+
+
+
+### TASK METADATA -- CONTENT NEGOTIATION ###
+
+# Category metadata – RDF/XML for dev release
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(v/dev/)?categories/([a-z]+)/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/dev/metadata.rdf [R=302,L]
+
+# Category metadata – RDF/XML for tagged releases
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^v/([a-z0-9.-]+)/categories/([a-z]+)/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/v$1/metadata.rdf [R=302,L]
+
+# Category metadata – N-Triples for dev release
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(v/dev/)?categories/([a-z]+)/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/dev/metadata.nt [R=302,L]
+
+# Category metadata – N-Triples for tagged releases
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^v/([a-z0-9.-]+)/categories/([a-z]+)/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/v$1/metadata.nt [R=302,L]
+
+# Category metadata – Turtle for dev release
+RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^(v/dev/)?categories/([a-z]+)/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/dev/metadata.ttl [R=302,L]
+
+# Category metadata – Turtle for tagged releases
+RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^v/([a-z0-9.-]+)/categories/([a-z]+)/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/v$1/metadata.ttl [R=302,L]
+
+# Category metadata – Jelly for dev release
+RewriteCond %{HTTP_ACCEPT} application/x-jelly-rdf
+RewriteRule ^(v/dev/)?categories/([a-z]+)/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/dev/metadata.jelly [R=302,L]
+
+# Category metadata – Jelly for tagged releases
+RewriteCond %{HTTP_ACCEPT} application/x-jelly-rdf
+RewriteRule ^v/([a-z0-9.-]+)/categories/([a-z]+)/?([#?].*)?$ https://github.com/RiverBench/category-$2/releases/download/v$1/metadata.jelly [R=302,L]
+
+
+
+### HTML DOCUMENTATION -- DEFAULT (FALLBACK) BEHAVIOR ###
 
 # Default response – redirect to documentation
 RewriteRule ^(.*)$ https://riverbench.github.io/$1 [R=302,L]

--- a/riverbench/README.md
+++ b/riverbench/README.md
@@ -1,31 +1,51 @@
 # RiverBench RDF benchmark suite
-[RiverBench](https://github.com/RiverBench) is a suite of curated and well-described datasets for benchmarking RDF systems, especially in streaming applications.
+
+[RiverBench](https://github.com/RiverBench) is a suite of curated and well-described datasets and tasks for benchmarking RDF systems, especially in streaming applications.
 
 ## Contents
-The .htaccess file is rather long, as it needs to serve various metadata for datasets, benchmark profiles, and schemas (ontologies). It also handles redirects to the actual data files and documentation pages.
+
+The .htaccess file is rather long, as it needs to serve various metadata for datasets, benchmark profiles, tasks, and schemas (ontologies). It also handles redirects to the actual data files and documentation pages.
 
 The docs are hosted on GitHub Pages, and the data and metadata files are stored as releases on GitHub.
 
 ### Test links
+
 Some test links that should always give a 200 response:
+
+#### Main metadata
 
 - https://w3id.org/riverbench/v/dev
 - https://w3id.org/riverbench/v/dev.rdf
 - https://w3id.org/riverbench/v/dev.nt
 - https://w3id.org/riverbench/v/dev.ttl
 - https://w3id.org/riverbench/v/dev.jelly
-- https://w3id.org/riverbench/profiles/stream-triples
-- https://w3id.org/riverbench/profiles/stream-triples.rdf
-- https://w3id.org/riverbench/profiles/stream-triples.nt
-- https://w3id.org/riverbench/profiles/stream-triples.ttl
-- https://w3id.org/riverbench/profiles/stream-triples/dev
-- https://w3id.org/riverbench/profiles/stream-triples/dev.rdf
-- https://w3id.org/riverbench/profiles/stream-triples/dev.nt
-- https://w3id.org/riverbench/profiles/stream-triples/dev.ttl
+
+#### Profiles
+
+- https://w3id.org/riverbench/profiles/stream-graphs
+- https://w3id.org/riverbench/profiles/stream-graphs.rdf
+- https://w3id.org/riverbench/profiles/stream-graphs.nt
+- https://w3id.org/riverbench/profiles/stream-graphs.ttl
+- https://w3id.org/riverbench/v/dev/profiles/stream-graphs
+- https://w3id.org/riverbench/v/dev/profiles/stream-graphs.rdf
+- https://w3id.org/riverbench/v/dev/profiles/stream-graphs.nt
+- https://w3id.org/riverbench/v/dev/profiles/stream-graphs.ttl
+
+
+#### Metadata dumps
+
 - https://w3id.org/riverbench/dumps/dev.rdf.gz
 - https://w3id.org/riverbench/dumps/dev.nt.gz
 - https://w3id.org/riverbench/dumps/dev.ttl.gz
 - https://w3id.org/riverbench/dumps/dev.jelly.gz
+
+#### Test links in the old (1.0.x) format
+
+- https://w3id.org/riverbench/profiles/stream-triples/1.0.1
+- https://w3id.org/riverbench/profiles/stream-triples/1.0.1.rdf
+- https://w3id.org/riverbench/profiles/stream-triples/1.0.1.nt
+- https://w3id.org/riverbench/profiles/stream-triples/1.0.1.ttl
+- https://w3id.org/riverbench/profiles/stream-triples/dev.ttl
 
 ## Maintainers
 Piotr Sowiński \


### PR DESCRIPTION
This pull request introduces a lot of changes in the handling of RiverBench's PURLs, due to adopting a new structure (with benchmark categories and tasks) in the upcoming version 2.0.0. Backwards compatibility was maintained where possible.

These changes were tested on a local instance of Apache.

RiverBench issue: https://github.com/RiverBench/RiverBench/issues/65