### PR TITLE
Add CEIR - Center for Enterprise Information Research

### DIFF
--- a/CEIR/.htaccess
+++ b/CEIR/.htaccess
@@ -1,0 +1,18 @@
+# Allow all (*) origins to access the resource on the server
+Header set Access-Control-Allow-Origin *
+
+# Allow following symbolic links / symlinks / softlinks
+Options +FollowSymLinks
+
+# Turn off MultiViews
+Options -MultiViews
+
+# Required for the redirects
+RewriteEngine On
+
+# Redirects
+RewriteRule ^(.*)IRECS$ https://github.com/ceir-koblenz/IRECS [R=303,L]
+RewriteRule ^(.*)MOBDA$ https://github.com/ceir-koblenz/MOBDA [R=303,L]
+
+# Default response: redirect to the CEIR github page
+RewriteRule ^(.*)$ https://github.com/ceir-koblenz [R=303,L]

--- a/CEIR/README.md
+++ b/CEIR/README.md
@@ -1,0 +1,15 @@
+# CEIR - Center for Enterprise Information Research
+
+"Our goal is to conduct high quality research in the area of IT-enabled business change and the digital workplace."
+
+## Founders
+[Susan Williams](https://www.uni-koblenz.de/en/computer-science/iwvi/williams/team/susan-p-williams)\
+[Petra Schubert](https://www.uni-koblenz.de/en/computer-science/iwvi/schubert/team/petra-schubert)
+
+## Links
+[CEIR-GitHub](https://github.com/ceir-koblenz)\
+[CEIR-Homepage](https://ceir.de)
+
+## Maintainers
+[Martin Just](https://github.com/Muffexx)\
+[Julian Mosen](https://github.com/jmosen)


### PR DESCRIPTION
Hello everyone,

I have added a permanent identifier for [CEIR (Center for Enterprise Information Research)](https://ceir.de/). This way we don't need to create a new "root" identifier for each of our projects. I think that our existing identifiers (SocDOnt & ColActDOnt) are still viable since the .htaccess-files for (these) ontologies are more complex (due to the individual versions and file formats) than the simple redirects we will use for CEIR/MOBDA, CEIR/IRECS, etc.

Regards
Martin