### PR TITLE
Fix mbdo per-directory rewrite rules to support optional slash and subpathsUpdate htaccess

### DIFF
--- a/mbdo/.htaccess
+++ b/mbdo/.htaccess
@@ -1,5 +1,10 @@
-# 开启重写引擎
+# mbdo/.htaccess  —— Make slash optional and proxy subpaths
+
+# 1) Enable rewrite engine
 RewriteEngine On
 
-# 将所有对 /mbdo 的请求永久重定向到你的 GitHub Pages
+# 2) Access /mbdo or /mbdo/ → redirect to GitHub Pages root
+RewriteRule ^$ https://samar-aqlan.github.io/MBDO-ManagingBridgeDataOntology/ [R=301,L]
+
+# 3) Access /mbdo/anything → redirect to the corresponding resource
 RewriteRule ^(.*)$ https://samar-aqlan.github.io/MBDO-ManagingBridgeDataOntology/$1 [R=301,L]


### PR DESCRIPTION
This PR updates the mbdo/.htaccess file to correct Apache’s per-directory rewrite behavior:

- Enable the rewrite engine.
- Redirect both /mbdo and /mbdo/ to the GH Pages root: https://samar-aqlan.github.io/MBDO-ManagingBridgeDataOntology/
- Proxy any subpath under /mbdo/ (e.g., /mbdo/foo/bar.ttl) to the corresponding resource on GH Pages.

Previously, requests to /mbdo (without trailing slash) fell through to a directory index. These rules ensure a 301 redirect for both slash‐and-no‐slash and all subpaths.
