### PR TITLE
iaam/i40fd: Added canopen and iolink paths for units and profiles

### DIFF
--- a/iaam/i40fd/profiles/canopen/.htaccess
+++ b/iaam/i40fd/profiles/canopen/.htaccess
@@ -1,0 +1,73 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
+
+RewriteEngine on
+
+# Rewrite rule for latest version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/profiles/canopen/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/profiles/canopen/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/profiles/canopen/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/profiles/canopen/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/profiles/canopen/ontology.ttl [R=303,L]
+
+
+# Rewrite rules for any other version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/profiles/canopen/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/profiles/canopen/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/profiles/canopen/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/profiles/canopen/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/profiles/canopen/ontology.ttl [R=303,L]
+
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^(.*)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/profiles/canopen/406.html [R=406,L]
+# Default response
+# ---------------------------
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/profiles/canopen/ontology.owl [R=303,L]

--- a/iaam/i40fd/profiles/canopen/README.md
+++ b/iaam/i40fd/profiles/canopen/README.md
@@ -1,0 +1,10 @@
+# Industry 4.0 Field Device CANOpen Profiles Ontology
+
+This ontology provides CANOpen Profiles integration with the [Industry 4.0 Field device](https://w3id.org/iaam/i40fd/) ontology.
+
+This is a research project of the [Institute for Applied Automation and Mechatronics](https://www.iaam.fh-aachen.de) (IaaM).
+
+## Contact 
+| Maintainer | Institute    | Email| ORCID| Github-ID |
+|----------- |--------------|------|------|------------|
+Victor Chavez |  University of Applied Sciences FH Aachen| chavez-bermudez@fh-aachen.de|   https://orcid.org/0000-0001-6419-1641 | [vChavezB](https://github.com/vChavezB)

--- a/iaam/i40fd/profiles/iolink/.htaccess
+++ b/iaam/i40fd/profiles/iolink/.htaccess
@@ -1,0 +1,73 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
+
+RewriteEngine on
+
+# Rewrite rule for latest version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/profiles/iolink/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/profiles/iolink/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/profiles/iolink/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/profiles/iolink/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/profiles/iolink/ontology.ttl [R=303,L]
+
+
+# Rewrite rules for any other version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/profiles/iolink/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/profiles/iolink/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/profiles/iolink/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/profiles/iolink/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/profiles/iolink/ontology.ttl [R=303,L]
+
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^(.*)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/profiles/iolink/406.html [R=406,L]
+# Default response
+# ---------------------------
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/profiles/iolink/ontology.owl [R=303,L]

--- a/iaam/i40fd/profiles/iolink/README.md
+++ b/iaam/i40fd/profiles/iolink/README.md
@@ -1,0 +1,10 @@
+# Industry 4.0 Field Device IO-Link Profiles Ontology
+
+This ontology provides IO-Link Profiles for integration with the [Industry 4.0 Field device](https://w3id.org/iaam/i40fd/) ontology.
+
+This is a research project of the [Institute for Applied Automation and Mechatronics](https://www.iaam.fh-aachen.de) (IaaM).
+
+## Contact 
+| Maintainer | Institute    | Email| ORCID| Github-ID |
+|----------- |--------------|------|------|------------|
+Victor Chavez |  University of Applied Sciences FH Aachen| chavez-bermudez@fh-aachen.de|   https://orcid.org/0000-0001-6419-1641 | [vChavezB](https://github.com/vChavezB)

--- a/iaam/i40fd/units/canopen/.htaccess
+++ b/iaam/i40fd/units/canopen/.htaccess
@@ -1,0 +1,73 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
+
+RewriteEngine on
+
+# Rewrite rule for latest version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/units/canopen/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/units/canopen/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/units/canopen/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/units/canopen/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/units/canopen/ontology.ttl [R=303,L]
+
+
+# Rewrite rules for any other version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/units/canopen/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/units/canopen/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/units/canopen/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/units/canopen/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/units/canopen/ontology.ttl [R=303,L]
+
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^(.*)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/units/canopen/406.html [R=406,L]
+# Default response
+# ---------------------------
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/units/canopen/ontology.owl [R=303,L]

--- a/iaam/i40fd/units/canopen/README.md
+++ b/iaam/i40fd/units/canopen/README.md
@@ -1,0 +1,10 @@
+# Industry 4.0 Field Device CANOpen Unit Ontology
+
+This ontology provides CANOpen Units for integration with the [Industry 4.0 Field device](https://w3id.org/iaam/i40fd/) ontology.
+
+This is a research project of the [Institute for Applied Automation and Mechatronics](https://www.iaam.fh-aachen.de) (IaaM).
+
+## Contact 
+| Maintainer | Institute    | Email| ORCID| Github-ID |
+|----------- |--------------|------|------|------------|
+Victor Chavez |  University of Applied Sciences FH Aachen| chavez-bermudez@fh-aachen.de|   https://orcid.org/0000-0001-6419-1641 | [vChavezB](https://github.com/vChavezB)

--- a/iaam/i40fd/units/iolink/.htaccess
+++ b/iaam/i40fd/units/iolink/.htaccess
@@ -1,0 +1,73 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
+
+RewriteEngine on
+
+# Rewrite rule for latest version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/units/iolink/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/units/iolink/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/units/iolink/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/units/iolink/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/units/iolink/ontology.ttl [R=303,L]
+
+
+# Rewrite rules for any other version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/units/iolink/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/units/iolink/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/units/iolink/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/units/iolink/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^(.+)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/$1/units/iolink/ontology.ttl [R=303,L]
+
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^(.*)$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/units/iolink/406.html [R=406,L]
+# Default response
+# ---------------------------
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^$ https://iaam.pages.fh-aachen.de/semantics/i40fd-ontology/latest/units/iolink/ontology.owl [R=303,L]

--- a/iaam/i40fd/units/iolink/README.md
+++ b/iaam/i40fd/units/iolink/README.md
@@ -1,0 +1,10 @@
+# Industry 4.0 Field Device IO-Link Unit Ontology
+
+This ontology provides IO-Link Units for integration with the [Industry 4.0 Field device](https://w3id.org/iaam/i40fd/) ontology.
+
+This is a research project of the [Institute for Applied Automation and Mechatronics](https://www.iaam.fh-aachen.de) (IaaM).
+
+## Contact 
+| Maintainer | Institute    | Email| ORCID| Github-ID |
+|----------- |--------------|------|------|------------|
+Victor Chavez |  University of Applied Sciences FH Aachen| chavez-bermudez@fh-aachen.de|   https://orcid.org/0000-0001-6419-1641 | [vChavezB](https://github.com/vChavezB)


### PR DESCRIPTION
This is an update to the iaam namespace. Added a path for units and profiles for iolink and canopen.