### PR TITLE
Add LaDeRR project

### DIFF
--- a/laderr/.htaccess
+++ b/laderr/.htaccess
@@ -1,0 +1,4 @@
+Options -MultiViews
+RewriteEngine on
+
+RedirectMatch 302 ^/laderr/(home|git|repo)/?$  https://github.com/pedropaulofb/laderr/

--- a/laderr/README.md
+++ b/laderr/README.md
@@ -1,0 +1,51 @@
+# LaDeRR - **La**nguage for **De**scribing **R**isk and **R**esilience
+
+<p align="center"><img src="https://raw.githubusercontent.com/pedropaulofb/laderr/main/resources/logo_laderr.png" width="500"></p>
+
+The **La**nguage for **De**scribing **R**isk and **R**esilience (**LaDeRR**) is an ontology-based domain-specific description language designed to standardize the way risks, resilience factors, and related entities are represented. LaDeRR enables precise definitions, structured querying, and automated reasoning.
+
+## Authors
+
+This work was developed by researchers from the [Business Informatics Group of Ghent University, Belgium](https://ugent-businessinformatics.github.io/) and the [Semantics, Cybersecurity & Services Group at the University of Twente, Netherlands](https://www.utwente.nl/en/eemcs/scs/).
+
+<table>
+  <tr>
+    <td><strong>Pedro Paulo F. Barcelos</strong></td>
+    <td>
+      <a href="https://orcid.org/0000-0003-2736-7817"><img src="https://upload.wikimedia.org/wikipedia/commons/0/06/ORCID_iD.svg" alt="ORCID" width="20"/></a>
+      <a href="https://github.com/pedropaulofb"><img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" width="20"/></a>
+      <a href="https://www.linkedin.com/in/pedro-paulo-favato-barcelos/"><img src="https://upload.wikimedia.org/wikipedia/commons/c/ca/LinkedIn_logo_initials.png" alt="LinkedIn" width="20"/></a>
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Tiago Prince Sales</strong></td>
+    <td>
+      <a href="https://orcid.org/0000-0002-5385-5761"><img src="https://upload.wikimedia.org/wikipedia/commons/0/06/ORCID_iD.svg" alt="ORCID" width="20"/></a>
+      <a href="https://github.com/tgoprince"><img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" width="20"/></a>
+      <a href="https://www.linkedin.com/in/tiago-sales/"><img src="https://upload.wikimedia.org/wikipedia/commons/c/ca/LinkedIn_logo_initials.png" alt="LinkedIn" width="20"/></a>
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Frederik Gailly</strong></td>
+    <td>
+      <a href="https://orcid.org/0000-0003-0481-9745"><img src="https://upload.wikimedia.org/wikipedia/commons/0/06/ORCID_iD.svg" alt="ORCID" width="20"/></a>
+      <a href="https://github.com/fgailly"><img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" width="20"/></a>
+      <a href="https://www.linkedin.com/in/fgailly/"><img src="https://upload.wikimedia.org/wikipedia/commons/c/ca/LinkedIn_logo_initials.png" alt="LinkedIn" width="20"/></a>
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Geert Poels</strong></td>
+    <td>
+      <a href="https://orcid.org/0000-0001-9247-6150"><img src="https://upload.wikimedia.org/wikipedia/commons/0/06/ORCID_iD.svg" alt="ORCID" width="20"/></a>
+      <a href="https://github.com/geertpoels"><img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" width="20"/></a>
+      <a href="https://www.linkedin.com/in/geert-p-039198287/"><img src="https://upload.wikimedia.org/wikipedia/commons/c/ca/LinkedIn_logo_initials.png" alt="LinkedIn" width="20"/></a>
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Giancarlo Guizzardi</strong></td>
+    <td>
+      <a href="https://orcid.org/0000-0002-3452-553X"><img src="https://upload.wikimedia.org/wikipedia/commons/0/06/ORCID_iD.svg" alt="ORCID" width="20"/></a>
+      <a href="https://www.linkedin.com/in/giancarlo-guizzardi/"><img src="https://upload.wikimedia.org/wikipedia/commons/c/ca/LinkedIn_logo_initials.png" alt="LinkedIn" width="20"/></a>
+    </td>
+  </tr>
+</table>


### PR DESCRIPTION
Could you please add the LaDeRR project folder?

"The Language for Describing Risk and Resilience (LaDeRR) is an ontology-based domain-specific description language designed to standardize the way risks, resilience factors, and related entities are represented."

My GitHub ID is in the README file, inside the html table. Is that ok?

Thank you.