### PR TITLE
Add redirect rule for v1 schema in .htaccess

### DIFF
--- a/openbadges/.htaccess
+++ b/openbadges/.htaccess
@@ -1,6 +1,7 @@
 RewriteEngine on
 RewriteRule ^$ https://openbadgespec.org/ [R=302,L]
 RewriteRule ^v1$ https://purl.imsglobal.org/spec/ob/v1p0/context/context.json [R=302,L]
+RewriteRule ^v1/schema/(.*)$ https://purl.imsglobal.org/spec/ob/v1p0/schema/$1 [R=302,L]
 RewriteRule ^v2$ https://purl.imsglobal.org/spec/ob/v2p0/context/context.json [R=302,L]
 RewriteRule ^legacy-v1$ https://openbadgespec.org/v1/legacy-v1.json [R=302,L]
 RewriteRule ^badgeconnect/v1$ https://purl.imsglobal.org/spec/ob/v2p1/context/ob_v2p1.jsonld [R=302,L]


### PR DESCRIPTION
This pull request includes a small change to the `.htaccess` file in the `openbadges` directory. The change adds a new rewrite rule to redirect requests for schema files in version 1 to the appropriate URL.

* [`openbadges/.htaccess`](diffhunk://#diff-e87c681fdba7000ed4eea740077e4d6fbc688e48bf4c429ce1c1175f81aa46d9R4): Added a rewrite rule to redirect requests matching `^v1/schema/(.*) to `https://purl.imsglobal.org/spec/ob/v1p0/schema/$1`.