### PR TITLE
adding crmrp conf

### DIFF
--- a/crmrp/.htaccess
+++ b/crmrp/.htaccess
@@ -1,0 +1,26 @@
+#
+# ## Contact
+# This space is administered by:
+#
+# Chiara Eva Catalano
+# chiaraeva.catalano@cnr.it
+# GitHub username: chiaraevacataleno
+
+AddType application/rdf+xml .rdf
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .jsonld
+
+# https://w3id.org/crmrp  actual ontology in different syntaxes
+Options +FollowSymLinks
+RewriteEngine on
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://raw.githubusercontent.com/chiaraevacatalano/crmrp/main/rdf/crmrp.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} ^.*application/ld\+json.* 
+RewriteRule ^$ https://raw.githubusercontent.com/chiaraevacatalano/crmrp/main/rdf/crmrp.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.* 
+RewriteRule ^$ https://raw.githubusercontent.com/chiaraevacatalano/crmrp/main/rdf/crmrp.rdf [R=303,L]
+#default response: ttl
+RewriteRule ^$ https://raw.githubusercontent.com/chiaraevacatalano/crmrp/main/rdf/crmrp.ttl [R=303,L]
+
+

--- a/crmrp/README.MD
+++ b/crmrp/README.MD
@@ -1,0 +1,12 @@
+Persistent URIs related to the CRMro Ontology, an ontology to support the digital documentation of the conservation and restoration practice. 
+
+TThis work has been partially supported by Fondazione Cariplo in the framework of the project IncrASTible! The incredible Monastery of Astino Call Per la Cultura 2020, Rif. 2020-3879, June 2022 - June 2024 and is driven by Italian National Research Council - [Istituto di matematica applicata e tecnologie informatiche "Enrico Magenes" (IMATI)](https://imati.cnr.it/)
+
+===================
+
+We have created:
++  `https://w3id.org/crmrp` for actual ontology serialized in different syntaxes.
+
+
+Contacts:
++ Chiara Eva Catalano (CNR-IMATI): github (https://github.com/chiaraevacatalano) - email (chiaraeva.catalano@cnr.it)


### PR DESCRIPTION
Please consider to merge this PR adding content negotiation for https://w3id.org/crmrp uris .

Persistent URIs related to the CRMro Ontology, an ontology to support the digital documentation of the conservation and restoration practice. 

TThis work has been partially supported by Fondazione Cariplo in the framework of the project IncrASTible! The incredible Monastery of Astino Call Per la Cultura 2020, Rif. 2020-3879, June 2022 - June 2024 and is driven by Italian National Research Council - [Istituto di matematica applicata e tecnologie informatiche "Enrico Magenes" (IMATI)](https://imati.cnr.it/)

===================

We have created:
+  `https://w3id.org/crmrp` for actual ontology serialized in different syntaxes.


Contacts:
+ Chiara Eva Catalano (CNR-IMATI): github (https://github.com/chiaraevacatalano) - email (chiaraeva.catalano@cnr.it)
