### PR TITLE
Updated W3ID redirects for AlmesCore schema

### DIFF
--- a/AlmesCore/.htaccess
+++ b/AlmesCore/.htaccess
@@ -2,19 +2,19 @@ Options +FollowSymLinks
 RewriteEngine on
 
 # Redirects for individual terms within the schema
-RewriteRule ^data/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#data [R=302,L]
-RewriteRule ^descriptiveStatistics/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#descriptivestatistics [R=302,L]
-RewriteRule ^metadataId/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#metadataid [R=302,L]
-RewriteRule ^productGroup/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#productgroup [R=302,L]
-RewriteRule ^productGroupName/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#productgroupname [R=302,L]
-RewriteRule ^productGroupURI/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#productgroupuri [R=302,L]
-RewriteRule ^productType/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#producttype [R=302,L]
-RewriteRule ^productTypeName/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#producttypename [R=302,L]
-RewriteRule ^productTypeURI/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#producttypeuri [R=302,L]
-RewriteRule ^statisticalMethod/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#statisticalmethod [R=302,L]
-RewriteRule ^theme/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#theme [R=302,L]
-RewriteRule ^hasObservation/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#hasobservation [R=302,L]
-RewriteRule ^Observation/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#observation [R=302,L]
+RewriteRule ^data/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#data [R=302,L]
+RewriteRule ^descriptiveStatistics/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#descriptivestatistics [R=302,L]
+RewriteRule ^metadataId/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#metadataid [R=302,L]
+RewriteRule ^productGroup/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#productgroup [R=302,L]
+RewriteRule ^productGroupName/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#productgroupname [R=302,L]
+RewriteRule ^productGroupURI/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#productgroupuri [R=302,L]
+RewriteRule ^productType/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#producttype [R=302,L]
+RewriteRule ^productTypeName/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#producttypename [R=302,L]
+RewriteRule ^productTypeURI/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#producttypeuri [R=302,L]
+RewriteRule ^statisticalMethod/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#statisticalmethod [R=302,L]
+RewriteRule ^theme/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#theme [R=302,L]
+RewriteRule ^hasObservation/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#hasobservation [R=302,L]
+RewriteRule ^Observation/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#observation [R=302,L]
 
 # Prevent the rule below from catching the /rdf and /shacl paths
 RewriteCond %{REQUEST_URI} !^/(rdf|shacl)/?$ 

--- a/AlmesCore/.htaccess
+++ b/AlmesCore/.htaccess
@@ -1,7 +1,7 @@
 Options +FollowSymLinks
 RewriteEngine on
 
-# Redirects for individual terms within the schema
+# Specific redirects for individual terms within the schema
 RewriteRule ^data/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#data [R=302,L]
 RewriteRule ^descriptiveStatistics/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#descriptivestatistics [R=302,L]
 RewriteRule ^metadataId/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#metadataid [R=302,L]
@@ -19,5 +19,6 @@ RewriteRule ^[Oo]bservation/?$ https://github.com/AlmesCore/Almes-Core/blob/main
 # Exclude /rdf and /shacl paths
 RewriteCond %{REQUEST_URI} !^/(rdf|shacl)/
 
-# Catch-all rule to redirect everything else to the schema page
+# Specific final catch-all for anything else that should point to Terms.md
+RewriteCond %{REQUEST_URI} !^core2024-07-08.md$  # Exclude that page explicitly
 RewriteRule ^(.*)$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md [R=302,L]

--- a/AlmesCore/.htaccess
+++ b/AlmesCore/.htaccess
@@ -13,11 +13,11 @@ RewriteRule ^productTypeName/?$ https://github.com/AlmesCore/Almes-Core/blob/mai
 RewriteRule ^productTypeURI/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#producttypeuri [R=302,L]
 RewriteRule ^statisticalMethod/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#statisticalmethod [R=302,L]
 RewriteRule ^theme/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#theme [R=302,L]
-RewriteRule ^hasObservation/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#hasobservation [R=302,L]
-RewriteRule ^Observation/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#observation [R=302,L]
+RewriteRule ^[Hh]asObservation/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#hasobservation [R=302,L]
+RewriteRule ^[Oo]bservation/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#observation [R=302,L]
 
-# Prevent the rule below from catching the /rdf and /shacl paths
-RewriteCond %{REQUEST_URI} !^/(rdf|shacl)/?$ 
+# Exclude /rdf and /shacl paths
+RewriteCond %{REQUEST_URI} !^/(rdf|shacl)/
 
 # Catch-all rule to redirect everything else to the schema page
 RewriteRule ^(.*)$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md [R=302,L]

--- a/AlmesCore/.htaccess
+++ b/AlmesCore/.htaccess
@@ -2,7 +2,7 @@ Options +FollowSymLinks
 RewriteEngine on
 
 # Redirect deprecated terms to the deprecated elements page
-RewriteRule ^data/?$ https://almescore.github.io/Almes-Core/deprecatedElements.html#metadataid [R=302,L]
+RewriteRule ^data/?$ https://almescore.github.io/Almes-Core/deprecatedElements.html#data [R=302,L]
 RewriteRule ^metadataId/?$ https://almescore.github.io/Almes-Core/deprecatedElements.html#metadataid [R=302,L]
 
 # Redirect active terms to GitHub Pages reference guide

--- a/AlmesCore/.htaccess
+++ b/AlmesCore/.htaccess
@@ -13,6 +13,8 @@ RewriteRule ^productTypeName/?$ https://github.com/AlmesCore/Almes-Core/blob/mai
 RewriteRule ^productTypeURI/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#producttypeuri [R=302,L]
 RewriteRule ^statisticalMethod/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#statisticalmethod [R=302,L]
 RewriteRule ^theme/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#theme [R=302,L]
+RewriteRule ^hasObservation/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#hasobservation [R=302,L]
+RewriteRule ^Observation/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#observation [R=302,L]
 
 # Prevent the rule below from catching the /rdf and /shacl paths
 RewriteCond %{REQUEST_URI} !^/(rdf|shacl)/?$ 

--- a/AlmesCore/.htaccess
+++ b/AlmesCore/.htaccess
@@ -20,4 +20,4 @@ RewriteRule ^Observation/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Te
 RewriteCond %{REQUEST_URI} !^/(rdf|shacl)/?$ 
 
 # Catch-all rule to redirect everything else to the schema page
-RewriteRule ^(.*)$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md [R=302,L]
+RewriteRule ^(.*)$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md [R=302,L]

--- a/AlmesCore/.htaccess
+++ b/AlmesCore/.htaccess
@@ -2,23 +2,23 @@ Options +FollowSymLinks
 RewriteEngine on
 
 # Specific redirects for individual terms within the schema
-RewriteRule ^data/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#data [R=302,L]
-RewriteRule ^descriptiveStatistics/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#descriptivestatistics [R=302,L]
-RewriteRule ^metadataId/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#metadataid [R=302,L]
-RewriteRule ^productGroup/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#productgroup [R=302,L]
-RewriteRule ^productGroupName/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#productgroupname [R=302,L]
-RewriteRule ^productGroupURI/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#productgroupuri [R=302,L]
-RewriteRule ^productType/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#producttype [R=302,L]
-RewriteRule ^productTypeName/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#producttypename [R=302,L]
-RewriteRule ^productTypeURI/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#producttypeuri [R=302,L]
-RewriteRule ^statisticalMethod/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#statisticalmethod [R=302,L]
-RewriteRule ^theme/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#theme [R=302,L]
-RewriteRule ^[Hh]asObservation/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#hasobservation [R=302,L]
-RewriteRule ^[Oo]bservation/?$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md#observation [R=302,L]
+RewriteRule ^data/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#data [R=302,L]
+RewriteRule ^descriptiveStatistics/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#descriptivestatistics [R=302,L]
+RewriteRule ^metadataId/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#metadataid [R=302,L]
+RewriteRule ^productGroup/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#productgroup [R=302,L]
+RewriteRule ^productGroupName/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#productgroupname [R=302,L]
+RewriteRule ^productGroupURI/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#productgroupuri [R=302,L]
+RewriteRule ^productType/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#producttype [R=302,L]
+RewriteRule ^productTypeName/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#producttypename [R=302,L]
+RewriteRule ^productTypeURI/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#producttypeuri [R=302,L]
+RewriteRule ^statisticalMethod/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#statisticalmethod [R=302,L]
+RewriteRule ^theme/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#theme [R=302,L]
+RewriteRule ^[Hh]asObservation/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#hasobservation [R=302,L]
+RewriteRule ^[Oo]bservation/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#observation [R=302,L]
 
 # Exclude /rdf and /shacl paths
 RewriteCond %{REQUEST_URI} !^/(rdf|shacl)/
 
-# Specific final catch-all for anything else that should point to Terms.md
+# Specific final catch-all for anything else that should point to core2024-07-08.md
 RewriteCond %{REQUEST_URI} !^core2024-07-08.md$  # Exclude that page explicitly
-RewriteRule ^(.*)$ https://github.com/AlmesCore/Almes-Core/blob/main/Terms.md [R=302,L]
+RewriteRule ^(.*)$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md [R=302,L]

--- a/AlmesCore/.htaccess
+++ b/AlmesCore/.htaccess
@@ -1,24 +1,22 @@
 Options +FollowSymLinks
 RewriteEngine on
 
-# Specific redirects for individual terms within the schema
-RewriteRule ^data/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#data [R=302,L]
-RewriteRule ^descriptiveStatistics/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#descriptivestatistics [R=302,L]
-RewriteRule ^metadataId/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#metadataid [R=302,L]
-RewriteRule ^productGroup/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#productgroup [R=302,L]
-RewriteRule ^productGroupName/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#productgroupname [R=302,L]
-RewriteRule ^productGroupURI/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#productgroupuri [R=302,L]
-RewriteRule ^productType/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#producttype [R=302,L]
-RewriteRule ^productTypeName/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#producttypename [R=302,L]
-RewriteRule ^productTypeURI/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#producttypeuri [R=302,L]
-RewriteRule ^statisticalMethod/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#statisticalmethod [R=302,L]
-RewriteRule ^theme/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#theme [R=302,L]
-RewriteRule ^[Hh]asObservation/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#hasobservation [R=302,L]
-RewriteRule ^[Oo]bservation/?$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md#observation [R=302,L]
+# Redirect deprecated terms to the deprecated elements page
+RewriteRule ^data/?$ https://almescore.github.io/Almes-Core/#deprecated-data [R=302,L]
+RewriteRule ^metadataId/?$ https://almescore.github.io/Almes-Core/#deprecated-metadataid [R=302,L]
 
-# Exclude /rdf and /shacl paths
-RewriteCond %{REQUEST_URI} !^/(rdf|shacl)/
+# Redirect active terms to GitHub Pages reference guide
+RewriteRule ^descriptiveStatistics/?$ https://almescore.github.io/Almes-Core/#descriptivestatistics [R=302,L]
+RewriteRule ^productGroup/?$ https://almescore.github.io/Almes-Core/#productgroup [R=302,L]
+RewriteRule ^productGroupName/?$ https://almescore.github.io/Almes-Core/#productgroupname [R=302,L]
+RewriteRule ^productGroupURI/?$ https://almescore.github.io/Almes-Core/#productgroupuri [R=302,L]
+RewriteRule ^productType/?$ https://almescore.github.io/Almes-Core/#producttype [R=302,L]
+RewriteRule ^productTypeName/?$ https://almescore.github.io/Almes-Core/#producttypename [R=302,L]
+RewriteRule ^productTypeURI/?$ https://almescore.github.io/Almes-Core/#producttypeuri [R=302,L]
+RewriteRule ^statisticalMethod/?$ https://almescore.github.io/Almes-Core/#statisticalmethod [R=302,L]
+RewriteRule ^theme/?$ https://almescore.github.io/Almes-Core/#theme [R=302,L]
+RewriteRule ^[Hh]asObservation/?$ https://almescore.github.io/Almes-Core/#hasobservation [R=302,L]
+RewriteRule ^[Oo]bservation/?$ https://almescore.github.io/Almes-Core/#observation [R=302,L]
 
-# Specific final catch-all for anything else that should point to core2024-07-08.md
-RewriteCond %{REQUEST_URI} !^core2024-07-08.md$  # Exclude that page explicitly
-RewriteRule ^(.*)$ https://github.com/AlmesCore/Almes-Core/blob/main/core2024-07-08.md [R=302,L]
+# Final catch-all - Redirects to main reference guide
+RewriteRule ^(.*)$ https://almescore.github.io/Almes-Core/ [R=302,L]

--- a/AlmesCore/.htaccess
+++ b/AlmesCore/.htaccess
@@ -2,8 +2,8 @@ Options +FollowSymLinks
 RewriteEngine on
 
 # Redirect deprecated terms to the deprecated elements page
-RewriteRule ^data/?$ https://almescore.github.io/Almes-Core/#deprecated-data [R=302,L]
-RewriteRule ^metadataId/?$ https://almescore.github.io/Almes-Core/#deprecated-metadataid [R=302,L]
+RewriteRule ^data/?$ https://almescore.github.io/Almes-Core/deprecatedElements.html#metadataid [R=302,L]
+RewriteRule ^metadataId/?$ https://almescore.github.io/Almes-Core/deprecatedElements.html#metadataid [R=302,L]
 
 # Redirect active terms to GitHub Pages reference guide
 RewriteRule ^descriptiveStatistics/?$ https://almescore.github.io/Almes-Core/#descriptivestatistics [R=302,L]

--- a/AlmesCore/json/.htaccess
+++ b/AlmesCore/json/.htaccess
@@ -1,5 +1,0 @@
-Options +FollowSymLinks
-RewriteEngine on
-
-# Redirect to the RDF serialization of the schema
-RewriteRule ^$ https://raw.githubusercontent.com/AlmesCore/Almes-Core/main/almes-core-schema.json [R=302,L]


### PR DESCRIPTION
- Redirected deprecated terms (`data`, `metadataId`) to https://almescore.github.io/Almes-Core/deprecatedElements.html
- Updated active term redirects to match the latest GitHub Pages structure
- Ensured no broken links