### PR TITLE
add ishikawa diagram ontology

### DIFF
--- a/ishikawa-diagram-ontology/.htaccess
+++ b/ishikawa-diagram-ontology/.htaccess
@@ -1,0 +1,69 @@
+Header set Access-Control-Allow-Origin *
+Options -MultiViews
+Options +FollowSymLinks
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
+
+RewriteEngine on
+SetEnvIf Accept ^.+$ SYNTAX=other
+SetEnvIf Accept ^.*application/rdf\+xml.* SYNTAX=rdf
+SetEnvIf Accept ^.*text/turtle.* SYNTAX=ttl
+SetEnvIf Accept ^.*application/json-ld.* SYNTAX=json
+SetEnvIf Accept ^.*application/n-triples.* SYNTAX=nt
+SetEnvIf Accept ^.*text/html.* SYNTAX=html
+SetEnvIf Accept ^\*/\*$ SYNTAX=ttl
+SetEnvIf Request_URI ^.*$ ROOT_URL=https://rexpek.github.io/ishikawa-diagram-ontology
+
+#####     Ontology     #####
+
+# Versioned ontology releases
+RewriteCond %{ENV:SYNTAX} ^(rdf|ttl|json|nt)$
+RewriteRule ^([0-9].[0-9].[0-9])/?$ %{ENV:ROOT_URL}/ishikawa-diagram-ontology/$1/ishikawa-diagram-ontology.%{ENV:SYNTAX} [R=303,L]
+
+# Latest ontology releases
+RewriteCond %{ENV:SYNTAX} ^(rdf|ttl|json|nt)$
+RewriteRule ^/?$ %{ENV:ROOT_URL}/ishikawa-diagram-ontology/latest/ishikawa-diagram-ontology.%{ENV:SYNTAX} [R=303,L]
+
+# Versioned ontology documentation
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^([0-9].[0-9].[0-9])/?$ %{ENV:ROOT_URL}/ishikawa-diagram-ontology/$1/index.html [R=303,L]
+
+# Latest ontology documentation
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^/?$ %{ENV:ROOT_URL}/ishikawa-diagram-ontology/latest/index.html [R=303,L]
+
+# No serialisation available
+RewriteCond %{ENV:SYNTAX} ^other$
+RewriteRule ^/?$ %{ENV:ROOT_URL}/406.html [R=406,L]
+
+#####     PKO modules     #####
+
+# Versioned vocabulary
+RewriteCond %{ENV:SYNTAX} ^(rdf|ttl|json|nt)$
+RewriteRule ^(.+)/([0-9].[0-9].[0-9])/?$ %{ENV:ROOT_URL}/$1/$2/$1.%{ENV:SYNTAX} [R=303,L]
+
+# Latest vocabulary
+RewriteCond %{ENV:SYNTAX} ^(rdf|ttl|json|nt)$
+RewriteRule ^([^/]+)/?$ %{ENV:ROOT_URL}/$1/latest/$1.%{ENV:SYNTAX} [R=303,L]
+
+# Versioned documentation
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^(.+)/([0-9].[0-9].[0-9])/?$ %{ENV:ROOT_URL}/$1/$2/index.html [R=303,L,NE]
+
+# Vocabulary documentation
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^([^/]+)/?$ %{ENV:ROOT_URL}/$1/latest/index.html [R=303,L,NE]
+
+#####     Default     #####
+
+# Specification repo
+RewriteCond %{ENV:MARKER} ^other$
+RewriteRule ^.*$ https://github.com/REXPEK/ishikawa-diagram-ontology [R=303,L]
+
+# Default response
+RewriteRule ^.*$ https://github.com/REXPEK/ishikawa-diagram-ontology [R=303,L]

--- a/ishikawa-diagram-ontology/README.md
+++ b/ishikawa-diagram-ontology/README.md
@@ -1,0 +1,14 @@
+# /ishikawa-diagram-ontology/
+
+This permanent w3id [`https://w3id.org/ishikawa-diagram-ontology/`](https://w3id.org/ishikawa-diagram-ontology/) redirects to the Ishikawa diagram ontology.
+
+The Ishikawa diagram ontology addresses the domain of Ishikawa diagrams which are one of the major tools for Root Cause Analysis (RCA) besides FMEA and Fault Tree Analysis. Ishikawa diagrams are also known as fishbone or cause and effect diagrams (CED). Ishikawa diagrams result from (iterative) workshops and are commonly stored as images which leads to ambiguous interpretations and a lack of machine-readability. Thus, the ontology contains the relevant concepts to describe Ishikawa diagrams as visual artifacts, their encoded data model, and the process the diagrams resulted from according to best practices.
+
+## Contact
+This space is administered by:  
+
+**Christian Fleiner**  
+[KU Leuven](https://www.kuleuven.be/wieiswie/en/person/00160306)  
+<christian.fleiner@kuleuven.be>  
+GitHub: [cfleiner](https://github.com/cfleiner)  
+ORCID: [0000-0003-4280-670X](https://orcid.org/0000-0003-4280-670X)


### PR DESCRIPTION
The Ishikawa diagram ontology addresses the domain of Ishikawa diagrams which are one of the major tools for Root Cause Analysis (RCA) besides FMEA and Fault Tree Analysis. Ishikawa diagrams are also known as fishbone or cause and effect diagrams (CED).