### PR TITLE
New proposed w3id space "standards" for the IEC/ISO SMART

### DIFF
--- a/standards/.htaccess
+++ b/standards/.htaccess
@@ -1,0 +1,10 @@
+# # /standards/
+#
+# Redirections for standards-related resources such as ontologies, data sets, etc.
+#
+# https://w3id.org/standards/ redirects to (WIP)
+#
+# Contacts: see README.md
+
+RewriteEngine on
+RewriteRule ^$ https://www.iso.org/smart [R=302,L]  # Will be edited after first commit demonstrates the process is effective

--- a/standards/README.md
+++ b/standards/README.md
@@ -1,0 +1,21 @@
+# standards
+
+Permanent URLs jointly defined and managed by 4 International Standards Organizations:
+
+- [CEN/CENELEC](https://www.cencenelec.eu/) - European Committee for Standardization & European Electrotechnical Committee for Standardization.
+- [IEC](https://www.iec.ch/) - International Electrotechnical Commission
+- [ISO](https://www.iso.org/home.html) - International Organization for Standardization
+
+URL redirections defined in this directory and subdirectories are
+used by IT solutions specified and implemented by joint projects
+of the above organizations.
+
+The first project to rely on ```w3id``` instead of ```purl``` URLs is
+[IEC/ISO SMART](https://www.iso.org/smart).
+
+Allowed maintainers of these redirects are:
+- Laurent Tettoni, tettoni@iso.org, github: [ltettoni](https://github.com/ltettoni)
+- Stéphane da Costa Silva, sco@iec.ch, github: [stephanecosta](https://github.com/stephanecosta)
+- Mikalai Zubok, Mikalai_Zubok@epam.com, github: [mzubok](https://github.com/mzubok)
+
+See also contacts details in file .htaccess

--- a/standards/README.md
+++ b/standards/README.md
@@ -17,5 +17,3 @@ Allowed maintainers of these redirects are:
 - Laurent Tettoni, tettoni@iso.org, github: [ltettoni](https://github.com/ltettoni)
 - Stéphane da Costa Silva, sco@iec.ch, github: [stephanecosta](https://github.com/stephanecosta)
 - Mikalai Zubok, Mikalai_Zubok@epam.com, github: [mzubok](https://github.com/mzubok)
-
-See also contacts details in file .htaccess


### PR DESCRIPTION
New proposed w3id space "standards" for the IEC/ISO SMART project and other resources used by CEN, CENELEC, IEC and ISO Standards Developing Organizations.