### PR TITLE
SSV: Use custom viewer for HTML requests

### DIFF
--- a/ssv/.htaccess
+++ b/ssv/.htaccess
@@ -20,4 +20,6 @@ RewriteRule ^([a-zA-Z0-9._\/:-]+)$ https://raw.githubusercontent.com/Signature-S
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ([a-zA-Z0-9._\/:-]+)$ https://primal.mdw.ac.at/?obj=https://raw.githubusercontent.com/Signature-Sound-Vienna/data/$1.jsonld [R=303,L]
 
-
+# Fallback rule if a non-supported content type is requested. Return 406 Not Acceptable.
+RewriteCond %{HTTP_ACCEPT} !(application/json|application/ld\+json|text/html)
+RewriteRule ^([a-zA-Z0-9._\/:-]+)$ - [R=406,L]

--- a/ssv/.htaccess
+++ b/ssv/.htaccess
@@ -9,37 +9,15 @@ AddType text/turtle .ttl
 
 RewriteEngine on
 
-# This is a digital musicology dataset (Signature Sound Vienna) served
-# in different RDF serialisations on request
-
-## If the base directory or /latest is used, we'll go to the current version (which is 0.9 in anticipation of a 1.0 release hosted by the university).
-
-## Rules to forward to annotations:
-
-# Rewrite rule to serve RDF/XML content if requested
-# RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-# RewriteRule ^(latest\/)?([a-zA-Z0-9._\/:-]+)$ https://raw.githubusercontent.com/Signature-Sound-Vienna/data/main/$2.xml [R=303,L]
-
-# Rewrite rules to serve JSON-LD if JSON or JSON-LD content if requested
+# Rewrite rule to serve JSON-LD if JSON or JSON-LD content is requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^(latest\/)?([a-zA-Z0-9._\/:-]+)$ https://raw.githubusercontent.com/Signature-Sound-Vienna/data/main/$2.jsonld [R=303,L]
+RewriteRule ^([a-zA-Z0-9._\/:-]+)$ https://raw.githubusercontent.com/Signature-Sound-Vienna/data/$1.jsonld [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/json
-RewriteRule ^(latest\/)?([a-zA-Z0-9._\/:-]+)$ https://raw.githubusercontent.com/Signature-Sound-Vienna/data/main/$2.jsonld [R=303,L]
-
-# Rewrite rule to serve N-Quads content if requested
-# RewriteCond %{HTTP_ACCEPT} application/n-quads
-# RewriteRule ^(latest\/)?([a-zA-Z0-9._\/:-]+)$ https://raw.githubusercontent.com/Signature-Sound-Vienna/data/main/$2.nq [R=303,L]
-
-# Rewrite rule to serve N-Triples content if requested
-# RewriteCond %{HTTP_ACCEPT} application/n-triples
-# RewriteRule ^(latest\/)?([a-zA-Z0-9._\/:-]+)$ https://raw.githubusercontent.com/Signature-Sound-Vienna/data/main/$2.nt [R=303,L]
-
-# Rewrite rule to serve Turtle content if requested
-# RewriteCond %{HTTP_ACCEPT} text/turtle
-# RewriteRule ^(latest\/)?([a-zA-Z0-9._\/:-]+)$ https://raw.githubusercontent.com/Signature-Sound-Vienna/data/main/$2.ttl [R=303,L]
+RewriteRule ^([a-zA-Z0-9._\/:-]+)$ https://raw.githubusercontent.com/Signature-Sound-Vienna/data/$1.jsonld [R=303,L]
 
 # Rewrite rule to forward to the project's custom Platform for Review and Interaction with Music Annotation Linked-data if HTML is requested
 RewriteCond %{HTTP_ACCEPT} text/html
-RewriteRule ^(latest\/)?([a-zA-Z0-9._\/:-]+)$ https://primal.mdw.ac.at/?obj=https://raw.githubusercontent.com/Signature-Sound-Vienna/data/main/$2.jsonld [R=303,L]
+RewriteRule ([a-zA-Z0-9._\/:-]+)$ https://primal.mdw.ac.at/?obj=https://raw.githubusercontent.com/Signature-Sound-Vienna/data/$1.jsonld [R=303,L]
+
 

--- a/ssv/.htaccess
+++ b/ssv/.htaccess
@@ -17,26 +17,29 @@ RewriteEngine on
 ## Rules to forward to annotations:
 
 # Rewrite rule to serve RDF/XML content if requested
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^(latest\/)?([a-zA-Z0-9._\/:-]+)$ https://raw.githubusercontent.com/Signature-Sound-Vienna/data/main/$2.xml [R=303,L]
+# RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+# RewriteRule ^(latest\/)?([a-zA-Z0-9._\/:-]+)$ https://raw.githubusercontent.com/Signature-Sound-Vienna/data/main/$2.xml [R=303,L]
 
-# Rewrite rule to serve JSON-LD content if requested
+# Rewrite rules to serve JSON-LD if JSON or JSON-LD content if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
 RewriteRule ^(latest\/)?([a-zA-Z0-9._\/:-]+)$ https://raw.githubusercontent.com/Signature-Sound-Vienna/data/main/$2.jsonld [R=303,L]
 
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^(latest\/)?([a-zA-Z0-9._\/:-]+)$ https://raw.githubusercontent.com/Signature-Sound-Vienna/data/main/$2.jsonld [R=303,L]
+
 # Rewrite rule to serve N-Quads content if requested
-RewriteCond %{HTTP_ACCEPT} application/n-quads
-RewriteRule ^(latest\/)?([a-zA-Z0-9._\/:-]+)$ https://raw.githubusercontent.com/Signature-Sound-Vienna/data/main/$2.nq [R=303,L]
+# RewriteCond %{HTTP_ACCEPT} application/n-quads
+# RewriteRule ^(latest\/)?([a-zA-Z0-9._\/:-]+)$ https://raw.githubusercontent.com/Signature-Sound-Vienna/data/main/$2.nq [R=303,L]
 
 # Rewrite rule to serve N-Triples content if requested
-RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^(latest\/)?([a-zA-Z0-9._\/:-]+)$ https://raw.githubusercontent.com/Signature-Sound-Vienna/data/main/$2.nt [R=303,L]
+# RewriteCond %{HTTP_ACCEPT} application/n-triples
+# RewriteRule ^(latest\/)?([a-zA-Z0-9._\/:-]+)$ https://raw.githubusercontent.com/Signature-Sound-Vienna/data/main/$2.nt [R=303,L]
 
 # Rewrite rule to serve Turtle content if requested
-RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^(latest\/)?([a-zA-Z0-9._\/:-]+)$ https://raw.githubusercontent.com/Signature-Sound-Vienna/data/main/$2.ttl [R=303,L]
+# RewriteCond %{HTTP_ACCEPT} text/turtle
+# RewriteRule ^(latest\/)?([a-zA-Z0-9._\/:-]+)$ https://raw.githubusercontent.com/Signature-Sound-Vienna/data/main/$2.ttl [R=303,L]
 
-# Rewrite rule to serve HTML content if requested
+# Rewrite rule to forward to the project's custom Platform for Review and Interaction with Music Annotation Linked-data if HTML is requested
 RewriteCond %{HTTP_ACCEPT} text/html
-RewriteRule ^(latest\/)?([a-zA-Z0-9._\/:-]+)$ https://raw.githubusercontent.com/Signature-Sound-Vienna/data/main/$2.html [R=303,L]
+RewriteRule ^(latest\/)?([a-zA-Z0-9._\/:-]+)$ https://primal.mdw.ac.at/?obj=https://raw.githubusercontent.com/Signature-Sound-Vienna/data/main/$2.jsonld [R=303,L]
 


### PR DESCRIPTION
This PR updates /ssv/ to correctly redirect to the Signature Sound Vienna project's custom Platform for Reviewing and Interacting with Music Annotation Linked-data (Primal) viewer when text/html is requested. It also updates redirects when application/json and applicaton/ld+json is requested, and politely declines (406) when other content-types are requested.