### PR TITLE
chore: upgrade to Catena-X 24.05 (and refer to intermediate 24.03)

### DIFF
--- a/catenax/.htaccess
+++ b/catenax/.htaccess
@@ -16,6 +16,12 @@ RewriteEngine On
 RewriteBase /
 
 # Rewrite rule to serve versioned domain ontology links
+RewriteRule ^v24.05/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/ontology/$1_ontology.ttl [R=302,L]
+
+# Rewrite rule to serve versioned domain ontology links
+RewriteRule ^v24.03/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.03/ontology/$1_ontology.ttl [R=302,L]
+
+# Rewrite rule to serve versioned domain ontology links
 RewriteRule ^v23.12/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain ontology links
@@ -25,7 +31,13 @@ RewriteRule ^v23.09/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catena
 RewriteRule ^next/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve domain ontology links
-RewriteRule ^ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology/$1_ontology.ttl [R=302,L]
+RewriteRule ^ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/ontology/$1_ontology.ttl [R=302,L]
+
+# Rewrite rule to serve versioned domain ontologies
+RewriteRule ^v24.05/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/ontology/$1_ontology.ttl [R=302,L]
+
+# Rewrite rule to serve versioned domain ontologies
+RewriteRule ^v24.03/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.03/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain ontologies
 RewriteRule ^v23.12/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology/$1_ontology.ttl [R=302,L]
@@ -37,7 +49,13 @@ RewriteRule ^v23.09/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/
 RewriteRule ^next/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve domain ontologies
-RewriteRule ^ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology/$1_ontology.ttl [R=302,L]
+RewriteRule ^ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/ontology/$1_ontology.ttl [R=302,L]
+
+# Rewrite rule to serve versioned complete ontology
+RewriteRule ^v24.05/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/ontology.ttl [R=302,L]
+
+# Rewrite rule to serve versioned complete ontology
+RewriteRule ^v24.03/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.03/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned complete ontology
 RewriteRule ^v23.12/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology.ttl [R=302,L]
@@ -49,7 +67,7 @@ RewriteRule ^v23.09/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catena
 RewriteRule ^next/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve complete ontology
-RewriteRule ^ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology.ttl [R=302,L]
+RewriteRule ^ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned use case ontology links
 RewriteRule ^v23.12/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
@@ -57,23 +75,35 @@ RewriteRule ^v23.12/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax
 # Rewrite rule to serve versioned use case ontology links
 RewriteRule ^v23.09/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
-# Rewrite rule to serve versioned use case ontology links
-RewriteRule ^next/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
-
-# Rewrite rule to serve use case ontology links
-RewriteRule ^usecase/(.+)?#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
-
 # Rewrite rule to serve versioned use case ontologies
 RewriteRule ^v23.12/usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned use case ontologies
 RewriteRule ^v23.09/usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
-# Rewrite rule to serve versioned use case ontologies
-RewriteRule ^next/usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
+# Rewrite rule to serve versioned domain taxonomy links
+RewriteRule ^v24.05/taxonomy/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/taxonomy/$1_taxonomy.ttl [R=302,L]
 
-# Rewrite rule to serve use case ontologies
-RewriteRule ^usecase/(.+)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
+# Rewrite rule to serve versioned domain ontology links
+RewriteRule ^next/taxonomy/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/taxonomy/$1_taxonomy.ttl [R=302,L]
+
+# Rewrite rule to serve domain taxonomy links
+RewriteRule ^taxonomy/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/taxonomy/$1_taxonomy.ttl [R=302,L]
+
+# Rewrite rule to serve versioned domain taxonomies
+RewriteRule ^v24.05/taxonomy/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/taxonomy/$1_taxonomy.ttl [R=302,L]
+
+# Rewrite rule to serve versioined domain ontologies
+RewriteRule ^next/taxonomy/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/taxonomy/$1_taxonomy.ttl [R=302,L]
+
+# Rewrite rule to serve domain ontologies
+RewriteRule ^taxonomy/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/taxonomy/$1_taxonomy.ttl [R=302,L]
+
+# Rewrite rule to serve versioned taxonomy
+RewriteRule ^v24.05/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/taxonomy.ttl [R=302,L]
+
+# Rewrite rule to serve versioned taxonomy
+RewriteRule ^v24.03/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.03/taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve versioned taxonomy
 RewriteRule ^v23.12/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/taxonomy.ttl [R=302,L]
@@ -85,7 +115,7 @@ RewriteRule ^v23.09/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catena
 RewriteRule ^next/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve complete taxonomy
-RewriteRule ^taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/taxonomy.ttl [R=302,L]
+RewriteRule ^taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/taxonomy.ttl [R=302,L]
 
 # ODRL Profile definition
 RewriteRule ^policy(/|.*)$ https://raw.githubusercontent.com/catenax-eV/cx-odrl-profile/main/profile.ttl [R=302,L]

--- a/catenax/README.md
+++ b/catenax/README.md
@@ -4,21 +4,35 @@ Documentation is available at: https://catena-x.net/, https://catenax-ng.github.
 
 The complete ontology is available as:
 
-TTL: https://github.com/catenax-ng/product-ontology/blob/v23.12/ontology.ttl (current)
+TTL: https://github.com/catenax-ng/product-ontology/blob/v24.05/ontology.ttl (current)
 TTL: https://github.com/catenax-ng/product-ontology/blob/main/ontology.ttl (next)
+TTL: https://github.com/catenax-ng/product-ontology/blob/v24.03/ontology.ttl (previous)
+TTL: https://github.com/catenax-ng/product-ontology/blob/v23.12/ontology.ttl (previous)
 TTL: https://github.com/catenax-ng/product-ontology/blob/v23.09/ontology.ttl (previous)
 
 The complete taxonomy is available as:
 
-TTL: https://github.com/catenax-ng/product-ontology/blob/v23.12/taxonomy.ttl (current)
+TTL: https://github.com/catenax-ng/product-ontology/blob/v24.05/taxonomy.ttl (current)
 TTL: https://github.com/catenax-ng/product-ontology/blob/main/taxonomy.ttl (next)
+TTL: https://github.com/catenax-ng/product-ontology/blob/v24.03/taxonomy.ttl (previous)
+TTL: https://github.com/catenax-ng/product-ontology/blob/v23.12/taxonomy.ttl (previous)
 TTL: https://github.com/catenax-ng/product-ontology/blob/v23.09/taxonomy.ttl (previous)
 
 Individual domain ontologies can be found under:
 
-https://github.com/catenax-ng/product-ontology/tree/v23.12/ontology (current)
+https://github.com/catenax-ng/product-ontology/tree/v24.05/ontology (current)
 https://github.com/catenax-ng/product-ontology/tree/main/ontology (next)
+https://github.com/catenax-ng/product-ontology/tree/v24.03/ontology (previous)
+https://github.com/catenax-ng/product-ontology/tree/v23.12/ontology (previous)
 https://github.com/catenax-ng/product-ontology/tree/v23.09/ontology (previous)
+
+Individual domain taxonomies can be found under:
+
+https://github.com/catenax-ng/product-ontology/tree/v24.05/taxonomy (current)
+https://github.com/catenax-ng/product-ontology/tree/main/taxonomy (next)
+https://github.com/catenax-ng/product-ontology/tree/v24.03/taxonomy (previous)
+https://github.com/catenax-ng/product-ontology/tree/v23.12/taxonomy (previous)
+https://github.com/catenax-ng/product-ontology/tree/v23.09/taxonomy (previous)
 
 Contact: 
 


### PR DESCRIPTION
- also includes domain taxonomy rules.
- tested with a suite of url patterns against a local apache equipped with the branch.

[test.csv](https://github.com/user-attachments/files/15514276/test.csv)
[test_local.csv](https://github.com/user-attachments/files/15514278/test_local.csv)

```console

#!/bin/bash

while IFS=";" read -r url1 url2; do
    ret=$(curl -L -s -o /dev/null "$url1" -w "%{url_effective}\n")
    if [ "$ret" != "$url2" ]; then
      echo "Expected redirect from $url1 to $url2 but got $ret";
      exit 1
    fi
    retr=$(curl -s -L -o /dev/null -w "%{http_code}\n" "$ret")
    if [ "$retr" != "200" ]; then
      echo "Expected success status 200 from $ret, but got $retr";
      exit 1
    fi
done < test_local.csv

```
