### PR TITLE
feat(catenax): link to updated odrl constraint schemas

### DIFF
--- a/catenax/.htaccess
+++ b/catenax/.htaccess
@@ -159,5 +159,11 @@ RewriteRule ^policy(/|.*)$ https://raw.githubusercontent.com/catenax-eV/cx-odrl-
 # Credential json-ld context resolution
 RewriteRule ^credentials/v1.0.0(.*)$ https://eclipse-tractusx.github.io/tractusx-profiles/cx/context/credentials.context.json [R=302,L]
 
+# Redirect to published 2025/9 context until it is properly released
+RewriteRule ^2025/9/policy/context.jsonld https://raw.githubusercontent.com/catenax-eV/cx-odrl-profile/refs/heads/main/schema/context/context.jsonld [R=302,L]
+
+# Redirect to published 2025/9 schemas until they are properly released
+RewriteRule ^2025/9/policy/(.+)$ https://raw.githubusercontent.com/catenax-eV/cx-odrl-profile/refs/heads/main/schema/constraint/$1 [R=302,L]
+
 # Rewrite rule to serve the TTL content from the vocabulary URI by default
 RewriteRule ^(.*)$ https://github.com/big-data-spaces/ontology/blob/v24.12/docs/README.md [R=303,L]

--- a/catenax/README.md
+++ b/catenax/README.md
@@ -2,6 +2,11 @@
 
 Documentation is available at: https://catena-x.net/, https://github.com/catenax-eV, https://eclipse-tractusx.github.io, https://big-data-spaces.github.io/ and https://big-data-spaces.github.io/ontology
 
+The Policy Constraint schemas for the Catena-X Saturn Release are in the ODRL Profile Repo:
+
+https://github.com/catenax-eV/cx-odrl-profile
+
+
 The complete ontology is available as:
 
 TTL: https://github.com/big-data-spaces/ontology/blob/v24.12/ontology.ttl (current)
@@ -47,7 +52,7 @@ Profiles can be found under:
 https://github.com/catenax-eV/cx-odrl-profile
 https://github.com/eclipse-tractusx/tractusx-profiles
 
-Contact: 
+Contact:
 
 - Hanno Focken <hanno.focken@catena-x.net> (https://github.com/HFocken)
 - Oguzhan Balandi <oguzhan.balandi@t-systems.com> (https://github.com/obalandi)


### PR DESCRIPTION
this PR adds rules linking to the json schemas representing the ODRL constraints for the Catena-X Saturn release.

cc @hfocken