### PR TITLE
Add .htaccess redirections for Health-RI homepage and semantic interoperability site

### DIFF
--- a/health-ri/.htaccess
+++ b/health-ri/.htaccess
@@ -16,3 +16,11 @@ RedirectMatch 302 ^/health-ri/metadata/releases/(.+)/?$  https://github.com/Heal
 
 RedirectMatch 302 ^/health-ri/metadata/?$  https://github.com/Health-RI/health-ri-metadata/
 RedirectMatch 302 ^/health-ri/metadata/(git|repo)/?$  https://github.com/Health-RI/health-ri-metadata/
+
+# GENERAL REDIRECTIONS ----------------------------------------------------------------------------------------
+
+# Redirect the root /health-ri path to the official website
+RedirectMatch 302 ^/health-ri/?$ https://www.health-ri.nl/
+
+# Redirect everything else to /health-ri/*
+RewriteRule ^(.*)$ /health-ri/$1 [R=302,L]

--- a/health-ri/.htaccess
+++ b/health-ri/.htaccess
@@ -14,8 +14,13 @@ RedirectMatch 302 ^/health-ri/metadata/releases/(.+)/?$  https://github.com/Heal
 
 # RESOURCES' HOMEPAGES ----------------------------------------------------------------------------------------
 
+# Health-RI Metadata Schema
 RedirectMatch 302 ^/health-ri/metadata/?$  https://github.com/Health-RI/health-ri-metadata/
 RedirectMatch 302 ^/health-ri/metadata/(git|repo)/?$  https://github.com/Health-RI/health-ri-metadata/
+
+# Health-RI Semantic Interoperability
+RedirectMatch 302 ^/health-ri/semantic-interoperability/?$  https://health-ri.github.io/semantic-interoperability/
+RedirectMatch 302 ^/health-ri/semantic-interoperability/git/?$  https://github.com/Health-RI/semantic-interoperability/
 
 # GENERAL REDIRECTIONS ----------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR introduces the following `.htaccess` routing updates under the `/health-ri` path:

1. **General Routing Enhancements**  
   - Redirects `/health-ri` to the official Health-RI website  
   - Adds a fallback rule to forward all unmatched `/health-ri/*` paths internally (temporary 302)

2. **Resource-Specific Redirections**  
   - Adds redirects for the **Health-RI Semantic Interoperability** project:
     - `/health-ri/semantic-interoperability` → GitHub Pages site  
     - `/health-ri/semantic-interoperability/git` → GitHub repository