### PR TITLE
Adding an identifier for the Construction Site Network Ontology (CNO) (EC3 Paper)

### DIFF
--- a/cno/.htaccess
+++ b/cno/.htaccess
@@ -1,0 +1,28 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+
+# If accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://kirnerlukas.github.io/Construction-Site-Network-Ontology-CNO-/ontology.ttl
+
+# If accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://kirnerlukas.github.io/Construction-Site-Network-Ontology-CNO-/ontology.xml
+
+# If suffix ttl, redirect to turtle 
+RewriteRule ^.ttl$ https://kirnerlukas.github.io/Construction-Site-Network-Ontology-CNO-/ontology.ttl
+
+# If suffix html, redirect to html 
+RewriteRule ^.html$ https://kirnerlukas.github.io/Construction-Site-Network-Ontology-CNO-
+
+# If suffix rdf, redirect to rdf 
+RewriteRule ^.rdf$ https://kirnerlukas.github.io/Construction-Site-Network-Ontology-CNO-/ontology.xml
+
+# Default response: html
+RewriteRule ^$ https://kirnerlukas.github.io/Construction-Site-Network-Ontology-CNO-

--- a/cno/README.md
+++ b/cno/README.md
@@ -1,0 +1,16 @@
+# /ioc/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for Construction Site Network Ontology (CNO).
+
+## Uses
+Enabling the signal strength estimation for 5G Networks on construction sites.
+See http://www.econom.one
+
+## Contact
+This space is administered by:  
+
+**Lukas Kirner**  
+  *Researcher*  
+Individualized Production, RWTH Aachen, Germany.  
+https://github.com/kirner-ip
+<kirner@ip.rwth-aachen.de>  
+ORCID: [0000-0001-9753-2422](https://orcid.org/0000-0001-9753-2422) 


### PR DESCRIPTION
Dear w3id Team,

with this pull request I kindly request the /cno# identifier for the construction site network ontology (cno) we will present at this years EC3 conference. The ontology adds concepts to describe networks to realize signal strength estimation calculations.

I copy pasted and modified the readme and htaccess from another identifier of one of our ontologies, as this works as it sould :)

Thank you for your work, and have a nice day,
Lukas