### PR TITLE
W3id for ODRE framework

### DIFF
--- a/odre/odre-time/.htaccess
+++ b/odre/odre-time/.htaccess
@@ -1,0 +1,24 @@
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+
+RewriteEngine on
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ https://odre-framework.github.io/odre-time/OnToology/Ontology/ontology.ttl/documentation/ontology.ttl [R=303,L]
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://odre-framework.github.io/odre-time/OnToology/Ontology/ontology.ttl/documentation/index-en.html [R=303,L]
+
+
+
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^$ https://odre-framework.github.io/odre-time/OnToology/Ontology/ontology.ttl/documentation/ontology.ttl [R=303,L]

--- a/odre/odre-time/readme.md
+++ b/odre/odre-time/readme.md
@@ -4,6 +4,6 @@ This [w3id](https://w3id.org/def/odre-time) provides a persistent URI namespace 
 
 # Contacts:
 - Andrea Cimmino [:email:](mailto:andreajesus.cimmino@upm.es) [:octocat:](https://github.com/AndreaCimminoArriaga)
-- Juan Cano de Benito [:email:](mailto:juan.cano.benito@gmail.es) [:octocat:](https://w3id.org/def/odre-time)
+- Juan Cano de Benito [:email:](mailto:juan.cano.benito@gmail.es) [:octocat:](https://github.com/jucanbe)
 
 

--- a/odre/odre-time/readme.md
+++ b/odre/odre-time/readme.md
@@ -1,0 +1,9 @@
+# ODRE-Time ontology
+
+This [w3id](https://w3id.org/def/odre-time) provides a persistent URI namespace for the ODRE time ontology.
+
+# Contacts:
+- Andrea Cimmino [:email:](mailto:andreajesus.cimmino@upm.es) [:octocat:](https://github.com/AndreaCimminoArriaga)
+- Juan Cano de Benito [:email:](mailto:juan.cano.benito@gmail.es) [:octocat:](https://w3id.org/def/odre-time)
+
+


### PR DESCRIPTION
This new identifier will serve to identify ontologies developed for [ODRE](https://github.com/ODRE-Framework/odre-framework) (an ODRL enforcement mechanism).