### PR TITLE
Built out and tested NLM Classification redirects.

### DIFF
--- a/NLM/.htaccess
+++ b/NLM/.htaccess
@@ -1,0 +1,21 @@
+# Example
+#
+# https://w3id.org/NLM/QS 642 redirects to https://classification.nlm.nih.gov/schedules/QS#QS 642 (https://classification.nlm.nih.gov/schedules/QS#QS%20642)
+#
+# ## Contact
+# This space is administered by:
+#
+# Clair Kronk
+# Clair.Kronk@mountsinai.org
+# GitHub username: Superraptor
+
+# Examples tested using:
+# https://htaccess.madewithlove.com/
+# (6 June 2025)
+
+RewriteEngine On
+RewriteBase /
+
+# Redirect URLs.
+RewriteRule ^([A-Z]{1,2})\ ([\d\.A-Z]+)$ https://classification.nlm.nih.gov/schedules/$1#$1%20$2 [R=301,NE,L]
+RewriteRule ^([A-Z]{1,2})%20([\d\.A-Z]+)$ https://classification.nlm.nih.gov/schedules/$1#$1%20$2 [R=301,NE,L]

--- a/NLM/.htaccess
+++ b/NLM/.htaccess
@@ -1,6 +1,6 @@
 # Example
 #
-# https://w3id.org/NLM/QS 642 redirects to https://classification.nlm.nih.gov/schedules/QS#QS 642 (https://classification.nlm.nih.gov/schedules/QS#QS%20642)
+# https://w3id.org/NLM/QS%20642 redirects to https://classification.nlm.nih.gov/schedules/QS#QS%20642
 #
 # ## Contact
 # This space is administered by:
@@ -18,4 +18,3 @@ RewriteBase /
 
 # Redirect URLs.
 RewriteRule ^([A-Z]{1,2})\ ([\d\.A-Z]+)$ https://classification.nlm.nih.gov/schedules/$1#$1%20$2 [R=301,NE,L]
-RewriteRule ^([A-Z]{1,2})%20([\d\.A-Z]+)$ https://classification.nlm.nih.gov/schedules/$1#$1%20$2 [R=301,NE,L]

--- a/NLM/README.md
+++ b/NLM/README.md
@@ -1,0 +1,9 @@
+# National Library of Medicine (NLM) Classification
+
+The [National Library of Medicine Classification](https://classification.nlm.nih.gov/) is a product of the National Library of Medicine for the arrangement of library materials in the field of medicine and related sciences. `.htaccess` file created by Clair Kronk for use at [lgbtDB](https://lgbtdb.wikibase.cloud/wiki/Property:P1165). "NLM" chosen as the prefix due to its use as an abbreviation for the classification by [BARTOC](https://bartoc.org/en/node/528).
+
+## Contact
+This space is administered by:
+* Clair Kronk
+* Clair.Kronk@mountsinai.org
+* GitHub username: Superraptor


### PR DESCRIPTION
Added a redirect mechanism for the National Library of Medicine (NLM) Classification. It uses an odd construction that is difficult to reference. For example, a code like "QS 642" has the equivalent link "https://classification.nlm.nih.gov/schedules/QS#QS 642", with the "QS" portion duplicated.