### PR TITLE
chore: renames dcp context

### DIFF
--- a/dspace-dcp/.htaccess
+++ b/dspace-dcp/.htaccess
@@ -4,7 +4,7 @@ AddType application/ld+json .jsonld
 RewriteEngine On
 
 ## Redirect main JSON-LD context
-RewriteRule ^(v[0-9][.][0-9])$ https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/resources/$1/context/dcp.jsonld [R=302,L]
+RewriteRule ^(v[0-9][.][0-9])/dcp.jsonld https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/resources/$1/context/dcp.jsonld [R=302,L]
 
 ## Redirect JSON Schemas
 RewriteRule ^(v[0-9][.][0-9])/(presentation|issuance|common)/([\w.-]+schema.json) https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/resources/$1/$2/$3 [R=302,L]


### PR DESCRIPTION

Changes the context URI to be  in format

`https://w3id.org/dspace-dcp/<version>/dcp.jsonld`

according to https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol/discussions/128

The json schema redirects are not affected