### PR TITLE
Revert "updated iiot entry redirection".

### DIFF
--- a/iiot/.htaccess
+++ b/iiot/.htaccess
@@ -1,4 +1,0 @@
-Options +FollowSymLinks
-RewriteEngine on
-RewriteRule ^$ https://OntoIT.github.io/IIoT/IIoT.owl [R=302,L]
-

--- a/iiot/readme.md
+++ b/iiot/readme.md
@@ -1,8 +1,0 @@
-https://w3id.org/IIoT is a permanent URI 
-
-for the IIoT ontology for Industrial Internet of Things: 
-
-https://ontoit.github.io/IIoT/IIoT.owl
-
-Maintainer: Liviana Tudor
-


### PR DESCRIPTION
Reverts perma-id/w3id.org#4479.

Reverting due to maintainer confusion and the `iiot` contents added here duplicate `IIoT` and we want to avoid case similar directories.