### PR TITLE
Create AgentCapabilityOntology

### DIFF
--- a/ontology/AgentCapabilityOntology
+++ b/ontology/AgentCapabilityOntology
@@ -1,0 +1,4 @@
+RewriteEngine On
+
+ # Redirect everything under /AgentCapabilityOntology/ (except the base) to documentation
+ RewriteRule ^.*$ https://cameronmore.github.io/AgentCapabilityOntology/AgentCapabilityOntologyDocs.html [R=302,L]


### PR DESCRIPTION
I am trying to direct w3id.org/ontology/AgentCapabilityOntology to my documentation page and use that as the namespace for new classes, properties, etc, but let me know if I am doing it wrong and how I can fix it.