### PR TITLE
Add ResilOnt perma-id

### DIFF
--- a/resiliont/.htaccess
+++ b/resiliont/.htaccess
@@ -1,0 +1,4 @@
+Options -MultiViews
+RewriteEngine on
+
+RedirectMatch 302 ^/resiliont/(home|git|repo)/?$  https://github.com/pedropaulofb/resiliont/

--- a/resiliont/Readme.md
+++ b/resiliont/Readme.md
@@ -1,0 +1,19 @@
+# ResiliOnt: The Resilience Core Ontology 
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/pedropaulofb/resiliont/main/resources/logos/Slide9.PNG" alt="Logo" style="width:500px">
+</p>
+
+ [ResiliOnt](https://github.com/pedropaulofb/resiliont/) is a core ontology that aims to provide a clear and robust definition of resilience by leveraging the Unified Foundational Ontology (UFO) and OntoUML. By addressing the ambiguities and inconsistencies in existing definitions of resilience, ResiliOnt seeks to ensure interoperability and clarity across various domains and facilitate interdisciplinary research.
+
+## Authors
+
+This work was developed by researchers from the [Business Informatics Group of Ghent University, Belgium](https://ugent-businessinformatics.github.io/) and the [Semantics, Cybersecurity & Services Group at the University of Twente, Netherlands](https://www.utwente.nl/en/eemcs/scs/).
+
+- [Pedro Paulo F. Barcelos](https://orcid.org/0000-0003-2736-7817) [[GitHub](https://github.com/pedropaulofb)] [[LinkedIn](https://www.linkedin.com/in/pedro-paulo-favato-barcelos/)]
+- [Rodrigo F. Calhau](https://orcid.org/0009-0006-6051-2165) [[GitHub](https://github.com/rfcalhau)] [[LinkedIn](https://www.linkedin.com/in/rodrigo-f-calhau-a6663776/)]
+- [Ítalo Oliveira](https://orcid.org/0000-0002-2384-3081) [[GitHub](https://github.com/italojsoliveira)] [[LinkedIn](https://www.linkedin.com/in/%C3%ADtalo-oliveira-800923162/)]
+- [Tiago Prince Sales](https://orcid.org/0000-0002-5385-5761) [[GitHub](https://github.com/tgoprince)] [[LinkedIn](https://www.linkedin.com/in/tiago-sales/)]
+- [Frederik Gailly](https://orcid.org/0000-0003-0481-9745) [[GitHub](https://github.com/fgailly)] [[LinkedIn](https://www.linkedin.com/in/fgailly/)]
+- [Geert Poels](https://orcid.org/0000-0001-9247-6150) [[GitHub](https://github.com/geertpoels)] [[LinkedIn](https://www.linkedin.com/in/geert-p-039198287/)]
+- [Giancarlo Guizzardi](https://orcid.org/0000-0002-3452-553X) [[LinkedIn](https://www.linkedin.com/in/giancarlo-guizzardi/)]


### PR DESCRIPTION
Could you create the perm-id for the ResiliOnt?

ResiliOnt is an OntoUML ontology for resilience. We had a paper accepted in this year's ER. Other related artifacts will be produced in the future.