### PR TITLE
fix: temporarily migrate catenax ontologies 

### DIFF
--- a/catenax/.htaccess
+++ b/catenax/.htaccess
@@ -16,106 +16,106 @@ RewriteEngine On
 RewriteBase /
 
 # Rewrite rule to serve versioned domain ontology links
-RewriteRule ^v24.05/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/ontology/$1_ontology.ttl [R=302,L]
+RewriteRule ^v24.05/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain ontology links
-RewriteRule ^v24.03/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.03/ontology/$1_ontology.ttl [R=302,L]
+RewriteRule ^v24.03/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.03/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain ontology links
-RewriteRule ^v23.12/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology/$1_ontology.ttl [R=302,L]
+RewriteRule ^v23.12/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v23.12/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain ontology links
-RewriteRule ^v23.09/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$1_ontology.ttl [R=302,L]
+RewriteRule ^v23.09/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v23.09/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain ontology links
-RewriteRule ^next/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology/$1_ontology.ttl [R=302,L]
+RewriteRule ^next/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/main/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve domain ontology links
-RewriteRule ^ontology/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/ontology/$1_ontology.ttl [R=302,L]
+RewriteRule ^ontology/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain ontologies
-RewriteRule ^v24.05/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/ontology/$1_ontology.ttl [R=302,L]
+RewriteRule ^v24.05/ontology/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain ontologies
-RewriteRule ^v24.03/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.03/ontology/$1_ontology.ttl [R=302,L]
+RewriteRule ^v24.03/ontology/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.03/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain ontologies
-RewriteRule ^v23.12/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology/$1_ontology.ttl [R=302,L]
+RewriteRule ^v23.12/ontology/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v23.12/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain ontologies
-RewriteRule ^v23.09/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology/$1_ontology.ttl [R=302,L]
+RewriteRule ^v23.09/ontology/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v23.09/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioined domain ontologies
-RewriteRule ^next/ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology/$1_ontology.ttl [R=302,L]
+RewriteRule ^next/ontology/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/main/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve domain ontologies
-RewriteRule ^ontology/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/ontology/$1_ontology.ttl [R=302,L]
+RewriteRule ^ontology/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned complete ontology
-RewriteRule ^v24.05/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/ontology.ttl [R=302,L]
+RewriteRule ^v24.05/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned complete ontology
-RewriteRule ^v24.03/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.03/ontology.ttl [R=302,L]
+RewriteRule ^v24.03/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.03/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned complete ontology
-RewriteRule ^v23.12/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology.ttl [R=302,L]
+RewriteRule ^v23.12/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/v23.12/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned complete ontology
-RewriteRule ^v23.09/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology.ttl [R=302,L]
+RewriteRule ^v23.09/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/v23.09/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned complete ontology
-RewriteRule ^next/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/ontology.ttl [R=302,L]
+RewriteRule ^next/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/main/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve complete ontology
-RewriteRule ^ontology(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/ontology.ttl [R=302,L]
+RewriteRule ^ontology(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned use case ontology links
-RewriteRule ^v23.12/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
+RewriteRule ^v23.12/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v23.12/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned use case ontology links
-RewriteRule ^v23.09/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
+RewriteRule ^v23.09/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v23.09/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned use case ontologies
-RewriteRule ^v23.12/usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
+RewriteRule ^v23.12/usecase/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v23.12/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned use case ontologies
-RewriteRule ^v23.09/usecase/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
+RewriteRule ^v23.09/usecase/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v23.09/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain taxonomy links
-RewriteRule ^v24.05/taxonomy/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/taxonomy/$1_taxonomy.ttl [R=302,L]
+RewriteRule ^v24.05/taxonomy/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/taxonomy/$1_taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain ontology links
-RewriteRule ^next/taxonomy/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/taxonomy/$1_taxonomy.ttl [R=302,L]
+RewriteRule ^next/taxonomy/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/main/taxonomy/$1_taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve domain taxonomy links
-RewriteRule ^taxonomy/(.+)#(.*)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/taxonomy/$1_taxonomy.ttl [R=302,L]
+RewriteRule ^taxonomy/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/taxonomy/$1_taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain taxonomies
-RewriteRule ^v24.05/taxonomy/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/taxonomy/$1_taxonomy.ttl [R=302,L]
+RewriteRule ^v24.05/taxonomy/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/taxonomy/$1_taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve versioined domain ontologies
-RewriteRule ^next/taxonomy/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/taxonomy/$1_taxonomy.ttl [R=302,L]
+RewriteRule ^next/taxonomy/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/main/taxonomy/$1_taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve domain ontologies
-RewriteRule ^taxonomy/(.+)$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/taxonomy/$1_taxonomy.ttl [R=302,L]
+RewriteRule ^taxonomy/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/taxonomy/$1_taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve versioned taxonomy
-RewriteRule ^v24.05/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/taxonomy.ttl [R=302,L]
+RewriteRule ^v24.05/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve versioned taxonomy
-RewriteRule ^v24.03/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.03/taxonomy.ttl [R=302,L]
+RewriteRule ^v24.03/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.03/taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve versioned taxonomy
-RewriteRule ^v23.12/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.12/taxonomy.ttl [R=302,L]
+RewriteRule ^v23.12/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/v23.12/taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve versioned taxonomy
-RewriteRule ^v23.09/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v23.09/taxonomy.ttl [R=302,L]
+RewriteRule ^v23.09/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/v23.09/taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve complete taxonomy
-RewriteRule ^next/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/main/taxonomy.ttl [R=302,L]
+RewriteRule ^next/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/main/taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve complete taxonomy
-RewriteRule ^taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/catenax-ng/product-ontology/v24.05/taxonomy.ttl [R=302,L]
+RewriteRule ^taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/taxonomy.ttl [R=302,L]
 
 # ODRL Profile definition
 RewriteRule ^policy(/|.*)$ https://raw.githubusercontent.com/catenax-eV/cx-odrl-profile/main/profile.ttl [R=302,L]
@@ -124,4 +124,4 @@ RewriteRule ^policy(/|.*)$ https://raw.githubusercontent.com/catenax-eV/cx-odrl-
 RewriteRule ^credentials/v1.0.0(.*)$ https://eclipse-tractusx.github.io/tractusx-profiles/cx/context/credentials.context.json [R=302,L]
 
 # Rewrite rule to serve the TTL content from the vocabulary URI by default
-RewriteRule ^(.*)$ https://catenax-ng.github.io/product-ontology [R=303,L]
+RewriteRule ^(.*)$ https://big-data-spaces.github.io/ontology [R=303,L]

--- a/catenax/README.md
+++ b/catenax/README.md
@@ -1,38 +1,43 @@
 # Catena-X Namespace
 
-Documentation is available at: https://catena-x.net/, https://catenax-ng.github.io/ and https://catenax-ng.github.io/product-ontology
+Documentation is available at: https://catena-x.net/, https://github.com/catenax-eV, https://eclipse-tractusx.github.io, https://big-data-spaces.github.io/ and https://big-data-spaces.github.io/ontology
 
 The complete ontology is available as:
 
-TTL: https://github.com/catenax-ng/product-ontology/blob/v24.05/ontology.ttl (current)
-TTL: https://github.com/catenax-ng/product-ontology/blob/main/ontology.ttl (next)
-TTL: https://github.com/catenax-ng/product-ontology/blob/v24.03/ontology.ttl (previous)
-TTL: https://github.com/catenax-ng/product-ontology/blob/v23.12/ontology.ttl (previous)
-TTL: https://github.com/catenax-ng/product-ontology/blob/v23.09/ontology.ttl (previous)
+TTL: https://github.com/big-data-spaces/ontology/blob/v24.05/ontology.ttl (current)
+TTL: https://github.com/big-data-spaces/ontology/blob/main/ontology.ttl (next)
+TTL: https://github.com/big-data-spaces/ontology/blob/v24.03/ontology.ttl (previous)
+TTL: https://github.com/big-data-spaces/ontology/blob/v23.12/ontology.ttl (previous)
+TTL: https://github.com/big-data-spaces/ontology/blob/v23.09/ontology.ttl (previous)
 
 The complete taxonomy is available as:
 
-TTL: https://github.com/catenax-ng/product-ontology/blob/v24.05/taxonomy.ttl (current)
-TTL: https://github.com/catenax-ng/product-ontology/blob/main/taxonomy.ttl (next)
-TTL: https://github.com/catenax-ng/product-ontology/blob/v24.03/taxonomy.ttl (previous)
-TTL: https://github.com/catenax-ng/product-ontology/blob/v23.12/taxonomy.ttl (previous)
-TTL: https://github.com/catenax-ng/product-ontology/blob/v23.09/taxonomy.ttl (previous)
+TTL: https://github.com/big-data-spaces/ontology/blob/v24.05/taxonomy.ttl (current)
+TTL: https://github.com/big-data-spaces/ontology/blob/main/taxonomy.ttl (next)
+TTL: https://github.com/big-data-spaces/ontology/blob/v24.03/taxonomy.ttl (previous)
+TTL: https://github.com/big-data-spaces/ontology/blob/v23.12/taxonomy.ttl (previous)
+TTL: https://github.com/big-data-spaces/ontology/blob/v23.09/taxonomy.ttl (previous)
 
 Individual domain ontologies can be found under:
 
-https://github.com/catenax-ng/product-ontology/tree/v24.05/ontology (current)
-https://github.com/catenax-ng/product-ontology/tree/main/ontology (next)
-https://github.com/catenax-ng/product-ontology/tree/v24.03/ontology (previous)
-https://github.com/catenax-ng/product-ontology/tree/v23.12/ontology (previous)
-https://github.com/catenax-ng/product-ontology/tree/v23.09/ontology (previous)
+https://github.com/big-data-spaces/ontology/tree/v24.05/ontology (current)
+https://github.com/big-data-spaces/ontology/tree/main/ontology (next)
+https://github.com/big-data-spaces/ontology/tree/v24.03/ontology (previous)
+https://github.com/big-data-spaces/ontology/tree/v23.12/ontology (previous)
+https://github.com/big-data-spaces/ontology/tree/v23.09/ontology (previous)
 
 Individual domain taxonomies can be found under:
 
-https://github.com/catenax-ng/product-ontology/tree/v24.05/taxonomy (current)
-https://github.com/catenax-ng/product-ontology/tree/main/taxonomy (next)
-https://github.com/catenax-ng/product-ontology/tree/v24.03/taxonomy (previous)
-https://github.com/catenax-ng/product-ontology/tree/v23.12/taxonomy (previous)
-https://github.com/catenax-ng/product-ontology/tree/v23.09/taxonomy (previous)
+https://github.com/big-data-spaces/ontology/tree/v24.05/taxonomy (current)
+https://github.com/big-data-spaces/ontology/tree/main/taxonomy (next)
+https://github.com/big-data-spaces/ontology/tree/v24.03/taxonomy (previous)
+https://github.com/big-data-spaces/ontology/tree/v23.12/taxonomy (previous)
+https://github.com/big-data-spaces/ontology/tree/v23.09/taxonomy (previous)
+
+Profiles can be found under:
+
+https://github.com/catenax-eV/cx-odrl-profile
+https://github.com/eclipse-tractusx/tractusx-profiles
 
 Contact: 
 


### PR DESCRIPTION
The Catena-X consortium ended at 2024-07-31
We are currently migrating the ontologies to the Catena-X association and its Open Source Organisation (Eclipse Tractus-X)
Until that migration is over, we temporarily introduce an intermediate location (at big-data-spaces orga) to avoid downtimes in any referring systems.
