### PR TITLE
Fixed issue with nesting directories (Greens/Greens e.g.) and added a base redirect.

### DIFF
--- a/GayLesbianBisexualTVCharacters/.htaccess
+++ b/GayLesbianBisexualTVCharacters/.htaccess
@@ -19,7 +19,10 @@ RewriteEngine On
 RewriteBase /
 
 # Redirect URLs of the form /GayLesbianBisexualTVCharacters/$1
-RewriteRule ^GayLesbianBisexualTVCharacters/([a-z]{1,10})$ https://home.cc.umanitoba.ca/~wyatt/tv-characters.html#$1 [R=301,NE,L]
+RewriteRule ^([a-z]{1,10})$ https://home.cc.umanitoba.ca/~wyatt/tv-characters.html#$1 [R=301,NE,L]
 
 # Redirect URLs of the form /GayLesbianBisexualTVCharacters/$1/$2
-RewriteRule ^GayLesbianBisexualTVCharacters/([1-2][9,0][6,7,8,9,0]0s)/([a-z]{1,10}[0-9]{0,4})$ https://home.cc.umanitoba.ca/~wyatt/tv-char$1.html#$2 [R=301,NE,L]
+RewriteRule ^([1-2][9,0][6,7,8,9,0]0s)/([a-z]{1,10}[0-9]{0,4})$ https://home.cc.umanitoba.ca/~wyatt/tv-char$1.html#$2 [R=301,NE,L]
+
+# Redirect /GayLesbianBisexualTVCharacters/ to https://home.cc.umanitoba.ca/~wyatt/tv-characters.html
+RewriteRule ^$ https://home.cc.umanitoba.ca/~wyatt/tv-characters.html [R=301,L]

--- a/Greens/.htaccess
+++ b/Greens/.htaccess
@@ -20,13 +20,16 @@ RewriteEngine On
 RewriteBase /
 
 # Redirect /Greens/$1 to https://greensdictofslang.com/entry/$1
-RewriteRule ^Greens/([0-9a-z]{7})$ https://greensdictofslang.com/entry/$1 [R=301,L]
+RewriteRule ^([0-9a-z]{7})$ https://greensdictofslang.com/entry/$1 [R=301,L]
 
 # Redirect /Greens/$1/$2 to https://greensdictofslang.com/entry/$1#$2
-RewriteRule ^Greens/([0-9a-z]{7})/([0-9a-z]{7})$ https://greensdictofslang.com/entry/$1#$2 [R=301,NE,L]
+RewriteRule ^([0-9a-z]{7})/([0-9a-z]{7})$ https://greensdictofslang.com/entry/$1#$2 [R=301,NE,L]
 
 # Redirect /Greens/$1/$2 to https://greensdictofslang.com/entry/$1#$2
-RewriteRule ^Greens/([0-9a-z]{7})/(sn[0-9]{1,3})$ https://greensdictofslang.com/entry/$1#$2 [R=301,NE,L]
+RewriteRule ^([0-9a-z]{7})/(sn[0-9]{1,3})$ https://greensdictofslang.com/entry/$1#$2 [R=301,NE,L]
 
 # Redirect /Greens/sources/$1 to https://greensdictofslang.com/sources/$1
-RewriteRule ^Greens/sources/([0-9]{1,5})$ https://greensdictofslang.com/sources/$1 [R=301,L]
+RewriteRule ^sources/([0-9]{1,5})$ https://greensdictofslang.com/sources/$1 [R=301,L]
+
+# Redirect /Greens/ to https://greensdictofslang.com/
+RewriteRule ^$ https://greensdictofslang.com/ [R=301,L]


### PR DESCRIPTION
Did not realize that including Greens or GayLesbianBisexualTVCharacters in the match pattern portion of the RewriteRule would nest the redirect, i.e. redirecting https://w3id.org/Greens/Greens/qv5rkjq to https://greensdictofslang.com/entry/qv5rkjq and not matching https://w3id.org/Greens/qv5rkjq at all.

Fixed this and added a base redirect so /Greens redirects as well. Apologies for the mistake!