### PR TITLE
Add redirections for Eclipse Dataspace Components project

### DIFF
--- a/edc/.htaccess
+++ b/edc/.htaccess
@@ -1,0 +1,18 @@
+#
+# Eclipse Dataspace Components Namespace Forwarding Rules
+# tested with https://htaccess.madewithlove.com/
+#
+
+Options -MultiViews
+
+AddType application/ld+json .jsonld
+# Rewrite engine setup
+RewriteEngine On
+#Change the path to the folder here
+RewriteBase /
+
+# Rewrite rule to resolve connector management context
+RewriteRule ^connector/management/v0.0.1(.*)$ https://eclipse-edc.github.io/Connector/context/management-context-v1.jsonld [R=302,L]
+
+# Rewrite rule to default to the EDC docs page
+RewriteRule ^(.*)$ https://eclipse-edc.github.io/docs [R=303,L]

--- a/edc/README.md
+++ b/edc/README.md
@@ -1,0 +1,9 @@
+# Eclipse Dataspace Components Namespace
+
+This namespace serves as redirection platform for multiple resources from the [Eclipse Dataspace Components](https://eclipse-edc.github.io/docs) project.
+
+Contact:
+
+- Enrico Risa <enrico.risa@gmail.com> (https://github.com/wolf4ood)
+- James Marino <jim.marino@gmail.com> (https://github.com/jimmarino)
+- Paul Latzelsperger <Paul.latzelsperger@beardyinc.com> (https://github.com/paullatzelsperger)


### PR DESCRIPTION
This PR add redirections for the [EDC](https://projects.eclipse.org/projects/technology.edc)  (Eclipse Dataspace Components) project.

It contains two redirects:

- The redirection for the JSON-LD context of the connector management API.  
- The fallback one to the docs website.