### PR TITLE
Fixes for ro/wfrun

### DIFF
--- a/ro/wfrun/process/.htaccess
+++ b/ro/wfrun/process/.htaccess
@@ -12,4 +12,4 @@ RewriteRule ^$ https://www.researchobject.org/workflow-run-crate/profiles/proces
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
 RewriteRule ^(.+)$ https://raw.githubusercontent.com/ResearchObject/workflow-run-crate/main/docs/profiles/$1/process_run_crate/ro-crate-metadata.json [R=303,L]
 # HTML as default for humans
-RewriteRule ^(.+)$ https://www.researchobject.org/workflow-run-crate/profiles/$1/process_run_crate/ [R=303,L]
+RewriteRule ^(.+)$ https://www.researchobject.org/workflow-run-crate/profiles/$1/process_run_crate [R=303,L]

--- a/ro/wfrun/provenance/.htaccess
+++ b/ro/wfrun/provenance/.htaccess
@@ -12,4 +12,4 @@ RewriteRule ^$ https://www.researchobject.org/workflow-run-crate/profiles/workfl
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
 RewriteRule ^(.+)$ https://raw.githubusercontent.com/ResearchObject/workflow-run-crate/main/docs/profiles/$1/workflow_run_crate/ro-crate-metadata.json [R=303,L]
 # HTML as default for humans
-RewriteRule ^(.+)$ https://www.researchobject.org/workflow-run-crate/profiles/$1/workflow_run_crate/ [R=303,L]
+RewriteRule ^(.+)$ https://www.researchobject.org/workflow-run-crate/profiles/$1/workflow_run_crate [R=303,L]

--- a/ro/wfrun/provenance/.htaccess
+++ b/ro/wfrun/provenance/.htaccess
@@ -4,12 +4,12 @@ RewriteEngine on
 
 # latest version (not supported yet until we publish draft)
 #RewriteCond %{HTTP_ACCEPT} application/ld\+json
-#RewriteRule ^$ https://raw.githubusercontent.com/ResearchObject/workflow-run-crate/main/docs/profiles/0.5-DRAFT/workflow_run_crate/ro-crate-metadata.json [R=303,L]
-RewriteRule ^$ https://www.researchobject.org/workflow-run-crate/profiles/workflow_run_crate [L]
+#RewriteRule ^$ https://raw.githubusercontent.com/ResearchObject/workflow-run-crate/main/docs/profiles/0.5-DRAFT/provenance_run_crate/ro-crate-metadata.json [R=303,L]
+RewriteRule ^$ https://www.researchobject.org/workflow-run-crate/profiles/provenance_run_crate [L]
 
 
 # Workflow Run RO-Crate profiles (versioned)
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^(.+)$ https://raw.githubusercontent.com/ResearchObject/workflow-run-crate/main/docs/profiles/$1/workflow_run_crate/ro-crate-metadata.json [R=303,L]
+RewriteRule ^(.+)$ https://raw.githubusercontent.com/ResearchObject/workflow-run-crate/main/docs/profiles/$1/provenance_run_crate/ro-crate-metadata.json [R=303,L]
 # HTML as default for humans
-RewriteRule ^(.+)$ https://www.researchobject.org/workflow-run-crate/profiles/$1/workflow_run_crate [R=303,L]
+RewriteRule ^(.+)$ https://www.researchobject.org/workflow-run-crate/profiles/$1/provenance_run_crate [R=303,L]

--- a/ro/wfrun/workflow/.htaccess
+++ b/ro/wfrun/workflow/.htaccess
@@ -4,12 +4,12 @@ RewriteEngine on
 
 # latest version (not supported yet until we publish draft)
 #RewriteCond %{HTTP_ACCEPT} application/ld\+json
-#RewriteRule ^$ https://raw.githubusercontent.com/ResearchObject/workflow-run-crate/main/docs/profiles/0.5-DRAFT/provenance_run_crate/ro-crate-metadata.json [R=303,L]
-RewriteRule ^$ https://www.researchobject.org/workflow-run-crate/profiles/provenance_run_crate [L]
+#RewriteRule ^$ https://raw.githubusercontent.com/ResearchObject/workflow-run-crate/main/docs/profiles/0.5-DRAFT/workflow_run_crate/ro-crate-metadata.json [R=303,L]
+RewriteRule ^$ https://www.researchobject.org/workflow-run-crate/profiles/workflow_run_crate [L]
 
 
 # Workflow Run RO-Crate profiles (versioned)
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^(.+)$ https://raw.githubusercontent.com/ResearchObject/workflow-run-crate/main/docs/profiles/$1/provenance_run_crate/ro-crate-metadata.json [R=303,L]
+RewriteRule ^(.+)$ https://raw.githubusercontent.com/ResearchObject/workflow-run-crate/main/docs/profiles/$1/workflow_run_crate/ro-crate-metadata.json [R=303,L]
 # HTML as default for humans
-RewriteRule ^(.+)$ https://www.researchobject.org/workflow-run-crate/profiles/$1/provenance_run_crate [R=303,L]
+RewriteRule ^(.+)$ https://www.researchobject.org/workflow-run-crate/profiles/$1/workflow_run_crate [R=303,L]

--- a/ro/wfrun/workflow/.htaccess
+++ b/ro/wfrun/workflow/.htaccess
@@ -12,4 +12,4 @@ RewriteRule ^$ https://www.researchobject.org/workflow-run-crate/profiles/proven
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
 RewriteRule ^(.+)$ https://raw.githubusercontent.com/ResearchObject/workflow-run-crate/main/docs/profiles/$1/provenance_run_crate/ro-crate-metadata.json [R=303,L]
 # HTML as default for humans
-RewriteRule ^(.+)$ https://www.researchobject.org/workflow-run-crate/profiles/$1/provenance_run_crate/ [R=303,L]
+RewriteRule ^(.+)$ https://www.researchobject.org/workflow-run-crate/profiles/$1/provenance_run_crate [R=303,L]


### PR DESCRIPTION
This PR removes trailing slashes from HTML redirect URLs (there was a similar fix previously in #2981). They are currently breaking versioned redirects such as https://w3id.org/ro/wfrun/process/0.4 (thanks @jmfernandez for reporting this).

It also reverts the swapping of `workflow_run_crate` and `provenance_run_crate` in `ro/wfrun/provenance/.htaccess` and `ro/wfrun/workflow/.htaccess`.

@dgarijo I think these problems were accidentally caused in #4137 when moving things around.
