### PR TITLE
Fixing ResiliOnt redirection to paper

### DIFF
--- a/resiliont/.htaccess
+++ b/resiliont/.htaccess
@@ -2,4 +2,4 @@ Options -MultiViews
 RewriteEngine on
 
 RedirectMatch 302 ^/resiliont/(home|git|repo)/?$  https://github.com/pedropaulofb/resiliont/
-RewriteRule ^er2024paper/?$ https://raw.githubusercontent.com/pedropaulofb/resiliont/main/resources/Ontological%20Foundations%20of%20Resilience.pdf [R=302,NE,L]
+RewriteRule ^er2024paper/?$ "https://raw.githubusercontent.com/pedropaulofb/resiliont/main/resources/Ontological%20Foundations%20of%20Resilience.pdf" [R=302,NE,L]

--- a/resiliont/Readme.md
+++ b/resiliont/Readme.md
@@ -1,7 +1,7 @@
 # ResiliOnt: The Resilience Core Ontology 
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/pedropaulofb/resiliont/main/resources/logos/Slide9.PNG" alt="Logo" style="width:500px">
+  <img src="https://raw.githubusercontent.com/pedropaulofb/resiliont/main/resources/logos/resiliont-logo-06.png" alt="Logo" style="width:500px">
 </p>
 
  [ResiliOnt](https://github.com/pedropaulofb/resiliont/) is a core ontology that aims to provide a clear and robust definition of resilience by leveraging the Unified Foundational Ontology (UFO) and OntoUML. By addressing the ambiguities and inconsistencies in existing definitions of resilience, ResiliOnt seeks to ensure interoperability and clarity across various domains and facilitate interdisciplinary research.


### PR DESCRIPTION
@dgarijo , the redirection is almost working. We are getting there. =)

Instead of redirecting to `https://raw.githubusercontent.com/pedropaulofb/resiliont/main/resources/Ontological%20Foundations%20of%20Resilience.pdf` it is redirecting to `https://raw.githubusercontent.com/pedropaulofb/resiliont/main/resources/Ontological0Foundations0of0Resilience.pdf``. Seems that adding quotation marks will solve the problem. 

Thank you for your patience regarding that.