### PR TITLE
added redirect for overarching schemas

### DIFF
--- a/catenax/.htaccess
+++ b/catenax/.htaccess
@@ -162,11 +162,11 @@ RewriteRule ^credentials/v1.0.0(.*)$ https://eclipse-tractusx.github.io/tractusx
 # Redirect to published 2025/9 context until it is properly released
 RewriteRule ^2025/9/policy/context.jsonld https://raw.githubusercontent.com/catenax-eV/cx-odrl-profile/refs/heads/main/schema/context/context.jsonld [R=302,L]
 
-# Redirect to published 2025/9 constraint schemas until they are properly released
-RewriteRule ^2025/9/policy/(.+)$ https://raw.githubusercontent.com/catenax-eV/cx-odrl-profile/refs/heads/main/schema/constraint/$1 [R=302,L]
-
 # Redirect to published 2025/9 overarching schemas until they are properly released
 RewriteRule ^2025/9/policy/schema/(.+)$ https://raw.githubusercontent.com/catenax-eV/cx-odrl-profile/refs/heads/main/schema/$1 [R=302,L]
+
+# Redirect to published 2025/9 constraint schemas until they are properly released
+RewriteRule ^2025/9/policy/(.+)$ https://raw.githubusercontent.com/catenax-eV/cx-odrl-profile/refs/heads/main/schema/constraint/$1 [R=302,L]
 
 # Rewrite rule to serve the TTL content from the vocabulary URI by default
 RewriteRule ^(.*)$ https://github.com/big-data-spaces/ontology/blob/v24.12/docs/README.md [R=303,L]

--- a/catenax/.htaccess
+++ b/catenax/.htaccess
@@ -162,8 +162,11 @@ RewriteRule ^credentials/v1.0.0(.*)$ https://eclipse-tractusx.github.io/tractusx
 # Redirect to published 2025/9 context until it is properly released
 RewriteRule ^2025/9/policy/context.jsonld https://raw.githubusercontent.com/catenax-eV/cx-odrl-profile/refs/heads/main/schema/context/context.jsonld [R=302,L]
 
-# Redirect to published 2025/9 schemas until they are properly released
+# Redirect to published 2025/9 constraint schemas until they are properly released
 RewriteRule ^2025/9/policy/(.+)$ https://raw.githubusercontent.com/catenax-eV/cx-odrl-profile/refs/heads/main/schema/constraint/$1 [R=302,L]
+
+# Redirect to published 2025/9 overarching schemas until they are properly released
+RewriteRule ^2025/9/policy/schema/(.+)$ https://raw.githubusercontent.com/catenax-eV/cx-odrl-profile/refs/heads/main/schema/$1 [R=302,L]
 
 # Rewrite rule to serve the TTL content from the vocabulary URI by default
 RewriteRule ^(.*)$ https://github.com/big-data-spaces/ontology/blob/v24.12/docs/README.md [R=303,L]


### PR DESCRIPTION
As the schemas atomic-constraint-schemas.json, context-schema.json and policy-schema.json are in the root , this needs to be covered by a separate redirect rule