### PR TITLE
Turn several redirects case-insensitive

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -5,7 +5,5 @@ RewriteEngine on
 
 # special directory redirects due to case insensitive file systems issues
 RewriteRule ^AIRO(.*)$ /airo$1
-RewriteRule ^CEIR(.*)$ /CEIR$1 [NC]
-RewriteRule ^ColActDOnt(.*)$ /ColActDOnt$1 [NC]
-RewriteRule ^SocDOnt(.*)$ /SocDOnt$1 [NC]
+RewriteRule ^ceir(.*)$ /CEIR$1
 RewriteRule ^UN(.*)$ /un$1

--- a/.htaccess
+++ b/.htaccess
@@ -5,4 +5,7 @@ RewriteEngine on
 
 # special directory redirects due to case insensitive file systems issues
 RewriteRule ^AIRO(.*)$ /airo$1
+RewriteRule ^CEIR(.*)$ /CEIR$1 [NC]
+RewriteRule ^ColActDOnt(.*)$ /ColActDOnt$1 [NC]
+RewriteRule ^SocDOnt(.*)$ /SocDOnt$1 [NC]
 RewriteRule ^UN(.*)$ /un$1

--- a/CEIR/.htaccess
+++ b/CEIR/.htaccess
@@ -11,9 +11,9 @@ Options -MultiViews
 RewriteEngine On
 
 # Redirects
-RewriteRule ^(.*)CWC$ https://github.com/ceir-koblenz/CWC [R=303,L]
-RewriteRule ^(.*)IRECS$ https://github.com/ceir-koblenz/IRECS [R=303,L]
-RewriteRule ^(.*)MOBDA$ https://github.com/ceir-koblenz/MOBDA [R=303,L]
+RewriteRule ^(.*)CWC$ https://github.com/ceir-koblenz/CWC [L,NC,R=303]
+RewriteRule ^(.*)IRECS$ https://github.com/ceir-koblenz/IRECS [L,NC,R=303]
+RewriteRule ^(.*)MOBDA$ https://github.com/ceir-koblenz/MOBDA [L,NC,R=303]
 
 # Default response: redirect to the CEIR github page
-RewriteRule ^(.*)$ https://github.com/ceir-koblenz [R=303,L]
+RewriteRule ^(.*)$ https://github.com/ceir-koblenz [L,NC,R=303]


### PR DESCRIPTION
Hello everyone,

in this commit we have made our sub-redirects case-**in**sensitive.

However, we have also made the main-redirects for CEIR, ColActDOnt and SocDOnt ( which are all **our** projects) case-**in**sensitive. Unfortunately, this is necessary because **lower-case** links are expected in some publications and misunderstandings have already occurred.

Kind regards