### PR TITLE
Update vc-render-method redirect.

### DIFF
--- a/vc/render-method/.htaccess
+++ b/vc/render-method/.htaccess
@@ -14,4 +14,4 @@ Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,
 Options +FollowSymLinks
 RewriteEngine on
 RewriteRule ^$ https://w3c-ccg.github.io/vc-render-method [R=302,L]
-RewriteRule ^v(.+)$ https://digitalbazaar.github.io/vc-render-method-context/contexts/vc-render-method-v$1.jsonld [R=302,L]
+RewriteRule ^v(.+)$ https://digitalbazaar.github.io/vc-render-method-context/contexts/v$1.jsonld [R=302,L]


### PR DESCRIPTION
- Use shorter version for the generated context package files.
- May use longer version if/when this links to a spec context.