### PR TITLE
Update FIP Wizard redirect

### DIFF
--- a/fip/.htaccess
+++ b/fip/.htaccess
@@ -5,4 +5,4 @@ RewriteRule ^$ https://www.go-fair.org/how-to-go-fair/fair-implementation-profil
 RewriteRule ^\/$ https://w3id.org/fip [R=301,L]
 
 # FIP Wizard projects
-RewriteRule ^wizard/?(.*)$ https://fip-wizard.ds-wizard.org/projects/$1 [R=307,L]
+RewriteRule ^wizard/?(.*)$ https://fip.fair-wizard.com/wizard/projects/$1 [R=307,L]

--- a/fip/README.md
+++ b/fip/README.md
@@ -8,5 +8,5 @@ https://www.go-fair.org/how-to-go-fair/fair-implementation-profile/
 
 ## Contacts
 
-* Barbara Magagna <barbara.magagna@umweltbundesamt.at>
-* Marek Suchánek <marek.suchanek@ds-wizard.org> (GitHub: @MarekSuchanek)
+* Barbara Magagna <barbara@gofair.foundation> (GitHub: [@mabablue](https://github.com/mabablue))
+* Marek Suchánek <marek.suchanek@ds-wizard.org> (GitHub: [@MarekSuchanek]https://github.com/MarekSuchanek)


### PR DESCRIPTION
We are migrating FIP Wizard from https://fip-wizard.ds-wizard.org/wizard/ to https://fip.fair-wizard.com/wizard/ ([FAIR Wizard](https://fair-wizard.com) cloud solution). Contact information has been also updated.