### PR TITLE
Create a permanent identifier for the bess ontology

### DIFF
--- a/bess/.htaccess
+++ b/bess/.htaccess
@@ -1,0 +1,17 @@
+# BESS: Built Environment Scanning System Ontology
+
+# BESS is an open data initiative to share built environment data in a structured way, relating to the dob ontology this ontology specifically describes the systems required for dob.
+#
+# https://w3id.org/bess/ redirects to https://github.com/abc-rp/bess/
+#
+# ## Contact
+# This space is administered by:  
+#
+# Gary Edwards
+# GitHub username: garyedwards
+
+# Nathaniel Hey
+# GitHub username: gnathoi
+
+RewriteEngine on
+RewriteRule ^ https://github.com/abc-rp/bess/ [R=302,L]

--- a/bess/README.md
+++ b/bess/README.md
@@ -1,0 +1,22 @@
+# BESS: Built Environment Scanning System Ontology
+
+BESS is an open data initiative to share built environment data in a structured way, relating to the dob ontology this ontology specifically describes the systems required for dob.
+
+[`https://w3id.org/bess`](https://w3id.org/bess) redirects to [`https://github.com/abc-rp/bess/`](https://github.com/abc-rp/bess/).
+
+## Vocabularies
+
+* Namespace: https://w3id.org/bess/voc#
+* Prefix: bess
+
+## Contact
+
+This space is administered by:  
+
+**Gary Edwards**
+
+GitHub: [garyedwards](https://github.com/garyedwards)
+
+**Nathaniel Hey**
+
+GitHub: [gnathoi](https://github.com/gnathoi)


### PR DESCRIPTION
Dear maintainer,

Could you please create a permanent identifier for the bess ontology?
I hope I provided you with the correct documents via this way.

Currently this project is under development so the redirect just goes to the github page. I will update the .htaccess file when the project is more stable and I have the HTTP + ttl representations backed off a triple store.

Project: Built Environment Scanning System Ontology
Prefix: bess
Namespace: https://w3id.org/bess

Best, Nat
[nathaniel@xri.online](mailto:nathaniel@xri.online)