### PR TITLE
Add "memuk" Namespace for Knowledge Graph (Bachelor Thesis)

### DIFF
--- a/memuk/.htaccess
+++ b/memuk/.htaccess
@@ -1,0 +1,28 @@
+# ## Contact
+# This space is administered by:
+#
+# Esther Giuliano
+# esther.giuliano@studio.unibo.it
+# GitHub username: esthy13
+
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+
+AddType application/rdf+xml .owl
+ 
+RewriteEngine on
+
+# https://w3id.org/memuk
+
+RewriteRule ^$ https://github.com/esthy13/memuk [R=303,L]
+
+# https://w3id.org/memuk/resource
+
+RewriteRule ^resource/?$ https://github.com/esthy13/memuk/tree/main/kg-generation/knowledge-graph [R=303,L]
+
+# https://w3id.org/memuk/ontology/meis
+
+RewriteRule ^ontology/meis/?$ https://raw.githubusercontent.com/esthy13/memuk/refs/heads/main/ontology/meis.owl [R=302,L]
+
+# https://w3id.org/memuk/<generic>
+RewriteRule ^(?!ontology/meis|resource)(.+)$ https://github.com/esthy13/memuk [R=303,L]

--- a/memuk/README.md
+++ b/memuk/README.md
@@ -8,9 +8,11 @@ The endpoint [https://w3id.org/memuk/resource](https://w3id.org/memuk/resource) 
 
 The endpoint [https://w3id.org/memuk/ontology/meis](https://w3id.org/memuk/ontology/meis) redirects to the ontology structure for MEI files.
 
-## P.S.:
+
+## Contact
+
 This knowledge graph was created as part of my bachelor’s thesis work.
-### Contact
-Esther Giuliano
-esther.giuliano@studio.unibo.it
+
+Esther Giuliano <br>
+esther.giuliano@studio.unibo.it <br>
 GitHub username: esthy13

--- a/memuk/README.md
+++ b/memuk/README.md
@@ -1,0 +1,16 @@
+# MEMUK
+
+MEMUK stands for the Melodic Music Knowledge Graph.
+
+The endpoint [https://w3id.org/memuk](https://w3id.org/memuk) contains all the necessary code to build and replicate the MEMUK knowledge graph, and the original dataset.
+
+The endpoint [https://w3id.org/memuk/resource](https://w3id.org/memuk/resource) redirects to the repository containing the whole knowledge graph.
+
+The endpoint [https://w3id.org/memuk/ontology/meis](https://w3id.org/memuk/ontology/meis) redirects to the ontology structure for MEI files.
+
+## P.S.:
+This knowledge graph was created as part of my bachelor’s thesis work.
+### Contact
+Esther Giuliano
+esther.giuliano@studio.unibo.it
+GitHub username: esthy13


### PR DESCRIPTION
This pull request introduces the "memuk" namespace, a key component of the knowledge graph created for my bachelor’s thesis. The knowledge graph is designed to represent concepts and relationships in the domain of melodic music information, particularly in the context of Music Information Retrieval (MIR) research.

### Changes:
- Created a dedicated namespace for `memuk` to provide access to relevant resources and ontologies.
- Implemented redirects for various paths under `w3id.org/memuk` to point to the corresponding resources hosted on GitHub.
  - Example redirects:
    - `/resource` → Redirect to the knowledge graph details on GitHub.
    - `/ontology/meis` → Redirect to the raw OWL file for the "meis" ontology.
    - `/memuk` → General redirect to the GitHub repository for the project.

### Request:
I would appreciate it if you could review the pull request and merge it so that the `memuk` namespace is available for use. Feel free to provide feedback or suggestions for further improvements.

Thank you for your time and consideration!