### PR TITLE
Add `evr` namespace for the Event Venue Registry

### DIFF
--- a/evr/.htaccess
+++ b/evr/.htaccess
@@ -1,0 +1,16 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Redirects for entities
+#
+# For example, we want https://w3id.org/evr/venue/0000001 to redirect to
+# https://event-venue-registry.github.io/evr/0000001
+
+RewriteRule ^venue/(.+) https://event-venue-registry.github.io/evr/$1
+
+# Redirects for ontology artifacts
+#
+# For example, we want https://w3id.org/evr/ontology/evr.obo to redirect to
+# https://github.com/event-venue-registry/evr/raw/refs/heads/main/output/venues.obo
+
+RewriteRule ^ontology/evr.(.+) https://github.com/event-venue-registry/evr/raw/refs/heads/main/output/venues.$1

--- a/evr/README.md
+++ b/evr/README.md
@@ -1,0 +1,29 @@
+# Event Venue Registry
+
+This [W3ID](https://w3id.org) provides persistent URLs for entities and artifacts in
+the [Event Venue Registry (EVR)](https://github.com/event-venue-registry/evr), a database
+and ontology cataloging and characterizing physical venues at which events (such as conferences)
+can take place.
+
+## Vocabulary
+
+Currently, the EVR auto-generates a site on GitHub. The identifier (`0000001`) representing
+the Cultural Center Altinate/San Gaetano in Padova, Italy can be found on the auto-generated
+site here: https://event-venue-registry.github.io/evr/0000001/
+
+The `.htaccess` file in this directory enables the construction of a PURL for this entity
+like https://w3id.org/evr/venue/0000001.
+
+## Ontology Artifacts
+
+There are OWL and OBO ontology artifacts generated that can be accessed at:
+
+- https://w3id.org/evr/ontology/evr.owl
+- https://w3id.org/evr/ontology/evr.obo
+
+## Contact
+
+Charles Tapley Hoyt<br />
+Email: cthoyt@gmail.com<br />
+GitHub: [@cthoyt](https://github.com/cthoyt)<br />
+ORCID: [0000-0003-4423-4370](https://orcid.org/0000-0003-4423-4370)


### PR DESCRIPTION
This [W3ID](https://w3id.org) provides persistent URLs for entities and artifacts in the [Event Venue Registry (EVR)](https://github.com/event-venue-registry/evr), a database and ontology cataloging and characterizing physical venues at which events (such as conferences) can take place.

This PR adds a configuration under the `evr` namespace for redirecting identifiers in this database and for resolving ontology artifacts generated from this database.