### PR TITLE
Fix vc-barcodes rules.

### DIFF
--- a/vc-barcodes/.htaccess
+++ b/vc-barcodes/.htaccess
@@ -1,8 +1,9 @@
-# Verifiable Credential Barcodes Resources
+# Verifiable Credential Barcodes
 #
-# homepages:
+# homepage:
 #  https://w3c-ccg.github.io/vc-barcodes/
-#  https://github.com/w3c-ccg/vc-barcodes
+# source:
+#  https://github.com/w3c-ccg/vc-barcodes/
 # maintainers:
 #   @davidlehn
 #   @dlongley
@@ -10,5 +11,5 @@
 #   @wes-smith
 
 RewriteEngine on
-RewriteRule ^$ https://github.com/w3c-ccg/vc-barcodes [R=302,L]
-RewriteRule ^v1$ https://w3c-ccg.github.io/vc-barcodes/contexts/vc-barcodes-v1.jsonld [R=302,L]
+RewriteRule ^$ https://w3c-ccg.github.io/vc-barcodes/ [R=302,L]
+RewriteRule ^v(.*)$ https://w3c-ccg.github.io/vc-barcodes/contexts/vc-barcodes-v$1.jsonld [R=302,L]


### PR DESCRIPTION
- Use main homepage for base path.
- Use generic pattern for context redirect.