### PR TITLE
First commit to declare `openebench` namespace within w3id.org

### DIFF
--- a/openebench/.htaccess
+++ b/openebench/.htaccess
@@ -1,0 +1,7 @@
+RewriteEngine on
+
+# Use a diferent redirect based on the protocol
+RewriteCond "%{SERVER_PROTOCOL}" "HTTP/(1.0|0.9)"
+RewriteRule ^$ https://openebench.bsc.es/ [R,L]
+
+RewriteRule ^$ https://openebench.bsc.es/ [R=307,L]

--- a/openebench/README.md
+++ b/openebench/README.md
@@ -1,0 +1,26 @@
+# /openebench/
+
+## Uses
+
+This namespace is going to serve different parts of the [OpenEBench](https://openebench.bsc.es) ecosystem.
+
+* PIDs pointing to scientific benchmarking JSON Schemas.
+* PIDs pointing to the different OpenEBench scientific benchmarking concept entries.
+
+In the future, the namespace will also provide mappings for technical monitoring area.
+
+## Contact
+
+This space is administered by members of [INB (Spanish National Bioinformatics Institute)](https://inb-elixir.es) and [Barcelona Supercomputing Center](https://www.bsc.es)
+
+| Person | GitHub user | ORCID |
+--------------------------------
+| José Mª Fernández | [@jmfernandez](https://github.com/jmfernandez) | [0000-0002-4806-5140](https://orcid.org/0000-0002-4806-5140) |
+| Laia Codó | [@lcodo](https://github.com/lcodo) | [0000-0002-6797-8746](https://orcid.org/0000-0002-6797-8746) |
+| Dmitry Repchevsky | [@redmitry](https://github.com/redmitry) | [0000-0001-6415-0532](https://orcid.org/0000-0001-6415-0532) |
+| Josep Ll. Gelpí | [@jlgelpi](https://github.com/jlgelpi) | [0000-0002-0566-7723](https://orcid.org/0000-0002-0566-7723) |
+| Salvador Capella | [@scapella](https://github.com/scapella) | [0000-0002-0309-604X](https://orcid.org/0000-0002-0309-604X) |
+
+
+Barcelona, Catalonia, Spain
+

--- a/openebench/scientific-schemas/.htaccess
+++ b/openebench/scientific-schemas/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine on
+
+RewriteRule ^$ https://github.com/inab/benchmarking-data-model/ [R,L]

--- a/openebench/scientific-schemas/1.0/.htaccess
+++ b/openebench/scientific-schemas/1.0/.htaccess
@@ -1,0 +1,14 @@
+RewriteEngine on
+
+RewriteRule ^$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/1.0.x/json-schemas/1.0.x/schema.json [R,L]
+RewriteRule ^_shared$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/1.0.x/json-schemas/1.0.x/_shared.json [R,L]
+RewriteRule ^BenchmarkingEvent$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/1.0.x/json-schemas/1.0.x/benchmarkingEvent.json [R,L]
+RewriteRule ^Challenge$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/1.0.x/json-schemas/1.0.x/challenge.json [R,L]
+RewriteRule ^Community$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/1.0.x/json-schemas/1.0.x/community.json [R,L]
+RewriteRule ^Contact$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/1.0.x/json-schemas/1.0.x/contact.json [R,L]
+RewriteRule ^Dataset$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/1.0.x/json-schemas/1.0.x/dataset.json [R,L]
+RewriteRule ^idSolv$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/1.0.x/json-schemas/1.0.x/idsolv.json [R,L]
+RewriteRule ^Metrics$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/1.0.x/json-schemas/1.0.x/metrics.json [R,L]
+RewriteRule ^Reference$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/1.0.x/json-schemas/1.0.x/reference.json [R,L]
+RewriteRule ^TestAction$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/1.0.x/json-schemas/1.0.x/testAction.json [R,L]
+RewriteRule ^Tool$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/1.0.x/json-schemas/1.0.x/tool.json [R,L]

--- a/openebench/scientific-schemas/2.0/.htaccess
+++ b/openebench/scientific-schemas/2.0/.htaccess
@@ -1,0 +1,17 @@
+RewriteEngine on
+
+RewriteRule ^$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/2.0.x/json-schemas/2.0.x/schema.json [R,L]
+RewriteRule ^_shared$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/2.0.x/json-schemas/2.0.x/_shared.json [R,L]
+RewriteRule ^BenchmarkingEvent$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/2.0.x/json-schemas/2.0.x/benchmarkingEvent.json [R,L]
+RewriteRule ^Challenge$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/2.0.x/json-schemas/2.0.x/challenge.json [R,L]
+RewriteRule ^Community$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/2.0.x/json-schemas/2.0.x/community.json [R,L]
+RewriteRule ^Contact$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/2.0.x/json-schemas/2.0.x/contact.json [R,L]
+RewriteRule ^Dataset$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/2.0.x/json-schemas/2.0.x/dataset.json [R,L]
+RewriteRule ^idSolv$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/2.0.x/json-schemas/2.0.x/idsolv.json [R,L]
+RewriteRule ^Metrics$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/2.0.x/json-schemas/2.0.x/metrics.json [R,L]
+RewriteRule ^Reference$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/2.0.x/json-schemas/2.0.x/reference.json [R,L]
+RewriteRule ^TestAction$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/2.0.x/json-schemas/2.0.x/testAction.json [R,L]
+RewriteRule ^Tool$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/2.0.x/json-schemas/2.0.x/tool.json [R,L]
+
+# Privilege
+RewriteRule ^Privilege$ https://raw.githubusercontent.com/inab/benchmarking-data-model/refs/heads/2.0.x/json-schemas/2.0.x/admin/privilege.json [R,L]


### PR DESCRIPTION
This namespace declares several redirections to elements of OpenEBench ecosystem. This first pull request is about providing PIDs for the JSON Schemas of OpenEBench Scientific Benchmarking