### PR TITLE
Add rdf-tensor

### DIFF
--- a/rdf-tensor/.htaccess
+++ b/rdf-tensor/.htaccess
@@ -1,0 +1,34 @@
+Options -MultiViews
+
+RewriteEngine on
+
+AddType text/turtle .ttl
+AddType application/n-triples .nt
+AddType application/x-jelly-rdf .jelly
+
+# Ontology files -- explicit file extension
+RewriteRule ^([a-z]+)\.(ttl|nt|jelly)([#?].*)?$ https://github.com/RDF-tensor/jena-datatensor/releases/download/dev/$1.$2 [R=302,L]
+
+# Ontology files -- content negotiation
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(datatypes|functions|aggregates)/?([#?].*)?$ https://github.com/RDF-tensor/jena-datatensor/releases/download/dev/$1.nt [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^(datatypes|functions|aggregates)/?([#?].*)?$ https://github.com/RDF-tensor/jena-datatensor/releases/download/dev/$1.ttl [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/x-jelly-rdf
+RewriteRule ^(datatypes|functions|aggregates)/?([#?].*)?$ https://github.com/RDF-tensor/jena-datatensor/releases/download/dev/$1.jelly [R=302,L]
+
+# Serve HTML if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^((datatypes|functions|aggregates)/?([#?].*)?)$ https://rdf-tensor.github.io/jena-datatensor/ontology/$1 [R=302,L]
+RewriteRule ^(.*)$ https://rdf-tensor.github.io/jena-datatensor/$1 [R=302,L]
+
+# Redirect by default to the docs
+RewriteRule ^((datatypes|functions|aggregates)/?([#?].*)?)$ https://rdf-tensor.github.io/jena-datatensor/ontology/$1 [R=302,L]
+RewriteRule ^$ https://rdf-tensor.github.io/jena-datatensor/$1 [R=302,L]

--- a/rdf-tensor/README.md
+++ b/rdf-tensor/README.md
@@ -1,0 +1,30 @@
+# Data tensors in RDF
+
+An extension of RDF and SPARQL to process multi-dimensional arrays of numerical data (data tensors).
+
+**[https://w3id.org/rdf-tensor](https://w3id.org/rdf-tensor)**
+
+## Test links
+
+- https://w3id.org/rdf-tensor
+- https://w3id.org/rdf-tensor/aggregates
+- https://w3id.org/rdf-tensor/functions
+- https://w3id.org/rdf-tensor/datatypes
+- https://w3id.org/rdf-tensor/aggregates.nt
+- https://w3id.org/rdf-tensor/functions.nt
+- https://w3id.org/rdf-tensor/datatypes.nt
+- https://w3id.org/rdf-tensor/aggregates.ttl
+- https://w3id.org/rdf-tensor/functions.ttl
+- https://w3id.org/rdf-tensor/datatypes.ttl
+- https://w3id.org/rdf-tensor/aggregates.jelly
+- https://w3id.org/rdf-tensor/functions.jelly
+- https://w3id.org/rdf-tensor/datatypes.jelly
+
+## Maintainers
+
+Piotr Sowiński \
+GitHub: https://github.com/Ostrzyciel \
+ORCID: https://orcid.org/0000-0002-2543-9461
+
+Piotr Marciniak \
+GitHub: https://github.com/cinekele


### PR DESCRIPTION
I'm requesting to register the `rdf-tensor` prefix for an extension of RDF and SPARQL to process multi-dimensional arrays of numerical data (data tensors).

Website: https://rdf-tensor.github.io/jena-datatensor/

I am a co-owner of the original repository: https://github.com/RDF-tensor/jena-datatensor

The other owner is Piotr Marciniak (@cinekele).

The README file includes test links and maintainer information. I tested the .htaccess configuration on a local Apache Server instance and everything seems to work fine.

