### PR TITLE
Redid Green's for subdefinitions (sn4a, for example). Currently the 'a' after 'sn4' would not match, so fixed that.

### DIFF
--- a/Greens/.htaccess
+++ b/Greens/.htaccess
@@ -3,6 +3,7 @@
 # https://w3id.org/Greens/qv5rkjq redirects to https://greensdictofslang.com/entry/qv5rkjq
 # https://w3id.org/Greens/cawbqqi/va3zesy redirects to https://greensdictofslang.com/entry/cawbqqi#va3zesy
 # https://w3id.org/Greens/qv5rkjq/sn1 redirects to https://greensdictofslang.com/entry/qv5rkjq#sn1
+# https://w3id.org/Greens/fiwvawq/sn4c redirects to https://greensdictofslang.com/entry/fiwvawq#sn4c
 # https://w3id.org/Greens/sources/5937 redirects to https://greensdictofslang.com/sources/5937
 #
 # ## Contact
@@ -26,7 +27,7 @@ RewriteRule ^([0-9a-z]{7})$ https://greensdictofslang.com/entry/$1 [R=301,L]
 RewriteRule ^([0-9a-z]{7})/([0-9a-z]{7})$ https://greensdictofslang.com/entry/$1#$2 [R=301,NE,L]
 
 # Redirect /Greens/$1/$2 to https://greensdictofslang.com/entry/$1#$2
-RewriteRule ^([0-9a-z]{7})/(sn[0-9]{1,3})$ https://greensdictofslang.com/entry/$1#$2 [R=301,NE,L]
+RewriteRule ^([0-9a-z]{7})/(sn[0-9]{1,3}[a-z]{0,1})$ https://greensdictofslang.com/entry/$1#$2 [R=301,NE,L]
 
 # Redirect /Greens/sources/$1 to https://greensdictofslang.com/sources/$1
 RewriteRule ^sources/([0-9]{1,5})$ https://greensdictofslang.com/sources/$1 [R=301,L]


### PR DESCRIPTION
Did not initially realize that subdefinitions were linkable in Green's (example: https://greensdictofslang.com/entry/fiwvawq#sn4c). Modified the regular expression to allow for matching.