### PR TITLE
Add riskman security shapes/ontology.

### DIFF
--- a/riskman/.htaccess
+++ b/riskman/.htaccess
@@ -5,7 +5,9 @@ RewriteEngine on
 
 RewriteRule ^$ https://cl-tud.github.io/riskman-documentation/ [R=301]
 
-RewriteRule ^ontology(.*)$ https://raw.githubusercontent.com/cl-tud/riskman/main/ontology.ttl [R=303,L]
-RewriteRule ^shapes(.*)$ https://raw.githubusercontent.com/cl-tud/riskman/main/shapes.ttl [R=303,L]
-RewriteRule ^repo(.*)$ https://github.com/cl-tud/riskman/ [R=303,L]
+RewriteRule ^ontology/security$ https://raw.githubusercontent.com/cl-tud/riskman/main/ontology-security.ttl [R=303,L]
+RewriteRule ^ontology$ https://raw.githubusercontent.com/cl-tud/riskman/main/ontology.ttl [R=303,L]
+RewriteRule ^shapes/security$ https://raw.githubusercontent.com/cl-tud/riskman/main/shapes-security.ttl [R=303,L]
+RewriteRule ^shapes$ https://raw.githubusercontent.com/cl-tud/riskman/main/shapes.ttl [R=303,L]
+RewriteRule ^repo$ https://github.com/cl-tud/riskman/ [R=303,L]
 

--- a/riskman/README.md
+++ b/riskman/README.md
@@ -4,12 +4,15 @@ The Risk Management Ontology defines various notions related to risk management 
 
 - [https://w3id.org/riskman/](https://w3id.org/riskman/) leads to the documentation.
 - [https://w3id.org/riskman/ontology/](https://w3id.org/riskman/ontology/) leads to a raw ttl file of the current ontology version.
+- [https://w3id.org/riskman/ontology/security](https://w3id.org/riskman/ontology/security) leads to a raw ttl file of the security ontology.
 - [https://w3id.org/riskman/shapes/](https://w3id.org/riskman/shapes/) leads to a raw file containing shape constraints for risk management validation.
+- [https://w3id.org/riskman/shapes/security](https://w3id.org/riskman/shapes/security) leads to a raw file containing security-related shape constraints.
 - [https://w3id.org/riskman/repo/](https://w3id.org/riskman/repo/) leads to the repository. 
 
 Contacts:
 - Dörthe Arndt (<doerthe.arndt@tu-dresden.de>)
-- Piort Gorczyca (<piotr.gorczyca@tu-dresden.de>)
+- Martin Diller (<martin.diller@tu-dresden.de>)
+- Piort Gorczyca (<piotr.gorczyca@tu-dresden.de>, Github [gorczyca](https://github.com/gorczyca))
 - Pascal Kettmann (<pascal.kettmann@tu-dresden.de>, GitHub: [diskettmann](https://github.com/diskettmann))
 - Stephan Mennicke (<stephan.mennicke@tu-dresden.de>)
 - Hannes Straß (<hannes.strass@tu-dresden.de>)


### PR DESCRIPTION
We added new ontology and SHACL shapes and would like new permanent ids to reflect that.

Thanks.