### PR TITLE
Add W3ID redirects for Circular Future Cities Ontology

### DIFF
--- a/cfc/.htaccess
+++ b/cfc/.htaccess
@@ -1,0 +1,16 @@
+RewriteEngine On
+
+# Base redirect to OWL ontology
+RewriteRule ^$ https://raw.githubusercontent.com/DigiConstructLab-TU-Delft/CircularFutureCitiesOntology/main/ontology/cfc.owl [R=302,L]
+
+# Documentation
+RewriteRule ^doc$ https://raw.githubusercontent.com/DigiConstructLab-TU-Delft/CircularFutureCitiesOntology/main/docs/index.md [R=302,L]
+
+# Namespace documentation
+RewriteRule ^namespace$ https://raw.githubusercontent.com/DigiConstructLab-TU-Delft/CircularFutureCitiesOntology/main/docs/namespace.md [R=302,L]
+
+# Examples
+RewriteRule ^examples/(.*)$ https://raw.githubusercontent.com/DigiConstructLab-TU-Delft/CircularFutureCitiesOntology/main/examples/$1 [R=302,L]
+
+# Ontology imports
+RewriteRule ^imports/(.*)$ https://raw.githubusercontent.com/DigiConstructLab-TU-Delft/CircularFutureCitiesOntology/main/ontology/imports/ontology/imports/$1 [R=302,L]

--- a/cfc/Readme.md
+++ b/cfc/Readme.md
@@ -1,0 +1,35 @@
+# Circular Future Cities Ontology (CFC)
+
+This W3ID provides a persistent URI namespace for the **Circular Future Cities Ontology** developed under the [Future Cities Laboratory – Circular Future Cities Project](https://fcl.ethz.ch/research/research-projects/circular-future-cities.html). The ontology is designed to support city-scale material passport applications and the transition to a circular built environment.
+
+The primary URI for the ontology is:
+
+📌 https://w3id.org/cfc
+
+## 🔁 Redirects
+
+| Path               | Redirect Target                                                                 |
+|--------------------|----------------------------------------------------------------------------------|
+| `/cfc`             | Main ontology file in OWL format                                                |
+| `/cfc/doc`         | Human-readable ontology documentation in Markdown                               |
+| `/cfc/namespace`   | Namespace definitions for the ontology                                          |
+| `/cfc/examples/*`  | Example files in Turtle format illustrating ontology usage                      |
+| `/cfc/imports/*`   | Imported ontologies (e.g., BOT, CAMO, OntoCityGML, etc.)                         |
+
+## 📚 Ontology Repository
+
+The ontology is maintained publicly at:  
+👉 https://github.com/DigiConstructLab-TU-Delft/CircularFutureCitiesOntology
+
+## 👤 Maintainer
+
+**Name**: Ranjith Kuttantharappel Soman  
+**Affiliation**: Assistant Professor, TU Delft  
+**Contact**: ranjithsomantudelft@gmail.com  
+**GitHub**: [@rkuttantharapp](https://github.com/rkuttantharapp)
+
+For questions or suggestions, feel free to raise an issue on the GitHub repository.
+
+## 🛠 License
+
+This ontology and its associated files are licensed under the [MIT License](https://opensource.org/licenses/MIT), unless otherwise specified.


### PR DESCRIPTION
This pull request registers the path `/cfc` for the Circular Future Cities Ontology (CFC), developed as part of the Future Cities Laboratory – Circular Future Cities Project.

- Ontology: https://raw.githubusercontent.com/DigiConstructLab-TU-Delft/CircularFutureCitiesOntology/main/ontology/cfc.owl
- Documentation: https://raw.githubusercontent.com/DigiConstructLab-TU-Delft/CircularFutureCitiesOntology/main/docs/index.md
- Examples: TTL files under `/examples/`
- Imports: TTL/OWL files under `/ontology/imports/ontology/imports/`

Maintainer: Ranjith Kuttantharappel Soman  
Email: r.soman@tudelft.nl
Thank you for providing the W3ID infrastructure.