### PR TITLE
Update .htaccess

### DIFF
--- a/xapi/.htaccess
+++ b/xapi/.htaccess
@@ -62,7 +62,7 @@ RewriteRule ^adl/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.go
 #################### XAPI Published Profiles | HTML Content Negotiation RULES #########################
 #######################################################################################################
 
-# Manual Redirect Rules for specific profiles
+# Manual Redirect Rules for Navy xAPI Profile Library
 # ---------------------------
 # Serve HTML content at profile IRI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
@@ -74,7 +74,7 @@ RewriteRule ^navy/index.html$ https://navy-xapi-library.bitbucket.io [R=303]
 RewriteRule ^navy/(.*?)\.html$ https://navy-xapi-library.bitbucket.io [R=303]
 
 
-# Consolidated HTML Rules to account for vocab/profile pattern match and two child paths after
+# Multiple HTML Rules Below to account for ADL profile server change from vocab server  - persistent IRI pattern matching not supported since they use UUIDs
 # ---------------------------
 # Serve HTML content at profile IRI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
@@ -82,7 +82,7 @@ RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 # Old Rule RewriteRule ^([0-9a-zA-Z\-]+)/?$ http://xapi.vocab.pub/describe/?url=https://w3id.org/xapi/$1 [R=303]
-RewriteRule ^([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.gov/api/profile?iri=https://w3id.org/xapi/$1 [R=303]
+RewriteRule ^([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.gov/profiles [R=303]
 
 # Serve HTML content at profile IRI if x.x.x version requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
@@ -90,7 +90,7 @@ RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 # Old Rule RewriteRule ^([0-9a-zA-Z\-]+)/v[0-9][0-9.]*/?$ http://xapi.vocab.pub/describe/?url=https://w3id.org/xapi/$1 [R=303]
-RewriteRule ^([0-9a-zA-Z\-]+)/v[0-9][0-9.]*/?$ https://profiles.adlnet.gov/api/profile?iri=https://w3id.org/xapi/$1 [R=303]
+RewriteRule ^([0-9a-zA-Z\-]+)/v[0-9][0-9.]*/?$ https://profiles.adlnet.gov/profiles [R=303]
 
 # Serve HTML content at type IRI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
@@ -98,7 +98,7 @@ RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 # Old Rule RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ http://xapi.vocab.pub/describe/?url=https://w3id.org/xapi/$1 [R=303]
-RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.gov/api/profile?iri=https://w3id.org/xapi/$1 [R=303]
+RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.gov/profiles [R=303]
 
 # Serve HTML content at vocabulary term IRI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
@@ -106,7 +106,7 @@ RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 # Old Rule RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ http://xapi.vocab.pub/describe/?url=https://w3id.org/xapi/$1/$2/$3 [R=303]
-RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.gov/api/profile?iri=https://w3id.org/xapi/$1/$2/$3 [R=303]
+RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.gov/profiles [R=303]
 
 # Serve HTML content at vocabulary term IRI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
@@ -114,117 +114,56 @@ RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 # Old Rule RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ http://xapi.vocab.pub/describe/?url=https://w3id.org/xapi/$1/$2/$3/$4 [R=303]
-RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.gov/api/profile?iri=https://w3id.org/xapi/$1/$2/$3/$4 [R=303]
+RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.gov/profiles [R=303]
 
 #######################################################################################################
 ##################### XAPI Authored Profiles | RDF Content Negotiation RULES ##########################
 #######################################################################################################
-
-# Serve Turtle at profile IRI if requested
-RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^([0-9a-zA-Z\-]+)/?$ https://adlnet.github.io/xapi-authored-profiles/$1/$1.ttl [R=303]
-
-# Serve Turtle for the x.x.x version of the profile if requested
-RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^([0-9a-zA-Z\-]+)/v[0-9][0-9.]*/?$ https://adlnet.github.io/xapi-authored-profiles/$1/$2/$1.ttl [R=303]
-
-# Serve Turtle at vocabulary type IRI if requested
-RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://adlnet.github.io/xapi-authored-profiles/$1/$1.ttl [R=303]
-
-# Serve Turtle at vocabulary term IRI if requested
-RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://adlnet.github.io/xapi-authored-profiles/$1/$1.ttl [R=303]
-
-# Serve Turtle at vocabulary term IRI if requested
-RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://adlnet.github.io/xapi-authored-profiles/$1/$1.ttl [R=303]
+# NOTE - Removed all RDF representations except JSON to account for ADL profile server change from vocab server  - persistent IRI pattern matching and RDF content negotiation not supported since they use UUIDs
 
 
 # Serve JSON-LD at profile IRI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^([0-9a-zA-Z\-]+)/?$ https://adlnet.github.io/xapi-authored-profiles/$1/$1.jsonld [R=303]
+RewriteRule ^([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.gov/api-info/metadata [R=303]
 
 # Serve JSON-LD for the x.x.x version of the profile
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^([0-9a-zA-Z\-]+)/v[0-9][0-9.]*/?$ https://adlnet.github.io/xapi-authored-profiles/$1/$2/$1.jsonld [R=303]
+RewriteRule ^([0-9a-zA-Z\-]+)/v[0-9][0-9.]*/?$ https://profiles.adlnet.gov/api-info/metadata [R=303]
 
 # Serve JSON-LD at vocabulary type IRI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://adlnet.github.io/xapi-authored-profiles/$1/$1.jsonld [R=303]
+RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.gov/api-info/metadata [R=303]
 
 # Serve JSON-LD at vocabulary term IRI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://adlnet.github.io/xapi-authored-profiles/$1/$1.jsonld [R=303]
+RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.gov/api-info/metadata [R=303]
 
 # Serve JSON-LD at vocabulary term IRI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://adlnet.github.io/xapi-authored-profiles/$1/$1.jsonld [R=303]
+RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.gov/api-info/metadata [R=303]
 
 # Serve JSON-LD at vocabulary term IRI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://adlnet.github.io/xapi-authored-profiles/$1/$1.jsonld [R=303]
-
+RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.gov/api-info/metadata [R=303]
 
 
 # Serve Constrained JSON-LD at profile IRI if JSON is requested
 RewriteCond %{HTTP_ACCEPT} application/json
-RewriteRule ^([0-9a-zA-Z\-]+)/?$ https://adlnet.github.io/xapi-authored-profiles/$1/$1.jsonld [R=303]
+RewriteRule ^([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.gov/api-info/metadata [R=303]
 
 # Serve Constrained JSON-LD at profile IRI if x.x.x version and JSON is requested
 RewriteCond %{HTTP_ACCEPT} application/json
-RewriteRule ^([0-9a-zA-Z\-]+)/v[0-9][0-9.]*/?$ https://adlnet.github.io/xapi-authored-profiles/$1/$2/$1.jsonld [R=303]
+RewriteRule ^([0-9a-zA-Z\-]+)/v[0-9][0-9.]*/?$ https://profiles.adlnet.gov/api-info/metadata [R=303]
 
 # Serve Constrained JSON-LD at vocabulary type IRI if JSON is requested
 RewriteCond %{HTTP_ACCEPT} application/json
-RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://adlnet.github.io/xapi-authored-profiles/$1/$1.jsonld [R=303]
+RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.gov/api-info/metadata [R=303]
 
 # Serve Constrained JSON-LD at vocabulary term IRI if JSON is requested
 RewriteCond %{HTTP_ACCEPT} application/json
-RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://adlnet.github.io/xapi-authored-profiles/$1/$1.jsonld [R=303]
+RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.gov/api-info/metadata [R=303]
 
 # Serve Constrained JSON-LD at vocabulary term IRI if JSON is requested
 RewriteCond %{HTTP_ACCEPT} application/json
-RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://adlnet.github.io/xapi-authored-profiles/$1/$1.jsonld [R=303]
+RewriteRule ^([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/([0-9a-zA-Z\-]+)/?$ https://profiles.adlnet.gov/api-info/metadata [R=303]
 
-
-
-
-#######################################################################################################
-################################ ACROSS X LANGUAGE NEGOTIATION RULES ##################################
-#######################################################################################################
-
-# Serve zh-tw HTML content at vocabulary IRI if requested
-RewriteCond %{HTTP:Accept-Language} ^zh-tw [NC]
-RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
-RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^acrossx/?$ http://xapi-cop.net/vocab/zh-tw [R=303]
-
-# Serve zh-tw content at vocabulary term IRI if requested
-RewriteCond %{HTTP:Accept-Language} ^zh-tw [NC]
-RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
-RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^acrossx/(.*)/(.*)$ http://xapi-cop.net/vocab/zh-tw/#$2 [R=303,NE]
-
-# Serve zh-cn HTML content at vocabulary IRI if requested
-RewriteCond %{HTTP:Accept-Language} ^zh-cn [NC]
-RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
-RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^acrossx/?$ http://xapi-cop.net/vocab/zh-cn [R=303]
-
-# Serve zh-cn content at vocabulary term IRI if requested
-RewriteCond %{HTTP:Accept-Language} ^zh-cn [NC]
-RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
-RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^acrossx/(.*)/(.*)$ http://xapi-cop.net/vocab/zh-cn/#$2 [R=303,NE]
-
-# END ACROSSX VOCABULARY LANGUAGE NEGOTIATION RULES
-# ---------------------------


### PR DESCRIPTION
Updated HTML and RDF content negotiation rules to account for ADL profile server no longer supporting it. Several years ago the profile server adopted UUIDs for profile IRIs and concepts, and also added the ability to create external IRIs, which prevents IRI pattern matching techniques for content negotiation of both HTML and linked data/RDF representations.