### PR TITLE
Add persistent identifier for elita ontology

### DIFF
--- a/elita/.htaccess
+++ b/elita/.htaccess
@@ -1,0 +1,11 @@
+# Name of the project: elita
+# Description: Emotions in Italian
+# Contact/Mantainer:
+# Eliana Di Palma
+
+RewriteEngine On
+
+
+# Redirect request to versioned/latest Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^([0-9]\.[0-9](?:\.[0-9])?)/?$ https://github.com/elianadipalma/ELIta/blob/main/Ontology/elita.ttl [R=303,NE,L]

--- a/elita/README.md
+++ b/elita/README.md
@@ -1,0 +1,14 @@
+## ELITA Persistent Identifier
+
+This w3id entry redirects to the ELITA ontology hosted on GitHub.
+
+### Redirect
+
+`https://w3id.org/elita` →  
+`https://github.com/elianadipalma/ELIta/blob/main/Ontology/elita.ttl`
+
+### Maintainer
+
+Eliana Di Palma  
+Email: eliana.dipalma [at] unito [dot] it  
+GitHub: [@elianadipalma](https://github.com/elianadipalma)


### PR DESCRIPTION
This PR adds a redirection for https://w3id.org/elita to the ELITA ontology hosted at:
https://github.com/elianadipalma/ELIta/blob/main/Ontology/elita.ttl

Includes:
- .htaccess for redirect
- README.md with maintainer information

Maintainer: Eliana Di Palma – eliana.dipalma [at] unito [dot] it
