### PR TITLE
feat(certi): Add initial redirection rules for certi project

### DIFF
--- a/certi/.htaccess
+++ b/certi/.htaccess
@@ -1,0 +1,7 @@
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ https://www.certi.world [R=302,L]
+RewriteRule ^v1$ https://api.certi.world/jsonld/v1/schema/context.json [R=302,L]
+RewriteRule ^(.*)$ https://api.certi.world/jsonld/$1 [R=302,L]

--- a/certi/README.md
+++ b/certi/README.md
@@ -1,0 +1,18 @@
+# Blockchain Certificates
+
+
+Homepage:
+
+https://w3id.org/certi
+
+
+JSON-LD contexts:
+
+https://w3id.org/certi/v1
+
+Contacts:
+
+sircoon4@nftime.world
+
+Maintainers:
+@sircoon4


### PR DESCRIPTION
This commit introduces the .htaccess file for the new 'certi' identifier.

It establishes the following redirection rules:
- The root path (/) redirects to https://www.certi.world.
- The path /v1 redirects to the specific context file at .../v1/schema/context.json.
- All other paths are redirected to https://api.certi.world/jsonld/$1.

Necessary CORS headers are also included.