### PR TITLE
Updated domain and people in charge of the ontology

### DIFF
--- a/contentdesc/.htaccess
+++ b/contentdesc/.htaccess
@@ -1,2 +1,2 @@
 RewriteEngine on
-RewriteRule ^$ http://everest.expertsystemlab.com/vocabulary/cdesc/ [R=301,L]
+RewriteRule ^$ https://reliance.expertcustomers.ai/vocabulary/cdesc/ [R=301,L]

--- a/contentdesc/readme.md
+++ b/contentdesc/readme.md
@@ -15,4 +15,8 @@ serves RDF serializations according to the accept header (text/turtle, applicati
 
 - Raúl Ortega rortega@expert.ai
 
+# Maintainer
+
+- rortegagit
+
 

--- a/contentdesc/readme.md
+++ b/contentdesc/readme.md
@@ -3,16 +3,16 @@ Ontology for the description of content
 
 URI: https://w3id.org/contentdesc (@prefix `cdesc`)
 
-serves HTML documentation : http://everest.expertsystemlab.com/vocabulary/cdesc/
+serves HTML documentation : https://reliance.expertcustomers.ai/vocabulary/cdesc/
 
 serves RDF serializations according to the accept header (text/turtle, application/rdf+xml, application/n-triples): 
 
-- http://everest.expertsystemlab.com/vocabulary/cdesc/ontology.ttl
-- http://everest.expertsystemlab.com/vocabulary/cdesc/ontology.xml
-- http://everest.expertsystemlab.com/vocabulary/cdesc/ontology.n3
+- https://reliance.expertcustomers.ai/vocabulary/cdesc/ontology.ttl
+- https://reliance.expertcustomers.ai/vocabulary/cdesc/ontology.xml
+- https://reliance.expertcustomers.ai/vocabulary/cdesc/ontology.n3
 
 ## Contacts
 
-- Andres Garcia-Silva agarcia@expertsystemc.om
+- Raúl Ortega rortega@expert.ai
 
 


### PR DESCRIPTION
This is an update of the urls used in this ontology. We have migrated the documentation to the following domain: reliance.expertcustomers.ai. We have also changed the maintainers of this ontology.