### PR TITLE
add /display path for the Display ontology

### DIFF
--- a/display/.htaccess
+++ b/display/.htaccess
@@ -1,0 +1,86 @@
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType text/n3 .n3
+AddType application/n-triples .nt
+AddType application/ld+json .json
+
+
+### Rewrite rules for latest version
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://ouvroir.github.io/display-ontology/ [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle 
+RewriteRule ^$ https://ouvroir.github.io/display-ontology/ontology.ttl [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://ouvroir.github.io/display-ontology/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://ouvroir.github.io/display-ontology/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://ouvroir.github.io/display-ontology/ontology.nt [R=303,L]
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^display.ttl$ https://ouvroir.github.io/display-ontology/ontology.ttl [R=303,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^display.html$ https://ouvroir.github.io/display-ontology/ [R=303,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^display.rdf$ https://ouvroir.github.io/display-ontology/ontology.owl [R=303,L]
+
+# If suffix jsonld, redirect to jsonld version
+RewriteRule ^display.jsonld$ https://ouvroir.github.io/display-ontology/ontology.jsonld [R=303,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^display.nt$ https://ouvroir.github.io/display-ontology/ontology.nt [R=303,L]
+
+### Rewrite rules for any other version
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+.*)$ https://ouvroir.github.io/display-ontology/$1/ [R=302,NE,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+.*)$ https://ouvroir.github.io/display-ontology/$1/ontology.ttl [R=302,NE,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+.*)$ https://ouvroir.github.io/display-ontology/$1/ontology.jsonld [R=302,NE,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+.*)$ https://ouvroir.github.io/display-ontology/$1/ontology.owl [R=302,NE,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+.*)$ https://ouvroir.github.io/display-ontology/$1/ontology.nt [R=302,NE,L]
+
+### Default response
+RewriteRule ^$ https://ouvroir.github.io/display-ontology/ [R=303,L]

--- a/display/README.md
+++ b/display/README.md
@@ -1,0 +1,15 @@
+# The Display Ontology
+
+https://w3id.org/display# is the namespace URI for the Display ontology terms.
+
+https://ouvroir.github.io/display-ontology/ is the URL of the Display ontology documentation.
+
+https://w3id.org/display redirects to https://ouvroir.github.io/display-ontology/
+
+Ontology maintained by David Valentine at the [Ouvroir Laboratory](https://github.com/ouvroir).
+
+## Contacts
+
+- David Valentine <david.valentine@umontreal.ca>
+- Zoë Renaudie <zoe.renaudie@umontreal.ca>
+- Emmanuel Château-Dutier <emmanuel.chateau.dutier@umontreal.ca>


### PR DESCRIPTION
add /display path for the Display ontology

# The Display Ontology

https://w3id.org/display# is the namespace URI for the Display ontology terms.

https://ouvroir.github.io/display-ontology/ is the URL of the Display ontology documentation.

https://w3id.org/display redirects to https://ouvroir.github.io/display-ontology/

Ontology maintained by David Valentine at the [Ouvroir Laboratory](https://github.com/ouvroir).

## Contacts

- David Valentine <david.valentine@umontreal.ca>
- Zoë Renaudie <zoe.renaudie@umontreal.ca>
- Emmanuel Château-Dutier <emmanuel.chateau.dutier@umontreal.ca>