### PR TITLE
Update htaccess for iSamples Vocabs URIs without version number

### DIFF
--- a/isample/vocabulary/material/.htaccess
+++ b/isample/vocabulary/material/.htaccess
@@ -2,20 +2,43 @@ Options +FollowSymLinks
 RewriteEngine on 
 
 # set environmental variable for the current version
-SetEnvIf Request_URI ^.*$ currentversion=1-0
+SetEnvIf Request_URI ^.*$ currentversion=1-0  # 2024-12-02 don't use this; version number no longer in URI
 # 
+
+# get https://w3id.org/isample/vocabulary/material or https://w3id.org/isample/vocabulary/material/
 
 # ../isample/vocabulary/material get vocabulary ttl format with text/turtle accept header
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/3190/isamples_isamples-materials-vocabulary-%{ENV:currentversion}.ttl [R=303,L]
+RewriteRule  ^/?$  https://vocabs.ardc.edu.au/registry/api/resource/downloads/5063/material_type.ttl
+# was https://vocabs.ardc.edu.au/registry/api/resource/downloads/3190/isamples_isamples-materials-vocabulary-%{ENV:currentversion}.ttl [R=303,L]
 
 
 RewriteCond %{HTTP:Accept} application/rdf\+xml [NC]
-RewriteRule       ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/3190/isamples_isamples-materials-vocabulary-%{ENV:currentversion}.rdf [R=303,L]
-#https://vocabs.ardc.edu.au/registry/api/resource/downloads/3190/isamples_isamples-materials-vocabulary-1-0.rdf
+RewriteRule  ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/5065/isamples_isamples-materials-vocabulary_current.rdf
+# was https://vocabs.ardc.edu.au/registry/api/resource/downloads/3190/isamples_isamples-materials-vocabulary-%{ENV:currentversion}.rdf [R=303,L]
+
 
 RewriteCond %{HTTP:Accept} application/ld\+json [NC]
-RewriteRule       ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/3190/isamples_isamples-materials-vocabulary-%{ENV:currentversion}.jsonld [R=303,L]
+RewriteRule  ^/?$  https://vocabs.ardc.edu.au/registry/api/resource/downloads/5065/isamples_isamples-materials-vocabulary_current.jsonld
+# was https://vocabs.ardc.edu.au/registry/api/resource/downloads/3190/isamples_isamples-materials-vocabulary-%{ENV:currentversion}.jsonld [R=303,L]
 
 RewriteRule       ^/?$     https://vocabs.ardc.edu.au/viewById/664 [R=303,L]
 
+
+# get concept for URI with no version number. 0.9 and 1.0 will pass thru to old .htaccess files.
+#  uri to access individual term
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^([^0,1].+)$     https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-materials-vocabulary/current/resource.ttl?uri=https://w3id.org/isample/vocabulary/material/$1 [R=303,L]
+
+RewriteCond %{HTTP:Accept} application/json [NC]
+RewriteRule       ^([^0,1].+)$     https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-materials-vocabulary/current/resource.json?uri=https://w3id.org/isample/vocabulary/material/$1 [R=303,L]
+
+RewriteCond %{HTTP:Accept} application/rdf+xml [NC]
+RewriteRule       ^([^0,1].+)$     https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-materials-vocabulary/current/resource.rdf?uri=https://w3id.org/isample/vocabulary/material/$1 [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/html [NC]
+RewriteRule       ^([^0,1].+)$     https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-materials-vocabulary/current/resource.html?uri=https://w3id.org/isample/vocabulary/material/$1 [R=303,L]
+
+# default format is html
+RewriteRule       ^([^0,1].+)$     https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-materials-vocabulary/current/resource?uri=https://w3id.org/isample/vocabulary/material/$1 [R=303,L]

--- a/isample/vocabulary/materialsampleobjecttype/.htaccess
+++ b/isample/vocabulary/materialsampleobjecttype/.htaccess
@@ -1,22 +1,72 @@
 Options +FollowSymLinks
 RewriteEngine on 
 
-# set environmental variable for the current version
-SetEnvIf Request_URI ^.*$ currentversion=1-0
+#update 2024-12-02 to handle new policy of not included version numbers in URIs
+# set environmental variable for the current version (superseded, I'm leaving here for information/reminder)
+SetEnvIf Request_URI ^.*$ currentversion=current
 # 
 
+# no concept, just want whole vocabulary e.g. https://w3id.org/isample/vocabulary/materialsampleobjecttype (with or without terminal '/')
 # ../isample/vocabulary/materialsampleobjecttype get vocabulary ttl format with text/turtle accept header
+#update 2024-12-02 
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/4641/material_sample_object_type.ttl [R=303,L]
-#https://vocabs.ardc.edu.au/registry/api/resource/downloads/4641/material_sample_object_type.ttl
+RewriteRule       ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/5055/material_sample_object_type.ttl [R=303,L]
+# was  https://vocabs.ardc.edu.au/registry/api/resource/downloads/4641/material_sample_object_type.ttl  for version 1
+
+
+#  https://vocabs.ardc.edu.au/registry/api/resource/downloads/5057/isamples_isamples-material-sample-object-type-vocabulary_current.rdf
+RewriteCond %{HTTP:Accept} application/rdf+xml [NC]
+RewriteRule       ^/?$  https://vocabs.ardc.edu.au/registry/api/resource/downloads/5057/isamples_isamples-material-sample-object-type-vocabulary_current.rdf [R=303,L]
+# was https://vocabs.ardc.edu.au/registry/api/resource/downloads/4643/isamples_isamples-material-sample-object-type-vocabulary_version-1-0.rdf
+
+
+# https://vocabs.ardc.edu.au/registry/api/resource/downloads/5057/isamples_isamples-material-sample-object-type-vocabulary_current.jsonld
+RewriteCond %{HTTP:Accept} application/ld+json [NC]
+RewriteRule       ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/5057/isamples_isamples-material-sample-object-type-vocabulary_current.jsonld [R=303,L]
+#  for v1 was https://vocabs.ardc.edu.au/registry/api/resource/downloads/4643/isamples_isamples-material-sample-object-type-vocabulary_version-%{ENV:currentversion}.jsonld  with currentversion=1-0
+
+# no accept header, gets ARDC landing page
+RewriteRule       ^/?$     https://vocabs.ardc.edu.au/viewById/683 [R=303,L]
+
+#  **********************************
+
+# old style, with version number in URIs
+# get a concept like https://w3id.org/isample/vocabulary/materialsampleobjecttype/1.0/artifact
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^/1.0/(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-object-type-vocabulary/version-1-0/resource.ttl?uri=https://w3id.org/isample/vocabulary/materialsampleobjecttype/1.0/$1 [R=303,L]
+
+RewriteCond %{HTTP:Accept} application/json [NC]
+RewriteRule       ^/1.0/(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-object-type-vocabulary/version-1-0/resource.json?uri=https://w3id.org/isample/vocabulary/materialsampleobjecttype/1.0/$1 [R=303,L]
 
 RewriteCond %{HTTP:Accept} application/rdf+xml [NC]
-RewriteRule       ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/4643/isamples_isamples-material-sample-object-type-vocabulary_version-%{ENV:currentversion}.rdf [R=303,L]
-#https://vocabs.ardc.edu.au/registry/api/resource/downloads/4643/isamples_isamples-material-sample-object-type-vocabulary_version-1-0.rdf
+RewriteRule       ^/1.0/(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-object-type-vocabulary/version-1-0/resource.rdf?uri=https://w3id.org/isample/vocabulary/materialsampleobjecttype/1.0/$1 [R=303,L]
 
-RewriteCond %{HTTP:Accept} application/ld+json [NC]
-RewriteRule       ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/4643/isamples_isamples-material-sample-object-type-vocabulary_version-%{ENV:currentversion}.jsonld [R=303,L]
-#
+RewriteCond %{HTTP:Accept} text/html [NC]
+RewriteRule       ^/1.0/(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-object-type-vocabulary/version-1-0/resource.html?uri=https://w3id.org/isample/vocabulary/materialsampleobjecttype/1.0/$1 [R=303,L]
 
-RewriteRule       ^/?$     https://vocabs.ardc.edu.au/viewById/683 [R=303,L]
+# default format is html
+RewriteRule       ^/1.0/(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-object-type-vocabulary/version-1-0/resource?uri=https://w3id.org/isample/vocabulary/materialsampleobjecttype/1.0/$1 [R=303,L]
+
+
+#  **********************************
+#  2024-12-02 no version number URI. These get the 'current' version from ARDC using the htaccess ENV variable.
+
+# get a concept like https://w3id.org/isample/vocabulary/materialsampleobjecttype/artifact
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^/(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-object-type-vocabulary/%{ENV:currentversion}/resource.ttl?uri=https://w3id.org/isample/vocabulary/materialsampleobjecttype/$1 [R=303,L]
+
+RewriteCond %{HTTP:Accept} application/json [NC]
+RewriteRule       ^/(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-object-type-vocabulary/%{ENV:currentversion}/resource.json?uri=https://w3id.org/isample/vocabulary/materialsampleobjecttype/$1 [R=303,L]
+
+RewriteCond %{HTTP:Accept} application/rdf+xml [NC]
+RewriteRule       ^/(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-object-type-vocabulary/%{ENV:currentversion}/resource.rdf?uri=https://w3id.org/isample/vocabulary/materialsampleobjecttype/$1 [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/html [NC]
+RewriteRule       ^/(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-object-type-vocabulary/%{ENV:currentversion}/resource.html?uri=https://w3id.org/isample/vocabulary/materialsampleobjecttype/$1 [R=303,L]
+
+# default format is html
+RewriteRule       ^/(.+)$               https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-material-sample-object-type-vocabulary/%{ENV:currentversion}/resource?uri=https://w3id.org/isample/vocabulary/materialsampleobjecttype/$1 [R=303,L]
+
+
 

--- a/isample/vocabulary/sampledfeature/.htaccess
+++ b/isample/vocabulary/sampledfeature/.htaccess
@@ -7,16 +7,38 @@ SetEnvIf Request_URI "^.*" currentversion=1-0
 
 # ../isample/vocabulary/sampledfeature get vocabulary ttl format with text/turtle accept header
 RewriteCond %{HTTP:Accept} text/turtle [NC]
-RewriteRule       ^/?$   https://vocabs.ardc.edu.au/registry/api/resource/downloads/3199/isamples_isamples-sampled-feature-type-vocabulary_%{ENV:currentversion}.ttl [R=303,L]
+RewriteRule       ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/5059/sampled_feature_type.ttl
+# was   https://vocabs.ardc.edu.au/registry/api/resource/downloads/3199/isamples_isamples-sampled-feature-type-vocabulary_%{ENV:currentversion}.ttl [R=303,L]
 
 RewriteCond %{HTTP:Accept} application/rdf+xml [NC]
-RewriteRule       ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/3199/isamples_isamples-sampled-feature-type-vocabulary_%{ENV:currentversion}.rdf [R=303,L]
+RewriteRule  ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/5061/isamples_isamples-sampled-feature-type-vocabulary_current.rdf
+# was https://vocabs.ardc.edu.au/registry/api/resource/downloads/3199/isamples_isamples-sampled-feature-type-vocabulary_%{ENV:currentversion}.rdf [R=303,L]
 
 RewriteCond %{HTTP:Accept} application/ld+json [NC]
-RewriteRule       ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/3199/isamples_isamples-sampled-feature-type-vocabulary_%{ENV:currentversion}.jsonld [R=303,L]
+RewriteRule       ^/?$ https://vocabs.ardc.edu.au/registry/api/resource/downloads/5061/isamples_isamples-sampled-feature-type-vocabulary_current.jsonld
+# was https://vocabs.ardc.edu.au/registry/api/resource/downloads/3199/isamples_isamples-sampled-feature-type-vocabulary_%{ENV:currentversion}.jsonld [R=303,L]
 
 RewriteRule       ^/?$     https://vocabs.ardc.edu.au/viewById/665 [R=303,L]
 
+# **********************************************************
+
+#  uri to access individual term
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule       ^([^0,1].+)$   https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-sampled-feature-type-vocabulary/current/resource.ttl?uri=https://w3id.org/isample/vocabulary/sampledfeature/$1 [R=303,L]
+
+RewriteCond %{HTTP:Accept} application/json [NC]
+RewriteRule       ^([^0,1].+)$   https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-sampled-feature-type-vocabulary/current/resource.json?uri=https://w3id.org/isample/vocabulary/sampledfeature/$1 [R=303,L]
+
+RewriteCond %{HTTP:Accept} application/rdf+xml [NC]
+RewriteRule       ^([^0,1].+)$   https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-sampled-feature-type-vocabulary/current/resource.rdf?uri=https://w3id.org/isample/vocabulary/sampledfeature/$1 [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/html [NC]
+RewriteRule       ^([^0,1].+)$   https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-sampled-feature-type-vocabulary/current/resource.html?uri=https://w3id.org/isample/vocabulary/sampledfeature/$1 [R=303,L]
+
+# default format is html
+
+RewriteRule       ^([^0,1].+)$   https://vocabs.ardc.edu.au/repository/api/lda/isamples/isamples-sampled-feature-type-vocabulary/current/resource?uri=https://w3id.org/isample/vocabulary/sampledfeature/$1 [R=303,L]
 
 
 


### PR DESCRIPTION
This reverts commit 861ed74a554b67252f1bb87ac3e9c6bd476f9a54 (this was an update for codata, should be in separate PR, which isn't ready yet).  add cdif directory with readme; no redirects yet

this PR only affects the iSamples redirects.   update htaccess for no-version-number URIs