### PR TITLE
Add redirect for fyp-ontology

### DIFF
--- a/fyp-ontology/.htaccess
+++ b/fyp-ontology/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine On
+RewriteRule ^$ https://raw.githubusercontent.com/your-username/repo-name/main/university.owl [R=303,L]


### PR DESCRIPTION
This adds a permanent redirect for [fyp ontology]() to:
`https://raw.githubusercontent.com/iharoonasim/semantic-web/main/semantic123%20(1).owl`