### PR TITLE
Fix for WEHI-RCP

### DIFF
--- a/WEHI-RCP/.htaccess
+++ b/WEHI-RCP/.htaccess
@@ -1,2 +1,2 @@
 RewriteEngine on
-RewriteRule ^ https://wehi-researchcomputing.github.io/ [R=302,L]
+RewriteRule ^(.*)$ https://wehi-researchcomputing.github.io/$1 [R=302,L]


### PR DESCRIPTION
Sorry, my last PR was incorrect. I intended to support `https://w3id.org/WEHI-RCP/<ANYTHING>` to redirect to `https://wehi-researchcomputing.github.io/<ANYTHING>`. Let me know if this rule is incorrect.