### PR TITLE
move from 303 to x303 due to qname issue

### DIFF
--- a/303/.htaccess
+++ b/303/.htaccess
@@ -4,21 +4,5 @@ DirectorySlash Off
 RewriteOptions AllowNoSlash
 Options -Indexes
 
-# All machine-readable versions should be referred to by a generic document
-RewriteCond %{REQUEST_FILENAME} -d
-RewriteCond %{HTTP:Accept} text/turtle [NC,OR]
-RewriteCond %{HTTP:Accept} application/ld\+json [NC]
-RewriteRule . https://w3id.org/303/doc [R=303,L]
-
-# Default to the HTML representation. 
-# As it is very different from the machine readable representations --> direct 303, no link via generic document
-RewriteCond %{REQUEST_FILENAME} -d
-RewriteRule . https://github.com/athalhammer/303voc [R=303,L]
-
-# Turtle version of generic doc
-RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule ^doc$ https://athalhammer.github.io/303voc/303.ttl [R=302,L]
-
-# JSON-LD version of generic doc
-RewriteCond %{HTTP:Accept} application/ld\+json [NC]
-RewriteRule ^doc$ https://athalhammer.github.io/303voc/303.jsonld [R=302,L]
+# moved permanently to https://w3id.org/x303
+RewriteRule . https://w3id.org/x303 [R=301]

--- a/303/README.md
+++ b/303/README.md
@@ -1,14 +1,5 @@
-# 303 predicate
 
-This folder hosts the 303 redirect for the <https://w3id.org/303> predicate. The project is hosted at https://github.com/athalhammer/303voc/.
-
-## Uses
-
-The idea of the <https://w3id.org/303> predicate is to point to the 
-  1. canonical URI for the described real-world resource 
-  2. the (preferred) canonical URI of the RDF document describing it
-  
-in the subject position (1) and object postion (2) respectively.
+This folder hosts a DEPRECATED version of the  <https://w3id.org/x303> (formerly <https://w3id.org/303>) predicate. It now features a 301 redirect to the new URL of the predicate.
 
 ## This space is administered by:
 Andreas Thalhammer \

--- a/x303/.htaccess
+++ b/x303/.htaccess
@@ -1,0 +1,24 @@
+# Rewrite engine setup
+RewriteEngine On
+DirectorySlash Off
+RewriteOptions AllowNoSlash
+Options -Indexes
+
+# All machine-readable versions should be referred to by a generic document
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteCond %{HTTP:Accept} text/turtle [NC,OR]
+RewriteCond %{HTTP:Accept} application/ld\+json [NC]
+RewriteRule . https://w3id.org/x303/doc [R=303,L]
+
+# Default to the HTML representation. 
+# As it is very different from the machine readable representations --> direct 303, no link via generic document
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule . https://github.com/athalhammer/303voc [R=303,L]
+
+# Turtle version of generic doc
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule ^doc$ https://athalhammer.github.io/303voc/303.ttl [R=302,L]
+
+# JSON-LD version of generic doc
+RewriteCond %{HTTP:Accept} application/ld\+json [NC]
+RewriteRule ^doc$ https://athalhammer.github.io/303voc/303.jsonld [R=302,L]

--- a/x303/README.md
+++ b/x303/README.md
@@ -1,0 +1,16 @@
+# 303 predicate
+
+This folder hosts the 303 redirect for the <https://w3id.org/x303> predicate. The project is hosted at https://github.com/athalhammer/303voc/.
+
+## Uses
+
+The idea of the <https://w3id.org/x303> predicate is to point to the 
+  1. canonical URI for the described real-world resource 
+  2. the (preferred) canonical URI of the RDF document describing it
+  
+in the subject position (1) and object postion (2) respectively.
+
+## This space is administered by:
+Andreas Thalhammer \
+ORCID: https://orcid.org/0000-0002-0991-5771 \
+Github: [@athalhammer](https://github.com/athalhammer/)


### PR DESCRIPTION
We came to realize that https://w3id.org/303 is not a good solution as it doesn't work well with RDF+XML, in particular qnames do not permit local parts that start with a number.