### PR TITLE
Request to add identifiers for the GNSS-BE-REPO and for the GNSS-BE-REPO

### DIFF
--- a/EUREF-HDC/.htaccess
+++ b/EUREF-HDC/.htaccess
@@ -1,0 +1,12 @@
+Options +FollowSymLinks
+RewriteEngine on
+# Rewrite rule for the html
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(.*)$ https://epncb.oma.be/PID/$1  [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^(.*)$ https://epncb.oma.be/PID/$1.json  [R=303,L]

--- a/EUREF-HDC/README.md
+++ b/EUREF-HDC/README.md
@@ -1,0 +1,6 @@
+EUREF-HDC stands for “EUREF HISTORICAL DATA CENTRE”
+Daily 30s Global Navigation Satellite System (GNSS) Receiver Independent Exchange Format (RINEX) data available from the EUREF historical data centre.
+
+For more info check https://epncb.oma.be/
+
+**contact:** Andras Fabian <andras.fabian@oma.be> (@andrasfabian12) — Royal Observatory of Belgium 

--- a/GNSS-BE-REPO/.htaccess
+++ b/GNSS-BE-REPO/.htaccess
@@ -1,0 +1,12 @@
+Options +FollowSymLinks
+RewriteEngine on
+# Rewrite rule for the html
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(.*)$ https://gnss.be/PID/$1  [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^(.*)$ https://gnss.be/PID/$1.json  [R=303,L]

--- a/GNSS-BE-REPO/README.md
+++ b/GNSS-BE-REPO/README.md
@@ -1,0 +1,6 @@
+EUREF-HDC stands for “EUREF HISTORICAL DATA CENTRE”
+Daily 30s Global Navigation Satellite System (GNSS) Receiver Independent Exchange Format (RINEX) data available from the EUREF historical data centre.
+
+For more info check https://epncb.oma.be/
+
+**contact:** Andras Fabian <andras.fabian@oma.be> (@andrasfabian12) — Royal Observatory of Belgium 

--- a/GNSS-BE-REPO/README.md
+++ b/GNSS-BE-REPO/README.md
@@ -1,6 +1,6 @@
-EUREF-HDC stands for “EUREF HISTORICAL DATA CENTRE”
-Daily 30s Global Navigation Satellite System (GNSS) Receiver Independent Exchange Format (RINEX) data available from the EUREF historical data centre.
+GNSS-BE-REPO
+Daily 30s Global Navigation Satellite System (GNSS) Receiver Independent Exchange Format (RINEX) data available from the Belgian GNSS repository.
 
-For more info check https://epncb.oma.be/
+For more info check https://gnss.be/
 
 **contact:** Andras Fabian <andras.fabian@oma.be> (@andrasfabian12) — Royal Observatory of Belgium 


### PR DESCRIPTION
EUREF-HDC 
EUREF HISTORICAL DATA CENTRE
Daily 30s Global Navigation Satellite System (GNSS) Receiver Independent Exchange Format (RINEX) data available from the EUREF historical data centre.
(example: https://epncb.oma.be/PID/catalog)

GNSS-BE-REPO
Daily 30s Global Navigation Satellite System (GNSS) Receiver Independent Exchange Format (RINEX) data available from the Belgian GNSS repository.
(example: https://gnss.be/PID/catalog)