### PR TITLE
Add Iprok ontology to w3id.org

### DIFF
--- a/iprok/.htaccess
+++ b/iprok/.htaccess
@@ -1,54 +1,36 @@
 # Apache .htaccess file for w3id.org/iprok/
-# This file should be placed in the 'iprok' directory (or your chosen ontology ID directory)
-# within the perma-id/w3id.org GitHub repository.
-
-# Enable symbolic link following, if necessary (often a default or server-wide setting).
 Options +FollowSymLinks
-
-# Enable the rewrite engine.
 RewriteEngine On
 
 # --- Rule for the base PURL (e.g., https://w3id.org/iprok/) ---
-# This redirects requests for the base PURL of the ontology to its main HTML documentation.
-# R=308: Permanent Redirect, indicating the resource itself (the ontology's conceptual URI)
-#        can be found at the target URL for human consumption.
-# L: Last rule; if this rule matches, no further rules are processed.
+# Redirects to the main HTML documentation.
 RewriteRule ^/?$ https://konevenkatesh.github.io/IprokDoc/main.html [R=308,L]
 
-
 # --- Rules for versioned PURLs (e.g., https://w3id.org/iprok/1.0/) ---
-# These rules handle content negotiation for requests that include a version number.
-# The version pattern ([0-9]+\.[0-9]+(?:\.[0-9]+)?) captures versions like "1.0", "2.1", "1.0.3".
-# The captured version is available as $1.
+# The version pattern is captured as $1, e.g., "1.0" or "1.0.3".
 #
 # IMPORTANT NOTE ON TARGET URLs AND VERSIONING:
-# The target GitHub URLs in the rules below (e.g., .../IprokDoc/iprok.owl) currently DO NOT
-# use the captured version $1 in their path. This means that any version specified in the
-# PURL (e.g., /iprok/1.0/, /iprok/1.1/) will redirect to the SAME "latest" files located
-# directly under your /IprokDoc/ directory on GitHub Pages.
-#
-# If you later implement version-specific directories on your GitHub Pages site
-# (e.g., https://konevenkatesh.github.io/IprokDoc/1.0/iprok.owl),
-# YOU MUST UPDATE these target URLs to include $1. For example:
-# https://konevenkatesh.github.io/IprokDoc/$1/iprok.owl
-#
-# R=303: See Other. This is the appropriate redirect code for providing a specific
-#        representation of a resource (the ontology version) based on content negotiation.
-# NE: No Escape. Prevents Apache from escaping special characters in the redirect URL.
-# L: Last rule.
+# The target GitHub URLs below currently DO NOT use the captured version $1
+# in their path. This means all versioned PURLs will point to the same "latest" files.
+# If you set up versioned directories on GitHub (e.g., /IprokDoc/1.0/ontology.owl),
+# you MUST update the target URLs to include $1.
 
 # If Accept: application/rdf+xml is requested for a versioned PURL
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^([0-9]+\.[0-9]+(?:\.[0-9]+)?)/?$ https://konevenkatesh.github.io/IprokDoc/iprok.owl [R=303,NE,L]
+RewriteRule ^([0-9]+\.[0-9]+(?:\.[0-9]+)?)/?$ https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.owl [R=303,NE,L]
 
 # If Accept: text/turtle is requested for a versioned PURL
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^([0-9]+\.[0-9]+(?:\.[0-9]+)?)/?$ https://konevenkatesh.github.io/IprokDoc/iprok.ttl [R=303,NE,L]
+RewriteRule ^([0-9]+\.[0-9]+(?:\.[0-9]+)?)/?$ https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.ttl [R=303,NE,L]
 
 # If Accept: application/ld+json is requested for a versioned PURL
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^([0-9]+\.[0-9]+(?:\.[0-9]+)?)/?$ https://konevenkatesh.github.io/IprokDoc/iprok.jsonld [R=303,NE,L]
+RewriteRule ^([0-9]+\.[0-9]+(?:\.[0-9]+)?)/?$ https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.jsonld [R=303,NE,L]
 
-# Default rule for a versioned PURL (if no specific Accept header above matches, or if Accept: text/html)
-# This redirects to the main HTML documentation. It acts as a fallback for versioned PURLs.
+# If Accept: application/n-triples is requested for a versioned PURL
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^([0-9]+\.[0-9]+(?:\.[0-9]+)?)/?$ https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.nt [R=303,NE,L]
+
+# Default for a versioned PURL (if no specific Accept header above matches, or if Accept: text/html)
+# Redirects to the main HTML documentation.
 RewriteRule ^([0-9]+\.[0-9]+(?:\.[0-9]+)?)/?$ https://konevenkatesh.github.io/IprokDoc/main.html [R=303,NE,L]

--- a/iprok/.htaccess
+++ b/iprok/.htaccess
@@ -1,0 +1,54 @@
+# Apache .htaccess file for w3id.org/iprok/
+# This file should be placed in the 'iprok' directory (or your chosen ontology ID directory)
+# within the perma-id/w3id.org GitHub repository.
+
+# Enable symbolic link following, if necessary (often a default or server-wide setting).
+Options +FollowSymLinks
+
+# Enable the rewrite engine.
+RewriteEngine On
+
+# --- Rule for the base PURL (e.g., https://w3id.org/iprok/) ---
+# This redirects requests for the base PURL of the ontology to its main HTML documentation.
+# R=308: Permanent Redirect, indicating the resource itself (the ontology's conceptual URI)
+#        can be found at the target URL for human consumption.
+# L: Last rule; if this rule matches, no further rules are processed.
+RewriteRule ^/?$ https://konevenkatesh.github.io/IprokDoc/main.html [R=308,L]
+
+
+# --- Rules for versioned PURLs (e.g., https://w3id.org/iprok/1.0/) ---
+# These rules handle content negotiation for requests that include a version number.
+# The version pattern ([0-9]+\.[0-9]+(?:\.[0-9]+)?) captures versions like "1.0", "2.1", "1.0.3".
+# The captured version is available as $1.
+#
+# IMPORTANT NOTE ON TARGET URLs AND VERSIONING:
+# The target GitHub URLs in the rules below (e.g., .../IprokDoc/iprok.owl) currently DO NOT
+# use the captured version $1 in their path. This means that any version specified in the
+# PURL (e.g., /iprok/1.0/, /iprok/1.1/) will redirect to the SAME "latest" files located
+# directly under your /IprokDoc/ directory on GitHub Pages.
+#
+# If you later implement version-specific directories on your GitHub Pages site
+# (e.g., https://konevenkatesh.github.io/IprokDoc/1.0/iprok.owl),
+# YOU MUST UPDATE these target URLs to include $1. For example:
+# https://konevenkatesh.github.io/IprokDoc/$1/iprok.owl
+#
+# R=303: See Other. This is the appropriate redirect code for providing a specific
+#        representation of a resource (the ontology version) based on content negotiation.
+# NE: No Escape. Prevents Apache from escaping special characters in the redirect URL.
+# L: Last rule.
+
+# If Accept: application/rdf+xml is requested for a versioned PURL
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^([0-9]+\.[0-9]+(?:\.[0-9]+)?)/?$ https://konevenkatesh.github.io/IprokDoc/iprok.owl [R=303,NE,L]
+
+# If Accept: text/turtle is requested for a versioned PURL
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^([0-9]+\.[0-9]+(?:\.[0-9]+)?)/?$ https://konevenkatesh.github.io/IprokDoc/iprok.ttl [R=303,NE,L]
+
+# If Accept: application/ld+json is requested for a versioned PURL
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^([0-9]+\.[0-9]+(?:\.[0-9]+)?)/?$ https://konevenkatesh.github.io/IprokDoc/iprok.jsonld [R=303,NE,L]
+
+# Default rule for a versioned PURL (if no specific Accept header above matches, or if Accept: text/html)
+# This redirects to the main HTML documentation. It acts as a fallback for versioned PURLs.
+RewriteRule ^([0-9]+\.[0-9]+(?:\.[0-9]+)?)/?$ https://konevenkatesh.github.io/IprokDoc/main.html [R=303,NE,L]

--- a/iprok/.htaccess
+++ b/iprok/.htaccess
@@ -17,19 +17,19 @@ RewriteRule ^/?$ https://konevenkatesh.github.io/IprokDoc/main.html [R=308,L]
 
 # If Accept: application/rdf+xml is requested for a versioned PURL
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^([0-9]+\.[0-9]+(?:\.[0-9]+)?)/?$ https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.owl [R=303,NE,L]
+RewriteRule ^([0-9]+\.[0-9]+(?:\.[0-9]+)?)/?$ https://konevenkatesh.github.io/IprokDoc/ontology.owl [R=303,NE,L]
 
 # If Accept: text/turtle is requested for a versioned PURL
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^([0-9]+\.[0-9]+(?:\.[0-9]+)?)/?$ https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.ttl [R=303,NE,L]
+RewriteRule ^([0-9]+\.[0-9]+(?:\.[0-9]+)?)/?$ https://konevenkatesh.github.io/IprokDoc/ontology.ttl [R=303,NE,L]
 
 # If Accept: application/ld+json is requested for a versioned PURL
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^([0-9]+\.[0-9]+(?:\.[0-9]+)?)/?$ https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.jsonld [R=303,NE,L]
+RewriteRule ^([0-9]+\.[0-9]+(?:\.[0-9]+)?)/?$ https://konevenkatesh.github.io/IprokDoc/ontology.jsonld [R=303,NE,L]
 
 # If Accept: application/n-triples is requested for a versioned PURL
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^([0-9]+\.[0-9]+(?:\.[0-9]+)?)/?$ https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.nt [R=303,NE,L]
+RewriteRule ^([0-9]+\.[0-9]+(?:\.[0-9]+)?)/?$ https://konevenkatesh.github.io/IprokDoc/ontology.nt [R=303,NE,L]
 
 # Default for a versioned PURL (if no specific Accept header above matches, or if Accept: text/html)
 # Redirects to the main HTML documentation.

--- a/iprok/readme.md
+++ b/iprok/readme.md
@@ -1,0 +1,57 @@
+# Iprok Ontology PURL Redirection (w3id.org/iprok/)
+
+This directory configures the persistent URL (PURL) `https://w3id.org/iprok/` for the Iprok Ontology. It uses an `.htaccess` file to redirect requests to the appropriate ontology serializations or HTML documentation hosted on GitHub.
+
+## Persistent URL (PURL)
+
+The primary persistent URL for the Iprok Ontology is:
+
+**`https://w3id.org/iprok/`**
+
+## Redirection Behavior
+
+Accessing the PURL `https://w3id.org/iprok/` (or versioned PURLs like `https://w3id.org/iprok/1.0/`) will result in the following redirections based on HTTP content negotiation:
+
+1.  **HTML Documentation (Default for Browsers):**
+
+    - Requests with an `Accept` header of `text/html` (typical for web browsers) or when no specific content type is strongly preferred.
+    - **Redirects to:** `https://konevenkatesh.github.io/IprokDoc/main.html`
+
+2.  **Turtle (TTL):**
+
+    - Requests with an `Accept` header of `text/turtle`.
+    - **Redirects to:** `https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.ttl`
+
+3.  **RDF/XML (OWL):**
+
+    - Requests with an `Accept` header of `application/rdf+xml`.
+    - **Redirects to:** `https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.owl`
+
+4.  **JSON-LD:**
+
+    - Requests with an `Accept` header of `application/ld+json`.
+    - **Redirects to:** `https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.jsonld`
+
+5.  **N-Triples (NT):**
+    - Requests with an `Accept` header of `application/n-triples`.
+    - **Redirects to:** `https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.nt`
+
+## Ontology Files & Documentation Hosted At:
+
+The source files for the Iprok ontology and its documentation are hosted on GitHub:
+
+- **HTML Documentation:** [https://konevenkatesh.github.io/IprokDoc/main.html](https://konevenkatesh.github.io/IprokDoc/main.html)
+- **Turtle (TTL):** [https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.ttl](https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.ttl)
+- **RDF/XML (OWL):** [https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.owl](https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.owl)
+- **JSON-LD:** [https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.jsonld](https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.jsonld)
+- **N-Triples (NT):** [https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.nt](https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.nt)
+
+## Configuration
+
+The redirection logic is managed by the `.htaccess` file located in this directory (`iprok/.htaccess` within the `perma-id/w3id.org` GitHub repository).
+
+## Maintainer / Contact
+
+- Kone Venkatesh
+- GitHub: [konevenkatesh](https://github.com/konevenkatesh)
+  _(You can add your email or other contact details here if you wish)_

--- a/iprok/readme.md
+++ b/iprok/readme.md
@@ -13,38 +13,34 @@ The primary persistent URL for the Iprok Ontology is:
 Accessing the PURL `https://w3id.org/iprok/` (or versioned PURLs like `https://w3id.org/iprok/1.0/`) will result in the following redirections based on HTTP content negotiation:
 
 1.  **HTML Documentation (Default for Browsers):**
-
-    - Requests with an `Accept` header of `text/html` (typical for web browsers) or when no specific content type is strongly preferred.
-    - **Redirects to:** `https://konevenkatesh.github.io/IprokDoc/main.html`
+    * Requests with an `Accept` header of `text/html` (typical for web browsers) or when no specific content type is strongly preferred.
+    * Redirects to the main HTML documentation hosted on GitHub Pages.
 
 2.  **Turtle (TTL):**
-
-    - Requests with an `Accept` header of `text/turtle`.
-    - **Redirects to:** `https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.ttl`
+    * Requests with an `Accept` header of `text/turtle`.
+    * Redirects to the `ontology.ttl` file hosted on GitHub (raw content).
 
 3.  **RDF/XML (OWL):**
-
-    - Requests with an `Accept` header of `application/rdf+xml`.
-    - **Redirects to:** `https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.owl`
+    * Requests with an `Accept` header of `application/rdf+xml`.
+    * Redirects to the `ontology.owl` file hosted on GitHub (raw content).
 
 4.  **JSON-LD:**
-
-    - Requests with an `Accept` header of `application/ld+json`.
-    - **Redirects to:** `https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.jsonld`
+    * Requests with an `Accept` header of `application/ld+json`.
+    * Redirects to the `ontology.jsonld` file hosted on GitHub (raw content).
 
 5.  **N-Triples (NT):**
-    - Requests with an `Accept` header of `application/n-triples`.
-    - **Redirects to:** `https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.nt`
+    * Requests with an `Accept` header of `application/n-triples`.
+    * Redirects to the `ontology.nt` file hosted on GitHub (raw content).
 
 ## Ontology Files & Documentation Hosted At:
 
 The source files for the Iprok ontology and its documentation are hosted on GitHub:
 
-- **HTML Documentation:** [https://konevenkatesh.github.io/IprokDoc/main.html](https://konevenkatesh.github.io/IprokDoc/main.html)
-- **Turtle (TTL):** [https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.ttl](https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.ttl)
-- **RDF/XML (OWL):** [https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.owl](https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.owl)
-- **JSON-LD:** [https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.jsonld](https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.jsonld)
-- **N-Triples (NT):** [https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.nt](https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.nt)
+* **HTML Documentation:** [https://konevenkatesh.github.io/IprokDoc/main.html](https://konevenkatesh.github.io/IprokDoc/main.html)
+* **Turtle (TTL):** [https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.ttl](https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.ttl)
+* **RDF/XML (OWL):** [https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.owl](https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.owl)
+* **JSON-LD:** [https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.jsonld](https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.jsonld)
+* **N-Triples (NT):** [https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.nt](https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.nt)
 
 ## Configuration
 
@@ -52,6 +48,6 @@ The redirection logic is managed by the `.htaccess` file located in this directo
 
 ## Maintainer / Contact
 
-- Kone Venkatesh
-- GitHub: [konevenkatesh](https://github.com/konevenkatesh)
-  _(You can add your email or other contact details here if you wish)_
+* Kone Venkatesh
+* GitHub: [konevenkatesh](https://github.com/konevenkatesh)
+* Email: konevenkatesh92@gmail.com

--- a/iprok/readme.md
+++ b/iprok/readme.md
@@ -1,6 +1,6 @@
-# Iprok Ontology PURL Redirection (w3id.org/iprok/)
+# Iprok Ontology and PURL (`https://w3id.org/iprok/`)
 
-This directory configures the persistent URL (PURL) `https://w3id.org/iprok/` for the Iprok Ontology. It uses an `.htaccess` file to redirect requests to the appropriate ontology serializations or HTML documentation hosted on GitHub.
+This directory in the `w3id.org` repository provides the configuration for the persistent URL (PURL) for the Iprok Ontology.
 
 ## Persistent URL (PURL)
 
@@ -8,46 +8,86 @@ The primary persistent URL for the Iprok Ontology is:
 
 **`https://w3id.org/iprok/`**
 
-## Redirection Behavior
+---
 
-Accessing the PURL `https://w3id.org/iprok/` (or versioned PURLs like `https://w3id.org/iprok/1.0/`) will result in the following redirections based on HTTP content negotiation:
+## About the Iprok Ontology
 
-1.  **HTML Documentation (Default for Browsers):**
-    * Requests with an `Accept` header of `text/html` (typical for web browsers) or when no specific content type is strongly preferred.
-    * Redirects to the main HTML documentation hosted on GitHub Pages.
+The Iprok Ontology is a formal, structured knowledge representation designed to model and integrate heterogeneous data primarily within project-centric and business intelligence domains. Its main purpose is to provide a standardized schema that enables consistent data interpretation, aggregation, and analysis from diverse sources.
 
-2.  **Turtle (TTL):**
-    * Requests with an `Accept` header of `text/turtle`.
-    * Redirects to the `ontology.ttl` file hosted on GitHub (raw content).
+**Key Aims & Problems Solved:**
+* **Data Integration:** Addresses the challenge of integrating data from disparate systems and formats by providing a common semantic framework.
+* **Knowledge Structuring:** Organizes information related to projects, resources, processes, and performance metrics into a coherent and machine-readable structure.
+* **Enhanced Analytics:** Facilitates advanced business analytics and data visualization by ensuring data is well-defined, interconnected, and queryable.
+* **Improved Decision Making:** Aims to support better-informed decision-making by offering comprehensive insights derived from integrated data.
 
-3.  **RDF/XML (OWL):**
-    * Requests with an `Accept` header of `application/rdf+xml`.
-    * Redirects to the `ontology.owl` file hosted on GitHub (raw content).
+**Key Features & Components:**
+* **Modular Design:** Structured to cover various aspects of project and business operations. For example, it includes well-defined modules such as Schedule Management (detailing projects, tasks, WBS elements, dependencies, milestones, and calendars).
+* **Extensibility:** Designed to be adaptable and extendable to new domains or more granular levels of detail as required.
+* **Semantic Clarity:** Defines clear relationships and properties for its concepts, enhancing data quality and understanding.
+* **Foundation for Applications:** Serves as the conceptual backbone for applications requiring structured knowledge, such as the Iprok Web Application.
 
-4.  **JSON-LD:**
-    * Requests with an `Accept` header of `application/ld+json`.
-    * Redirects to the `ontology.jsonld` file hosted on GitHub (raw content).
+---
 
-5.  **N-Triples (NT):**
-    * Requests with an `Accept` header of `application/n-triples`.
-    * Redirects to the `ontology.nt` file hosted on GitHub (raw content).
+## Iprok Web Application
 
-## Ontology Files & Documentation Hosted At:
+The Iprok Web Application is a platform developed to leverage the Iprok Ontology for practical data management and business intelligence.
 
-The source files for the Iprok ontology and its documentation are hosted on GitHub:
+* **What does the web application do?**
+    The application serves as a central hub for integrating heterogeneous data streams from various sources. It transforms this data to conform to the Iprok Ontology schema, making it structured and semantically rich. Key functionalities include:
+    * Data ingestion and consolidation.
+    * An extended, interactive dashboard for visualizing key performance indicators, project statuses, and other relevant metrics.
+    * Tools for performing business analytics, generating reports, and deriving actionable insights from the integrated data.
 
-* **HTML Documentation:** [https://konevenkatesh.github.io/IprokDoc/main.html](https://konevenkatesh.github.io/IprokDoc/main.html)
-* **Turtle (TTL):** [https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.ttl](https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.ttl)
-* **RDF/XML (OWL):** [https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.owl](https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.owl)
-* **JSON-LD:** [https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.jsonld](https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.jsonld)
-* **N-Triples (NT):** [https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.nt](https://raw.githubusercontent.com/konevenkatesh/IprokDoc/main/ontology.nt)
+* **How does it utilize the Iprok Ontology?**
+    The Iprok Ontology is the core of the web application's data model. It dictates how data is structured, stored, linked, and interpreted. By using the ontology:
+    * The application ensures data consistency and interoperability across different modules and data sources.
+    * The dashboards can dynamically query and present complex information in an intuitive way because the underlying data has clear semantics and relationships.
+    * The business analytics engine can perform more sophisticated queries and reasoning over the structured knowledge base.
 
-## Configuration
+* **Link to the web application:**
+    [https://iprok-web.streamlit.app/](https://iprok-web.streamlit.app/)
 
-The redirection logic is managed by the `.htaccess` file located in this directory (`iprok/.htaccess` within the `perma-id/w3id.org` GitHub repository).
+---
+
+## Future Applications
+
+The Iprok Ontology and its associated tools are envisioned to evolve with the following future directions:
+
+* **Ontology Expansion:**
+    * Developing new modules to cover additional domains such as risk management, resource optimization, quality assurance, and financial performance tracking in greater detail.
+    * Refining existing modules with more granular concepts and properties based on user feedback and emerging industry best practices.
+* **Enhanced Analytics & AI:**
+    * Integrating more advanced analytical capabilities, including predictive analytics and machine learning models trained on the structured ontological data.
+    * Exploring AI-driven insights, automated reporting, and intelligent alerting features within the web application.
+* **Interoperability & Integration:**
+    * Improving and expanding connectors for seamless data integration with a wider range of enterprise systems, APIs, and data formats.
+    * Publishing and promoting SPARQL endpoints for external applications to query the IproK knowledge base.
+* **Community & Standardization:**
+    * Fostering a user and developer community around the Iprok Ontology to encourage wider adoption, contribution, and the development of compatible tools.
+    * Aligning with relevant industry standards to further enhance interoperability.
+* **Decision Support Systems:**
+    * Developing more sophisticated decision support tools that leverage the ontology to simulate scenarios, evaluate alternatives, and recommend optimal courses of action.
+
+The long-term goal is to establish the Iprok Ontology as a robust and comprehensive framework for knowledge-driven management and analytics in complex project environments.
+
+---
+
+## Accessing the Ontology and Documentation
+
+* **HTML Documentation:** The primary human-readable documentation for the Iprok Ontology can be found at:
+    [https://konevenkatesh.github.io/IprokDoc/main.html](https://konevenkatesh.github.io/IprokDoc/main.html)
+
+* **Ontology Serializations:** The Iprok Ontology is available in various RDF formats (such as Turtle, RDF/XML, JSON-LD, N-Triples). These can be accessed by using the PURL `https://w3id.org/iprok/` (or its versioned variants like `https://w3id.org/iprok/1.0/`) with appropriate HTTP `Accept` headers for content negotiation. The specific RDF files are hosted on GitHub.
+
+## PURL Configuration
+
+The redirection and content negotiation for the `https://w3id.org/iprok/` PURL are managed by an `.htaccess` file located in this directory (`iprok/.htaccess`).
+
+
 
 ## Maintainer / Contact
 
 * Kone Venkatesh
 * GitHub: [konevenkatesh](https://github.com/konevenkatesh)
 * Email: konevenkatesh92@gmail.com
+* [Research Profile](https://orcid.org/0000-0002-6398-5850)


### PR DESCRIPTION
Hi w3id.org maintainers,

This pull request adds the necessary files to configure a persistent URL (PURL) for the Iprok ontology.

**PURL:** `https://w3id.org/iprok/`

**Changes include:**
* Creation of the `/iprok/` directory.
* An `.htaccess` file within `/iprok/` to handle content negotiation and redirect to the ontology files and HTML documentation.
* A `README.md` file in `/iprok/` explaining the PURL setup and linking to the resources.

**The primary HTML documentation for the Iprok ontology is hosted at:**
https://konevenkatesh.github.io/IprokDoc/main.html

**The ontology source files are in the repository:**
https://github.com/konevenkatesh/IprokDoc/

Please let me know if any changes are required.

Thank you!