### PR TITLE
Add redirect for RoboAlchemyVaV ontology

### DIFF
--- a/RoboAlchemyVaV/.htaccess
+++ b/RoboAlchemyVaV/.htaccess
@@ -1,0 +1,12 @@
+RewriteEngine On
+
+# If browser asks for RDF/XML
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://Chris-Bishop8.github.io/RoboAlchemyVaV/RoboAlchemyVaV.owx [R=303,L]
+
+# If browser asks for HTML
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^$ https://Chris-Bishop8.github.io/RoboAlchemyVaV/index.html [R=303,L]
+
+# Fallback
+RewriteRule ^$ https://Chris-Bishop8.github.io/RoboAlchemyVaV/RoboAlchemyVaV.owx [R=303,L]

--- a/RoboAlchemyVaV/README.md
+++ b/RoboAlchemyVaV/README.md
@@ -1,0 +1,11 @@
+# RoboAlchemyVaV Ontology
+
+This folder sets up a permanent identifier via w3id.org:
+
+https://w3id.org/RoboAlchemyVaV
+
+It redirects to:
+
+https://yourusername.github.io/RoboAlchemyVaV/RoboAlchemyVaV.owx
+
+Maintainer: Christopher Bishop

--- a/RoboAlchemyVaV/README.md
+++ b/RoboAlchemyVaV/README.md
@@ -8,4 +8,5 @@ It redirects to:
 
 https://Chris-Bishop8.github.io/RoboAlchemyVaV/RoboAlchemyVaV.owx
 
-Maintainer: Christopher Bishop
+Maintainer: Christopher Bishop 
+Username: Chris-Bishop8

--- a/RoboAlchemyVaV/README.md
+++ b/RoboAlchemyVaV/README.md
@@ -6,6 +6,6 @@ https://w3id.org/RoboAlchemyVaV
 
 It redirects to:
 
-https://yourusername.github.io/RoboAlchemyVaV/RoboAlchemyVaV.owx
+https://Chris-Bishop8.github.io/RoboAlchemyVaV/RoboAlchemyVaV.owx
 
 Maintainer: Christopher Bishop


### PR DESCRIPTION
This pull request registers the permanent IRI:

https://w3id.org/RoboAlchemyVaV

It redirects to the OWL ontology file hosted at:

https://chris-bishop8.github.io/RoboAlchemyVaV/RoboAlchemyVaV.owx

The folder includes:
- `.htaccess` file for content negotiation (RDF/XML and HTML)
- `README.md` with maintainer info

This ontology is under development and focuses on V&V for robotic systems.