### PR TITLE
Update gfo-light redirects

### DIFF
--- a/gfo-light/.htaccess
+++ b/gfo-light/.htaccess
@@ -20,19 +20,19 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/$1/ [R=303,L]
+RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/gfo-light/$1/ [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/$1/gfo-light.jsonld [R=303,L]
+RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/gfo-light/$1/gfo-light.jsonld [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/$1/gfo-light.owl [R=303,L]
+RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/gfo-light/$1/gfo-light.owl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/$1/gfo-light.nt [R=303,L]
+RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/gfo-light/$1/gfo-light.nt [R=303,L]
 
-RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/$1/gfo-light.ttl [R=303,L]
+RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/gfo-light/$1/gfo-light.ttl [R=303,L]
 
 ##
 # Rewrite rules for latest version.
@@ -41,19 +41,19 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://onto-med.github.io/gfo-light/latest/ [R=303,L]
+RewriteRule ^$ https://onto-med.github.io/gfo-light/gfo-light/latest/ [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^$ https://onto-med.github.io/gfo-light/latest/gfo-light.jsonld [R=303,L]
+RewriteRule ^$ https://onto-med.github.io/gfo-light/gfo-light/latest/gfo-light.jsonld [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^$ https://onto-med.github.io/gfo-light/latest/gfo-light.owl [R=303,L]
+RewriteRule ^$ https://onto-med.github.io/gfo-light/gfo-light/latest/gfo-light.owl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^$ https://onto-med.github.io/gfo-light/latest/gfo-light.nt [R=303,L]
+RewriteRule ^$ https://onto-med.github.io/gfo-light/gfo-light/latest/gfo-light.nt [R=303,L]
 
-RewriteRule ^$ https://onto-med.github.io/gfo-light/latest/gfo-light.ttl [R=303,L]
+RewriteRule ^$ https://onto-med.github.io/gfo-light/gfo-light/latest/gfo-light.ttl [R=303,L]
 
 ##
 # Rewrite rule to serve classes and properties via RDF browser Rickview.

--- a/gfo-light/README.md
+++ b/gfo-light/README.md
@@ -7,12 +7,12 @@ development and foundation of domain/application ontologies.
 ## Redirects
 
 https://w3id.org/gfo-light redirects to:
-- https://onto-med.github.io/gfo-light/latest/
-- <https://onto-med.github.io/gfo-light/latest/gfo-light.(jsonld|owl|nt|ttl)> (according to HTTP `Accept` header)
+- https://onto-med.github.io/gfo-light/gfo-light/latest/
+- <https://onto-med.github.io/gfo-light/gfo-light/latest/gfo-light.(jsonld|owl|nt|ttl)> (according to HTTP `Accept` header)
 
 https://w3id.org/gfo-light/release/_ redirects to:
-- https://onto-med.github.io/gfo-light/_/
-- <https://onto-med.github.io/gfo-light/_/gfo-light.(jsonld|owl|nt|ttl)> (according to HTTP `Accept` header)
+- https://onto-med.github.io/gfo-light/gfo-light/_/
+- <https://onto-med.github.io/gfo-light/gfo-light/_/gfo-light.(jsonld|owl|nt|ttl)> (according to HTTP `Accept` header)
 
 https://w3id.org/gfo-light/_ redirects to https://top.imise.uni-leipzig.de/ontology/gfo-light/_
 (RDF browser [Rickview](https://github.com/KonradHoeffner/rickview))


### PR DESCRIPTION
This PR contains some minor modifications to the gfo-light configurations. Ontology artefacts now reside in a sub directory.