### PR TITLE
Add aerOS Data Catalog Ontology

### DIFF
--- a/aerOS/README.md
+++ b/aerOS/README.md
@@ -5,6 +5,7 @@
 This folder contains the following ontologies that have been developed in the aerOS project:
 
 - Continuum Ontology: https://w3id.org/aerOS/continuum#
+- Data Catalog Ontology: https://w3id.org/aerOS/data-catalog#
 - Building Ontology: https://w3id.org/aerOS/building#
 
 # Contact

--- a/aerOS/data-catalog/.htaccess
+++ b/aerOS/data-catalog/.htaccess
@@ -1,0 +1,48 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .jsonld
+# Rewrite engine setup
+RewriteEngine On
+#Change the path to the folder here
+RewriteBase /
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+# Placed before HTML to support serving JSON-LD from a browser (e.g., JSON Playground)
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://wp4.pages.aeros-project.eu/t4.1/data-catalog-ontology/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://wp4.pages.aeros-project.eu/t4.1/data-catalog-ontology/index.html [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://wp4.pages.aeros-project.eu/t4.1/data-catalog-ontology/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://wp4.pages.aeros-project.eu/t4.1/data-catalog-ontology/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ https://wp4.pages.aeros-project.eu/t4.1/data-catalog-ontology/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^$ https://wp4.pages.aeros-project.eu/t4.1/data-catalog-ontology/406.html [R=406,L]
+# Default response
+# ---------------------------
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^$ https://wp4.pages.aeros-project.eu/t4.1/data-catalog-ontology/ontology.owl [R=303,L]


### PR DESCRIPTION
This PR adds a new namespace for the Data Catalog Ontology of the [aerOS](https://aeros-project.eu) project.