### PR TITLE
Create .htaccess (Add persistent identifier for Onfoods Ontology)

### DIFF
--- a/onfood/ontology/.htaccess
+++ b/onfood/ontology/.htaccess
@@ -1,2 +1,0 @@
-RewriteEngine On
-RewriteRule ^$ https://gitlab.inf.unibz.it/dbs/onfood-ontology/-/raw/main/onfood_ontology.owl [R=302,L]

--- a/onfood/ontology/.htaccess
+++ b/onfood/ontology/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine On
+RewriteRule ^$ https://gitlab.inf.unibz.it/dbs/onfood-ontology/-/raw/main/onfood_ontology.owl [R=302,L]

--- a/onfoods/ontology/.htaccess
+++ b/onfoods/ontology/.htaccess
@@ -1,2 +1,2 @@
 RewriteEngine On
-RewriteRule ^$ https://gitlab.inf.unibz.it/dbs/onfoods_ontology/-/blob/main/onfoods_ontology.owl [R=302,L]
+RewriteRule ^$ https://gitlab.inf.unibz.it/dbs/onfoods_ontology/-/raw/main/onfoods_ontology.owl [R=302,L]

--- a/onfoods/ontology/.htaccess
+++ b/onfoods/ontology/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine On
+RewriteRule ^$ https://gitlab.inf.unibz.it/dbs/onfoods_ontology/-/blob/main/onfoods_ontology.owl [R=302,L]

--- a/onfoods/ontology/README.md
+++ b/onfoods/ontology/README.md
@@ -1,0 +1,7 @@
+# Onfoods Ontology
+
+This persistent identifier is maintained for the Onfoods project.
+
+**Maintainer:**  
+Maryam Mozaffari  
+maryam.mozaffari@unibz.it

--- a/onfoods/ontology/README.md
+++ b/onfoods/ontology/README.md
@@ -5,3 +5,4 @@ This persistent identifier is maintained for the Onfoods project.
 **Maintainer:**  
 Maryam Mozaffari  
 maryam.mozaffari@unibz.it
+GitHub: [mozaffari-mm](https://github.com/mozaffari-mm)


### PR DESCRIPTION
This PR registers a new persistent identifier for the Onfood ontology.

- Persistent IRI: https://w3id.org/onfood/ontology
- Redirects to: https://gitlab.inf.unibz.it/dbs/onfood-ontology/-/raw/main/onfood_ontology.owl

The goal is to make the ontology findable and citable in research papers and by the wider semantic web community.



Maryam Mozaffari
maryam.mozaffari@unibz.it

Thank you for your support!