### PR TITLE
Add OBPI Ontology under w3id.org

### DIFF
--- a/obpi/.htaccess
+++ b/obpi/.htaccess
@@ -1,0 +1,29 @@
+# Enable following symlinks and turn on rewrite engine
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+# Serve Turtle and RDF formats
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+
+# If the client accepts HTML or is a browser, redirect root to the HTML page
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://sebseis.github.io/OBPI/ [R=302,NE,L]
+
+# If the client accepts Turtle, redirect root to the Turtle file
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* 
+RewriteRule ^$ https://sebseis.github.io/OBPI/obpi.ttl [R=303,NE,L]
+
+# If the request explicitly asks for the Turtle file
+RewriteRule ^obpi\.ttl$ https://sebseis.github.io/OBPI/obpi.ttl [R=302,NE,L]
+
+# If the request explicitly asks for the HTML version
+RewriteRule ^obpi\.html$ https://sebseis.github.io/OBPI/ [R=302,NE,L]
+
+# Default for root if none of the above matched: serve HTML
+RewriteRule ^$ https://sebseis.github.io/OBPI/ [R=303,NE,L]

--- a/obpi/readme.md
+++ b/obpi/readme.md
@@ -1,0 +1,18 @@
+## Ontology for Building Permit Inspection (OBPI)
+
+## Description
+The  Ontology for Building Permit Inspection, is designed to represent knowledge about the domain of building-permit-related inspection. The ontology is intended to provide a standardized vocabulary for describing concepts, entities, and relationships relevant to on site inspections planned and executed by building authorities. Additionally, the ontology uses SHACL to semi-automate the processes of inspection planning and evaluation.
+
+## Ontology resources
+* HTML      https://sebseis.github.io/OBPI/
+* Turtle    https://sebseis.github.io/OBPI/obpi.ttl
+* GitHub    https://github.com/SebSeis/OBPI
+
+## Contacts
+* Sebastian Seiss <sebastian.seiss@uni-weimar.de>
+* Yuan Zheng <yuan.zheng@aalto.fi>
+
+
+## This space is administered by:  
+**Sebastian Seiß**  
+*Research Assistant, Bauhaus-University Weimar, Germany*  


### PR DESCRIPTION
This pull request adds a new directory `obpi/` to define the w3id for the OBPI ontology, which represents building permit–related inspections in construction. It includes:
- `.htaccess` redirect rules pointing to the GitHub Pages URLs
- `README.md` describing the ontology, its namespace, usage, contact, and license

Please review and merge if acceptable. Let us know if any changes are needed.