### PR TITLE
Add oso w3id

### DIFF
--- a/lara/.htaccess
+++ b/lara/.htaccess
@@ -1,0 +1,19 @@
+# LARA (Laboratory Automation Robotic Assistent)
+#
+# https://w3id.org/lara/ redirects to https://gitlab.com/LARAsuite/
+#
+# ## Contact
+# This space is administered by:
+#
+# mark doerr
+# mark.doerr@uni-greifswald.de
+# GitHub username: markdoerr
+
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+# BASE: Visit homepage
+RewriteRule ^ https://gitlab.com/LARAsuite/ [R=303,L]
+
+

--- a/lara/README.md
+++ b/lara/README.md
@@ -1,0 +1,19 @@
+LARA
+=====
+
+LARA (Laboratory Automation Robotic Assistent) is an open source Research Data Management Suite and 2nd generation Electronic Lab Notebook with the goal to automate most of the data and metadata entering process by providing a rich infrastructure for lab communication, orchestration, data/metadata storage, evaluation and exchange. It utilises Ontology based semantic web technology to make data findable via SPARAQL.
+
+
+### Homepage
+
+* [LARA](https://gitlab.com/LARAsuite/)
+
+* [LARA robotic platform](https://lara.uni-greifswald.de/)
+
+
+### Contacts
+
+* General contact: [mark.doerr@uni-greifswald.de](mailto:mark.doerr@uni-greifswald.de)
+* GitHub w3id management:
+  * Mark Doerr (GitHub): [markdoerr](https://github.com/markdoerr), email: <mark.doerr@uni-greifswald.de>)
+

--- a/oso/.htaccess
+++ b/oso/.htaccess
@@ -1,0 +1,19 @@
+# OSO - Open Science Ontology
+#
+# https://w3id.org/oso/ redirects to https://gitlab.com/opensourcelab/scientificdata/ontologies/openscienceontology/
+#
+# ## Contact
+# This space is administered by:
+#
+# mark doerr
+# mark.doerr@uni-greifswald.de
+# GitHub username: markdoerr
+
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+# BASE: Visit homepage
+RewriteRule ^ https://gitlab.com/opensourcelab/scientificdata/ontologies/openscienceontology/ [R=303,L]
+
+

--- a/oso/README.md
+++ b/oso/README.md
@@ -1,0 +1,16 @@
+OSO
+===
+
+The Open Science Ontologies - (OSO) are a set of lean, open and modular top-level and domain ontologies designed for interoperable scientific experimentation, fast reasoning and machine learning / AI applications in mind. 
+
+### Homepage
+
+* [OpenScienceOntology](https://gitlab.com/opensourcelab/scientificdata/ontologies/openscienceontology)
+
+
+### Contacts
+
+* General contact: [mark.doerr@uni-greifswald.de](mailto:mark.doerr@uni-greifswald.de)
+* GitHub w3id management:
+  * Mark Doerr (GitHub: [markdoerr](https://github.com/markdoerr), email: <mark.doerr@uni-greifswald.de>)
+


### PR DESCRIPTION
Please add  oso w3id

The Open Science Ontologies - (OSO) are a set of lean, open and modular top-level and domain ontologies designed for interoperable scientific experimentation, fast reasoning and machine learning / AI applications in mind. 

Thanks a lot :)