### PR TITLE
Added redirections to emmo-lite

### DIFF
--- a/emmo/.htaccess
+++ b/emmo/.htaccess
@@ -226,3 +226,15 @@ RewriteRule ^([^0-9].*[^/])/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/
 # Redirect to specified version branch
 # Turtle file for given version and module of EMMO
 RewriteRule ^([0-9][^/]*)/([^0-9].*[^/])/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/$2.ttl [R=303,NE,L]
+
+
+
+##########################################################################
+##  Redirections for EMMO-LITE
+##########################################################################
+
+# Rule 13: https://w3id.org/emmo/emmo-lite
+RewriteRule ^emmo-lite/?$ https://raw.githubusercontent.com/emmo-repo/EMMO-LITE/master/emmo-lite.ttl [R=303,NE,L]
+
+# Rule 14: https://w3id.org/emmo/{VERSION}/emmo-lite
+RewriteRule ^([0-9][^/]*)/emmo-lite/?$ https://raw.githubusercontent.com/emmo-repo/EMMO-LITE/$1/emmo-lite.ttl [R=303,NE,L]

--- a/emmo/README.md
+++ b/emmo/README.md
@@ -82,6 +82,12 @@ Rule 1-6 also applies to application ontologies starting with `application-`. Fo
    - Target: Turtle file for given version and module of EMMO.
 
 
+### Redirections to EMMO-LITE
+13. `https://w3id.org/emmo/emmo-lite           --> https://raw.githubusercontent.com/emmo-repo/EMMO-LITE/master/emmo-lite.ttl`
+14. `https://w3id.org/emmo/{VERSION}/emmo-lite --> https://raw.githubusercontent.com/emmo-repo/EMMO-LITE/{VERSION}/emmo-lite.ttl`
+
+
+
 ### Meaning of placeholders
 - `{NAME}`: Name part of an IRI, i.e., what follows after the hash sign.
 - `{VERSION}`: Version number. Must start with a digit to distinguish it from domain or path names.


### PR DESCRIPTION
EMMO-LITE lives under EMMO, but is neither a domain or application ontology, so it needs it own redirections.
