### PR TITLE
Update for final VC 2.0 URLs.

### DIFF
--- a/security/.htaccess
+++ b/security/.htaccess
@@ -2,7 +2,33 @@ Header set Access-Control-Allow-Origin *
 Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^$ https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.html [R=302,L]
+
+# Serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://www.w3.org/2025/credentials/vcdi/vocab/v2/vocabulary.html [R=302,L]
+
+# Serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/json [OR]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://www.w3.org/2025/credentials/vcdi/vocab/v2/vocabulary.jsonld [R=302,L]
+
+# Serve Turtle content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^$ https://www.w3.org/2025/credentials/vcdi/vocab/v2/vocabulary.ttl [R=302,L]
+
+# Serve SVG images if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(image/svg\+xml)
+RewriteCond %{HTTP_ACCEPT} image/svg\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://www.w3.org/2025/credentials/vcdi/vocab/v2/vocabulary.svg [R=302,L]
+
+# Serve default
+RewriteRule ^$ https://www.w3.org/2025/credentials/vcdi/vocab/v2/vocabulary.html [R=302,L]
+
 RewriteRule ^v1$ https://w3c-ccg.github.io/security-vocab/contexts/security-v1.jsonld [R=302,L]
 RewriteRule ^v2$ https://w3c-ccg.github.io/security-vocab/contexts/security-v2.jsonld [R=302,L]
 
@@ -14,17 +40,17 @@ RewriteRule ^v3-unstable$ https://w3c-ccg.github.io/security-vocab/contexts/secu
 
 RewriteRule ^data-integrity$ https://www.w3.org/TR/vc-data-integrity/ [R=302,L]
 RewriteRule ^data-integrity/v1$ https://w3c.github.io/vc-data-integrity/contexts/data-integrity/v1.jsonld [R=302,L]
-RewriteRule ^data-integrity/v2$ https://w3c.github.io/vc-data-integrity/contexts/data-integrity/v2.jsonld [R=302,L]
+RewriteRule ^data-integrity/v2$ https://www.w3.org/2025/credentials/vcdi/context/v2.jsonld [R=302,L]
 
 # https://w3id.org/security/multikey
 
 RewriteRule ^multikey$ https:/w3id.org/security/ [R=302,L]
-RewriteRule ^multikey/v1$ https://w3c.github.io/vc-data-integrity/contexts/multikey/v1.jsonld [R=302,L]
+RewriteRule ^multikey/v1$ https://www.w3.org/2025/credentials/vcdi/multikey/context/v1.jsonld [R=302,L]
 
 # https://w3id.org/security/jwk
 
 RewriteRule ^jwk$ https:/w3id.org/security/ [R=302,L]
-RewriteRule ^jwk/v1$ https://w3c.github.io/vc-data-integrity/contexts/jwk/v1.jsonld [R=302,L]
+RewriteRule ^jwk/v1$ https://www.w3.org/2025/credentials/vcdi/jwk/context/v1.jsonld [R=302,L]
 
 # https://w3id.org/security/suites
 


### PR DESCRIPTION
> [!IMPORTANT]
> Wait to merge until VC side is ready.

- See https://github.com/w3c/verifiable-credentials/issues/61.
- https://w3id.org/security/data-integrity/v2
  - https://www.w3.org/2025/credentials/vcdi/context/v2.jsonld
- https://w3id.org/security# (with content negotiation)
  - https://www.w3.org/2025/credentials/vcdi/vocab/v2/vocabulary.html
  - https://www.w3.org/2025/credentials/vcdi/vocab/v2/vocabulary.jsonld
  - https://www.w3.org/2025/credentials/vcdi/vocab/v2/vocabulary.ttl
  - https://www.w3.org/2025/credentials/vcdi/vocab/v2/vocabulary.svg
- https://w3id.org/security/multikey/v1
  - https://www.w3.org/2025/credentials/vcdi/multikey/context/v1.jsonld
- https://w3id.org/security/jwk/v1
  - https://www.w3.org/2025/credentials/vcdi/jwk/context/v1.jsonld

@iherman please review.