### PR TITLE
improve redirect rules for BEAM ontologies

### DIFF
--- a/beam/.htaccess
+++ b/beam/.htaccess
@@ -11,5 +11,5 @@
 
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^ https://semsys.ai.wu.ac.at/beam/ [R=302,L]
+RewriteRule ^$ https://semsys.ai.wu.ac.at/beam/ [R=302,L]
 RewriteRule ^(.*)$ https://semantic-systems.org/beam/$1 [R=302,L]


### PR DESCRIPTION
change first RewriteRule to only redirect request to root URL, s.t. the second rule can be applied for paths