### PR TITLE
[AD4GD] Update RAINBOW URIs

### DIFF
--- a/ad4gd/.htaccess
+++ b/ad4gd/.htaccess
@@ -63,10 +63,6 @@ RewriteRule ^model/(.*)$  https://raw.githubusercontent.com/AD4GD/GDIM/main/$1.t
 # default
 RewriteRule ^model/(.*)$  https://raw.githubusercontent.com/AD4GD/GDIM/main/$1.ttl [R=303,L]
 
-# Sensors and manufacturers in Hosted RAINBOW
-RewriteRule ^sensors/?$ https://defs-dev.opengis.net/vocprez-hosted/object?uri=https://w3id.org/ad4gd/sensors [R=302,L]
-RewriteRule ^sensors/(.+)$ https://defs-dev.opengis.net/vocprez-hosted/object?uri=https://w3id.org/ad4gd/sensors/$1 [R=303,L]
-
-# Properties in Hosted RAINBOW
-RewriteRule ^properties/?$ https://defs-dev.opengis.net/vocprez-hosted/object?uri=https://w3id.org/ad4gd/properties [R=302,L]
-RewriteRule ^properties/(.+)$ https://defs-dev.opengis.net/vocprez-hosted/object?uri=https://w3id.org/ad4gd/properties/$1 [R=303,L]
+# Properties, sensors, sensor manufacturers and procedures in Hosted RAINBOW
+RewriteRule ^([^/]+/(properties|sensors|sensor-manufacturers|procedures))/?$ https://defs-dev.opengis.net/vocprez-hosted/object?uri=https://w3id.org/ad4gd/$1 [R=303,L]
+RewriteRule ^([^/]+/(properties|sensors|sensor-manufacturers|procedures)/.+)$ https://defs-dev.opengis.net/vocprez-hosted/object?uri=https://w3id.org/ad4gd/$1 [R=303,L]


### PR DESCRIPTION
Update generic RAINBOW URIs.

The new rules work will redirect `https://w3id.org/ad4gd/<pilot-name>/<type>/<term>` to the Hosted RAINBOW instance, where:
* `pilot-name` is a path component (`water-quality` and `air-quality` for now, with more to come later)
* `type` is one of `properties`, `sensors`, `sensor-manufacturers` and `procedures`.
* `term` is the URI component for the term. If omitted, the CS will be displayed instead.

@rapw3k , please confirm you're ok with this. Thanks.