### PR TITLE
Add redirects for SCIMOF ontology suite

### DIFF
--- a/SCIMOnto-ontologies/CFMO.owl/.htaccess
+++ b/SCIMOnto-ontologies/CFMO.owl/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine On
+RewriteRule ^$ https://zhu-huiwen.github.io/scimonto-ontology/CFMO.owl [R=302,L]

--- a/SCIMOnto-ontologies/ECMO.owl/.htaccess
+++ b/SCIMOnto-ontologies/ECMO.owl/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine On
+RewriteRule ^$ https://zhu-huiwen.github.io/scimonto-ontology/ECMO.owl [R=302,L]

--- a/SCIMOnto-ontologies/EvMO.owl/.htaccess
+++ b/SCIMOnto-ontologies/EvMO.owl/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine On
+RewriteRule ^$ https://zhu-huiwen.github.io/scimonto-ontology/EvMO.owl [R=302,L]

--- a/SCIMOnto-ontologies/IMO.owl/.htaccess
+++ b/SCIMOnto-ontologies/IMO.owl/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine On
+RewriteRule ^$ https://zhu-huiwen.github.io/scimonto-ontology/IMO.owl [R=302,L]

--- a/SCIMOnto-ontologies/README.md
+++ b/SCIMOnto-ontologies/README.md
@@ -1,0 +1,76 @@
+This repository hosts six interrelated domain ontologies developed for the Station-City Integrated Maintenance Ontology Framework (SCIMOF). These ontologies are designed to facilitate semantic modeling and reasoning for intelligent operation and maintenance (O&M) of urban rail transit hubs.
+
+**SCIMOnto.owl**
+
+Ontology URI: https://w3id.org/SClMOnto-ontologies/SCIMOnto.owl 
+Redirect target: https://zhu-huiwen.github.io/scimonto-ontology/SCIMOnto.owl
+Maintainer: [@zhu-huiwen](https://github.com/zhu-huiwen)
+
+**CFMO.owl**
+
+Ontology URI: https://w3id.org/SClMOnto-ontologies/CFMO.owl  
+Redirect target: https://zhu-huiwen.github.io/scimonto-ontology/CFMO.owl  
+Maintainer: [@zhu-huiwen](https://github.com/zhu-huiwen)
+
+**ECMO.owl**
+
+Ontology URI: https://w3id.org/SClMOnto-ontologies/ECMO.owl  
+Redirect target: https://zhu-huiwen.github.io/scimonto-ontology/ECMO.owl  
+Maintainer: [@zhu-huiwen](https://github.com/zhu-huiwen)
+
+**EvMO.owl**
+
+Ontology URI: https://w3id.org/SClMOnto-ontologies/EvMO.owl  
+Redirect target: https://zhu-huiwen.github.io/scimonto-ontology/EvMO.owl  
+Maintainer: [@zhu-huiwen](https://github.com/zhu-huiwen)
+
+**IMO.owl**
+
+Ontology URI: https://w3id.org/SClMOnto-ontologies/IMO.owl  
+Redirect target: https://zhu-huiwen.github.io/scimonto-ontology/IMO.owl  
+Maintainer: [@zhu-huiwen](https://github.com/zhu-huiwen)
+
+**SMO.owl**
+
+Ontology URI: https://w3id.org/SClMOnto-ontologies/SMO.owl  
+Redirect target: https://zhu-huiwen.github.io/scimonto-ontology/SMO.owl  
+Maintainer: [@zhu-huiwen](https://github.com/zhu-huiwen)
+
+
+## Included Ontologies
+- `CFMO.owl` — **Crowd Flow Monitoring Ontology**
+CFMO captures the spatiotemporal characteristics of crowd movement in large public spaces, enabling semantic representation of people flow, density, direction, and activity patterns for intelligent crowd management.  
+- `ECMO.owl` — **Energy Consumption Monitoring Ontology**
+This ontology models concepts related to the monitoring and analysis of energy consumption within smart buildings and infrastructures. It supports semantic integration of sensor data such as electricity, HVAC, and lighting usage.
+- `EvMO.owl` — **Environmental Monitoring Ontology**
+EvMO represents various environmental parameters—such as temperature, humidity, air quality, and noise levels—to support context-aware monitoring and adaptive decision-making in built environments.
+- `IMO.owl` — **Incident Monitoring Ontology**
+IMO provides a structured semantic framework to describe, classify, and reason about abnormal or emergency events occurring in urban or building-scale scenarios, including fire, accidents, and system failures.
+- `SMO.owl` — **Structural Monitoring Ontology**
+This ontology focuses on representing the physical condition of structural components, supporting semantic interpretation of stress, displacement, vibration, and structural damage for health monitoring.
+- `SCIMOnto.owl` — **Station-City Integrated Maintenance Ontology Framework**
+SCIMOF integrates five domain ontologies (ECMO, CFMO, EvMO, IMO, SMO) into a unified semantic framework to support cross-domain intelligent operation and maintenance in smart railway stations and urban systems.
+
+## Key Features
+- Modular Domain Design Ensuring Semantic Clarity and Maintainability
+- Unified Semantic Integration for Bridging Cross-Domain Data Silos
+- Support for Semantic Reasoning Rules to Enhance Intelligent Analysis
+- Alignment with Upper Ontologies for Improved Interoperability and Compatibility
+- Real-World Data Adaptability Enabling Semantic-Driven Smart O&M
+
+## Use Cases
+- Structural Safety Risk Detection During Crowd Peaks in Railway Stations
+- Event-Driven Emergency Response and Dispatch Optimization
+- Abnormal Building Energy Consumption Detection and Behavior Feedback
+- Multi-Source Anomaly Detection and Alerting in Monitoring Areas
+- Semantic-Driven Automatic Planning and Scheduling of O&M Tasks
+
+## Directory Contents
+- .htaccess — Configuration file for w3id.org permanent URL redirection
+- README.md — Project description and maintainer information
+- CFMO.owl to SCIMOnto.owl — The ontology files comprising the SCIMOF suite
+
+If you have any questions, feedback, or would like to contribute to the ontology suite, feel free to reach out:
+**zhu-huiwen**
+📧 Email: huiwenzhu0530@163.com
+🔗 GitHub: https://github.com/zhu-huiwen

--- a/SCIMOnto-ontologies/SCIMOnto.owl/.htaccess
+++ b/SCIMOnto-ontologies/SCIMOnto.owl/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine On
+RewriteRule ^$ https://zhu-huiwen.github.io/scimonto-ontology/SCIMOnto.owl [R=302,L]

--- a/SCIMOnto-ontologies/SMO.owl/.htaccess
+++ b/SCIMOnto-ontologies/SMO.owl/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine On
+RewriteRule ^$ https://zhu-huiwen.github.io/scimonto-ontology/SMO.owl [R=302,L]


### PR DESCRIPTION
This pull request adds new persistent identifier entries for the SCIMOF Ontology Suite under '/SCIMOnto-ontologies/'.

The following redirects are included:

https://w3id.org/SClMOnto-ontologies/CFMO.owl → https://zhu-huiwen.github.io/scimonto-ontology/CFMO.owl
https://w3id.org/SClMOnto-ontologies/ECMO.owl → https://zhu-huiwen.github.io/scimonto-ontology/ECMO.owl
https://w3id.org/SClMOnto-ontologies/EvMO.owl → https://zhu-huiwen.github.io/scimonto-ontology/EvMO.owl
https://w3id.org/SClMOnto-ontologies/IMO.owl → https://zhu-huiwen.github.io/scimonto-ontology/IMO.owl
https://w3id.org/SClMOnto-ontologies/SMO.owl → https://zhu-huiwen.github.io/scimonto-ontology/SMO.owl
https://w3id.org/SClMOnto-ontologies/SCIMOnto.owl → https://zhu-huiwen.github.io/scimonto-ontology/SCIMOnto.owl

Each entry contains an '.htaccess' file using '302' redirect to the corresponding GitHub Pages-hosted OWL file.

Maintainer: [@zhu-huiwen](https://github.com/zhu-huiwen)

Thank you!