### PR TITLE
New Modules for OCQA

### DIFF
--- a/ocqa/.htaccess
+++ b/ocqa/.htaccess
@@ -43,6 +43,14 @@ RewriteRule ^regulation$ https://sebseis.github.io/OCQA/Modules/Regulation/ [R=3
 RewriteRule ^rule.ttl$ https://sebseis.github.io/OCQA/Modules/Rule/OCQA-Rule.ttl [R=302,NE,L]
 RewriteRule ^rule.html$ https://sebseis.github.io/OCQA/Modules/Rule/ [R=302,NE,L]
 RewriteRule ^rule$ https://sebseis.github.io/OCQA/Modules/Rule/ [R=303,NE,L] # Default response: html
+# AC Module
+RewriteRule ^ocqa-ac.ttl$          https://sebseis.github.io/OCQA/Modules/AC/OCQA-AC.ttl [R=302,NE,L]
+RewriteRule ^ocqa-ac.html$         https://sebseis.github.io/OCQA/Modules/AC/            [R=302,NE,L]
+RewriteRule ^ocqa-ac$              https://sebseis.github.io/OCQA/Modules/AC/            [R=303,NE,L]
+# Risk Module
+RewriteRule ^ocqa-risk.ttl$        https://sebseis.github.io/OCQA/Modules/Risk/OCQA-Risk.ttl [R=302,NE,L]
+RewriteRule ^ocqa-risk.html$       https://sebseis.github.io/OCQA/Modules/Risk/              [R=302,NE,L]
+RewriteRule ^ocqa-risk$            https://sebseis.github.io/OCQA/Modules/Risk/ [R=302,NE,L]
 
 # Link to Extensions, already described in main document
 # Screed Extension


### PR DESCRIPTION
Dear Support,

We have added new modules to the OCQA. Please add the ocqa-risk and ocqa-ac to the current ocqa repository. 

Thanks for your support and for taking care of the perma-id repo of w3id.org.

Regards
Sebastian