### PR TITLE
chore(routing): add redirect for EDOC example scenarios in LaDeRR Engine

### DIFF
--- a/laderr/.htaccess
+++ b/laderr/.htaccess
@@ -40,4 +40,4 @@ RedirectMatch 302 ^/laderr/engine/(git|repo)/?$  https://github.com/pedropaulofb
 
 # SPECIFIC CASES ----------------------------------------------------------------------------------------
 
-RedirectMatch 302 ^/laderr/engine/edoc_examples/?$  https://github.com/pedropaulofb/laderr-engine/tree/main/example/edoc_example
+RedirectMatch 302 ^/laderr/engine/edoc_examples/?$  https://github.com/pedropaulofb/laderr-engine/tree/main/example/edoc_examples

--- a/laderr/.htaccess
+++ b/laderr/.htaccess
@@ -37,3 +37,7 @@ RedirectMatch 302 ^/laderr/(git|repo)/?$  https://github.com/pedropaulofb/laderr
 
 RedirectMatch 302 ^/laderr/engine/?$  https://pedropaulofb.github.io/laderr-engine
 RedirectMatch 302 ^/laderr/engine/(git|repo)/?$  https://github.com/pedropaulofb/laderr-engine
+
+# SPECIFIC CASES ----------------------------------------------------------------------------------------
+
+RedirectMatch 302 ^/laderr/engine/edoc_examples/?$  https://github.com/pedropaulofb/laderr-engine/tree/main/example/edoc_example


### PR DESCRIPTION
Added a specific redirect rule in the .htaccess file to map `/laderr/engine/edoc_examples` to the corresponding GitHub folder containing EDOC example scenarios.