### PR TITLE
Add JSON-LD redirect for `fair/fip/terms` URL

### DIFF
--- a/fair/.htaccess
+++ b/fair/.htaccess
@@ -66,6 +66,9 @@ RewriteRule ^fip/terms/$ https://peta-pico.github.io/FAIR-nanopubs/fip/ontology.
 RewriteCond %{HTTP_ACCEPT} application/trig
 RewriteRule ^fip/terms/$ https://peta-pico.github.io/FAIR-nanopubs/fip/ontology.trig [R=302,L,NE]
 
+RewriteCond %{HTTP_ACCEPT} application/ld+json
+RewriteRule ^fip/terms/$ https://peta-pico.github.io/FAIR-nanopubs/fip/ontology.json [R=302,L,NE]
+
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^fip/terms/(.+)$ https://peta-pico.github.io/FAIR-nanopubs/fip/index-en.html#https://w3id.org/fair/fip/terms/$1 [R=302,L,NE]
 


### PR DESCRIPTION
https://w3id.org/fair/fip/terms/ features RDF/XML, TriG, Turtle, N-Triples versions provided via Content Negotiation but seemingly does not provide that same thing for JSON-LD version, even though the JSON-LD version is available.

Creating such a redirect by analogy.