### PR TITLE
Add redirect for soil-dsi-bridge ontology

### DIFF
--- a/projects/soil-dsi-bridge/.htaccess
+++ b/projects/soil-dsi-bridge/.htaccess
@@ -1,2 +1,0 @@
-RewriteEngine On
-RewriteRule ^$ https://guapi-d.github.io/soil-dsi-bridge/soil-dsi-bridge.ttl [R=302,L]

--- a/projects/soil-dsi-bridge/.htaccess
+++ b/projects/soil-dsi-bridge/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine On
+RewriteRule ^$ https://guapi-d.github.io/soil-dsi-bridge/soil-dsi-bridge.ttl [R=302,L]

--- a/soil-dsi-bridge/.htaccess
+++ b/soil-dsi-bridge/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine On
+RewriteRule ^(.*)$ https://guapi-d.github.io/soil-dsi-bridge/$1 [R=302,L]

--- a/soil-dsi-bridge/README.md
+++ b/soil-dsi-bridge/README.md
@@ -1,0 +1,7 @@
+# SOIL ↔ D‑SI Bridge
+
+This W3ID is maintained by Zeyuan D.
+
+Redirects to: https://guapi-d.github.io/soil-dsi-bridge/
+
+Maintainer: https://github.com/guapi-d


### PR DESCRIPTION
This pull request adds a redirect for https://w3id.org/projects/soil-dsi-bridge
pointing to https://guapi-d.github.io/soil-dsi-bridge/soil-dsi-bridge.ttl
