### PR TITLE
Add PIDs for the ARUNA Data Orchestration Engine

### DIFF
--- a/aruna/.htaccess
+++ b/aruna/.htaccess
@@ -1,0 +1,8 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+
+RewriteEngine on
+
+RewriteRule ^$ https://aruna-storage.org/ [R=302,L]
+RewriteRule ^([0-7][0-9A-HJKMNP-TV-Z]{25})$ https://aruna-storage.org/objects/$1 [R=302,L]
+RewriteRule ^dev/([0-7][0-9A-HJKMNP-TV-Z]{25})$ https://dev.aruna-storage.org/objects/$1 [R=302,L]

--- a/aruna/README.md
+++ b/aruna/README.md
@@ -1,0 +1,31 @@
+# ARUNA Data Orchestration Engine
+
+This perma-id provides a persistent URI namespaces for the [ARUNA Data Orchestration Engine](https://aruna-storage.org).
+
+The ARUNA data orchestration engine is an open source data management platform that enables scientists and industry partners to store, annotate and share their data according to FAIR principles.
+
+## Contacts
+
+General contact:
+
+* [support@aruna-storage.org](mailto:support@aruna-storage.org)
+
+This perma-id is administered by:
+
+**Frank Förster, [@greatfireball](https://github.com/greatfireball)**  
+[Bioinformatics Core Facility](https://www.uni-giessen.de/de/fbz/fb08/Inst/bioinformatik/bcf)  
+Justus Liebig University Giessen  
+Giessen, Germany  
+ORCID: [0000-0003-4166-5423](https://orcid.org/0000-0003-4166-5423)
+
+**Sebastian Beyvers, [@St4NNi](https://github.com/St4NNi)**  
+[Bioinformatics and Systems Biology](https://www.uni-giessen.de/de/fbz/fb08/Inst/bioinformatik/people/current_members/sebastianbeyvers/sebastianbeyvers)  
+Justus Liebig University Giessen  
+Giessen, Germany  
+ORCID: [0000-0002-9747-7096](https://orcid.org/0000-0002-9747-7096)
+
+**Jannis Hochmuth, [@das-Abroxas](https://github.com/das-Abroxas)**  
+[Bioinformatics and Systems Biology](https://www.uni-giessen.de/de/fbz/fb08/Inst/bioinformatik/people/current_members/jannishochmuth/jannis_hochmuth))  
+Justus Liebig University Giessen  
+Giessen, Germany  
+ORCID: [0009-0004-4382-4760](https://orcid.org/0009-0004-4382-4760)


### PR DESCRIPTION
Purpose: This pull request is submitted to request an identifier for the [ARUNA Data Orchestration Engine](https://aruna-storage.org).

As the representative of the ARUNA team, I am submitting this request on behalf of our team.
The identifier is needed to offer PIDs to our users, which is required for a FAIR data managment.

Notes: Please process this request to issue an identifier for the ARUNA Data Orchestration Engine. If any further information or documentation is needed, feel free to contact me.