### PR TITLE
ADDED: https://w3id.org/odissei/cv/ redirect

### DIFF
--- a/odissei/cv/.htaccess
+++ b/odissei/cv/.htaccess
@@ -1,0 +1,5 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+RewriteRule ^(.*)$ http://api.odissei.triply.cc/redirect/https://w3id.org/odissei/cv/$1 [R=307,L]


### PR DESCRIPTION
Also redirect controlled vocabularies in the https://w3id.org/odissei/cv/ namespace to the triply triple store