### PR TITLE
Redirect to .jsonld variant of JSON-LD context

### DIFF
--- a/ro/terms/.htaccess
+++ b/ro/terms/.htaccess
@@ -9,7 +9,7 @@ RewriteEngine on
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^$ https://www.researchobject.org/ro-terms/context.json [R=303,L]
+RewriteRule ^$ https://www.researchobject.org/ro-terms/context.jsonld [R=303,L]
 
 # Anything else, return csv
 RewriteRule ^$ https://www.researchobject.org/ro-terms/vocabulary.csv [R=303,L]
@@ -41,12 +41,12 @@ RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
 RewriteRule ^workflow-run$ https://www.researchobject.org/ro-terms/workflow-run [R=303,L]
 
 #context
-RewriteRule ^workflow-run/context(.+)$ https://www.researchobject.org/ro-terms/workflow-run/context.json [R=303,L]
+RewriteRule ^workflow-run/context(.+)$ https://www.researchobject.org/ro-terms/workflow-run/context.jsonld [R=303,L]
 
 
 # Any other subfolders
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule (.+)$ https://www.researchobject.org/ro-terms/$1/context.json [R=303,L]
+RewriteRule (.+)$ https://www.researchobject.org/ro-terms/$1/context.jsonld [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle


### PR DESCRIPTION
... to ensure the Content-Type from GitHub Pages matches content negotiation

Also avoid file extension (which should not be in PIDs) for https://w3id.org/ro/terms/workflow-run/context