### PR TITLE
Add redirect for OntoUML dashboard

### DIFF
--- a/ontouml-models/.htaccess
+++ b/ontouml-models/.htaccess
@@ -30,6 +30,9 @@ RedirectMatch 302 ^/ontouml-models/vocabulary(/|#)?$      https://ontouml.github
 ### Git Repository
 RedirectMatch 302 ^/ontouml-models/git(/?)$ https://github.com/OntoUML/ontouml-models
 
+### Dashboard
+RedirectMatch 302 ^/ontouml-models/dash(board)?(/?)$ https://ontouml-dashboard-995390128580.herokuapp.com/
+
 ### Latest release
 RedirectMatch 302 ^/ontouml-models/release(/?)$ https://github.com/OntoUML/ontouml-models/releases/latest
 


### PR DESCRIPTION
This PR adds a new redirect rule under the `/ontouml-models/` path to point to the OntoUML dashboard service hosted at:

```
https://ontouml-dashboard-995390128580.herokuapp.com/
```

The following redirection was added to `.htaccess`:

```
RedirectMatch 302 ^/ontouml-models/dash(board)?(/?)$ https://ontouml-dashboard-995390128580.herokuapp.com/
```

This supports both `/dash` and `/dashboard` variants for flexibility.
