### PR TITLE
Fixed: rewrite rule for escaping `#`

### DIFF
--- a/spec-ontology/.htaccess
+++ b/spec-ontology/.htaccess
@@ -25,7 +25,7 @@ RewriteCond %{HTTP_ACCEPT} text/n3
 RewriteRule ^doco/.*$ https://docs.crow.nl/spec-ontology/data/spec-doco.ttl [R=302,L]
 
 # Final, matching anything (includes Accept = text/html)
-RewriteRule ^spec/(.*)$ https://docs.crow.nl/spec-ontology/#$1 [R=302,L]
-RewriteRule ^bind/(.*)$ https://docs.crow.nl/spec-ontology/spec-bind/#$1 [R=302,L]
-RewriteRule ^cat/(.*)$ https://docs.crow.nl/spec-ontology/spec-cat/#$1 [R=302,L]
-RewriteRule ^doco/(.*)$ https://docs.crow.nl/spec-ontology/spec-doco/#$1 [R=302,L]
+RewriteRule ^spec/(.*)$ https://docs.crow.nl/spec-ontology/#$1 [R=302,L,NE]
+RewriteRule ^bind/(.*)$ https://docs.crow.nl/spec-ontology/spec-bind/#$1 [R=302,L,NE]
+RewriteRule ^cat/(.*)$ https://docs.crow.nl/spec-ontology/spec-cat/#$1 [R=302,L,NE]
+RewriteRule ^doco/(.*)$ https://docs.crow.nl/spec-ontology/spec-doco/#$1 [R=302,L,NE]


### PR DESCRIPTION
My apologies, the rewrite rule did not escape the `#` character