### PR TITLE
Add w3id redirect for salemWitchTrials project

### DIFF
--- a/salemWitchTrials/.htaccess
+++ b/salemWitchTrials/.htaccess
@@ -1,0 +1,1 @@
+Redirect 301 /salemwitchtrials https://github.com/salem-witCHes/salemWitchTrials

--- a/salemWitchTrials/README.md
+++ b/salemWitchTrials/README.md
@@ -1,0 +1,3 @@
+# SalemWitchTrials Identifier
+
+This directory manages permanent identifier redirects for the SalemWitchTrials project, providing stable URLs for our data resources.

--- a/salemWitchTrials/README.md
+++ b/salemWitchTrials/README.md
@@ -1,3 +1,6 @@
 # SalemWitchTrials Identifier
 
 This directory manages permanent identifier redirects for the SalemWitchTrials project, providing stable URLs for our data resources.
+
+Maintainer
+- GitHub: sararoggi https://github.com/sararoggi


### PR DESCRIPTION
This Pull Request adds a new permanent identifier redirect for the salemWitchTrials project under the salem-witCHes organization.

Changes included:
- Created a new directory salemWitchTrials/ to hold the redirect rules.
- Added an .htaccess file with a permanent redirect from https://w3id.org/salemWitchTrials to the project’s official GitHub repository:
https://github.com/salem-witCHes/salemWitchTrials/
- Added a README.md file containing contact and project information.

Redirect details:
- Source URL: https://w3id.org/salemWitchTrials
- Target URL: https://github.com/salem-witCHes/salemWitchTrials/
- HTTP status code: 301 (Permanent Redirect)