### PR TITLE
Add /healthdata namespace

### DIFF
--- a/healthdata/.htaccess
+++ b/healthdata/.htaccess
@@ -1,0 +1,8 @@
+Options -MultiViews
+RewriteEngine on
+
+# Redirect the root /healthdata path to the official website
+RedirectMatch 302 ^/healthdata/?$ https://healthdata.nl
+
+# Redirect everything else under /healthdata/* to /health-ri/*
+RewriteRule ^healthdata/(.*)$ /health-ri/$1 [R=302,L]

--- a/healthdata/README.md
+++ b/healthdata/README.md
@@ -1,0 +1,31 @@
+# Health-RI & HealthData
+
+[**Health-RI**](https://www.health-ri.nl/) is a Dutch national initiative that supports the development of a federated infrastructure for responsible and efficient reuse of health data. Our mission is to enable personalized medicine, health innovations, and improved healthcare outcomes by making health data more accessible, reusable, and FAIR (Findable, Accessible, Interoperable, and Reusable).
+
+> **Note:** The term **HealthData** is used throughout our ecosystem to refer to the core domain of data that Health-RI supports. As such, `HealthData` is considered an integral part of the Health-RI namespace and is directly aligned with its mission and technical infrastructure.
+
+## What We Do
+
+Health-RI brings together stakeholders from research, healthcare, policy, and industry to co-create an integrated health data infrastructure in the Netherlands. We focus on:
+
+- Building a national infrastructure for health data reuse
+- Supporting personalized health and medicine initiatives
+- Promoting FAIR data principles and data stewardship
+- Facilitating collaboration across sectors and domains
+
+To learn more about our mission and activities, visit our [About page](https://www.health-ri.nl/over-health-ri).
+
+## Meet the Team
+
+Health-RI is driven by a passionate and multidisciplinary team committed to advancing health data reuse in the Netherlands.  
+🔗 [Meet the Health-RI Team](https://www.health-ri.nl/over-ons/ontmoet-het-team)
+
+For more information about our organizational structure, visit our [Organization page](https://www.health-ri.nl/over-ons/organisatie).
+
+## Maintainers
+
+- [Ana Konrad](https://github.com/konradana)
+- [Hannah Neikes](https://github.com/hneikes)
+- [Niek van Ulzen](https://github.com/nrvanulzen)
+- [Pedro Paulo F. Barcelos](https://github.com/pedropaulofb)
+- [Reinier Groeneveld](https://github.com/reiniergr)


### PR DESCRIPTION
This PR adds a new folder for the `/healthdata` namespace.

- Redirects were tested using [htaccess.madewithlove.com](https://htaccess.madewithlove.com/)
- The [README file](https://github.com/Health-RI/health-ri-metadata/blob/develop/README.md#health-ri) explains the connection between `healthdata` and Health-RI
- The same README lists the responsible maintainers with links to their GitHub profiles

Thanks!
