### PR TITLE
New re3ids for dummyrepository.org (drp)

### DIFF
--- a/drp/.htaccess
+++ b/drp/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine on
+RewriteRule ^dataset$ https://dummyrepository.org/dataset.html [R=302,L]
+RewriteRule ^catalog$ https://dummyrepository.org/catalog.html [R=302,L]

--- a/drp/README.md
+++ b/drp/README.md
@@ -4,4 +4,4 @@
 This [w3id](https://w3id.org/dummyrepository) provides a persistent URI namespace for the [dummyrepository demontrator](https://dummyrepository.org) .
 
 # Contacts:
-- Robert Huber [:email:](mailto:rhuber@uni-bremen.de)
+- Robert Huber [:email:](mailto:rhuber@uni-bremen.de) (@huberrob)

--- a/drp/README.md
+++ b/drp/README.md
@@ -1,0 +1,7 @@
+# Dummyrepository (drp)
+## Description: dummyrepository.org is a demonstrator designed to show the possibilities for sharing and publishing the capabilities and metadata of (data) repositories. The general goal is to improve the FAIRness of (data) repositories. To show this, the demonstrator needs a few persistent identifiers.
+
+This [w3id](https://w3id.org/dummyrepository) provides a persistent URI namespace for the [dummyrepository demontrator](https://dummyrepository.org) .
+
+# Contacts:
+- Robert Huber [:email:](mailto:rhuber@uni-bremen.de)


### PR DESCRIPTION
dummyrepository.org is a demonstrator designed to show the possibilities for sharing and publishing the capabilities and metadata of (data) repositories. Therefore, the demonstrator needs a few persistent identifiers.