### PR TITLE
Update nfdi4cat with new pid4cat redirect

### DIFF
--- a/nfdi4cat/.htaccess
+++ b/nfdi4cat/.htaccess
@@ -5,12 +5,12 @@ RewriteEngine on
 # BASE: Visit homepage
 RewriteRule ^$ https://nfdi4cat.org/ [R=303,L]
 
-# VOC4CAT:TURTLE - individual concept or collection turtle files of latest release
+# VOC4CAT: TURTLE - individual concept or collection turtle files of latest release
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
 RewriteRule "^voc4cat_([0-9]{7,})" https://nfdi4cat.github.io/voc4cat/latest/voc4cat/$1.ttl [R=303,L,NE]
 
-# HTML - documentation
+# VOC4Cat: HTML - documentation
 # redirect to fragment-urls should work fine https://stackoverflow.com/a/2305927
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule "^voc4cat_([0-9]{7,})" "https://nfdi4cat.github.io/voc4cat/latest/voc4cat/index.html#https://w3id.org/nfdi4cat/voc4cat_$1" [R=303,L,NE,NC]

--- a/nfdi4cat/README.md
+++ b/nfdi4cat/README.md
@@ -11,6 +11,7 @@ We develop terminologies and ontologies as base for FAIR data management in cata
 ### Resources that use w3id.org for permanent URIs
 
 * [voc4cat](https://github.com/nfdi4cat/voc4cat) - A SKOS vocabulary for catalysis maintained by NFDI4Cat & friends.
+* [pid4cat](https://github.com/nfdi4cat/pid4cat-model) - A LinkML data model for meta data of pid4cat persistent indentifiers that are based on the handle system.
 
 ### Contacts
 

--- a/nfdi4cat/pid4cat/.htaccess
+++ b/nfdi4cat/pid4cat/.htaccess
@@ -1,0 +1,13 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+# Notes on used flags:
+# NC - sets case-insensitive matching
+# NE - noescape, prevents that special characters, such as & and ?, will be converted to their hexcode equivalent for rules that result in external redirects.
+# L - last, tells mod_rewrite to stop processing further rules sets.
+# R=303 - status code for "See Other". It indicates that the redirects don't link to the requested resource itself, but to another page.
+
+# Order of rules: A more specific rules must come before a more general rule.
+
+RewriteRule "^(.*)$" "https://nfdi4cat.github.io/pid4cat-model/$1" [R=303,L,NE,NC]

--- a/nfdi4cat/pid4cat/README.md
+++ b/nfdi4cat/pid4cat/README.md
@@ -1,0 +1,18 @@
+# pid4cat model
+
+**pid4cat** is a handle-based PID system with a custom API and an underlying LinkML model for PID-related metadata.
+It provides persistent identifiers for samples, devices, and more, supporting early-stage research and integration from local RDM systems like ELNs to the central data repository [Repo4Cat](https://repository.nfdi4cat.org/).
+w3id.org is used to provide permanent URIs for the elements in the metadata model.
+
+- GitHub-repository [https://github.com/nfdi4cat/pid4cat-model](https://github.com/nfdi4cat/pid4cat-model)
+- Documentation [https://nfdi4cat.github.io/pid4cat-model](https://nfdi4cat.github.io/pid4cat-model)
+
+## Redirects to LinkML model elements
+
+- https://w3id.org/nfdi4cat/pid4cat-model/ --> https://w3id.org/nfdi4cat/pid4cat-model/
+
+Future updates will include more specific redirects based on media types for different model representations.
+
+## Contacts
+
+- David Linke (GitHub: [dalito](https://github.com/dalito), email: <david.linke@catalysis.de>)

--- a/nfdi4cat/voc4cat/README.md
+++ b/nfdi4cat/voc4cat/README.md
@@ -1,11 +1,11 @@
-Voc4Cat
-=======
+# Voc4Cat
+
 
 A SKOS vocabulary for catalysis maintained by NFDI4Cat & friends.
 
 - GitHub-repository [https://github.com/nfdi4cat/voc4cat](https://github.com/nfdi4cat/voc4cat)
 
-### Redirects to the latest release
+## Redirects to the latest release
 
 Documentation / vocabulary as one large turtle file
 
@@ -15,7 +15,7 @@ Individual turtle files for concepts or collections
 
 -  https://w3id.org/nfdi4cat/voc4cat_0000002 <BR>-(turtle)-> https://nfdi4cat.github.io/voc4cat/latest/voc4cat/0000002.ttl<BR>-(html)-> https://nfdi4cat.github.io/voc4cat/latest/voc4cat/index.html#https://w3id.org/nfdi4cat/voc4cat_0000002
 
-### Redirects to releases using the release tag
+## Redirects to releases using the release tag
 
 Documentation / vocabulary as one large turtle file
 
@@ -25,7 +25,7 @@ Individual turtle files for concepts or collections
 - https://w3id.org/nfdi4cat/voc4cat/2023-08-17/voc4cat_0000002 <BR>-(turtle)-> https://nfdi4cat.github.io/voc4cat/v2023-08-17/voc4cat/0000002.ttl
     <BR>-(html)-> https://nfdi4cat.github.io/voc4cat/v2023-08-17/voc4cat/index.html#https://w3id.org/nfdi4cat/voc4cat_0000002
 
-### Redirects for "in-development" version
+## Redirects for "in-development" version
 
 *The "in-development" version is built from the most recent commit.*
 
@@ -36,7 +36,7 @@ Documentation / vocabulary as one large turtle file
 Individual turtle files for concepts or collections
 - https://w3id.org/nfdi4cat/voc4cat/dev/voc4cat_0000002 <BR>-(turtle)-> https://nfdi4cat.github.io/voc4cat/dev/voc4cat/0000002.ttl<BR>-(html)-> https://nfdi4cat.github.io/voc4cat/dev/voc4cat/index.html#https://w3id.org/nfdi4cat/voc4cat_0000002
 
-### Contacts
+## Contacts
 
 - David Linke (GitHub: [dalito](https://github.com/dalito), email: <david.linke@catalysis.de>)
 - Nikolaos Moustakas (GitHub: [nmoust](https://github.com/nmoust), email: <nikolaos.moustakas@catalysis.de>)


### PR DESCRIPTION
The PR also adds minor fixes to vo4vcat README

Closes nfdi4cat/pid4cat-model#44