### PR TITLE
Add redirect for orbac.owl

### DIFF
--- a/orbac.owl/.htaccess
+++ b/orbac.owl/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine On
+RewriteRule ^$ https://raw.githubusercontent.com/bleuontologies/orbac.owl/refs/heads/main/orbac.owl [R=302,L]

--- a/orbac.owl/README.md
+++ b/orbac.owl/README.md
@@ -1,0 +1,10 @@
+# ORBAC OWL Redirect
+
+This W3ID is used to provide a persistent URI for the ORBAC ontology in OWL format.
+
+## Maintainer
+
+- GitHub: https://github.com/blueontologies
+- Email: blueontologies@proton.me
+
+The ontology is maintained for the purpose of research reproducibility and semantic web application.


### PR DESCRIPTION
This PR adds a redirect from https://w3id.org/orbac.owl to an ontology hosted on GitHub.