### PR TITLE
Security: Forbid browsing of .git directory

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -3,6 +3,13 @@
 Options +FollowSymLinks
 RewriteEngine on
 
+# If you use version control systems in your document root, you should
+# probably deny access to their directories. 
+#
+<DirectoryMatch "/.git">
+   Require all denied
+</DirectoryMatch
+
 # special directory redirects due to case insensitive file systems issues
 RewriteRule ^AIRO(.*)$ /airo$1
 RewriteRule ^ceir(.*)$ /CEIR$1


### PR DESCRIPTION
Hi, although we don't manage your site, w3.org got a report related to your site for  a potential security issue. Here's the fix for it.
> 
> Hi team
> 
> Description
> .git repository exposed at  https://w3id.org/.git/
> 
> Step
> 1. In your terminal type   wget -mirror -I .git https://w3id.org/.git/
> 2. go to the downloaded file directory
> 3. git status
> 4. Deleted files will appear
> 5. git restore (any file)
> 6. check git log also
> 
> Impact
> Attacker can restore deleted files and any of file consist of db user and
> db password
> 
> Best regards
> Manjot Singh