### PR TITLE
fix(dspace): name for odrl profile

### DIFF
--- a/dspace/.htaccess
+++ b/dspace/.htaccess
@@ -30,7 +30,7 @@ RewriteRule ^2024/1/common/([\w.-]+shapes?.ttl) https://international-data-space
 # Rules controlling links explicitly for release /2025-1/ pointing to EDWG
 ## Redirect main JSON-LD context
 RewriteRule ^2025/1/context.jsonld https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/message/schema/dspace.jsonld [R=302,L,QSA]
-RewriteRule ^2025/1/odrl.jsonld https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/message/schema/odrl.jsonld [R=302,L,QSA]
+RewriteRule ^2025/1/odrl-profile.jsonld https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/message/schema/odrl.jsonld [R=302,L,QSA]
 
 ## Redirect JSON Schemas
 RewriteRule ^2025/1/(catalog|negotiation|transfer|common)/([\w.-]+schema.json) https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/message/schema/$2 [R=302,L,QSA]

--- a/dspace/README.md
+++ b/dspace/README.md
@@ -4,15 +4,20 @@ This [W3ID](https://w3id.org) provides a persistent URI namespace for the Datasp
 
 ## Uses
 
-The Dataspace Protocol is a set of specifications designed to facilitate interoperable data sharing between entities governed by usage control and based on Web technologies. These specifications define the schemas and protocols required for entities to publish data, negotiate usage agreements, and access data as part of a federation of technical systems termed a dataspace.
+The Dataspace Protocol is a set of specifications designed to facilitate interoperable data sharing between entities
+governed by usage control and based on Web technologies. These specifications define the schemas and protocols required
+for entities to publish data, negotiate usage agreements, and access data as part of a federation of technical systems
+termed a dataspace.
 
-It has a similar background as the [idsa](../idsa/) namespace but is not exclusively containing IDSA content, therefore requiring the new location.
+It has a similar background as the [idsa](../idsa/) namespace but is not exclusively containing IDSA content, therefore
+requiring the new location.
 
 Find more information at [https://internationaldataspaces.org/](https://internationaldataspaces.org/).
 
-
 ### Redirections:
+
 1. Links for V0.8:
+
 * https://w3id.org/dspace/v0.8/context.json --> https://international-data-spaces-association.github.io/ids-specification/v0.8/common/schema/context.json
 * https://w3id.org/dspace/v0.8/catalog/catalog-schema.json --> https://international-data-spaces-association.github.io/ids-specification/v0.8/catalog/message/schema/catalog-schema.json
 * https://w3id.org/dspace/v0.8/catalog/dataset-schema.json --> https://international-data-spaces-association.github.io/ids-specification/v0.8/catalog/message/schema/dataset-schema.json
@@ -23,6 +28,7 @@ Find more information at [https://internationaldataspaces.org/](https://internat
 * https://w3id.org/dspace/v0.8/common/message-shape.ttl --> https://international-data-spaces-association.github.io/ids-specification/v0.8/common/shape/message-shape.ttl
 
 2. Links for the 2024-1 release version:
+
 * https://w3id.org/dspace/2024/1/context.json --> https://international-data-spaces-association.github.io/ids-specification/2024-1/common/schema/context.json
 * https://w3id.org/dspace/2024/1/catalog/catalog-schema.json --> https://international-data-spaces-association.github.io/ids-specification/2024-1/catalog/message/schema/catalog-schema.json
 * https://w3id.org/dspace/2024/1/catalog/dataset-schema.json --> https://international-data-spaces-association.github.io/ids-specification/2024-1/catalog/message/schema/dataset-schema.json
@@ -33,15 +39,16 @@ Find more information at [https://internationaldataspaces.org/](https://internat
 * https://w3id.org/dspace/2024/1/common/version-shape.ttl --> https://international-data-spaces-association.github.io/ids-specification/2024-1/common/shape/version-shape.ttl
 
 3. Links for the 2025-1 release version:
+
 * https://w3id.org/dspace/2025/1/context.jsonld --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/message/schema/dspace.jsonld
-* https://w3id.org/dspace/2025/1/odrl.jsonld --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/message/schema/odrl.jsonld
+* https://w3id.org/dspace/2025/1/odrl-profile.jsonld --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/message/schema/odrl.jsonld
 * https://w3id.org/dspace/2025/1/catalog/catalog-schema.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/message/schema/catalog-schema.json
 * https://w3id.org/dspace/2025/1/catalog/dataset-schema.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/message/schema/dataset-schema.json
 * https://w3id.org/dspace/2025/1/negotiation/contract-schema.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/message/schema/contract-schema.json
 
 4. Version-independent links:
-* https://w3id.org/dspace* --> https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocol
 
+* https://w3id.org/dspace* --> https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocol
 
 ## Contact
 


### PR DESCRIPTION
There's agreement to rename the json-ld context file for the Dataspace Protocol's profile of ODRL.
relates https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocol/issues/71

@ssteinbuss 