### PR TITLE
SML added

### DIFF
--- a/sml/.htaccess
+++ b/sml/.htaccess
@@ -1,0 +1,32 @@
+RewriteEngine on
+
+
+# 1: Explicit URL of normative file (no content-negotiation)
+# Only TTL => SKOS | RDFS | OWL | SHACL
+
+RewriteRule ^skos/term$ https://docs.crow.nl/sml/data/sml-skos.ttl [R=302,L]
+RewriteRule ^rdfs/def$ https://docs.crow.nl/sml/data/sml-rdfs.ttl [R=302,L]
+RewriteRule ^owl/def$ https://docs.crow.nl/sml/data/sml-owl.ttl [R=302,L]
+RewriteRule ^shacl/def$ https://docs.crow.nl/sml/data/sml-shacl.ttl [R=302,L]
+RewriteRule ^sparql$ https://hub.laces.tech/crow/sml/all/sparql [R=302,L]
+
+
+# 2: Non-explicit URL, explicit Accept-header
+# Serve specific serializations => TriG | JSON-LD | Turtle | RDF/XML
+RewriteCond %{HTTP_ACCEPT} application/trig
+RewriteRule ^$ https://docs.crow.nl/sml/data/concat/sml.trig [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld+json
+RewriteRule ^$ https://docs.crow.nl/sml/data/concat/sml.json [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/n3
+RewriteRule ^$ https://docs.crow.nl/sml/data/concat/sml.ttl [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/owl\+xml
+RewriteRule ^$ https://docs.crow.nl/sml/data/concat/sml.rdf [R=302,L]
+
+
+# Final, matching anything (includes Accept = text/html)
+RewriteRule ^(.*)$ https://docs.crow.nl/sml/$1 [R=302,L]

--- a/sml/README.md
+++ b/sml/README.md
@@ -1,0 +1,42 @@
+# /nen2660/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the normative CEN-EN 17632 resources.
+
+[CEN-EN 17632][cen] is the European Standard “_Building information modelling (BIM) - Semantic modelling and linking (SML)_”.
+
+[cen]: https://standards.cencenelec.eu/dyn/www/f?p=205:110:0::::FSP_PROJECT:67839&cs=13BE091B11208910B30E53F9215AFDE96
+
+## Uses
+This namespace contains 
+SKOS terms,
+an RDFS ontology,
+an OWL extension,
+and
+SHACL shapes.
+
+The ontology define terms like 
+`Activity`,
+`AmountOfBulkMatter`,
+`consistsOf`,
+`DiscreteObject`,
+`hasFunctionalPart`,
+`hasUnit`,
+`isImplementedBy`,
+`PhysicalObject`.
+
+The ontology refers to OWL Time, GeoSPARQL and QUDT ontologies.
+
+The ontology can be browsed from <https://docs.crow.nl/sml/>, where the constituent files may also be downloaded from. 
+
+## Preferred Prefixes
+```turtle
+prefix sml-term: <https://w3id.org/sml/term#>
+prefix sml:      <https://w3id.org/sml/def#>
+```
+
+## Contact
+This space is administered by:
+
+- **Redmer Kronemeijer**   
+E-mail: <redmer.kronemeijer@crow.nl>  
+ORCID: [0000-0001-9821-0193](https://orcid.org/0000-0001-9821-0193)  
+GitHub: [@redmer](https://github.com/redmer)

--- a/sml/README.md
+++ b/sml/README.md
@@ -36,7 +36,7 @@ prefix sml:      <https://w3id.org/sml/def#>
 ## Contact
 This space is administered by:
 
-- **Redmer Kronemeijer**   
-E-mail: <redmer.kronemeijer@crow.nl>  
-ORCID: [0000-0001-9821-0193](https://orcid.org/0000-0001-9821-0193)  
+- **Stichting CROW**   
+E-mail: <data@crow.nl>  
 GitHub: [@redmer](https://github.com/redmer)
+GitHub: [@RiX012](https://github.com/RiX012)

--- a/sml/README.md
+++ b/sml/README.md
@@ -13,7 +13,7 @@ an OWL extension,
 and
 SHACL shapes.
 
-The ontology define terms like 
+The ontology defines terms like 
 `Activity`,
 `AmountOfBulkMatter`,
 `consistsOf`,

--- a/sml/README.md
+++ b/sml/README.md
@@ -1,4 +1,4 @@
-# /nen2660/
+# /sml/
 This [W3ID](https://w3id.org) provides a persistent URI namespace for the normative CEN-EN 17632 resources.
 
 [CEN-EN 17632][cen] is the European Standard “_Building information modelling (BIM) - Semantic modelling and linking (SML)_”.

--- a/sml/README.md
+++ b/sml/README.md
@@ -23,7 +23,7 @@ The ontology defines terms like
 `isImplementedBy`,
 `PhysicalObject`.
 
-The ontology refers to OWL Time, GeoSPARQL and QUDT ontologies.
+The ontology refers to OWL Time, GeoSPARQL, and QUDT ontologies.
 
 The ontology can be browsed from <https://docs.crow.nl/sml/>, where the constituent files may also be downloaded from. 
 


### PR DESCRIPTION
This [W3ID](https://w3id.org) provides a persistent URI namespace for the normative CEN-EN 17632 resources.

[CEN-EN 17632][cen] is the European Standard “_Building information modelling (BIM) - Semantic modelling and linking (SML)_”.

[cen]: https://standards.cencenelec.eu/dyn/www/f?p=205:110:0::::FSP_PROJECT:67839&cs=13BE091B11208910B30E53F9215AFDE96