### PR TITLE
Jelly: add explicit redirect for "/"

### DIFF
--- a/jelly/.htaccess
+++ b/jelly/.htaccess
@@ -1,4 +1,7 @@
 RewriteEngine on
 
+# Redirect by default to the dev version of the docs
+RewriteRule ^$ https://jelly-rdf.github.io/dev/ [R=302,L]
+
 # Default response – redirect to documentation
 RewriteRule ^(.*)$ https://jelly-rdf.github.io/$1 [R=302,L]


### PR DESCRIPTION
Add an explicit redirect to avoid nasty HTML redirects on the side of GitHub Pages.

This change was tested on a local instance of Apache Server.