### PR TITLE
new rewrite rule with location.hash

### DIFF
--- a/g17/.htaccess
+++ b/g17/.htaccess
@@ -19,7 +19,7 @@ RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 RewriteRule ^ontology/?$ https://dhi-roma.github.io/g17-ontology/docs/widoco/doc/index.html  [R=303,L]
-RewriteRule ^ontology(.+)$ https://dhi-roma.github.io/g17-ontology/docs/widoco/doc/index.html$1  [R=303,L]
+RewriteRule ^ontology[/#](.+)$ https://dhi-roma.github.io/g17-ontology/docs/widoco/doc/index.html#$1  [R=303,L,NE]
 
 # Rewrite rule to serve <text/turtle>
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 

--- a/g17/.htaccess
+++ b/g17/.htaccess
@@ -20,6 +20,11 @@ RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 RewriteRule ^ontology/?$ https://dhi-roma.github.io/g17-ontology/docs/widoco/doc/index.html  [R=303,L]
 RewriteRule ^ontology[/#](.+)$ https://dhi-roma.github.io/g17-ontology/docs/widoco/doc/index.html#$1  [R=303,L,NE]
+RewriteRule ^widoco/?$ https://dhi-roma.github.io/g17-ontology/docs/widoco/doc/index.html  [R=303,L]
+RewriteRule ^widoco[/#](.+)$ https://dhi-roma.github.io/g17-ontology/docs/widoco/doc/index.html#$1  [R=303,L,NE]
+RewriteRule ^ontospy/?$ https://dhi-roma.github.io/g17-ontology/docs/ontospy/index.html  [R=303,L]
+
+
 
 # Rewrite rule to serve <text/turtle>
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 


### PR DESCRIPTION
Not sure if that works: redirection with location hash handling:

```RewriteRule ^ontology[/#](.+)$ https://dhi-roma.github.io/g17-ontology/docs/widoco/doc/index.html#$1  [R=303,L,NE]```

Do you have any idea?