### PR TITLE
Update gerps/ontology redirects 

### DIFF
--- a/gerps/README.md
+++ b/gerps/README.md
@@ -6,10 +6,17 @@ This repo (which replaces the legacy GerPS-onto) is the home for all GerPS (Germ
 
 Redirects:
 - https://w3id.org/gerps/ontology -> https://fusion-jena.github.io/gerps-onto-landingpage/#
-- https://w3id.org/gerps/ontology/process -> https://fusion-jena.github.io/gerps-ontology/ (with RDF content negotiation)
-- https://w3id.org/gerps/ontology/datafield -> https://fusion-jena.github.io/GerPS-Datafield/ (with RDF content negotiation)
+- https://w3id.org/gerps/ontology/process -> https://fusion-jena.github.io/GerPS-Process/ (with RDF content negotiation and versioning support)
+- https://w3id.org/gerps/ontology/datafield -> https://fusion-jena.github.io/GerPS-Datafield/ (with RDF content negotiation and versioning support)
+- https://w3id.org/gerps/ontology/software -> https://fusion-jena.github.io/GerPS-Software/ (with RDF content negotiation and versioning support)
 
-## Contact 
+### Versioning support
+
+Versioning support is enabled via regex. We currently use Github Pages for hosting our ontologies and thus need to do the redirects for each version here.
+We use the scheme `^w3id.org/gerps/ontology/datafield/(\d+\.\d+\/)?.*$` -> `https://fusion-jena.github.io/GerPS-Datafield/$1index-en.html`
+EG a request for HTML: `w3id.org/gerps/ontology/datafield/1.0/GOD_00000001`->`https://fusion-jena.github.io/GerPS-Datafield/1.0/index-en.html`
+
+## Contact
 | Maintainer           | Institute                           | Email                            | ORCID                                 | Location                                         | Phone | Github-ID                                     |
 | -------------------- | ----------------------------------- | -------------------------------- | ------------------------------------- | ------------------------------------------------ | ----- | --------------------------------------------- |
 | Maximilian Enderling | Friedrich-Schiller-Universität Jena | maximilian.enderling@uni-jena.de | https://orcid.org/0009-0007-5039-8538 | 07743 Jena; Leutragraben 1, JenTower, Room 18N03 | ---   | [BMI24](https://github.com/BMI24)             |

--- a/gerps/ontology/process/.htaccess
+++ b/gerps/ontology/process/.htaccess
@@ -11,36 +11,44 @@ AddType application/ld+json .jsonld
 # Rewrite engine setup
 RewriteEngine On
 
+# Rewrite rule to serve HTML content from the vocabulary URI if requested; including check for german 
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP:Accept-Language} ^de [NC]
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(\d+\.\d+\/)?.*$ https://fusion-jena.github.io/GerPS-Process/$1index-de.html [R=303,L]
+
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://fusion-jena.github.io/gerps-ontology/index.html [R=303,L]
+RewriteRule ^(\d+\.\d+\/)?.*$ https://fusion-jena.github.io/GerPS-Process/$1index-en.html [R=303,L]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^$ https://fusion-jena.github.io/gerps-ontology/ontology.jsonld [R=303,L]
+RewriteRule ^(\d+\.\d+\/)?.*$ https://fusion-jena.github.io/GerPS-Process/$1ontology.jsonld [R=303,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^$ https://fusion-jena.github.io/gerps-ontology/ontology.rdf [R=303,L]
+RewriteRule ^(\d+\.\d+\/)?.*$ https://fusion-jena.github.io/GerPS-Process/$1ontology.rdf [R=303,L]
 
 # Rewrite rule to serve N-Triples content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^$ https://fusion-jena.github.io/gerps-ontology/ontology.nt [R=303,L]
+RewriteRule ^(\d+\.\d+\/)?.*$ https://fusion-jena.github.io/GerPS-Process/$1ontology.nt [R=303,L]
 
 # Rewrite rule to serve TTL content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle 
-RewriteRule ^$ https://fusion-jena.github.io/gerps-ontology/ontology.ttl [R=303,L]
+RewriteRule ^(\d+\.\d+\/)?.*$ https://fusion-jena.github.io/GerPS-Process/$1ontology.ttl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} .+
-RewriteRule ^$ https://fusion-jena.github.io/gerps-ontology/406.html [R=406,L]
+RewriteRule ^$ https://fusion-jena.github.io/GerPS-Process/406.html [R=406,L]
 
 # Default response
 # ---------------------------
 # default response is the documentation page
-RewriteRule ^$ https://fusion-jena.github.io/gerps-ontology/ [R=303,L]
+RewriteRule ^$ https://fusion-jena.github.io/GerPS-Process/index-en.html [R=303,L]

--- a/gerps/ontology/software/.htaccess
+++ b/gerps/ontology/software/.htaccess
@@ -17,38 +17,38 @@ RewriteCond %{HTTP:Accept-Language} ^de [NC]
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(\d+\.\d+\/)?.*$ https://fusion-jena.github.io/GerPS-Datafield/$1index-de.html [R=303,L]
+RewriteRule ^(\d+\.\d+\/)?.*$ https://fusion-jena.github.io/GerPS-Software/$1index-de.html [R=303,L]
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(\d+\.\d+\/)?.*$ https://fusion-jena.github.io/GerPS-Datafield/$1index-en.html [R=303,L]
+RewriteRule ^(\d+\.\d+\/)?.*$ https://fusion-jena.github.io/GerPS-Software/$1index-en.html [R=303,L]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^(\d+\.\d+\/)?.*$ https://fusion-jena.github.io/GerPS-Datafield/$1ontology.jsonld [R=303,L]
+RewriteRule ^(\d+\.\d+\/)?.*$ https://fusion-jena.github.io/GerPS-Software/$1ontology.jsonld [R=303,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^(\d+\.\d+\/)?.*$ https://fusion-jena.github.io/GerPS-Datafield/$1ontology.rdf [R=303,L]
+RewriteRule ^(\d+\.\d+\/)?.*$ https://fusion-jena.github.io/GerPS-Software/$1ontology.rdf [R=303,L]
 
 # Rewrite rule to serve N-Triples content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^(\d+\.\d+\/)?.*$ https://fusion-jena.github.io/GerPS-Datafield/$1ontology.nt [R=303,L]
+RewriteRule ^(\d+\.\d+\/)?.*$ https://fusion-jena.github.io/GerPS-Software/$1ontology.nt [R=303,L]
 
 # Rewrite rule to serve TTL content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle 
-RewriteRule ^(\d+\.\d+\/)?.*$ https://fusion-jena.github.io/GerPS-Datafield/$1ontology.ttl [R=303,L]
+RewriteRule ^(\d+\.\d+\/)?.*$ https://fusion-jena.github.io/GerPS-Software/$1ontology.ttl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} .+
-RewriteRule ^$ https://fusion-jena.github.io/GerPS-Datafield/406.html [R=406,L]
+RewriteRule ^$ https://fusion-jena.github.io/GerPS-Software/406.html [R=406,L]
 
 # Default response
 # ---------------------------
 # default response is the documentation page
-RewriteRule ^$ https://fusion-jena.github.io/GerPS-Datafield/index-en.html [R=303,L]
+RewriteRule ^$ https://fusion-jena.github.io/GerPS-Software/index-en.html [R=303,L]


### PR DESCRIPTION
Update redirect targets for datafield and process ontologies; also enable version in the redirects using regex. Add software ontology redirect too (currently pointing at 404)