### PR TITLE
Update Omega-X redirection to capture website, repository and ontology files

### DIFF
--- a/omega-x/.htaccess
+++ b/omega-x/.htaccess
@@ -1,4 +1,14 @@
 Options +FollowSymLinks
-RewriteEngine on
-# Rewrite rules for omega-X
-RewriteRule ^(.*) https://github.com/FZ-HANNOU/Omega-X/$1 [R=302,L]
+RewriteEngine On
+
+# Documentation website redirection
+RewriteRule ^(.*)$ https://fz-hannou.github.io/Omega-X/$1 [R=301,L]
+
+# Main ontology file
+RewriteRule ^ontology$ https://github.com/FZ-HANNOU/Omega-X/blob/main/Omega-X-v1.0.ttl [R=303,L]
+
+# Ontology modules 
+RewriteRule ^ontology/([^/]+)$ https://github.com/FZ-HANNOU/Omega-X/blob/main/$1Ontology/$1Ontology-1.0.ttl [R=303,L]
+
+# Repository redirectiob
+RewriteRule ^repository$ https://github.com/FZ-HANNOU/Omega-X [R=303,L]

--- a/omega-x/README.md
+++ b/omega-x/README.md
@@ -5,5 +5,4 @@ Homepage:
 Contacts:
 * [Fatma-Zohra Hannou](https://www.linkedin.com/in/fatma-zohra-hannou/) <fatma-Zohra.hannou@edf.fr>
 * [Lina Nachabe](https://www.linkedin.com/in/lina-nachabe-2b292457/) <lina.nachabe@emse.fr>
-* [Bruno Traverson](https://www.linkedin.com/in/bruno-traverson-082b18196/) <fatma-Zohra.hannou@edf.fr>
-* [Marie Jubault](https://www.linkedin.com/in/marie-jubault-aa209113/) <fatma-Zohra.hannou@edf.fr>
+* [Marie Jubault](https://www.linkedin.com/in/marie-jubault-aa209113/) <marie.jubault@edf.fr>


### PR DESCRIPTION
This PR aims to update the redirection of the Omega-X to capture: 

The ontology documentation website https://fz-hannou.github.io/Omega-X
The ontology repository https://github.com/FZ-HANNOU/Omega-X
The ontology source files https://github.com/FZ-HANNOU/Omega-X/blob/main/Omega-X-v1.0.ttl and modules. 

Best regards, 