### PR TITLE
Add http://w3id.org/env/nea/alum8-get

### DIFF
--- a/env/.htaccess
+++ b/env/.htaccess
@@ -1,18 +1,77 @@
 Options +FollowSymLinks
 RewriteEngine on
 
+################# PUV #################
 # PUV ontology
 # match 'puv' followed by optional #{name} or /{name}
 # Turtle representation
 RewriteCond %{QUERY_STRING} ^(_format|_mediatype)=text/turtle$
-RewriteRule ^puv(\/\S+)?$ https://rawcdn.githack.com/CSIRO-enviro-informatics/PUV-ont/dd2d8762f80a58e618269593e99d3f840de0f150/rdf/puv.ttl [R=303,L]
+RewriteRule ^puv(\/\S*)?$ https://rawcdn.githack.com/CSIRO-enviro-informatics/PUV-ont/dd2d8762f80a58e618269593e99d3f840de0f150/rdf/puv.ttl [R=303,L]
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule ^puv(\/\S+)?$ https://rawcdn.githack.com/CSIRO-enviro-informatics/PUV-ont/dd2d8762f80a58e618269593e99d3f840de0f150/rdf/puv.ttl [R=303,L]
+RewriteRule ^puv(\/\S*)?$ https://rawcdn.githack.com/CSIRO-enviro-informatics/PUV-ont/dd2d8762f80a58e618269593e99d3f840de0f150/rdf/puv.ttl [R=303,L]
 # HTML representation
 RewriteCond %{QUERY_STRING} ^(_format|_mediatype)=text/html$
-RewriteRule ^puv(\/\S+)?$ https://rawcdn.githack.com/CSIRO-enviro-informatics/PUV-ont/dd2d8762f80a58e618269593e99d3f840de0f150/puv.html [R=303,L]
+RewriteRule ^puv(\/\S*)?$ https://rawcdn.githack.com/CSIRO-enviro-informatics/PUV-ont/dd2d8762f80a58e618269593e99d3f840de0f150/puv.html [R=303,L]
 RewriteCond %{HTTP:Accept} text/html [NC]
-RewriteRule ^puv(\/\S+)?$ https://rawcdn.githack.com/CSIRO-enviro-informatics/PUV-ont/dd2d8762f80a58e618269593e99d3f840de0f150/puv.html [R=303,L]
+RewriteRule ^puv(\/\S*)?$ https://rawcdn.githack.com/CSIRO-enviro-informatics/PUV-ont/dd2d8762f80a58e618269593e99d3f840de0f150/puv.html [R=303,L]
+# Example URIs
+# https://w3id.org/env/puv
+# https://w3id.org/env/puv#
+# https://w3id.org/env/puv#method 
 
+################# NEA #################
+# NEA National Ecosystem Accounting definitions and crosswalks
+# ALUM8-->GET
+# HTML representation
+RewriteCond %{QUERY_STRING} ^(_format|_mediatype)=text/html$
+RewriteRule ^nea/alum8-get$ https://demo.vocabs.ardc.edu.au/viewById/1099 [R=303,L]
+RewriteRule ^nea/alum8-get/$ https://demo.vocabs.ardc.edu.au/viewById/1099 [R=303,L]
+RewriteRule ^nea/alum8-get/([\S]+)$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.html?uri=https://w3id.org/env/nea/alum8-get/$1 [R=303,L]
+RewriteCond %{HTTP:Accept} text/html [NC]
+RewriteRule ^nea/alum8-get$ https://demo.vocabs.ardc.edu.au/viewById/1099 [R=303,L]
+RewriteRule ^nea/alum8-get/$ https://demo.vocabs.ardc.edu.au/viewById/1099 [R=303,L]
+RewriteRule ^nea/alum8-get/([\S]+)$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.html?uri=https://w3id.org/env/nea/alum8-get/$1 [R=303,L]
+# TTL representation
+RewriteCond %{QUERY_STRING} ^(_format|_mediatype)=text/turtle$
+RewriteRule ^nea/alum8-get$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.ttl?uri=http://w3id.org/env/nea/alum8-get/ [R=303,L]
+RewriteRule ^nea/alum8-get/$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.ttl?uri=http://w3id.org/env/nea/alum8-get/ [R=303,L]
+RewriteRule ^nea/alum8-get/([\S]+)$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.ttl?uri=http://w3id.org/env/nea/alum8-get/$1 [R=303,L]
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule ^nea/alum8-get$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.ttl?uri=http://w3id.org/env/nea/alum8-get/ [R=303,L]
+RewriteRule ^nea/alum8-get/$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.ttl?uri=http://w3id.org/env/nea/alum8-get/ [R=303,L]
+RewriteRule ^nea/alum8-get/([\S]+)$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.ttl?uri=http://w3id.org/env/nea/alum8-get/$1 [R=303,L]
+# JSON representation
+RewriteCond %{QUERY_STRING} ^(_format|_mediatype)=application/json$
+RewriteRule ^nea/alum8-get$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.json?uri=http://w3id.org/env/nea/alum8-get/ [R=303,L]
+RewriteRule ^nea/alum8-get/$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.json?uri=http://w3id.org/env/nea/alum8-get/ [R=303,L]
+RewriteRule ^nea/alum8-get/([\S]+)$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.json?uri=http://w3id.org/env/nea/alum8-get/$1 [R=303,L]
+RewriteCond %{HTTP:Accept} application/json [NC]
+RewriteRule ^nea/alum8-get$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.json?uri=http://w3id.org/env/nea/alum8-get/ [R=303,L]
+RewriteRule ^nea/alum8-get/$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.json?uri=http://w3id.org/env/nea/alum8-get/ [R=303,L]
+RewriteRule ^nea/alum8-get/([\S]+)$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.json?uri=http://w3id.org/env/nea/alum8-get/$1 [R=303,L]
+# XML representation
+RewriteCond %{QUERY_STRING} ^(_format|_mediatype)=application/xml$
+RewriteRule ^nea/alum8-get$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.xml?uri=http://w3id.org/env/nea/alum8-get/ [R=303,L]
+RewriteRule ^nea/alum8-get/$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.xml?uri=http://w3id.org/env/nea/alum8-get/ [R=303,L]
+RewriteRule ^nea/alum8-get/([\S]+)$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.xml?uri=http://w3id.org/env/nea/alum8-get/$1 [R=303,L]
+RewriteCond %{HTTP:Accept} application/xml [NC]
+RewriteRule ^nea/alum8-get$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.xml?uri=http://w3id.org/env/nea/alum8-get/ [R=303,L]
+RewriteRule ^nea/alum8-get/$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.xml?uri=http://w3id.org/env/nea/alum8-get/ [R=303,L]
+RewriteRule ^nea/alum8-get/([\S]+)$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.xml?uri=http://w3id.org/env/nea/alum8-get/$1 [R=303,L]
+# RDF/XML representation
+RewriteCond %{QUERY_STRING} ^(_format|_mediatype)=application/rdf+xml$
+RewriteRule ^nea/alum8-get$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.rdf?uri=http://w3id.org/env/nea/alum8-get/ [R=303,L]
+RewriteRule ^nea/alum8-get/$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.rdf?uri=http://w3id.org/env/nea/alum8-get/ [R=303,L]
+RewriteRule ^nea/alum8-get/([\S]+)$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.rdf?uri=http://w3id.org/env/nea/alum8-get/$1 [R=303,L]
+RewriteCond %{HTTP:Accept} application/rdf+xml [NC]
+RewriteRule ^nea/alum8-get$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.rdf?uri=http://w3id.org/env/nea/alum8-get/ [R=303,L]
+RewriteRule ^nea/alum8-get/$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.rdf?uri=http://w3id.org/env/nea/alum8-get/ [R=303,L]
+RewriteRule ^nea/alum8-get/([\S]+)$ https://demo.vocabs.ardc.edu.au/repository/api/lda/timelylogic/alum-v8-to-iucn-get-crosswalk/v1-2/resource.rdf?uri=http://w3id.org/env/nea/alum8-get/$1 [R=303,L]
+# Example URIs
+# http://w3id.org/env/nea/alum8-get
+# http://w3id.org/env/nea/alum8-get/
+# http://w3id.org/env/nea/alum8-get/13 
+
+####
 # other ENV definitions fall through to old definitions server
 RewriteRule ^\/?(.*)$ http://environment.data.gov.au/def/$1 [R=303,L]

--- a/env/README.md
+++ b/env/README.md
@@ -2,7 +2,7 @@
 
 Contacts: 
 
-- becky.schmidt@csiro.au
-- nicholas.car@surroundaustralia.com
-- sally.tetreault.campbell@csiro.au
-- simon.cox@csiro.au
+- craig.macfarlane@csiro.au - https://github.com/macfarlane99
+- ning.liu@csiro.au - https://github.com/ln1267
+- Nick Car - nick@kurrawong.net - https://github.com/nicholascar
+- Simon Cox - dr.shorthair@pm.me - https://github.com/dr-shorthair


### PR DESCRIPTION
Adding a new branch to /env/ for the Australian National Environmental Accounts (NEA) definitions and crosswalks

First crosswalk: ALUMv8 --> IUCN GET
Currently hosted on the ARDC demo service https://demo.vocabs.ardc.edu.au/viewById/1099

When this is proved up, will be moved to ARDC production service. 