### PR TITLE
Add /jelly

### DIFF
--- a/jelly/.htaccess
+++ b/jelly/.htaccess
@@ -1,0 +1,4 @@
+RewriteEngine on
+
+# Default response – redirect to documentation
+RewriteRule ^(.*)$ https://jelly-rdf.github.io/$1 [R=302,L]

--- a/jelly/README.md
+++ b/jelly/README.md
@@ -1,0 +1,25 @@
+# Jelly
+
+[Jelly](https://github.com/Jelly-RDF/) is a high-performance binary RDF serialization format and streaming protocol.
+
+## Contents
+
+The .htaccess file simply redirects the requests to GitHub Pages.
+
+### Test links
+
+Some test links that should always give a 200 response:
+
+- https://w3id.org/jelly/
+- https://w3id.org/jelly/dev/specification/serialization
+- https://w3id.org/jelly/dev/specification/streaming
+- https://w3id.org/jelly/jelly-jvm
+- https://w3id.org/jelly/jelly-jvm/dev
+- https://w3id.org/jelly/jelly-jvm/0.14.x
+- https://w3id.org/jelly/jelly-jvm/0.14.x/getting-started-plugins
+
+## Maintainers
+
+Piotr Sowiński \
+GitHub: https://github.com/Ostrzyciel \
+ORCID: https://orcid.org/0000-0002-2543-9461


### PR DESCRIPTION
This PR adds a new prefix (`jelly`) for the Jelly RDF serialization format and streaming protocol.

The .htaccess file simply redirects all requests to GitHub Pages. The README contains a few test links that should work after this is merged.

I have tested this on a local Apache instance.