### PR TITLE
Update .htaccess file for "opengpt-x" 

### DIFF
--- a/opengpt-x/.htaccess
+++ b/opengpt-x/.htaccess
@@ -1,4 +1,7 @@
 Options +FollowSymLinks
-   RewriteEngine On
-   RewriteRule ^$ https://github.com/OpenGPTX/AP5/blob/main/opengptx-ontology/opengptx-ontology.ttl [R=302,L]
-   RewriteRule ^(.*)$ https://github.com/OpenGPTX/AP5/tree/main/opengptx-ontology/ $1 [R=302,L]
+
+# Rewrite engine setup
+RewriteEngine On
+
+# Redirect to https://w3id.org/opengptx/
+RewriteRule	^$ https://github.com/OpenGPTX/AP5/blob/main/opengptx-ontology/opengptx-ontology.ttl/ [R=302,L]


### PR DESCRIPTION
The permalink for https://w3id.org/opengptx is not working. To update this, the .htaccess file has been updated. Please merge the pull request.