### PR TITLE
Request for permanent URI: https://w3id.org/my-ontology

### DIFF
--- a/my-ontology/.htaccess
+++ b/my-ontology/.htaccess
@@ -1,0 +1,18 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# HTML 文件（人類可讀）
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^$ https://umi0529.github.io/my-ontology/index.html [R=303,L]
+
+# Turtle (TTL) 文件（機器可讀）
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^$ https://umi0529.github.io/my-ontology/OntologyID(Anonymous-28751).ttl [R=303,L]
+
+# RDF/XML 文件
+RewriteCond %{HTTP_ACCEPT} application/rdf+xml
+RewriteRule ^$ https://umi0529.github.io/my-ontology/OntologyID(Anonymous-28751).rdf [R=303,L]
+
+# JSON-LD 文件
+RewriteCond %{HTTP_ACCEPT} application/ld+json
+RewriteRule ^$ https://umi0529.github.io/my-ontology/OntologyID(Anonymous-28751).jsonld [R=303,L]

--- a/my-ontology/.htaccess
+++ b/my-ontology/.htaccess
@@ -1,3 +1,6 @@
+# Maintainer: @Umi0529
+# Contact: https://github.com/Umi0529
+
 Options +FollowSymLinks
 RewriteEngine on
 
@@ -16,3 +19,4 @@ RewriteRule ^$ https://umi0529.github.io/my-ontology/OntologyID(Anonymous-28751)
 # JSON-LD 文件
 RewriteCond %{HTTP_ACCEPT} application/ld+json
 RewriteRule ^$ https://umi0529.github.io/my-ontology/OntologyID(Anonymous-28751).jsonld [R=303,L]
+


### PR DESCRIPTION
I would like to request a permanent URI for my ontology.

The new URI: https://w3id.org/my-ontology
It redirects to: https://umi0529.github.io/my-ontology/

The `.htaccess` file has been added to handle content negotiation, allowing different formats to be accessed.

Thank you for your time and consideration!