### PR TITLE
RiverBench: add support for dumps w/ benchmark results

### DIFF
--- a/riverbench/.htaccess
+++ b/riverbench/.htaccess
@@ -63,6 +63,11 @@ RewriteRule ^dumps/dev\.(rdf|ttl|nt|jelly)\.gz([#?].*)?$ https://github.com/Rive
 # Metadata dumps for tagged releases
 RewriteRule ^dumps/([a-z0-9.-]+)\.(rdf|ttl|nt|jelly)\.gz([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/v$1/dump.$2.gz [R=302,L]
 
+# Dumps with benchmark results for dev release
+RewriteRule ^dumps-with-results/dev\.(trig|nq|jelly)\.gz([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/dev/dump-with-results.$1.gz [R=302,L]
+
+# Dumps with benchmark results for tagged releases
+RewriteRule ^dumps-with-results/([a-z0-9.-]+)\.(trig|nq|jelly)\.gz([#?].*)?$ https://github.com/RiverBench/RiverBench/releases/download/v$1/dump-with-results.$2.gz [R=302,L]
 
 ### HTML DOCUMENTATION PAGES ###
 

--- a/riverbench/README.md
+++ b/riverbench/README.md
@@ -38,6 +38,9 @@ Some test links that should always give a 200 response:
 - https://w3id.org/riverbench/dumps/dev.nt.gz
 - https://w3id.org/riverbench/dumps/dev.ttl.gz
 - https://w3id.org/riverbench/dumps/dev.jelly.gz
+- https://w3id.org/riverbench/dumps-with-results/dev.nq.gz
+- https://w3id.org/riverbench/dumps-with-results/dev.trig.gz
+- https://w3id.org/riverbench/dumps-with-results/dev.jelly.gz
 
 #### Test links in the old (1.0.x) format
 


### PR DESCRIPTION
This PR adds two new routes to support a new feature of RiverBench: metadata dumps that include benchmark results.

This change was tested on a local instance of Apache. I've also added a few new links to the README that should work after this is merged.

Issue: https://github.com/RiverBench/RiverBench/issues/101