### PR TITLE
new path for aco

### DIFF
--- a/ontology/AgentCapabilityOntology
+++ b/ontology/AgentCapabilityOntology
@@ -1,4 +1,0 @@
-RewriteEngine On
-
- # Redirect everything under /AgentCapabilityOntology/ (except the base) to documentation
- RewriteRule ^.*$ https://cameronmore.github.io/AgentCapabilityOntology/AgentCapabilityOntologyDocs.html [R=302,L]

--- a/ontology/AgentCapabilityOntology
+++ b/ontology/AgentCapabilityOntology
@@ -1,0 +1,4 @@
+RewriteEngine On
+
+ # Redirect everything under /AgentCapabilityOntology/ (except the base) to documentation
+ RewriteRule ^.*$ https://cameronmore.github.io/AgentCapabilityOntology/AgentCapabilityOntologyDocs.html [R=302,L]

--- a/ontology/AgentCapabilityOntology/.htaccess
+++ b/ontology/AgentCapabilityOntology/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine on
+RewriteRule ^ontology/AgentCapabilityOntology https://cameronmore.github.io/AgentCapabilityOntology/AgentCapabilityOntologyDocs.html [R=303,L]

--- a/ontology/AgentCapabilityOntology/README.md
+++ b/ontology/AgentCapabilityOntology/README.md
@@ -1,0 +1,6 @@
+# Agent Capability Ontology
+
+Maintained at [this repository](https://github.com/cameronmore/AgentCapabilityOntology), this ontology is designed to represent the capabilities of agents and extends Basic Formal Ontology and the Common Core Ontologies.
+
+Current maintainer(s):
+- [Cameron More](https://github.com/cameronmore)


### PR DESCRIPTION
I am trying to direct w3id.org/ontology/AgentCapabilityOntology to my documentation page and use that as the namespace for new classes, properties, etc, but let me know if I am doing it wrong and how I can fix it. If it's easier, I would be fine omitting '/ontology/' from the URI.