### PR TITLE
Add hadids url

### DIFF
--- a/hadids/.htaccess
+++ b/hadids/.htaccess
@@ -1,10 +1,11 @@
-RewriteEngine on
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine On
 
-# https://w3id.org/hadid#dnsDomain -> https://www.ietf.org/archive/id/draft-carter-high-assurance-dids-with-dns-04.html
+# https://w3id.org/hadids -> https://www.ietf.org/archive/id/draft-carter-high-assurance-dids-with-dns-04.html
 
-RewriteRule #dnsDomain$ https://www.ietf.org/archive/id/draft-carter-high-assurance-dids-with-dns-04.html#name-the-dnsdomain-property [R=302,L]
+RewriteRule ^$ https://www.ietf.org/archive/id/draft-carter-high-assurance-dids-with-dns-04.html [R=302,L]
 
-# https://w3id.org/hadid/v0.4 -> https://ciralabs.github.io/DnsDomainJsonLd/dns-domain.jsonld
+# https://w3id.org/hadids/v0.4 -> https://ciralabs.github.io/DnsDomainJsonLd/dns-domain.jsonld
 
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
 RewriteRule ^v0.4$ https://ciralabs.github.io/DnsDomainJsonLd/dns-domain.jsonld [R=302,L]

--- a/hadids/.htaccess
+++ b/hadids/.htaccess
@@ -1,0 +1,10 @@
+RewriteEngine on
+
+# https://w3id.org/hadid#dnsDomain -> https://www.ietf.org/archive/id/draft-carter-high-assurance-dids-with-dns-04.html
+
+RewriteRule #dnsDomain$ https://www.ietf.org/archive/id/draft-carter-high-assurance-dids-with-dns-04.html#name-the-dnsdomain-property [R=302,L]
+
+# https://w3id.org/hadid/v0.4 -> https://ciralabs.github.io/DnsDomainJsonLd/dns-domain.jsonld
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^v0.4$ https://ciralabs.github.io/DnsDomainJsonLd/dns-domain.jsonld [R=302,L]

--- a/hadids/README.md
+++ b/hadids/README.md
@@ -1,0 +1,10 @@
+# High Assurance DIDs with DNS
+
+- https://datatracker.ietf.org/doc/draft-carter-high-assurance-dids-with-dns/
+
+# Contact:
+
+- Jesse Carter (CIRA - jesse.carter@cira.ca)
+- Tim Bouma (Digital Governance Council - tim.bouma@dgc-cgn.org)
+- Jacques Latour (CIRA - jacques.latour@cira.ca)
+- Mathieu Glaude (Northern Block - mathieu@northernblock.ca)


### PR DESCRIPTION
Added redirects for /hadids to https://datatracker.ietf.org/doc/draft-carter-high-assurance-dids-with-dns/