### PR TITLE
Add namespace `qualo` for the Qualification Ontology

### DIFF
--- a/qualo/.htaccess
+++ b/qualo/.htaccess
@@ -1,0 +1,16 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Redirects for entities
+#
+# For example, we want https://w3id.org/qualo/id/0000001 to redirect to
+# https://cthoyt.github.io/qualo/0000001
+
+RewriteRule ^id/(.+) https://cthoyt.github.io/qualo/$1
+
+# Redirects for ontology artifacts
+#
+# For example, we want https://w3id.org/qualo/qualo.obo to redirect to
+# https://github.com/cthoyt/qualo/raw/refs/heads/main/export/qualo.obo
+
+RewriteRule ^qualo.(.+) https://github.com/cthoyt/qualo/raw/refs/heads/main/export/qualo.$1

--- a/qualo/README.md
+++ b/qualo/README.md
@@ -1,0 +1,31 @@
+# Event Venue Registry
+
+This [W3ID](https://w3id.org) provides persistent URLs for entities and
+artifacts in the
+[Qualification Ontology](https://github.com/event-venue-registry/evr), an
+ontology of qualifications, distinctions, and certifications that uses the
+Phenotype And Trait Ontology term quality (PATO:0000001) as a root term.
+
+## Vocabulary
+
+Currently, the Qualification Ontology auto-generates a site on GitHub.
+
+The identifier (`0000001`) representing the root term _qualification_ site here:
+https://cthoyt.github.io/qualo/0000001.
+
+The `.htaccess` file in this directory enables the construction of a PURL for
+this entity like https://w3id.org/qualo/id/0000001.
+
+## Ontology Artifacts
+
+There are OWL and OBO ontology artifacts generated that can be accessed at:
+
+- https://w3id.org/qualo/qualo.owl
+- https://w3id.org/qualo/qualo.obo
+- https://w3id.org/qualo/qualo.ofn
+
+## Contact
+
+Charles Tapley Hoyt<br /> Email: cthoyt@gmail.com<br /> GitHub:
+[@cthoyt](https://github.com/cthoyt)<br /> ORCID:
+[0000-0003-4423-4370](https://orcid.org/0000-0003-4423-4370)


### PR DESCRIPTION
This pull request adds a namespace for the Qualification Ontology, an ontology of qualifications, distinctions, and certifications that uses the Phenotype And Trait Ontology term quality (PATO:0000001) as a root term.

It's available under the CC0 license at https://github.com/cthoyt/qualo

It includes an .htaccess file that enables redirecting to the website with the ontology terms at https://cthoyt.github.io/qualo/ as well as the ontology artifacts saved on GitHub