### PR TITLE
fix(dspace-dcp): hard-redirect versions

### DIFF
--- a/dspace-dcp/.htaccess
+++ b/dspace-dcp/.htaccess
@@ -3,11 +3,14 @@ AddType application/ld+json .jsonld
 
 RewriteEngine On
 
-## Redirect main JSON-LD context
-RewriteRule ^(v[0-9][.][0-9])/dcp.jsonld https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/resources/$1/context/dcp.jsonld [R=302,L]
+## Redirect main JSON-LD context for v0.8
+RewriteRule ^v0.8$ https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/0.8.1/specifications/context.jsonld [R=302,L]
 
-## Redirect JSON Schemas
-RewriteRule ^(v[0-9][.][0-9])/(presentation|issuance|common)/([\w.-]+schema.json) https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/resources/$1/$2/$3 [R=302,L]
+## Redirect main JSON-LD context for v1.0 (to HEAD before v1.0 release)
+RewriteRule ^v1.0/dcp.jsonld$ https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/HEAD/resources/context/dcp.jsonld [R=302,L]
+
+## Redirect JSON Schemas for 1.0 (to HEAD before v1.0 release)
+RewriteRule ^v1.0/(presentation|issuance|common)/([\w.-]+schema.json) https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/HEAD/resources/$1/$2 [R=302,L]
 
 # Redirect to GH pages
 RewriteRule ^.*$ https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol [R=302,L]


### PR DESCRIPTION
This PR makes the dspace-dcp links point to the correct locations in the github-pages deployment on https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/

Check the rules here:
[https://htaccess.madewithlove.com?share=b22a62ff-8449-4e3f-8e6f-caf537bdaaf3](https://htaccess.madewithlove.com/?share=b22a62ff-8449-4e3f-8e6f-caf537bdaaf3)

cc @wolf4ood 