### PR TITLE
Fixed schema and resource redirect

### DIFF
--- a/hereditary/ontology/genomics/.htaccess
+++ b/hereditary/ontology/genomics/.htaccess
@@ -27,6 +27,6 @@ RewriteRule ^$ http://hereditary.dei.unipd.it/ontology/genomics/schema/hero_geno
 RewriteRule ^$ http://hereditary.dei.unipd.it/ontology/genomics/schema/hero_genomics.ttl [R=303]
 
 # Rewrite rule to deal with two namespaces: schema and resource
-RewriteRule ^schema/(.*)$ http://hereditary.dei.unipd.it/ontology/genomics/schema/#$1 [R=302,L,NE]
-RewriteRule ^resource/(.*)$ http://hereditary.dei.unipd.it/ontology/genomics/resource/#$1 [R=302,L,NE]
+RewriteRule ^schema/(.*)$ http://hereditary.dei.unipd.it/ontology/genomics/#$1 [R=302,L,NE]
+RewriteRule ^resource/(.*)$ http://hereditary.dei.unipd.it/ontology/genomics/#$1 [R=302,L,NE]
 

--- a/hereditary/ontology/phenoclinical/.htaccess
+++ b/hereditary/ontology/phenoclinical/.htaccess
@@ -27,6 +27,7 @@ RewriteRule ^$ http://hereditary.dei.unipd.it/ontology/phenoclinical/schema/hero
 RewriteRule ^$ http://hereditary.dei.unipd.it/ontology/phenoclinical/schema/hero_phenoclinical.ttl [R=303]
 
 # Rewrite rule to deal with two namespaces: schema and resource
-RewriteRule ^schema/(.*)$ http://hereditary.dei.unipd.it/ontology/phenoclinical/schema/#$1 [R=302,L,NE]
-RewriteRule ^resource/(.*)$ http://hereditary.dei.unipd.it/ontology/phenoclinical/resource/#$1 [R=302,L,NE]
+RewriteRule ^schema/(.*)$ http://hereditary.dei.unipd.it/ontology/phenoclinical/
+#$1 [R=302,L,NE]
+RewriteRule ^resource/(.*)$ http://hereditary.dei.unipd.it/ontology/phenoclinical/#$1 [R=302,L,NE]
 


### PR DESCRIPTION
There was a problem with the redirect of https://w3id.org/hereditary/ontology/genomics/schema/ not redirecting to the correct URL.