### PR TITLE
Add gfo-core config

### DIFF
--- a/gfo-core/.htaccess
+++ b/gfo-core/.htaccess
@@ -1,0 +1,61 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .nt
+AddType application/ld+json .jsonld
+
+RewriteEngine on
+
+RewriteRule ^release/?$ "/"
+
+##
+# Rewrite rules for specific versions.
+##
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/gfo-core/$1/ [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/gfo-core/$1/gfo-core.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/gfo-core/$1/gfo-core.owl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/gfo-core/$1/gfo-core.nt [R=303,L]
+
+RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/gfo-core/$1/gfo-core.ttl [R=303,L]
+
+##
+# Rewrite rules for latest version.
+##
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://onto-med.github.io/gfo-light/gfo-core/latest/ [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://onto-med.github.io/gfo-light/gfo-core/latest/gfo-core.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://onto-med.github.io/gfo-light/gfo-core/latest/gfo-core.owl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://onto-med.github.io/gfo-light/gfo-core/latest/gfo-core.nt [R=303,L]
+
+RewriteRule ^$ https://onto-med.github.io/gfo-light/gfo-core/latest/gfo-core.ttl [R=303,L]
+
+##
+# Rewrite rule to serve classes and properties via RDF browser Rickview.
+##
+RewriteRule ^(.+)$ https://top.imise.uni-leipzig.de/ontology/gfo-core/$1 [R=303,L]

--- a/gfo-core/README.md
+++ b/gfo-core/README.md
@@ -1,0 +1,23 @@
+# General Formal Ontology (core version)
+
+GFO-core contains the core entities of the General Formal Ontology (GFO).
+For some use cases, it may be sufficient to use GFO-core alone as a kind of minimal top-level ontology.
+
+## Redirects
+
+https://w3id.org/gfo-core redirects to:
+- https://onto-med.github.io/gfo-light/gfo-core/latest/
+- <https://onto-med.github.io/gfo-light/gfo-core/latest/gfo-core.(jsonld|owl|nt|ttl)> (according to HTTP `Accept` header)
+
+https://w3id.org/gfo-core/release/_ redirects to:
+- https://onto-med.github.io/gfo-light/gfo-core/_/
+- <https://onto-med.github.io/gfo-light/gfo-core/_/gfo-core.(jsonld|owl|nt|ttl)> (according to HTTP `Accept` header)
+
+https://w3id.org/gfo-core/_ redirects to https://top.imise.uni-leipzig.de/ontology/gfo-core/_
+(RDF browser [Rickview](https://github.com/KonradHoeffner/rickview))
+
+## Maintainer
+
+Christoph Beger (https://github.com/ChristophB), on behalf of the Onto-Med research group.
+
+Institute for Medical Informatics, Statistics and Epidemiology, Leipzig University


### PR DESCRIPTION
This PR adds redirects to the General Formal Ontology (core version), which contains the core entities of GFO.