### PR TITLE
Add redirections to raw files.

### DIFF
--- a/emmo/.htaccess
+++ b/emmo/.htaccess
@@ -17,16 +17,25 @@ Options +FollowSymLinks
 RewriteEngine On
 
 
+##########################################################################
+##  Redirections to raw files in the GitHub repo
+##########################################################################
+
+# Redirect to raw files in the GitHub repo (like figures, etc)
+RewriteRule ^raw/([^0-9].*)$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/$1 [R=303,NE,L]
+RewriteRule ^raw/([0-9][^/]*)/(.*)$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/$2 [R=303,NE,L]
+
+
 
 ##########################################################################
 ##  Redirections for EMMO-LITE
 ##########################################################################
 
-# Src: https://w3id.org/emmo/emmo-lite
+# Source: https://w3id.org/emmo/emmo-lite
 RewriteRule ^emmo-lite/?$ https://raw.githubusercontent.com/emmo-repo/EMMO-LITE/master/emmo-lite.ttl [R=303,NE,L]
 
-# Src: https://w3id.org/emmo/{VERSION}/emmo-lite
-RewriteRule ^([0-9][^/]*)/emmo-lite/?$ https://raw.githubusercontent.com/emmo-repo/EMMO-LITE/$1/emmo-lite.ttl [R=303,NE,L]
+# Source: https://w3id.org/emmo/{VERSION}/emmo-lite
+RewriteRule ^emmo-lite/([0-9][^/]*)/?$ https://raw.githubusercontent.com/emmo-repo/EMMO-LITE/$1/emmo-lite.ttl [R=303,NE,L]
 
 
 

--- a/emmo/README.md
+++ b/emmo/README.md
@@ -84,7 +84,12 @@ Rule 1-6 also applies to application ontologies starting with `application-`. Fo
 
 ### Redirections to EMMO-LITE
 13. `https://w3id.org/emmo/emmo-lite           --> https://raw.githubusercontent.com/emmo-repo/EMMO-LITE/master/emmo-lite.ttl`
-14. `https://w3id.org/emmo/{VERSION}/emmo-lite --> https://raw.githubusercontent.com/emmo-repo/EMMO-LITE/{VERSION}/emmo-lite.ttl`
+14. `https://w3id.org/emmo/emmo-lite/{VERSION} --> https://raw.githubusercontent.com/emmo-repo/EMMO-LITE/{VERSION}/emmo-lite.ttl`
+
+
+### Redirections to raw files on GitHub repo (like figures, etc)
+15. `https://w3id.org/emmo/raw/{PATH}           --> https://raw.githubusercontent.com/emmo-repo/EMMO/{PATH}`
+16. `https://w3id.org/emmo/raw/{VERSION}/{PATH} --> https://raw.githubusercontent.com/emmo-repo/EMMO/{VERSION}/{PATH}`
 
 
 


### PR DESCRIPTION
For now, we want to use this to be able to refer to figures in the annotations.  Other uses might come.

Also, for consistency with domain ontologies, placed the version number after the name of the ontology, e.e. after "emmo-lite".