### PR TITLE
Added dseco rules (access to documentation and ontology files)

### DIFF
--- a/dseco/.htaccess
+++ b/dseco/.htaccess
@@ -9,6 +9,11 @@ RewriteEngine on
 # e.g. https://w3id.org/dseco/ => https://github.com/Orange-OpenSource/dseco
 RewriteRule ^$ https://github.com/Orange-OpenSource/dseco [R=302,L]
 
+# Direct access to versioned ontology file
+# e.g. https://w3id.org/dseco/ontology/dseco-1.5.0 => https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/dseco-1.5.0/dseco.ttl
+# e.g. https://w3id.org/dseco/ontology/dseco-1.5.0/ => https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/dseco-1.5.0/dseco.ttl
+RewriteRule ^ontology/(.*-\d+\.\d+)/?$ https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/$1/dseco.ttl [R=302,L]
+
 # Redirect anything to code repo (i.e. GitHub UI)
 # e.g. https://w3id.org/dseco/lib => https://github.com/Orange-OpenSource/dseco/tree/main/lib
 RewriteRule (.*) https://github.com/Orange-OpenSource/dseco/tree/main/$1 [R=302,L]

--- a/dseco/.htaccess
+++ b/dseco/.htaccess
@@ -14,6 +14,16 @@ RewriteRule ^$ https://github.com/Orange-OpenSource/dseco [R=302,L]
 # e.g. https://w3id.org/dseco/ontology/dseco-1.5.0/ => https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/dseco-1.5.0/dseco.ttl
 RewriteRule ^ontology/(.*-\d+\.\d+)/?$ https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/$1/dseco.ttl [R=302,L]
 
+# Redirect doc/<concept|property> to documentation for user-friendly display of a concept/property
+# See also: https://httpd.apache.org/docs/2.2/rewrite/flags.html#flag_ne
+# e.g. https://w3id.org/dseco/ontology/FQDN => https://orange-opensource.github.io/dseco/DSecO/doc/index-en.html#FQDN
+RewriteRule ^doc/(.+)$ https://orange-opensource.github.io/dseco/DSecO/doc/index-en.html#$1 [R=302,NE,L]
+
+# Redirect for documentation (general case)
+# e.g. https://w3id.org/dseco/doc => https://orange-opensource.github.io/dseco/
+# e.g. https://w3id.org/dseco/doc/ => https://orange-opensource.github.io/dseco/
+RewriteRule ^doc/?$ https://orange-opensource.github.io/dseco/ [R=302,L]
+
 # Redirect anything to code repo (i.e. GitHub UI)
 # e.g. https://w3id.org/dseco/lib => https://github.com/Orange-OpenSource/dseco/tree/main/lib
 RewriteRule (.*) https://github.com/Orange-OpenSource/dseco/tree/main/$1 [R=302,L]

--- a/dseco/.htaccess
+++ b/dseco/.htaccess
@@ -14,6 +14,10 @@ RewriteRule ^$ https://github.com/Orange-OpenSource/dseco [R=302,L]
 # e.g. https://w3id.org/dseco/ontology/dseco-1.5.0/ => https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/dseco-1.5.0/dseco.ttl
 RewriteRule ^ontology/(.*-\d+\.\d+)/?$ https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/$1/dseco.ttl [R=302,L]
 
+# Direct access to named ontology file
+# e.g. https://w3id.org/dseco/ontology/dseco-1.5.0/dseco.ttl => https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/dseco-1.5.0/dseco.ttl
+RewriteRule ^ontology/(.*\.ttl)$ https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/$1 [R=302,L]
+
 # Redirect doc/<concept|property> to documentation for user-friendly display of a concept/property
 # See also: https://httpd.apache.org/docs/2.2/rewrite/flags.html#flag_ne
 # e.g. https://w3id.org/dseco/ontology/FQDN => https://orange-opensource.github.io/dseco/DSecO/doc/index-en.html#FQDN


### PR DESCRIPTION
Please note that the dseco project (https://github.com/Orange-OpenSource/dseco) is work in progress, hence some redirection tests might fail right now (notably for the https://w3id.org/dseco/doc/ link).