### PR TITLE
GerPS Ontologies: fix version redirects

### DIFF
--- a/gerps/ontology/datafield/.htaccess
+++ b/gerps/ontology/datafield/.htaccess
@@ -17,16 +17,16 @@ RewriteCond %{HTTP:Accept-Language} ^de [NC]
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(\d+\.\d+\/)?(.+)$ "https://fusion-jena.github.io/GerPS-Datafield/$1index-de.html#$2" [R=303,L,NE]
 RewriteRule ^(\d+\.\d+\/)?$ "https://fusion-jena.github.io/GerPS-Datafield/$1index-de.html" [R=303,L,NE]
+RewriteRule ^(\d+\.\d+\/)(.*)$ "https://fusion-jena.github.io/GerPS-Datafield/$1index-de.html#$2" [R=303,L,NE]
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(\d+\.\d+\/)?(.+)$ "https://fusion-jena.github.io/GerPS-Datafield/$1index-en.html#$2" [R=303,L,NE]
 RewriteRule ^(\d+\.\d+\/)?$ "https://fusion-jena.github.io/GerPS-Datafield/$1index-en.html" [R=303,L,NE]
+RewriteRule ^(\d+\.\d+\/)(.*)$ "https://fusion-jena.github.io/GerPS-Datafield/$1index-en.html#$2" [R=303,L,NE]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json

--- a/gerps/ontology/process/.htaccess
+++ b/gerps/ontology/process/.htaccess
@@ -17,16 +17,16 @@ RewriteCond %{HTTP:Accept-Language} ^de [NC]
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(\d+\.\d+\/)?(.+)$ "https://fusion-jena.github.io/GerPS-Process/$1index-de.html#$2" [R=303,L,NE]
 RewriteRule ^(\d+\.\d+\/)?$ "https://fusion-jena.github.io/GerPS-Process/$1index-de.html" [R=303,L,NE]
+RewriteRule ^(\d+\.\d+\/)(.*)$ "https://fusion-jena.github.io/GerPS-Process/$1index-de.html#$2" [R=303,L,NE]
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(\d+\.\d+\/)?(.+)$ "https://fusion-jena.github.io/GerPS-Process/$1index-en.html#$2" [R=303,L,NE]
 RewriteRule ^(\d+\.\d+\/)?$ "https://fusion-jena.github.io/GerPS-Process/$1index-en.html" [R=303,L,NE]
+RewriteRule ^(\d+\.\d+\/)(.*)$ "https://fusion-jena.github.io/GerPS-Process/$1index-en.html#$2" [R=303,L,NE]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json

--- a/gerps/ontology/software/.htaccess
+++ b/gerps/ontology/software/.htaccess
@@ -17,16 +17,16 @@ RewriteCond %{HTTP:Accept-Language} ^de [NC]
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(\d+\.\d+\/)?(.+)$ "https://fusion-jena.github.io/GerPS-Software/$1index-de.html#$2" [R=303,L,NE]
 RewriteRule ^(\d+\.\d+\/)?$ "https://fusion-jena.github.io/GerPS-Software/$1index-de.html" [R=303,L,NE]
+RewriteRule ^(\d+\.\d+\/)(.*)$ "https://fusion-jena.github.io/GerPS-Software/$1index-de.html#$2" [R=303,L,NE]
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(\d+\.\d+\/)?(.+)$ "https://fusion-jena.github.io/GerPS-Software/$1index-en.html#$2" [R=303,L,NE]
 RewriteRule ^(\d+\.\d+\/)?$ "https://fusion-jena.github.io/GerPS-Software/$1index-en.html" [R=303,L,NE]
+RewriteRule ^(\d+\.\d+\/)(.*)$ "https://fusion-jena.github.io/GerPS-Software/$1index-en.html#$2" [R=303,L,NE]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json


### PR DESCRIPTION
Sorry for creating a pull request again so soon. With our last commit I broke a case which I had not tested properly, which is now being addressed: 
- eg w3id.org/gerps/ontology/process/1.0/ should redirect to localhost/gerps/ontology/process/1.0/, but is redirecting to https://fusion-jena.github.io/GerPS-Process/index-de.html#1.0/ right now