### PR TITLE
Geomapi Permalink

### DIFF
--- a/geomapi/.htaccess
+++ b/geomapi/.htaccess
@@ -10,6 +10,8 @@
 #
 # Jelle Vermandere
 # GitHub username: JelleKUL
+# Maarten Bassier
+# Github username: Saiga1105
 
 RewriteEngine on
-RewriteRule ^ https://raw.githubusercontent.com/KU-Leuven-Geomatics/geomapi/refs/heads/main/geomapi/ontology/ [R=302,L]
+RewriteRule ^ https://raw.githubusercontent.com/KU-Leuven-Geomatics/geomapi/refs/heads/main/geomapi/ontology/geomapi_ontology.ttl [R=302,L]

--- a/geomapi/.htaccess
+++ b/geomapi/.htaccess
@@ -1,0 +1,15 @@
+# # /examples/
+#
+# A collection of URL redirection examples.
+#
+# https://w3id.org/geomapi/ redirects to
+# https://github.com/perma-id/w3id.org/tree/master/examples
+#
+# ## Contact
+# This space is administered by:  
+#
+# Jelle Vermandere
+# GitHub username: JelleKUL
+
+RewriteEngine on
+RewriteRule ^ https://raw.githubusercontent.com/KU-Leuven-Geomatics/geomapi/refs/heads/main/geomapi/ontology/ [R=302,L]

--- a/geomapi/.htaccess
+++ b/geomapi/.htaccess
@@ -13,15 +13,15 @@ Options +FollowSymLinks
 RewriteEngine on
 
 # Redirect requests for geomapi ontology to the raw GitHub URL
-RewriteRule ^geomapi$ https://raw.githubusercontent.com/KU-Leuven-Geomatics/geomapi/refs/heads/main/geomapi/ontology/geomapi_ontology.ttl [R=303,L]
+RewriteRule ^$ https://raw.githubusercontent.com/KU-Leuven-Geomatics/geomapi/refs/heads/main/geomapi/ontology/geomapi_ontology.ttl [R=303,L]
 
 # Content negotiation for different RDF formats
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^geomapi$ https://raw.githubusercontent.com/KU-Leuven-Geomatics/geomapi/refs/heads/main/geomapi/ontology/geomapi_ontology.ttl [R=303,L]
+RewriteRule ^$ https://raw.githubusercontent.com/KU-Leuven-Geomatics/geomapi/refs/heads/main/geomapi/ontology/geomapi_ontology.ttl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^geomapi$ https://raw.githubusercontent.com/KU-Leuven-Geomatics/geomapi/refs/heads/main/geomapi/ontology/geomapi_ontology.ttl [R=303,L]
+RewriteRule ^$ https://raw.githubusercontent.com/KU-Leuven-Geomatics/geomapi/refs/heads/main/geomapi/ontology/geomapi_ontology.ttl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^geomapi$ https://raw.githubusercontent.com/KU-Leuven-Geomatics/geomapi/refs/heads/main/geomapi/ontology/geomapi_ontology.ttl [R=303,L]
+RewriteRule ^$ https://raw.githubusercontent.com/KU-Leuven-Geomatics/geomapi/refs/heads/main/geomapi/ontology/geomapi_ontology.ttl [R=303,L]
 

--- a/geomapi/.htaccess
+++ b/geomapi/.htaccess
@@ -14,14 +14,3 @@ RewriteEngine on
 
 # Redirect requests for geomapi ontology to the raw GitHub URL
 RewriteRule ^$ https://raw.githubusercontent.com/KU-Leuven-Geomatics/geomapi/refs/heads/main/geomapi/ontology/geomapi_ontology.ttl [R=303,L]
-
-# Content negotiation for different RDF formats
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^$ https://raw.githubusercontent.com/KU-Leuven-Geomatics/geomapi/refs/heads/main/geomapi/ontology/geomapi_ontology.ttl [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^$ https://raw.githubusercontent.com/KU-Leuven-Geomatics/geomapi/refs/heads/main/geomapi/ontology/geomapi_ontology.ttl [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^$ https://raw.githubusercontent.com/KU-Leuven-Geomatics/geomapi/refs/heads/main/geomapi/ontology/geomapi_ontology.ttl [R=303,L]
-

--- a/geomapi/.htaccess
+++ b/geomapi/.htaccess
@@ -1,9 +1,5 @@
-# # /examples/
-#
-# A collection of URL redirection examples.
-#
 # https://w3id.org/geomapi/ redirects to
-# https://github.com/perma-id/w3id.org/tree/master/examples
+# https://raw.githubusercontent.com/KU-Leuven-Geomatics/geomapi/refs/heads/main/geomapi/ontology/geomapi_ontology.ttl
 #
 # ## Contact
 # This space is administered by:  
@@ -13,5 +9,19 @@
 # Maarten Bassier
 # Github username: Saiga1105
 
+Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^ https://raw.githubusercontent.com/KU-Leuven-Geomatics/geomapi/refs/heads/main/geomapi/ontology/geomapi_ontology.ttl [R=302,L]
+
+# Redirect requests for geomapi ontology to the raw GitHub URL
+RewriteRule ^geomapi$ https://raw.githubusercontent.com/KU-Leuven-Geomatics/geomapi/refs/heads/main/geomapi/ontology/geomapi_ontology.ttl [R=303,L]
+
+# Content negotiation for different RDF formats
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^geomapi$ https://raw.githubusercontent.com/KU-Leuven-Geomatics/geomapi/refs/heads/main/geomapi/ontology/geomapi_ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^geomapi$ https://raw.githubusercontent.com/KU-Leuven-Geomatics/geomapi/refs/heads/main/geomapi/ontology/geomapi_ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^geomapi$ https://raw.githubusercontent.com/KU-Leuven-Geomatics/geomapi/refs/heads/main/geomapi/ontology/geomapi_ontology.ttl [R=303,L]
+

--- a/geomapi/README.md
+++ b/geomapi/README.md
@@ -1,8 +1,8 @@
 # GEOMAPI
 
-Top-level domain for the GEOMAPI ontology
+Top-level domain for the GEOMAPI ontology created by the Geomatics research group at KU Leuven.
 
 ## Contacts
 
-Maarten Bassier <maarten.bassier@kuleuven.be>
-Jelle Vermandere <jelle.vermandere@kuleuven.be>
+* Maarten Bassier <maarten.bassier@kuleuven.be>
+* Jelle Vermandere <jelle.vermandere@kuleuven.be>

--- a/geomapi/README.md
+++ b/geomapi/README.md
@@ -1,0 +1,8 @@
+# GEOMAPI
+
+Top-level domain for the GEOMAPI ontology
+
+## Contacts
+
+Maarten Bassier <maarten.bassier@kuleuven.be>
+Jelle Vermandere <jelle.vermandere@kuleuven.be>


### PR DESCRIPTION
Added a readme and .htaccess file to redirect w3id.org/geomapi to out ontology file on github.
(also removed all the unnecessary extra redirects)