### PR TITLE
Modified dseco redirect rules

### DIFF
--- a/dseco/.htaccess
+++ b/dseco/.htaccess
@@ -10,17 +10,17 @@ RewriteEngine on
 RewriteRule ^$ https://github.com/Orange-OpenSource/dseco [R=302,L]
 
 # Direct access to versioned ontology file
-# e.g. https://w3id.org/dseco/ontology/dseco-1.5.0 => https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/dseco-1.5.0/dseco.ttl
-# e.g. https://w3id.org/dseco/ontology/dseco-1.5.0/ => https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/dseco-1.5.0/dseco.ttl
+# e.g. https://w3id.org/dseco/ontology/dseco-1.6.1 => https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/dseco-1.6.1/dseco.ttl
+# e.g. https://w3id.org/dseco/ontology/dseco-1.6.1/ => https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/dseco-1.6.1/dseco.ttl
 RewriteRule ^ontology/(.*-\d+\.\d+\.?\d?)/?$ https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/$1/dseco.ttl [R=302,L]
 
 # Direct access to named ontology file
-# e.g. https://w3id.org/dseco/ontology/dseco-1.5.0/dseco.ttl => https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/dseco-1.5.0/dseco.ttl
+# e.g. https://w3id.org/dseco/ontology/dseco-1.6.1/dseco.ttl => https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/dseco-1.6.1/dseco.ttl
 RewriteRule ^ontology/(.*\.ttl)$ https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/$1 [R=302,L]
 
 # Redirect ontology/<concept|property> to full **latest ontology Turtle file** for computer access
-# e.g. https://w3id.org/dseco/ontology/FQDN => https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/dseco-1.5.0/dseco.ttl
-RewriteRule ^ontology/?(.*)$ https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/dseco-1.5.0/dseco.ttl [R=302,L]
+# e.g. https://w3id.org/dseco/ontology/FQDN => https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/dseco-1.6.1/dseco.ttl
+RewriteRule ^ontology/?(.*)$ https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/dseco-1.6.1/dseco.ttl [R=302,L]
 
 # Redirect doc/<concept|property> to documentation for user-friendly display of a concept/property
 # See also: https://httpd.apache.org/docs/2.2/rewrite/flags.html#flag_ne


### PR DESCRIPTION
Modified path to v1.6.1 for the `Redirect ontology/<concept|property>` rule.