### PR TITLE
Update rewrite rules of gfo-core and gfo-light for release handling

### DIFF
--- a/gfo-core/.htaccess
+++ b/gfo-core/.htaccess
@@ -11,7 +11,7 @@ AddType application/ld+json .jsonld
 
 RewriteEngine on
 
-RewriteRule ^release/?$ "/"
+RewriteRule ^release/?$ release/latest
 
 ##
 # Rewrite rules for specific versions.
@@ -20,19 +20,19 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/gfo-core/$1/ [R=303,L]
+RewriteRule ^release/(.+?)/?$ https://onto-med.github.io/gfo-light/gfo-core/$1/ [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/gfo-core/$1/gfo-core.jsonld [R=303,L]
+RewriteRule ^release/(.+?)/?$ https://onto-med.github.io/gfo-light/gfo-core/$1/gfo-core.jsonld [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/gfo-core/$1/gfo-core.owl [R=303,L]
+RewriteRule ^release/(.+?)/?$ https://onto-med.github.io/gfo-light/gfo-core/$1/gfo-core.owl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/gfo-core/$1/gfo-core.nt [R=303,L]
+RewriteRule ^release/(.+?)/?$ https://onto-med.github.io/gfo-light/gfo-core/$1/gfo-core.nt [R=303,L]
 
-RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/gfo-core/$1/gfo-core.ttl [R=303,L]
+RewriteRule ^release/(.+?)/?$ https://onto-med.github.io/gfo-light/gfo-core/$1/gfo-core.ttl [R=303,L]
 
 ##
 # Rewrite rules for latest version.

--- a/gfo-light/.htaccess
+++ b/gfo-light/.htaccess
@@ -11,7 +11,7 @@ AddType application/ld+json .jsonld
 
 RewriteEngine on
 
-RewriteRule ^release/?$ "/"
+RewriteRule ^release/?$ release/latest
 
 ##
 # Rewrite rules for specific versions.
@@ -20,19 +20,19 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/gfo-light/$1/ [R=303,L]
+RewriteRule ^release/(.+?)/?$ https://onto-med.github.io/gfo-light/gfo-light/$1/ [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/gfo-light/$1/gfo-light.jsonld [R=303,L]
+RewriteRule ^release/(.+?)/?$ https://onto-med.github.io/gfo-light/gfo-light/$1/gfo-light.jsonld [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/gfo-light/$1/gfo-light.owl [R=303,L]
+RewriteRule ^release/(.+?)/?$ https://onto-med.github.io/gfo-light/gfo-light/$1/gfo-light.owl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/gfo-light/$1/gfo-light.nt [R=303,L]
+RewriteRule ^release/(.+?)/?$ https://onto-med.github.io/gfo-light/gfo-light/$1/gfo-light.nt [R=303,L]
 
-RewriteRule ^release/(.+)$ https://onto-med.github.io/gfo-light/gfo-light/$1/gfo-light.ttl [R=303,L]
+RewriteRule ^release/(.+?)/?$ https://onto-med.github.io/gfo-light/gfo-light/$1/gfo-light.ttl [R=303,L]
 
 ##
 # Rewrite rules for latest version.


### PR DESCRIPTION
A trailing slash after a release tag is now properly handled