### PR TITLE
Update .htaccess to Bioportal

### DIFF
--- a/CMECS/.htaccess
+++ b/CMECS/.htaccess
@@ -7,4 +7,4 @@
 # GitHub username: r0sek
 
 RewriteEngine on
-RewriteRule ^(.*)$ https://mmisw.org/ont?iri=https://w3id.org/CMECS/$1 [R=302,L]
+RewriteRule ^(.*)$ https://bioportal.bioontology.org/ontologies/CMECS?iri=https://w3id.org/CMECS/$1 [R=302,L]


### PR DESCRIPTION
Changed rewrite rule to redirect to CMECS on Bioportal site but am not sure this will work. 

I am hoping that the redirect will resolve to the individual Class pages via the IRIs, e.g., https://bioportal.bioontology.org/ontologies/CMECS/?p=classes&conceptid=https://w3id.org/CMECS/CMECS_00000395 resolves to the Gravelly Mixes Class page.

However, testing the rule in an [htaccess tester](https://htaccess.madewithlove.com?share=3c8fdaa3-5d98-499f-a1dd-c07c528b8f7e) the generated link only resolves to the main CMECS ontology summary page https://bioportal.bioontology.org/ontologies/CMECS

Should I ask about this on the public-perma-id@w3.org mailing list?