### PR TITLE
Fix: trailing slash and lookup order for FEP documents

### DIFF
--- a/fep/.htaccess
+++ b/fep/.htaccess
@@ -1,20 +1,56 @@
 RewriteEngine on
 
+
+# catch root request
+RewriteRule ^\/?$ https://codeberg.org/fediverse/fep [R=302,L]
+
+
+
+# Catch FEP documents
+
+## By content negotiation
+
+### JSON-LD
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^([A-Za-z0-9]+)\/?$ https://raw.codeberg.page/fediverse/fep/fep/$1/fep-$1.jsonld [R=302,L]
+
+### RDF+XML
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^([A-Za-z0-9]+)\/?$ https://fediverse.codeberg.page/fep/fep/$1/fep-$1.rdf [R=302,L]
+
+### Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^([A-Za-z0-9]+)\/?$ https://fediverse.codeberg.page/fep/fep/$1/fep-$1.ttl [R=302,L]
+
+## By URL hacking
+RewriteRule ^([A-Za-z0-9]+).jsonld$ https://raw.codeberg.page/fediverse/fep/fep/$1/fep-$1.jsonld [R=302,L]
+RewriteRule ^([A-Za-z0-9]+).rdf$ https://raw.codeberg.page/fediverse/fep/fep/$1/fep-$1.rdf [R=302,L]
+RewriteRule ^([A-Za-z0-9]+).ttl$ https://raw.codeberg.page/fediverse/fep/fep/$1/fep-$1.ttl [R=302,L]
+
+## By default, take you to the FEP document
+RewriteRule ^([A-Za-z0-9]+)\/?$ https://codeberg.org/fediverse/fep/src/branch/main/fep/$1/fep-$1.md [R=302,L]
+
+
+
 # Catch term definitions/schemas/ontologies
 
 ## By content negotiation
 
-### JSON-LD               
+### JSON-LD
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^([A-Za-z0-9]+)\/(.*?)$ https://raw.codeberg.page/fediverse/fep/fep/$1/$2/$2.jsonld [R=302,L]
+RewriteRule ^([A-Za-z0-9]+)\/(.*?)\/?$ https://raw.codeberg.page/fediverse/fep/fep/$1/$2/$2.jsonld [R=302,L]
 
-### RDF+XML              
+### RDF+XML
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^([A-Za-z0-9]+)\/(.*?)$ https://fediverse.codeberg.page/fep/fep/$1/$2/$2.rdf [R=302,L]
+RewriteRule ^([A-Za-z0-9]+)\/(.*?)\/?$ https://fediverse.codeberg.page/fep/fep/$1/$2/$2.rdf [R=302,L]
 
-### Turtle               
+### Turtle
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^([A-Za-z0-9]+)\/(.*?)$ https://fediverse.codeberg.page/fep/fep/$1/$2/$2.ttl [R=302,L]
+RewriteRule ^([A-Za-z0-9]+)\/(.*?)\/?$ https://fediverse.codeberg.page/fep/fep/$1/$2/$2.ttl [R=302,L]
+
+### test html
+RewriteCond %{HTTP_ACCEPT} ^text/html$
+RewriteRule ^([A-Za-z0-9]+)\/(.*?)\/?$ https://fediverse.codeberg.page/fep/fep/$1/$2/$2.html [R=302,L]
 
 ## By URL hacking
 RewriteRule ^([A-Za-z0-9]+)\/(.*?).jsonld$ https://raw.codeberg.page/fediverse/fep/fep/$1/$2/$2.jsonld [R=302,L]
@@ -24,34 +60,9 @@ RewriteRule ^([A-Za-z0-9]+)\/(.*?).html$ https://fediverse.codeberg.page/fep/fep
 RewriteRule ^([A-Za-z0-9]+)\/(.*?).md$ https://fediverse.codeberg.page/fep/fep/$1/$2/README.md [R=302,L]
 
 ## By default, just take you to the term's folder
-RewriteRule ^([A-Za-z0-9]+)\/(.*?)$ https://codeberg.org/fediverse/fep/src/branch/main/fep/$1/$2 [R=302,L]
+RewriteRule ^([A-Za-z0-9]+)\/(.*?)\/?$ https://codeberg.org/fediverse/fep/src/branch/main/fep/$1/$2 [R=302,L]
 
-# Catch FEP documents     
 
-## By content negotiation
-
-### JSON-LD                                  
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^([A-Za-z0-9]+)\/?$ https://raw.codeberg.page/fediverse/fep/fep/$1/fep-$1.jsonld [R=302,L]
-
-### RDF+XML                
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^([A-Za-z0-9]+)\/?$ https://fediverse.codeberg.page/fep/fep/$1/fep-$1.rdf [R=302,L]
-
-### Turtle                 
-RewriteCond %{HTTP_ACCEPT} text/turtle         
-RewriteRule ^([A-Za-z0-9]+)\/?$ https://fediverse.codeberg.page/fep/fep/$1/fep-$1.ttl [R=302,L]
-
-## By URL hacking
-RewriteRule ^([A-Za-z0-9]+).jsonld$ https://raw.codeberg.page/fediverse/fep/fep/$1/fep-$1.jsonld [R=302,L]
-RewriteRule ^([A-Za-z0-9]+).rdf$ https://raw.codeberg.page/fediverse/fep/fep/$1/fep-$1.rdf [R=302,L]
-RewriteRule ^([A-Za-z0-9]+).ttl$ https://raw.codeberg.page/fediverse/fep/fep/$1/fep-$1.ttl [R=302,L]
-
-# catch FEP proposal documents
-RewriteRule ^([A-Za-z0-9]+)\/?$ https://codeberg.org/fediverse/fep/src/branch/main/fep/$1/fep-$1.md [R=302,L]
-
-# catch root request
-RewriteRule ^$ https://codeberg.org/fediverse/fep [R=302,L]
 
 # a generic catch-all rule
 RewriteRule ^(.*)\/?$  https://codeberg.org/fediverse/fep/raw/branch/main/fep/$1 [R=302,L]


### PR DESCRIPTION
URLs of the form https://w3id.org/fep/888d/ used to land you on the FEP folder instead of the FEP document. This issue was made worse by some autolinkers inserting a / before a fragment identifier. Fix this so that FEP documents are looked up before subresources in the case of a single trailing slash.