### PR TITLE
feature: setup up to Catena-X 2412

### DIFF
--- a/catenax/.htaccess
+++ b/catenax/.htaccess
@@ -16,6 +16,12 @@ RewriteEngine On
 RewriteBase /
 
 # Rewrite rule to serve versioned domain ontology links
+RewriteRule ^v24.12/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.12/ontology/$1_ontology.ttl [R=302,L]
+
+# Rewrite rule to serve versioned domain ontology links
+RewriteRule ^v24.08/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.08/ontology/$1_ontology.ttl [R=302,L]
+
+# Rewrite rule to serve versioned domain ontology links
 RewriteRule ^v24.05/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain ontology links
@@ -31,7 +37,13 @@ RewriteRule ^v23.09/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/big-da
 RewriteRule ^next/ontology/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/main/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve domain ontology links
-RewriteRule ^ontology/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/ontology/$1_ontology.ttl [R=302,L]
+RewriteRule ^ontology/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.12/ontology/$1_ontology.ttl [R=302,L]
+
+# Rewrite rule to serve versioned domain ontologies
+RewriteRule ^v24.12/ontology/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.12/ontology/$1_ontology.ttl [R=302,L]
+
+# Rewrite rule to serve versioned domain ontologies
+RewriteRule ^v24.08/ontology/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.08/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain ontologies
 RewriteRule ^v24.05/ontology/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/ontology/$1_ontology.ttl [R=302,L]
@@ -49,7 +61,13 @@ RewriteRule ^v23.09/ontology/(.+)$ https://raw.githubusercontent.com/big-data-sp
 RewriteRule ^next/ontology/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/main/ontology/$1_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve domain ontologies
-RewriteRule ^ontology/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/ontology/$1_ontology.ttl [R=302,L]
+RewriteRule ^ontology/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.12/ontology/$1_ontology.ttl [R=302,L]
+
+# Rewrite rule to serve versioned complete ontology
+RewriteRule ^v24.12/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.12/ontology.ttl [R=302,L]
+
+# Rewrite rule to serve versioned complete ontology
+RewriteRule ^v24.08/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.08/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned complete ontology
 RewriteRule ^v24.05/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/ontology.ttl [R=302,L]
@@ -67,7 +85,7 @@ RewriteRule ^v23.09/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/big-da
 RewriteRule ^next/ontology(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/main/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve complete ontology
-RewriteRule ^ontology(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/ontology.ttl [R=302,L]
+RewriteRule ^ontology(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.12/ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned use case ontology links
 RewriteRule ^v23.12/usecase/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v23.12/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
@@ -82,13 +100,25 @@ RewriteRule ^v23.12/usecase/(.+)$ https://raw.githubusercontent.com/big-data-spa
 RewriteRule ^v23.09/usecase/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v23.09/ontology_use_case/$1_use_case_ontology.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain taxonomy links
+RewriteRule ^v24.12/taxonomy/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.12/taxonomy/$1_taxonomy.ttl [R=302,L]
+
+# Rewrite rule to serve versioned domain taxonomy links
+RewriteRule ^v24.08/taxonomy/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.08/taxonomy/$1_taxonomy.ttl [R=302,L]
+
+# Rewrite rule to serve versioned domain taxonomy links
 RewriteRule ^v24.05/taxonomy/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/taxonomy/$1_taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain ontology links
 RewriteRule ^next/taxonomy/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/main/taxonomy/$1_taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve domain taxonomy links
-RewriteRule ^taxonomy/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/taxonomy/$1_taxonomy.ttl [R=302,L]
+RewriteRule ^taxonomy/(.+)#(.*)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.12/taxonomy/$1_taxonomy.ttl [R=302,L]
+
+# Rewrite rule to serve versioned domain taxonomies
+RewriteRule ^v24.12/taxonomy/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.12/taxonomy/$1_taxonomy.ttl [R=302,L]
+
+# Rewrite rule to serve versioned domain taxonomies
+RewriteRule ^v24.08/taxonomy/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.08/taxonomy/$1_taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve versioned domain taxonomies
 RewriteRule ^v24.05/taxonomy/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/taxonomy/$1_taxonomy.ttl [R=302,L]
@@ -97,7 +127,13 @@ RewriteRule ^v24.05/taxonomy/(.+)$ https://raw.githubusercontent.com/big-data-sp
 RewriteRule ^next/taxonomy/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/main/taxonomy/$1_taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve domain ontologies
-RewriteRule ^taxonomy/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/taxonomy/$1_taxonomy.ttl [R=302,L]
+RewriteRule ^taxonomy/(.+)$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.12/taxonomy/$1_taxonomy.ttl [R=302,L]
+
+# Rewrite rule to serve versioned taxonomy
+RewriteRule ^v24.12/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.12/taxonomy.ttl [R=302,L]
+
+# Rewrite rule to serve versioned taxonomy
+RewriteRule ^v24.08/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.08/taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve versioned taxonomy
 RewriteRule ^v24.05/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/taxonomy.ttl [R=302,L]
@@ -115,7 +151,7 @@ RewriteRule ^v23.09/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/big-da
 RewriteRule ^next/taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/main/taxonomy.ttl [R=302,L]
 
 # Rewrite rule to serve complete taxonomy
-RewriteRule ^taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.05/taxonomy.ttl [R=302,L]
+RewriteRule ^taxonomy(/|\.ttl)?$ https://raw.githubusercontent.com/big-data-spaces/ontology/v24.12/taxonomy.ttl [R=302,L]
 
 # ODRL Profile definition
 RewriteRule ^policy(/|.*)$ https://raw.githubusercontent.com/catenax-eV/cx-odrl-profile/main/profile.ttl [R=302,L]
@@ -124,4 +160,4 @@ RewriteRule ^policy(/|.*)$ https://raw.githubusercontent.com/catenax-eV/cx-odrl-
 RewriteRule ^credentials/v1.0.0(.*)$ https://eclipse-tractusx.github.io/tractusx-profiles/cx/context/credentials.context.json [R=302,L]
 
 # Rewrite rule to serve the TTL content from the vocabulary URI by default
-RewriteRule ^(.*)$ https://big-data-spaces.github.io/ontology [R=303,L]
+RewriteRule ^(.*)$ https://github.com/big-data-spaces/ontology/blob/v24.12/docs/README.md [R=303,L]

--- a/catenax/README.md
+++ b/catenax/README.md
@@ -4,32 +4,40 @@ Documentation is available at: https://catena-x.net/, https://github.com/catenax
 
 The complete ontology is available as:
 
-TTL: https://github.com/big-data-spaces/ontology/blob/v24.05/ontology.ttl (current)
+TTL: https://github.com/big-data-spaces/ontology/blob/v24.12/ontology.ttl (current)
 TTL: https://github.com/big-data-spaces/ontology/blob/main/ontology.ttl (next)
+TTL: https://github.com/big-data-spaces/ontology/blob/v24.08/ontology.ttl (previous)
+TTL: https://github.com/big-data-spaces/ontology/blob/v24.05/ontology.ttl (previous)
 TTL: https://github.com/big-data-spaces/ontology/blob/v24.03/ontology.ttl (previous)
 TTL: https://github.com/big-data-spaces/ontology/blob/v23.12/ontology.ttl (previous)
 TTL: https://github.com/big-data-spaces/ontology/blob/v23.09/ontology.ttl (previous)
 
 The complete taxonomy is available as:
 
-TTL: https://github.com/big-data-spaces/ontology/blob/v24.05/taxonomy.ttl (current)
+TTL: https://github.com/big-data-spaces/ontology/blob/v24.12/taxonomy.ttl (current)
 TTL: https://github.com/big-data-spaces/ontology/blob/main/taxonomy.ttl (next)
+TTL: https://github.com/big-data-spaces/ontology/blob/v24.08/taxonomy.ttl (previous)
+TTL: https://github.com/big-data-spaces/ontology/blob/v24.05/taxonomy.ttl (previous)
 TTL: https://github.com/big-data-spaces/ontology/blob/v24.03/taxonomy.ttl (previous)
 TTL: https://github.com/big-data-spaces/ontology/blob/v23.12/taxonomy.ttl (previous)
 TTL: https://github.com/big-data-spaces/ontology/blob/v23.09/taxonomy.ttl (previous)
 
 Individual domain ontologies can be found under:
 
-https://github.com/big-data-spaces/ontology/tree/v24.05/ontology (current)
+https://github.com/big-data-spaces/ontology/tree/v24.12/ontology (current)
 https://github.com/big-data-spaces/ontology/tree/main/ontology (next)
+https://github.com/big-data-spaces/ontology/tree/v24.08/ontology (previous)
+https://github.com/big-data-spaces/ontology/tree/v24.05/ontology (previous)
 https://github.com/big-data-spaces/ontology/tree/v24.03/ontology (previous)
 https://github.com/big-data-spaces/ontology/tree/v23.12/ontology (previous)
 https://github.com/big-data-spaces/ontology/tree/v23.09/ontology (previous)
 
 Individual domain taxonomies can be found under:
 
-https://github.com/big-data-spaces/ontology/tree/v24.05/taxonomy (current)
+https://github.com/big-data-spaces/ontology/tree/v24.12/taxonomy (current)
 https://github.com/big-data-spaces/ontology/tree/main/taxonomy (next)
+https://github.com/big-data-spaces/ontology/tree/v24.08/taxonomy (previous)
+https://github.com/big-data-spaces/ontology/tree/v24.05/taxonomy (previous)
 https://github.com/big-data-spaces/ontology/tree/v24.03/taxonomy (previous)
 https://github.com/big-data-spaces/ontology/tree/v23.12/taxonomy (previous)
 https://github.com/big-data-spaces/ontology/tree/v23.09/taxonomy (previous)


### PR DESCRIPTION
- documents the catena-x namespace releases
- links to the new markdown documentation base (without github pages)
- introduces rewrite rules for intermediate versions and links current and next version to the right tags.
- tested on a local installation of w3id.org