### PR TITLE
Create permalink for OpenGPT-x ontology

### DIFF
--- a/opengpt-x/.htaccess
+++ b/opengpt-x/.htaccess
@@ -1,0 +1,4 @@
+Options +FollowSymLinks
+   RewriteEngine On
+   RewriteRule ^$ https://github.com/OpenGPTX/AP5/blob/main/opengptx-ontology/opengptx-ontology.ttl [R=302,L]
+   RewriteRule ^(.*)$ https://github.com/OpenGPTX/AP5/tree/main/opengptx-ontology/ $1 [R=302,L]

--- a/opengpt-x/README.md
+++ b/opengpt-x/README.md
@@ -1,0 +1,10 @@
+# The OpenGPT-x ontology
+
+This is the permalink for OpenGPT-x Ontology: [https://w3id.org/opengptx](https://w3id.org/opengptx) 
+The original repository github link is: https://github.com/OpenGPTX/AP5/tree/main/opengptx-ontology
+
+# Contact
+
+Tasneem Tazeen Rashid (tasneem.tazeen.rashid@iais.fraunhofer.de)
+Fraunhofer IAIS
+Germanyt

--- a/opengpt-x/README.md
+++ b/opengpt-x/README.md
@@ -7,4 +7,4 @@ The original repository github link is: https://github.com/OpenGPTX/AP5/tree/mai
 
 Tasneem Tazeen Rashid (tasneem.tazeen.rashid@iais.fraunhofer.de)
 Fraunhofer IAIS
-Germanyt
+Germany


### PR DESCRIPTION
[OpenGPT-X](https://github.com/OpenGPTX/AP5/tree/main/opengptx-ontology) ontology is designed by Fraunhofer IAIS to establish a comprehensive and standardized framework for describing Large Langage Models (LLMs) within the Gaia-X infrastructure. It includes classes, properties, and relationships necessary to model LLMs related datasets.

We need the permalink for the ontology for the users to leverage the ontology.