### PR TITLE
/dpv fix examples 404 - redirect to version

### DIFF
--- a/dpv/.htaccess
+++ b/dpv/.htaccess
@@ -739,6 +739,19 @@ RewriteRule ^2.0/justifications/owl$ %{ENV:BASE}/2.0/justifications/justificatio
 
 RewriteRule ^2.0/justifications/owl$ %{ENV:BASE}/2.0/justifications/justifications-owl.html [R=302,L]
 
+### Examples
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^examples#([\w-]+)$ %{ENV:BASE}/examples/$1.rdf [R=302,L]
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^examples#([\w-]+)$ %{ENV:BASE}/examples/$1.ttl [R=302,L]
+RewriteCond %{HTTP_ACCEPT} application/n\-triples
+RewriteRule ^examples#([\w-]+)$ %{ENV:BASE}/examples/$1.n3 [R=302,L]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^examples#([\w-]+)$ %{ENV:BASE}/examples/$1.jsonld [R=302,L]
+
+RewriteRule ^examples#([\w-]+)$ %{ENV:BASE}/2.0/examples#$1 [NE,R=302,L]
+
 ########## DEPRECATED URLS ARE REDIRECTED
 
 RewriteRule ^dpv-gdpr$ https://w3id.org/dpv/legal/eu/gdpr [R=302,L]


### PR DESCRIPTION
- the examples links e.g. https://w3id.org/dpv/examples#E0029 give a 404 as the rule is set to go to https://w3c.github.io/dpv/examples/#E0066 which results in a 404
- the correct link should go to the 2.0 versioned page as examples are declared in every version even if the files are outside the versioned folders at root level
- so the file https://w3c.github.io/dpv/examples/E0066.ttl is shown as https://w3c.github.io/dpv/2.0/examples#E0066
- the fix is to write rules that go to the actual file for RDF content types and go to the versioned page for HTML content type
- fixes w3c/dpv#200