### PR TITLE
fixing typo nfc --> ncf

### DIFF
--- a/ctp/.htaccess
+++ b/ctp/.htaccess
@@ -44,7 +44,7 @@ RewriteRule ^tabular$ https://docs.google.com/spreadsheets/d/1qAHCUKAJaNcs_p7jHj
 
 ## https://w3id.org/ctp/ncf 
 #RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
-RewriteRule ^nfc$ https://raw.githubusercontent.com/TizianaPasciuto/CTP_Ontology/master/Instances/CTP_Ontology_core_InstanceNCF.ttl [R=303,L]
+RewriteRule ^ncf$ https://raw.githubusercontent.com/TizianaPasciuto/CTP_Ontology/master/Instances/CTP_Ontology_core_InstanceNCF.ttl [R=303,L]
 
 ## https://w3id.org/ctp/santiagodecompostela
 #RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 


### PR DESCRIPTION
Please consider merging this pull. It fixes a typo (https://w3id.org/https://w3id.org/ctp/nfc should be https://w3id.org/ctp/ncf).
Thanks, 
Riccardo