### PR TITLE
Modified to be able to match a special character found in a specific special character found in a GayCities URL

### DIFF
--- a/GayCities/.htaccess
+++ b/GayCities/.htaccess
@@ -16,7 +16,7 @@
 
 # Examples tested using:
 # https://htaccess.madewithlove.com/
-# (22 September 2024)
+# (27 June 2025)
 
 RewriteEngine On
 RewriteBase /
@@ -28,7 +28,7 @@ RewriteRule ^([a-z\-]{1,50})$ https://$1.gaycities.com/ [R=301,NE,L]
 RewriteRule ^([a-z\-]{1,50})/([a-z]{1,50})$ https://$1.gaycities.com/$2 [R=301,NE,L]
 
 # Redirect URLs of the form /GayCities/$1/$2/$3
-RewriteRule ^([a-z\-]{1,50})/([a-z]{1,50})/([0-9]{1,10}\-[a-z]{1,20}(\-[a-z]{1,20}){0,10})$ https://$1.gaycities.com/$2/$3 [R=301,L]
+RewriteRule ^([a-z\-]{1,50})/([a-z]{1,50})/([0-9]{1,10}\-[a-zł]{1,20}(\-[a-z]{1,20}){0,10})$ https://$1.gaycities.com/$2/$3 [R=301,L]
 
 # Redirect URLs of the form /GayCities/$1/$2/$3
 RewriteRule ^(articles)/([0-9]{1,10})/(([a-z]{1,30}\-){0,60}[a-z]{1,30})$ https://www.gaycities.com/$1/$2/$3 [R=301,L]

--- a/GayCities/README.md
+++ b/GayCities/README.md
@@ -2,6 +2,8 @@
 
 [Website](https://gaycities.com/) that is called the "world's #1 LGBTQ travel" site. `.htaccess` file created by Clair Kronk for use at [lgbtDB](https://lgbtdb.wikibase.cloud/wiki/Property:P813).
 
+* 27 June 2025: Updated to allow for matching "https://warsaw.gaycities.com/bars/308665-pogłos".
+
 ## Contact
 This space is administered by:
 * Clair Kronk


### PR DESCRIPTION
I was trying to add a specific URL and noticed that there was a special character I hadn't prepared for. The URL was "https://warsaw.gaycities.com/bars/308665-pogłos" and the character was "ł". On lgbtDB, the URL is represented in the entity here: https://lgbtdb.wikibase.cloud/wiki/Item:Q86607, so you can see that it currently is not functioning.

I added this to the character to the appropriate line, tested the new regex using htaccess, and documented the change in the README.