### PR TITLE
feat: redirections for Eclipse Decentralized Claims Protocol project

### DIFF
--- a/dspace-dcp/.htaccess
+++ b/dspace-dcp/.htaccess
@@ -1,0 +1,13 @@
+
+AddType application/ld+json .jsonld
+
+RewriteEngine On
+
+## Redirect main JSON-LD context
+RewriteRule ^(v[0-9][.][0-9])$ https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/resources/$1/context/dcp.jsonld [R=302,L]
+
+## Redirect JSON Schemas
+RewriteRule ^(v[0-9][.][0-9])/(presentation|issuance|common)/([\w.-]+schema.json) https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/resources/$1/$2/$3 [R=302,L]
+
+# Redirect to GH pages
+RewriteRule ^.*$ https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol [R=302,L]

--- a/dspace-dcp/README.md
+++ b/dspace-dcp/README.md
@@ -1,0 +1,12 @@
+# dspace-dcp - Eclipse Decentralized Claims Protocol
+
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the [Eclipse Decentralized Claims Protocol (DCP)](https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol).
+
+The Eclipse Decentralized Claims Protocol (DCP) defines an interoperable overlay to the [Dataspace Protocol (DSP)](https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocol) Specifications for conveying organizational identities and establishing trust in a way that preserves privacy and limits the possibility of network disruption.
+
+## Contact
+
+- Enrico Risa <enrico.risa@gmail.com> (https://github.com/wolf4ood)
+- James Marino <jim.marino@gmail.com> (https://github.com/jimmarino)
+- Paul Latzelsperger <Paul.latzelsperger@beardyinc.com> (https://github.com/paullatzelsperger)
+- Arno Weiß <arno.weiss@sap.com> (https://github.com/arnoweiss)


### PR DESCRIPTION
This PR adds redirection for [DCP](https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol) 

It contains redirect for:

- JSON-LD context
- JSON Schemas
- and a fallback to GH pages