### PR TITLE
Add permanent redirect for GOLEM ontology

### DIFF
--- a/golem/.htaccess
+++ b/golem/.htaccess
@@ -1,0 +1,11 @@
+RewriteEngine On
+
+# Redirect to TTL when RDF is requested
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^ontology$ https://ontology.golemlab.eu/golem.ttl [R=302,L]
+
+# Fallback to HTML if not RDF
+RewriteRule ^ontology$ https://ontology.golemlab.eu/golem.html [R=302,L]
+

--- a/golem/.htaccess
+++ b/golem/.htaccess
@@ -1,11 +1,12 @@
 RewriteEngine On
 
-# Redirect to TTL when RDF is requested
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
-RewriteCond %{HTTP_ACCEPT} application/xml [OR]
-RewriteCond %{HTTP_ACCEPT} text/turtle
+# If Accept header prefers RDF/XML, XML, or Turtle — serve TTL
+RewriteCond %{HTTP_ACCEPT} "application/rdf\+xml" [NC,OR]
+RewriteCond %{HTTP_ACCEPT} "application/xml" [NC,OR]
+RewriteCond %{HTTP_ACCEPT} "text/turtle" [NC]
 RewriteRule ^ontology$ https://ontology.golemlab.eu/golem.ttl [R=302,L]
 
-# Fallback to HTML if not RDF
+# Otherwise serve HTML
 RewriteRule ^ontology$ https://ontology.golemlab.eu/golem.html [R=302,L]
+
 

--- a/golem/README.md
+++ b/golem/README.md
@@ -1,0 +1,16 @@
+# GOLEM Ontology
+
+This W3ID provides a persistent identifier for the GOLEM Ontology of Fiction and Narrative.
+
+## Identifier
+
+**https://w3id.org/golem/ontology**
+
+## Redirection Target
+
+- **RDF/Turtle:** https://ontology.golemlab.eu/golem.ttl
+- **HTML:** https://ontology.golemlab.eu/golem.html
+
+## Maintainer
+
+- GOLEM Lab (https://ontology.golemlab.eu)

--- a/golem/README.md
+++ b/golem/README.md
@@ -13,4 +13,5 @@ This W3ID provides a persistent identifier for the GOLEM Ontology of Fiction and
 
 ## Maintainer
 
-- GOLEM Lab (https://ontology.golemlab.eu)
+- GOLEM Lab (<https://ontology.golemlab.eu>)  
+- [@ljutach](https://github.com/ljutach)


### PR DESCRIPTION
Dear support,

This pull request adds a permanent redirect for the GOLEM ontology, a project developed within the Digital Humanities field to support the ontological modeling of narrative and fiction through Semantic Web technologies.

Thanks for your support,
Luca