### PR TITLE
Fix redirect for /healthdata/* paths

### DIFF
--- a/healthdata/.htaccess
+++ b/healthdata/.htaccess
@@ -4,5 +4,5 @@ RewriteEngine on
 # Redirect the root /healthdata path to the official website
 RedirectMatch 302 ^/healthdata/?$ https://healthdata.nl
 
-# Redirect everything else under /healthdata/* to /health-ri/*
-RewriteRule ^healthdata/(.*)$ /health-ri/$1 [R=302,L]
+# Redirect everything else to /health-ri/*
+RewriteRule ^(.*)$ /health-ri/$1 [R=302,L]


### PR DESCRIPTION
This PR updates the .htaccess file in the /healthdata folder to ensure all subpaths (e.g., /healthdata/metadata) correctly redirect to the corresponding /health-ri/* paths.