### PR TITLE
Update .htaccess

### DIFF
--- a/arto/.htaccess
+++ b/arto/.htaccess
@@ -9,7 +9,7 @@ RewriteEngine On
 #RewriteCond %{HTTP_ACCEPT} ^.*text/html.* [OR]
 #RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 #RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-#RewriteRule ^$ https://github.com/socialMachineLab/ArtworkOntology/ [R=303,L]
+#RewriteRule ^$ https://rsmsrv01.nci.org.au:8443/ARTO/ [R=303,L]
 
 # Default Rule
-RewriteRule ^$ https://github.com/socialMachineLab/ArtworkOntology/ [R=303,L]
+RewriteRule ^$ https://rsmsrv01.nci.org.au:8443/ARTO/ [R=303,L]


### PR DESCRIPTION
We have deployed the ontology spec to the following site:
<https://rsmsrv01.nci.org.au:8443/ARTO/>

From there, one can access its public repository.