### PR TITLE
Adding Green's Dictionary of Slang and Gay/Lesbian/Bisexual Television Characters.

### DIFF
--- a/GayLesbianBisexualTVCharacters/.htaccess
+++ b/GayLesbianBisexualTVCharacters/.htaccess
@@ -1,0 +1,16 @@
+# Example
+#
+# https://w3id.org/GayLesbianBisexualTVCharacters/1980s/insi redirects to https://home.cc.umanitoba.ca/~wyatt/tv-char1980s.html#insi
+#
+# ## Contact
+# This space is administered by:
+#
+# Clair Kronk
+# Clair.Kronk@mountsinai.org
+# GitHub username: Superraptor
+
+RewriteEngine On
+RewriteBase /
+
+# Redirect URLs of the form /GayLesbianBisexualTVCharacters/$1/$2
+RewriteRule ^GayLesbianBisexualTVCharacters/([1-2][9,0][6,7,8,9,0]0s)/([a-z]{1,10}[0-9]{0,4})$ https://home.cc.umanitoba.ca/~wyatt/tv-char$1.html#$2 [R=301,L]

--- a/GayLesbianBisexualTVCharacters/.htaccess
+++ b/GayLesbianBisexualTVCharacters/.htaccess
@@ -1,6 +1,8 @@
 # Example
 #
 # https://w3id.org/GayLesbianBisexualTVCharacters/1980s/insi redirects to https://home.cc.umanitoba.ca/~wyatt/tv-char1980s.html#insi
+# https://w3id.org/GayLesbianBisexualTVCharacters/road redirects to https://home.cc.umanitoba.ca/~wyatt/tv-characters.html#road
+# https://w3id.org/GayLesbianBisexualTVCharacters/days redirects to https://home.cc.umanitoba.ca/~wyatt/tv-characters.html#days
 #
 # ## Contact
 # This space is administered by:
@@ -9,8 +11,15 @@
 # Clair.Kronk@mountsinai.org
 # GitHub username: Superraptor
 
+# Examples tested using:
+# https://htaccess.madewithlove.com/
+# (22 September 2024)
+
 RewriteEngine On
 RewriteBase /
 
+# Redirect URLs of the form /GayLesbianBisexualTVCharacters/$1
+RewriteRule ^GayLesbianBisexualTVCharacters/([a-z]{1,10})$ https://home.cc.umanitoba.ca/~wyatt/tv-characters.html#$1 [R=301,NE,L]
+
 # Redirect URLs of the form /GayLesbianBisexualTVCharacters/$1/$2
-RewriteRule ^GayLesbianBisexualTVCharacters/([1-2][9,0][6,7,8,9,0]0s)/([a-z]{1,10}[0-9]{0,4})$ https://home.cc.umanitoba.ca/~wyatt/tv-char$1.html#$2 [R=301,L]
+RewriteRule ^GayLesbianBisexualTVCharacters/([1-2][9,0][6,7,8,9,0]0s)/([a-z]{1,10}[0-9]{0,4})$ https://home.cc.umanitoba.ca/~wyatt/tv-char$1.html#$2 [R=301,NE,L]

--- a/GayLesbianBisexualTVCharacters/README.md
+++ b/GayLesbianBisexualTVCharacters/README.md
@@ -1,0 +1,5 @@
+# Gay/Lesbian/Bisexual Television Characters
+
+[Webpage](
+https://home.cc.umanitoba.ca/~wyatt/tv-characters.html) created by [David A. Wyatt](https://home.cc.umanitoba.ca/~wyatt/). `.htaccess` file created by Clair Kronk for use at [lgbtDB](https://lgbtdb.wikibase.cloud/wiki/Property:P689). Webpage last updated 10 September 2016.
+

--- a/Greens/.htaccess
+++ b/Greens/.htaccess
@@ -12,17 +12,21 @@
 # Clair.Kronk@mountsinai.org
 # GitHub username: Superraptor
 
+# Examples tested using:
+# https://htaccess.madewithlove.com/
+# (22 September 2024)
+
 RewriteEngine On
 RewriteBase /
 
 # Redirect /Greens/$1 to https://greensdictofslang.com/entry/$1
-RewriteRule ^Greens/([0-9a-zA-Z]{7})$ https://greensdictofslang.com/entry/$1 [R=301,L]
+RewriteRule ^Greens/([0-9a-z]{7})$ https://greensdictofslang.com/entry/$1 [R=301,L]
 
 # Redirect /Greens/$1/$2 to https://greensdictofslang.com/entry/$1#$2
-RewriteRule ^Greens/([0-9a-zA-Z]{7})/([0-9a-zA-Z]{7})$ https://greensdictofslang.com/entry/$1#$2 [R=301,L]
+RewriteRule ^Greens/([0-9a-z]{7})/([0-9a-z]{7})$ https://greensdictofslang.com/entry/$1#$2 [R=301,NE,L]
 
 # Redirect /Greens/$1/$2 to https://greensdictofslang.com/entry/$1#$2
-RewriteRule ^Greens/([0-9a-zA-Z]{7})/(sn[0,9]{1,3})$ https://greensdictofslang.com/entry/$1#$2 [R=301,L]
+RewriteRule ^Greens/([0-9a-z]{7})/(sn[0-9]{1,3})$ https://greensdictofslang.com/entry/$1#$2 [R=301,NE,L]
 
 # Redirect /Greens/sources/$1 to https://greensdictofslang.com/sources/$1
 RewriteRule ^Greens/sources/([0-9]{1,5})$ https://greensdictofslang.com/sources/$1 [R=301,L]

--- a/Greens/.htaccess
+++ b/Greens/.htaccess
@@ -1,0 +1,28 @@
+# Examples
+#
+# https://w3id.org/Greens/qv5rkjq redirects to https://greensdictofslang.com/entry/qv5rkjq
+# https://w3id.org/Greens/cawbqqi/va3zesy redirects to https://greensdictofslang.com/entry/cawbqqi#va3zesy
+# https://w3id.org/Greens/qv5rkjq/sn1 redirects to https://greensdictofslang.com/entry/qv5rkjq#sn1
+# https://w3id.org/Greens/sources/5937 redirects to https://greensdictofslang.com/sources/5937
+#
+# ## Contact
+# This space is administered by:
+#
+# Clair Kronk
+# Clair.Kronk@mountsinai.org
+# GitHub username: Superraptor
+
+RewriteEngine On
+RewriteBase /
+
+# Redirect /Greens/$1 to https://greensdictofslang.com/entry/$1
+RewriteRule ^Greens/([0-9a-zA-Z]{7})$ https://greensdictofslang.com/entry/$1 [R=301,L]
+
+# Redirect /Greens/$1/$2 to https://greensdictofslang.com/entry/$1#$2
+RewriteRule ^Greens/([0-9a-zA-Z]{7})/([0-9a-zA-Z]{7})$ https://greensdictofslang.com/entry/$1#$2 [R=301,L]
+
+# Redirect /Greens/$1/$2 to https://greensdictofslang.com/entry/$1#$2
+RewriteRule ^Greens/([0-9a-zA-Z]{7})/(sn[0,9]{1,3})$ https://greensdictofslang.com/entry/$1#$2 [R=301,L]
+
+# Redirect /Greens/sources/$1 to https://greensdictofslang.com/sources/$1
+RewriteRule ^Greens/sources/([0-9]{1,5})$ https://greensdictofslang.com/sources/$1 [R=301,L]

--- a/Greens/README.md
+++ b/Greens/README.md
@@ -1,0 +1,4 @@
+# Green's Dictionary of Slang
+
+[Website](
+https://greensdictofslang.com/) created by Jonathon Green. `.htaccess` file created by Clair Kronk for use at [lgbtDB](https://lgbtdb.wikibase.cloud/wiki/Property:P689).


### PR DESCRIPTION
Adding redirects from two sources that utilized hashes (`#`) in their identifiers. The reason for doing this is so that the external identifiers datatype property utilized in instances of Wikibase can access these identifiers. These redirects have been tested using the online tool (https://htaccess.madewithlove.com/).