### PR TITLE
new w3id  /lehrplan

### DIFF
--- a/lehrplan/.htaccess
+++ b/lehrplan/.htaccess
@@ -1,0 +1,40 @@
+# .htaccess for lehrplan ontology
+RewriteEngine On
+
+SetEnvIf Request_URI ^/lehrplan$ ONT_BASE=https://dini-ag-kim.github.io/school-curriculum-pg
+SetEnvIf Request_URI ^/lehrplan(.*)$ ONT_ANCHOR=$1 ONT_BASE=https://dini-ag-kim.github.io/school-curriculum-pg 
+SetEnvIf Request_URI ^/lehrplan(\d+\.\d+\.\d+)$ ONT_VERSION=/$1 ONT_BASE=https://dini-ag-kim.github.io/school-curriculum-pg 
+SetEnvIf Request_URI ^/lehrplan/(\d+\.\d+\.\d+)/(.*)$ ONT_VERSION=/$1 ONT_ANCHOR=$2 ONT_BASE=https://dini-ag-kim.github.io/school-curriculum-pg 
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml 
+RewriteRule ^(.*)$ %{ENV:ONT_BASE}%{ENV:ONT_VERSION}/index-en.html#%{ENV:ONT_ANCHOR} [R=303,L,NE]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(.*)$ %{ENV:ONT_BASE}%{ENV:ONT_VERSION}/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(.*)$ %{ENV:ONT_BASE}%{ENV:ONT_VERSION}/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(.*)$ %{ENV:ONT_BASE}%{ENV:ONT_VERSION}/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^(.*)$ %{ENV:ONT_BASE}%{ENV:ONT_VERSION}/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^.*$ %{ENV:ONT_BASE}%{ENV:ONT_VERSION}/406.html [R=406,L]
+
+# Default response
+# ---------------------------
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^(.*)$ %{ENV:ONT_BASE}%{ENV:ONT_VERSION}/base_ontology.rdf [R=303,L]

--- a/lehrplan/README.md
+++ b/lehrplan/README.md
@@ -1,0 +1,12 @@
+# /lehrplan/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for vocabularies related to the German curricula in school education. 
+
+
+
+see https://github.com/dini-ag-kim/school-curriculum-pg and https://dini-ag-kim.github.io/school-curriculum-pg/
+
+
+## Contact
+Current maintainers are:
+* [@joergwa](https://github.com/joergwa)
+* [@sroertgen](https://github.com/sroertgen)


### PR DESCRIPTION
We would like to introduce the /lehrplan identifier namespace.

It is intended to support the publication, referencing, and interlinking of structured data describing German school curricula. The goal is to provide a stable, dereferenceable URI pattern for digital representations of curricular elements, including learning objectives, subjects, grade levels, and competencies.