### PR TITLE
Modified redirect URL

### DIFF
--- a/hereditary/ontology/genomics/.htaccess
+++ b/hereditary/ontology/genomics/.htaccess
@@ -27,6 +27,6 @@ RewriteRule ^$ http://hereditary.dei.unipd.it/ontology/genomics/schema/hero_geno
 RewriteRule ^$ http://hereditary.dei.unipd.it/ontology/genomics/schema/hero_genomics.ttl [R=303]
 
 # Rewrite rule to deal with two namespaces: schema and resource
-RewriteRule ^/schema/(.*)$ http://hereditary.dei.unipd.it/ontology/genomics/schema/#$1 [R=302,L,NE]
-RewriteRule ^/resource/(.*)$ http://hereditary.dei.unipd.it/ontology/#https://w3id.org/hereditary/ontology/genomics/resource/$1 [R=302,L,NE]
+RewriteRule ^schema/(.*)$ http://hereditary.dei.unipd.it/ontology/genomics/schema/#$1 [R=302,L,NE]
+RewriteRule ^resource/(.*)$ http://hereditary.dei.unipd.it/ontology/genomics/resource/#$1 [R=302,L,NE]
 

--- a/hereditary/ontology/genomics/.htaccess
+++ b/hereditary/ontology/genomics/.htaccess
@@ -33,6 +33,6 @@ RewriteRule ^$ http://hereditary.dei.unipd.it/ontology/genomics/schema/hero_geno
 RewriteRule ^$ http://hereditary.dei.unipd.it/ontology/genomics/schema/hero_genomics.ttl [R=303]
 
 # Rewrite rule to deal with two namespaces: schema and resource
-RewriteRule ^schema/(.*)$ http://hereditary.dei.unipd.it/ontology/genomics/schema/#$1 [R=302,L,NE]
-RewriteRule ^resource/(.*)$ http://hereditary.dei.unipd.it/ontology/#https://w3id.org/hereditary/ontology/genomics/resource/$1 [R=302,L,NE]
+RewriteRule ^/schema/(.*)$ http://hereditary.dei.unipd.it/ontology/genomics/schema/#$1 [R=302,L,NE]
+RewriteRule ^/resource/(.*)$ http://hereditary.dei.unipd.it/ontology/#https://w3id.org/hereditary/ontology/genomics/resource/$1 [R=302,L,NE]
 

--- a/hereditary/ontology/genomics/.htaccess
+++ b/hereditary/ontology/genomics/.htaccess
@@ -18,12 +18,6 @@ RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 RewriteRule ^$ http://hereditary.dei.unipd.it/ontology/genomics/
 
-RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
-RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(.*)$ http://hereditary.dei.unipd.it/ontology/genomics$1 [R=302,L]
-
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
 RewriteRule ^$ http://hereditary.dei.unipd.it/ontology/genomics/schema/hero_genomics.owl [R=303]

--- a/hereditary/ontology/phenoclinical/.htaccess
+++ b/hereditary/ontology/phenoclinical/.htaccess
@@ -33,6 +33,6 @@ RewriteRule ^$ http://hereditary.dei.unipd.it/ontology/phenoclinical/schema/hero
 RewriteRule ^$ http://hereditary.dei.unipd.it/ontology/phenoclinical/schema/hero_phenoclinical.ttl [R=303]
 
 # Rewrite rule to deal with two namespaces: schema and resource
-RewriteRule ^schema/(.*)$ http://hereditary.dei.unipd.it/ontology/phenoclinical/schema/#$1 [R=302,L,NE]
-RewriteRule ^resource/(.*)$ http://hereditary.dei.unipd.it/ontology/#https://w3id.org/hereditary/ontology/phenoclinical/resource/$1 [R=302,L,NE]
+RewriteRule ^/schema/(.*)$ http://hereditary.dei.unipd.it/ontology/phenoclinical/schema/#$1 [R=302,L,NE]
+RewriteRule ^/resource/(.*)$ http://hereditary.dei.unipd.it/ontology/#https://w3id.org/hereditary/ontology/phenoclinical/resource/$1 [R=302,L,NE]
 

--- a/hereditary/ontology/phenoclinical/.htaccess
+++ b/hereditary/ontology/phenoclinical/.htaccess
@@ -18,12 +18,6 @@ RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 RewriteRule ^$ http://hereditary.dei.unipd.it/ontology/phenoclinical/
 
-RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
-RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(.*)$ http://hereditary.dei.unipd.it/ontology/phenoclinical$1 [R=302,L]
-
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
 RewriteRule ^$ http://hereditary.dei.unipd.it/ontology/phenoclinical/schema/hero_phenoclinical.owl [R=303]

--- a/hereditary/ontology/phenoclinical/.htaccess
+++ b/hereditary/ontology/phenoclinical/.htaccess
@@ -27,6 +27,6 @@ RewriteRule ^$ http://hereditary.dei.unipd.it/ontology/phenoclinical/schema/hero
 RewriteRule ^$ http://hereditary.dei.unipd.it/ontology/phenoclinical/schema/hero_phenoclinical.ttl [R=303]
 
 # Rewrite rule to deal with two namespaces: schema and resource
-RewriteRule ^/schema/(.*)$ http://hereditary.dei.unipd.it/ontology/phenoclinical/schema/#$1 [R=302,L,NE]
-RewriteRule ^/resource/(.*)$ http://hereditary.dei.unipd.it/ontology/#https://w3id.org/hereditary/ontology/phenoclinical/resource/$1 [R=302,L,NE]
+RewriteRule ^schema/(.*)$ http://hereditary.dei.unipd.it/ontology/phenoclinical/schema/#$1 [R=302,L,NE]
+RewriteRule ^resource/(.*)$ http://hereditary.dei.unipd.it/ontology/phenoclinical/resource/#$1 [R=302,L,NE]
 


### PR DESCRIPTION
The redirect seems to not work as expected.
1. From https://w3id.org/hereditary/ontology/phenoclinical/ I should be redirected to https://hereditary.dei.unipd.it/ontology/phenoclinical, instead the redirected URL is http://hereditary.dei.unipd.it/ontology/phenoclinical/http://hereditary.dei.unipd.it/ontology/phenoclinical/. 
2. Rewrite rules with schema and resource were missing a backslash. The URL https://w3id.org/hereditary/ontology/phenoclinical/schema wrongly redirected to https://hereditary.dei.unipd.it/ontology/phenoclinicalschema/.

I should have fixed it now.