### PR TITLE
feat: enable redirection for Compliance Document criteria

### DIFF
--- a/gaia-x/.htaccess
+++ b/gaia-x/.htaccess
@@ -17,6 +17,12 @@ RewriteEngine on
 # Redirect to ODRL Verifiable Credential Profile
 RewriteRule ^ovc/* https://gitlab.com/gaia-x/lab/policy-reasoning/odrl-vc-profile/-/raw/main/ovc-1.ttl [R=303,L]
 
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^specs/cd24.06/criteria/(.*)$ https://docs.gaia-x.eu/policy-rules-committee/compliance-document/24.06/criterions/?id=$1 [R=303,L,NE]
+
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^specs/cd24.06/criteria/(.*)$ https://docs.gaia-x.eu/policy-rules-committee/compliance-document/24.06/criterions/#$1 [R=303,L,NE]
+
 # Redirect to LinkML ontology
 RewriteRule ^/?development/linkml/types.yaml$ https://registry.lab.gaia-x.eu/development/linkml/types.yaml [R=303,L]
 

--- a/gaia-x/README.md
+++ b/gaia-x/README.md
@@ -7,6 +7,7 @@ Homepage:
 
 Redirections:
 * `ovc/*` [ODRL profile for Verifiable Credentials](https://gitlab.com/gaia-x/lab/policy-reasoning/odrl-vc-profile/-/blob/main/README.md)
+* `specs/criteria/cd24.06/criteria/$id` redirects to the Compliance Document 24.06 on the criteria \$id
 * `<version>` (e.g. `development` or `2404`)
   * with `Accept: text/turtle` returns the Gaia-X Shacl shapes
   * with `Accept: application/ld+json` returns the Gaia-X JSON-LD context (or schema)


### PR DESCRIPTION
Enables a redirect from specs/criteria/cd24.06/criteria/XXX to either the JSON criteria or its HTML documentation depending on the Accept header.