### PR TITLE
feat: add namespace redirection for ODRL Formal Semantics Ontology definition

### DIFF
--- a/odrl-fs/.htaccess
+++ b/odrl-fs/.htaccess
@@ -1,0 +1,29 @@
+Header set Access-Control-Allow-Origin *
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType text/n3 .ttl
+AddType application/n-triples .nt
+AddType application/ld+json .json
+
+Options +FollowSymLinks
+
+RewriteEngine on
+
+# Redirect to Shacl shapes
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^$ https://w3c.github.io/odrl/formal-semantics/ontology/shacl.ttl [R=303,L]
+
+# Redirect to JSON-LD context
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://w3c.github.io/odrl/formal-semantics/ontology/json-ld_context.json [R=303,L]
+
+# Redirect to OWL ontology
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://w3c.github.io/odrl/formal-semantics/ontology/owl.ttl [R=303,L]
+
+# Default redirection to the Formal Semantics document
+RewriteRule ^/?$ https://w3c.github.io/odrl/formal-semantics/ [R=303,L]

--- a/odrl-fs/README.md
+++ b/odrl-fs/README.md
@@ -1,0 +1,19 @@
+# ODRL Formal Semantics
+
+The Formal Semantics document specifies the expected behaviour of an ODRL Evaluator, a piece of software that performs computations based on a set of policies and a certain state of the world.
+
+This [w3id.org/odrl-fs](https://w3id.org/odrl-fs) redirects to the proper Ontology formalization.
+
+[The formal Semantics Document](https://w3c.github.io/odrl/formal-semantics/)
+
+## Redirections
+* Using an _HTTP GET_ request with the header Accept such as described in [HTTP Content Negotiation](https://www.w3.org/blog/2006/content-negotiation/)
+* with `Accept: text/turtle` returns the `odrl-fs` Shacl shapes
+* with `Accept: application/ld+json` returns the `odrl-fs` JSON-LD context
+* with `Accept: application/rdf+xml` returns the `odrl-fs` OWL ontology
+* For more details, please visit: [Formal description of the Evaluation Request](https://w3c.github.io/odrl/formal-semantics/#formal-description-of-the-evaluation-request)
+
+## Contacts:
+* [Nicoletta Fornara](https://github.com/fornaran)
+* [Víctor Rodríguez-Doncel](https://github.com/vroddon)
+* [Yassir SELLAMI](https://github.com/YassirSellami)


### PR DESCRIPTION
Add namespace `odrl-fs` to redirect to the ontology definition of the ODRL Formal Semantics. 

Relates to this Pull Request in the ODRL repository: https://github.com/w3c/odrl/pull/130