### PR TITLE
feat(dspace): separate redirects to IDSA and EDWG depending on version

### DIFF
--- a/dspace/.htaccess
+++ b/dspace/.htaccess
@@ -1,29 +1,39 @@
+
+AddType application/ld+json .jsonld
+
 RewriteEngine On
 
-# Rules controling links with the /vX.Y/ path segment
+# Rules controlling links with the /vX.Y/ path segment pointing to IDSA
 ## Redirect main JSON-LD context
-RewriteRule ^(head|v[0-9][.][0-9])/context.json https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/$1/common/schema/context.json [R=302,L,QSA]
+RewriteRule ^(head|v[0-9][.][0-9])/context.json https://international-data-spaces-association.github.io/ids-specification/$1/common/schema/context.json [R=302,L,QSA]
 
 ## Redirect JSON Schemas
-RewriteRule ^(head|v[0-9][.][0-9])/(catalog|negotiation|transfer)/([\w.-]+schema.json) https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/$1/$2/message/schema/$3 [R=302,L,QSA]
-RewriteRule ^(head|v[0-9][.][0-9])/common/([\w.-]+schema.json) https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/$1/common/schema/$2 [R=302,L,QSA]
+RewriteRule ^(head|v[0-9][.][0-9])/(catalog|negotiation|transfer)/([\w.-]+schema.json) https://international-data-spaces-association.github.io/ids-specification/$1/$2/message/schema/$3 [R=302,L,QSA]
+RewriteRule ^(head|v[0-9][.][0-9])/common/([\w.-]+schema.json) https://international-data-spaces-association.github.io/ids-specification/$1/common/schema/$2 [R=302,L,QSA]
 
 ## Redirect SHACL Shapes
-RewriteRule ^(head|v[0-9][.][0-9])/(catalog|negotiation|transfer)/([\w.-]+shapes?.ttl) https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/$1/$2/message/shape/$3 [R=302,L,QSA]
-RewriteRule ^(head|v[0-9][.][0-9])/common/([\w.-]+shapes?.ttl) https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/$1/common/shape/$2 [R=302,L,QSA]
+RewriteRule ^(head|v[0-9][.][0-9])/(catalog|negotiation|transfer)/([\w.-]+shapes?.ttl) https://international-data-spaces-association.github.io/ids-specification/$1/$2/message/shape/$3 [R=302,L,QSA]
+RewriteRule ^(head|v[0-9][.][0-9])/common/([\w.-]+shapes?.ttl) https://international-data-spaces-association.github.io/ids-specification/$1/common/shape/$2 [R=302,L,QSA]
 
-# Rules controling links with the /<year>/<number>/ path segment, e.g. /2024-1/
+# Rules controlling links explicitly for release /2024-1/ pointing to IDSA
 ## Redirect main JSON-LD context
-RewriteRule ^([0-9]+)/([0-9]+)/context.json https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/$1-$2/common/schema/context.json [R=302,L,QSA]
+RewriteRule ^2024/1/context.json https://international-data-spaces-association.github.io/ids-specification/2024-1/common/schema/context.json [R=302,L,QSA]
 
 ## Redirect JSON Schemas
-RewriteRule ^([0-9]+)/([0-9]+)/(catalog|negotiation|transfer)/([\w.-]+schema.json) https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/$1-$2/$3/message/schema/$4 [R=302,L,QSA]
-RewriteRule ^([0-9]+)/([0-9]+)/common/([\w.-]+schema.json) https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/$1-$2/common/schema/$3 [R=302,L,QSA]
+RewriteRule ^2024/1/(catalog|negotiation|transfer)/([\w.-]+schema.json) https://international-data-spaces-association.github.io/ids-specification/2024-1/$1/message/schema/$2 [R=302,L,QSA]
+RewriteRule ^2024/1/common/([\w.-]+schema.json) https://international-data-spaces-association.github.io/ids-specification/2024-1/common/schema/$1 [R=302,L,QSA]
 
 ## Redirect SHACL Shapes
-RewriteRule ^([0-9]+)/([0-9]+)/(catalog|negotiation|transfer)/([\w.-]+shapes?.ttl) https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/$1-$2/$3/message/shape/$4 [R=302,L,QSA]
-RewriteRule ^([0-9]+)/([0-9]+)/common/([\w.-]+shapes?.ttl) https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/$1-$2/common/shape/$3 [R=302,L,QSA]
+RewriteRule ^2024/1/(catalog|negotiation|transfer)/([\w.-]+shapes?.ttl) https://international-data-spaces-association.github.io/ids-specification/2024-1/$1/message/shape/$2 [R=302,L,QSA]
+RewriteRule ^2024/1/common/([\w.-]+shapes?.ttl) https://international-data-spaces-association.github.io/ids-specification/2024-1/common/shape/$1 [R=302,L,QSA]
 
+# Rules controlling links explicitly for release /2025-1/ pointing to EDWG
+## Redirect main JSON-LD context
+RewriteRule ^2025/1/context.jsonld https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/message/schema/dspace.jsonld [R=302,L,QSA]
+RewriteRule ^2025/1/odrl.jsonld https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/message/schema/odrl.jsonld [R=302,L,QSA]
+
+## Redirect JSON Schemas
+RewriteRule ^2025/1/(catalog|negotiation|transfer|common)/([\w.-]+schema.json) https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/message/schema/$2 [R=302,L,QSA]
 
 # Redirect to repository
 RewriteRule ^.*$ https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocol [R=302,L,QSA]

--- a/dspace/README.md
+++ b/dspace/README.md
@@ -13,37 +13,43 @@ Find more information at [https://internationaldataspaces.org/](https://internat
 
 ### Redirections:
 1. Links for V0.8:
-* https://w3id.org/dspace/v0.8/context.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/v0.8/common/schema/context.json
-* https://w3id.org/dspace/v0.8/catalog/catalog-schema.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/v0.8/catalog/message/schema/catalog-schema.json
-* https://w3id.org/dspace/v0.8/catalog/dataset-schema.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/v0.8/catalog/message/schema/dataset-schema.json
-* https://w3id.org/dspace/v0.8/negotiation/contract-schema.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/v0.8/negotiation/message/schema/contract-schema.json
-* https://w3id.org/dspace/v0.8/catalog/dcat-shapes.ttl --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/v0.8/catalog/message/shape/dcat-shapes.ttl
-* https://w3id.org/dspace/v0.8/common/definitions.schema.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/v0.8/common/schema/definitions.schema.json
-* https://w3id.org/dspace/v0.8/common/odrl-shapes.ttl --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/v0.8/common/shape/odrl-shapes.ttl
-* https://w3id.org/dspace/v0.8/common/message-shape.ttl --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/v0.8/common/shape/message-shape.ttl
+* https://w3id.org/dspace/v0.8/context.json --> https://international-data-spaces-association.github.io/ids-specification/v0.8/common/schema/context.json
+* https://w3id.org/dspace/v0.8/catalog/catalog-schema.json --> https://international-data-spaces-association.github.io/ids-specification/v0.8/catalog/message/schema/catalog-schema.json
+* https://w3id.org/dspace/v0.8/catalog/dataset-schema.json --> https://international-data-spaces-association.github.io/ids-specification/v0.8/catalog/message/schema/dataset-schema.json
+* https://w3id.org/dspace/v0.8/negotiation/contract-schema.json --> https://international-data-spaces-association.github.io/ids-specification/v0.8/negotiation/message/schema/contract-schema.json
+* https://w3id.org/dspace/v0.8/catalog/dcat-shapes.ttl --> https://international-data-spaces-association.github.io/ids-specification/v0.8/catalog/message/shape/dcat-shapes.ttl
+* https://w3id.org/dspace/v0.8/common/definitions.schema.json --> https://international-data-spaces-association.github.io/ids-specification/v0.8/common/schema/definitions.schema.json
+* https://w3id.org/dspace/v0.8/common/odrl-shapes.ttl --> https://international-data-spaces-association.github.io/ids-specification/v0.8/common/shape/odrl-shapes.ttl
+* https://w3id.org/dspace/v0.8/common/message-shape.ttl --> https://international-data-spaces-association.github.io/ids-specification/v0.8/common/shape/message-shape.ttl
 
 2. Links for the 2024-1 release version:
-* https://w3id.org/dspace/2024/1/context.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2024/1/common/schema/context.json
-* https://w3id.org/dspace/2024/1/catalog/catalog-schema.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2024/1/catalog/message/schema/catalog-schema.json
-* https://w3id.org/dspace/2024/1/catalog/dataset-schema.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2024/1/catalog/message/schema/dataset-schema.json
-* https://w3id.org/dspace/2024/1/negotiation/contract-schema.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2024/1/negotiation/message/schema/contract-schema.json
-* https://w3id.org/dspace/2024/1/catalog/dcat-shapes.ttl --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2024/1/catalog/message/shape/dcat-shapes.ttl
-* https://w3id.org/dspace/2024/1/common/definitions.schema.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2024/1/common/schema/definitions.schema.json
-* https://w3id.org/dspace/2024/1/common/odrl-shapes.ttl --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2024/1/common/shape/odrl-shapes.ttl
-* https://w3id.org/dspace/2024/1/common/version-shape.ttl --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2024/1/common/shape/version-shape.ttl
+* https://w3id.org/dspace/2024/1/context.json --> https://international-data-spaces-association.github.io/ids-specification/2024-1/common/schema/context.json
+* https://w3id.org/dspace/2024/1/catalog/catalog-schema.json --> https://international-data-spaces-association.github.io/ids-specification/2024-1/catalog/message/schema/catalog-schema.json
+* https://w3id.org/dspace/2024/1/catalog/dataset-schema.json --> https://international-data-spaces-association.github.io/ids-specification/2024-1/catalog/message/schema/dataset-schema.json
+* https://w3id.org/dspace/2024/1/negotiation/contract-schema.json --> https://international-data-spaces-association.github.io/ids-specification/2024-1/negotiation/message/schema/contract-schema.json
+* https://w3id.org/dspace/2024/1/catalog/dcat-shapes.ttl --> https://international-data-spaces-association.github.io/ids-specification/2024-1/catalog/message/shape/dcat-shapes.ttl
+* https://w3id.org/dspace/2024/1/common/definitions.schema.json --> https://international-data-spaces-association.github.io/ids-specification/2024-1/common/schema/definitions.schema.json
+* https://w3id.org/dspace/2024/1/common/odrl-shapes.ttl --> https://international-data-spaces-association.github.io/ids-specification/2024-1/common/shape/odrl-shapes.ttl
+* https://w3id.org/dspace/2024/1/common/version-shape.ttl --> https://international-data-spaces-association.github.io/ids-specification/2024-1/common/shape/version-shape.ttl
 
+3. Links for the 2025-1 release version:
+* https://w3id.org/dspace/2025/1/context.jsonld --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/message/schema/dspace.jsonld
+* https://w3id.org/dspace/2025/1/odrl.jsonld --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/message/schema/odrl.jsonld
+* https://w3id.org/dspace/2025/1/catalog/catalog-schema.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/message/schema/catalog-schema.json
+* https://w3id.org/dspace/2025/1/catalog/dataset-schema.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/message/schema/dataset-schema.json
+* https://w3id.org/dspace/2025/1/negotiation/contract-schema.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/message/schema/contract-schema.json
 
-3. Version-independent links:
+4. Version-independent links:
 * https://w3id.org/dspace* --> https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocol
 
 
 ## Contact
 
-This space is administered by:  
+This space is administered by:
 
-**Sebastian Steinbuss**  
-*CTO*  
-[International Data Spaces Association](https://internationaldataspaces.org/)  
-Dortmund, Germany  
-<Sebastian.Steinbuss@internationaldataspaces.org>  
+**Sebastian Steinbuss**
+*CTO*
+[International Data Spaces Association](https://internationaldataspaces.org/)
+Dortmund, Germany
+<Sebastian.Steinbuss@internationaldataspaces.org>
 GitHub: [ssteinbuss](https://github.com/ssteinbuss)


### PR DESCRIPTION
This changes the redirects:

- version 0.8 and before redirect to the IDSA's github pages deployment for the ids-specifications repo
- version 2024-1 as well
- version 2025-1 redirects to the github pages deployed by the EDWG.