### PR TITLE
Add rewrite rule for stil

### DIFF
--- a/stil/.htaccess
+++ b/stil/.htaccess
@@ -1,0 +1,4 @@
+RewriteEngine on
+
+RewriteRule ^(.*) https://sroertgen.github.io/stil-vocabs/$1 [R=302,L]
+

--- a/stil/README.md
+++ b/stil/README.md
@@ -1,0 +1,9 @@
+# STIL
+
+The "Stiftung Innovation in der Hochschullehre" (STIL) is a non-profit organization. According to the statutes, StIL has the task of Innovations In the area of teaching and learning at universities, as well as the ability to renew University teaching to continually strengthen.
+
+The w3id.org URIs are used as permanent URLs for standards and vocabularies (specifications of application profiles, schemas etc.).
+
+* Contact: [Steffen Rörtgen](https://github.com/sroertgen)
+
+


### PR DESCRIPTION
Hello!

I added a new redirect entry `stil` which we want to use for hosting metadata profiles and SKOS vocabularies.

It will e.g. point to this vocabulary of higher education institutions: https://sroertgen.github.io/stil-vocabs/w3id.org/stil/einrichtungen/index.html

Thank you!