### PR TITLE
Add YANG Library Ontology

### DIFF
--- a/yang/README.md
+++ b/yang/README.md
@@ -3,7 +3,8 @@
 This folder contains the following ontologies related to network management based on the YANG data modeling language  [RFC 7950](https://datatracker.ietf.org/doc/rfc7950/):
 
 - YANG Server Ontology: https://w3id.org/yang/server#
+- YANG Library Ontology: https://w3id.org/yang/library#
 
-# Contact
+## Contact
 
 Ignacio Dominguez – GitHub [idomingu](https://github.com/idomingu)

--- a/yang/library/.htaccess
+++ b/yang/library/.htaccess
@@ -1,0 +1,48 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .jsonld
+# Rewrite engine setup
+RewriteEngine On
+#Change the path to the folder here
+RewriteBase /
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+# Placed before HTML to support serving JSON-LD from a browser (e.g., JSON Playground)
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://candil-data-fabric.github.io/yang-library-ontology/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://candil-data-fabric.github.io/yang-library-ontology/index.html [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://candil-data-fabric.github.io/yang-library-ontology/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://candil-data-fabric.github.io/yang-library-ontology/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ https://candil-data-fabric.github.io/yang-library-ontology/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^$ https://candil-data-fabric.github.io/yang-library-ontology/406.html [R=406,L]
+# Default response
+# ---------------------------
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^$ https://candil-data-fabric.github.io/yang-library-ontology/ontology.owl [R=303,L]


### PR DESCRIPTION
This PR adds a namespace for the YANG Library Ontology under `/yang/library`.