### PR TITLE
added .htaccess and readme

### DIFF
--- a/MonarchRyuzaki/foodwaste/ontology/.htaccess
+++ b/MonarchRyuzaki/foodwaste/ontology/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine On
+RewriteRule ^$ https://raw.githubusercontent.com/MonarchRyuzaki/FoodWastageOntology/refs/heads/master/FoodWastageOntologyNew.rdf [R=302,L]

--- a/MonarchRyuzaki/foodwaste/ontology/README.md
+++ b/MonarchRyuzaki/foodwaste/ontology/README.md
@@ -1,0 +1,15 @@
+# Food Wastage Ontology
+
+This [w3id.org](https://w3id.org) permanent identifier redirects to the RDF/XML serialization of the **Food Wastage Ontology**, which models key concepts related to food donation, spoilage, stakeholders (NGOs, consumers), and logistics.
+
+**Persistent IRI:**
+https://w3id.org/MonarchRyuzaki/foodwaste/ontology
+
+**Redirects to:**
+https://raw.githubusercontent.com/MonarchRyuzaki/FoodWastageOntology/refs/heads/master/FoodWastageOntologyNew.rdf
+
+## Maintainer
+
+Shivam Ganguly
+Email: [shivamganguly2004@gmail.com](mailto:shivamganguly2004@gmail.com)
+GitHub: [@MonarchRyuzaki](https://github.com/MonarchRyuzaki)


### PR DESCRIPTION
Adding a new persistent identifier for the Food Wastage Ontology.

w3id: https://w3id.org/MonarchRyuzaki/foodwaste/ontology  
Target: https://raw.githubusercontent.com/MonarchRyuzaki/FoodWastageOntology/refs/heads/master/FoodWastageOntologyNew.rdf

The ontology models food donation and spoilage management, including key stakeholders like NGOs, and consumers.

Maintained by: Shivam Ganguly (shivamganguly2004@gmail.com)
