### PR TITLE
Fix redirections to the SSSOM documentation.

### DIFF
--- a/sssom/.htaccess
+++ b/sssom/.htaccess
@@ -2,9 +2,9 @@ Options +FollowSymLinks
 RewriteEngine on
 
 # Making sure the legacy link to the spec still works
-RewriteRule ^$ https://mapping-commons.github.io/sssom/home/ [R=302,L]
-RewriteRule ^SSSOM.md$ https://mapping-commons.github.io/sssom/spec/ [R=302,L]
-RewriteRule ^spec/?$ https://mapping-commons.github.io/sssom/ [R=302,L]
+RewriteRule ^$ https://mapping-commons.github.io/sssom/ [R=302,L]
+RewriteRule ^SSSOM.md$ https://mapping-commons.github.io/sssom/introduction/ [R=302,L]
+RewriteRule ^spec/?$ https://mapping-commons.github.io/sssom/spec-intro/ [R=302,L]
 
 # make schema resolvable
 RewriteRule ^sssom.yaml$ https://raw.githubusercontent.com/mapping-commons/sssom/master/model/schema/sssom.yaml [R=302,L]


### PR DESCRIPTION
The documentation for the SSSOM specification was recently overhauled and several parts of it have moved, so some redirections currently point to 404 errors.

This commit fixes those redirections to get them to point to the appropriate new documents.

CC @matentzn 