### PR TITLE
Update v1 redirect to point to the correct context JSON URL

### DIFF
--- a/openbadges/.htaccess
+++ b/openbadges/.htaccess
@@ -1,6 +1,6 @@
 RewriteEngine on
 RewriteRule ^$ https://openbadgespec.org/ [R=302,L]
-RewriteRule ^v1$ https://openbadgespec.org/v1/context.json [R=302,L]
+RewriteRule ^v1$ https://purl.imsglobal.org/spec/ob/v1p0/context/context.json [R=302,L]
 RewriteRule ^v2$ https://purl.imsglobal.org/spec/ob/v2p0/context/context.json [R=302,L]
 RewriteRule ^legacy-v1$ https://openbadgespec.org/v1/legacy-v1.json [R=302,L]
 RewriteRule ^badgeconnect/v1$ https://purl.imsglobal.org/spec/ob/v2p1/context/ob_v2p1.jsonld [R=302,L]


### PR DESCRIPTION
This pull request includes a small but important change to the `.htaccess` file in the `openbadges` directory. The change updates the URL for the `v1` context JSON to point to a new location.

* [`openbadges/.htaccess`](diffhunk://#diff-e87c681fdba7000ed4eea740077e4d6fbc688e48bf4c429ce1c1175f81aa46d9L3-R3): Updated the `RewriteRule` for `^v1 to redirect to `https://purl.imsglobal.org/spec/ob/v1p0/context/context.json` instead of `https://openbadgespec.org/v1/context.json`.