### PR TITLE
Add nanolinks namespace to w3id.org

### DIFF
--- a/nanolinks/.htaccess
+++ b/nanolinks/.htaccess
@@ -1,0 +1,7 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine On
+
+RewriteRule ^$ 	https://nanolinks.rdf.bigcat-bioinformatics.org/ [R=302,L]
+
+RewriteRule "^(.+)$" 	https://nanolinks.rdf.bigcat-bioinformatics.org/$1 [R=302,L]

--- a/nanolinks/README.md
+++ b/nanolinks/README.md
@@ -1,0 +1,17 @@
+# /psnpbind/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for NanoLinks, a demo Knowledge Graph for interoperable nanosafety data semantic model.
+
+## Uses
+This namespace is used to resolve the IRIs of the NanoLinks knowledge graph and provide a globalry uinique persistent identifier for the entities in the graph.
+
+## Contact
+This space is administered by:  
+
+**Ammar Ammar**  
+*PhD*  
+[Maastricht University](https://maastrichtuniversity.nl)  
+Maastricht, The Netherlands  
+<a.ammar@maastrichtuniversity.nl>  
+GitHub: [ammar257ammar](https://github.com/ammar257ammar)
+ORCID: [0000-0002-8399-8990](https://orcid.org/0000-0002-8399-8990)  
+

--- a/nanolinks/README.md
+++ b/nanolinks/README.md
@@ -12,6 +12,6 @@ This space is administered by:
 [Maastricht University](https://maastrichtuniversity.nl)  
 Maastricht, The Netherlands  
 <a.ammar@maastrichtuniversity.nl>  
-GitHub: [ammar257ammar](https://github.com/ammar257ammar)
+GitHub: [ammar257ammar](https://github.com/ammar257ammar)  
 ORCID: [0000-0002-8399-8990](https://orcid.org/0000-0002-8399-8990)  
 

--- a/nanolinks/README.md
+++ b/nanolinks/README.md
@@ -1,4 +1,4 @@
-# /psnpbind/
+# /nanolinks/
 This [W3ID](https://w3id.org) provides a persistent URI namespace for NanoLinks, a demo Knowledge Graph for interoperable nanosafety data semantic model.
 
 ## Uses


### PR DESCRIPTION
This namespace provides a persistent URI namespace for NanoLinks, a demo Knowledge Graph for interoperable nanosafety data semantic data model.
