### PR TITLE
CityOWL Permanent Identifier

### DIFF
--- a/CityOWL/.htaccess
+++ b/CityOWL/.htaccess
@@ -1,0 +1,7 @@
+Options +FollowSymLinks
+
+# Rewrite engine setup
+RewriteEngine On
+
+# Redirect to w3id.org/CityOWL/
+ RewriteRule	^$ https://dataset-dl.liris.cnrs.fr/rdf-owl-urban-data-ontologies/Ontologies/CityOWL/ [R=303,L]

--- a/CityOWL/README.md
+++ b/CityOWL/README.md
@@ -1,7 +1,10 @@
 # CityOWL Ontology
 [https://w3id.org/CityOWL/](https://w3id.org/CityOWL/) -> [https://dataset-dl.liris.cnrs.fr/rdf-owl-urban-data-ontologies/Ontologies/CityOWL/](https://dataset-dl.liris.cnrs.fr/rdf-owl-urban-data-ontologies/Ontologies/CityOWL/)
 
-
+Created as a part of the research work of the [LIRIS VCity Project](https://projet.liris.cnrs.fr/vcity/)
 
 ## Contact
-[Diego Vinasco-Alvarez - diego.vinasco-alvarez@liris.cnrs.fr](mailto:diego.vinasco-alvarez@liris.cnrs.fr)
+* [Diego Vinasco-Alvarez - diego.vinasco-alvarez@liris.cnrs.fr](mailto:diego.vinasco-alvarez@liris.cnrs.fr)
+* [Gilles Gesquière - gilles.gesquiere@univ-lyon2.fr](mailto:gilles.gesquiere@univ-lyon2.fr)
+* [Sylvie Servigne - sylvie.servigne@insa-lyon.fr](mailto:sylvie.servigne@insa-lyon.fr)
+* [John Samuel - john.samuel@cpe.fr](mailto:john.samuel@cpe.fr)

--- a/CityOWL/README.md
+++ b/CityOWL/README.md
@@ -1,0 +1,7 @@
+# CityOWL Ontology
+[https://w3id.org/CityOWL/](https://w3id.org/CityOWL/) -> [https://dataset-dl.liris.cnrs.fr/rdf-owl-urban-data-ontologies/Ontologies/CityOWL/](https://dataset-dl.liris.cnrs.fr/rdf-owl-urban-data-ontologies/Ontologies/CityOWL/)
+
+
+
+## Contact
+[Diego Vinasco-Alvarez - diego.vinasco-alvarez@liris.cnrs.fr](mailto:diego.vinasco-alvarez@liris.cnrs.fr)


### PR DESCRIPTION
CityOWL is an ontology network created from the CityGML 3.0 UML model

* Two ontology networks for describing semantic 3D city models created from the [CityGML 3.0 UML model:](https://github.com/VCityTeam/UD-Graph/blob/master/Transformations/test-data/UML/CityGML_3.0-workspaces-documents.eap)
  * [CityOWL CWA](https://dataset-dl.liris.cnrs.fr/rdf-owl-urban-data-ontologies/Ontologies/CityOWL/CWA/3.0/): a more constrained representation of the CityGML 3.0 UML model
  * [CityOWL OWA](https://dataset-dl.liris.cnrs.fr/rdf-owl-urban-data-ontologies/Ontologies/CityOWL/OWA/3.0/): a less constrained representation of the CityGML 3.0 UML model
* Transformed using [ShapeChange](https://shapechange.net/) and [a model-driven transformation pipeline](https://github.com/VCityTeam/UD-Reproducibility/tree/c91daaede8165b7289b09b674cdbd081e79e7b76/Computations/RDF/CityOWL) as defined in [[Vinasco-Alvarez et al. 2024]](https://isprs-annals.copernicus.org/articles/X-4-W4-2024/231/2024/)
