### PR TITLE
initialization of objectcore redirect

### DIFF
--- a/objectcore/.htaccess
+++ b/objectcore/.htaccess
@@ -1,0 +1,15 @@
+# https://w3id.org/objectcore/<ANYTHING> redirects to https://n4o-rse.github.io/OCMDP/<ANYTHING>
+#
+# ## Contact
+# This space is administered by:  
+#
+# Lasse Mempel-Länger
+# GitHub username: LasseMempel
+# email: lasse.mempellaenger@leiza.de
+#
+# Florian Thiery
+# GitHub username: @florianthiery
+# email: florian.thiery@leiza.de
+
+RewriteEngine on
+RewriteRule ^(.*)$ https://n4o-rse.github.io/OCMDP/$1 [R=303,L]

--- a/objectcore/README.md
+++ b/objectcore/README.md
@@ -1,5 +1,3 @@
-## 
-
 Redirections from entities defined in the NFDI4Objects Object Core Metadata Profile
 
 

--- a/objectcore/README.md
+++ b/objectcore/README.md
@@ -1,0 +1,11 @@
+## 
+
+Redirections from entities defined in the NFDI4Objects Object Core Metadata Profile
+
+
+## Contacts
+
+* Lasse Mempel-Länger, lasse.mempellaenger@leiza.de, @LasseMempel
+* Florian Thiery, florian.thiery@leiza.de, @florianthiery
+
+


### PR DESCRIPTION
Added README.md  and .htaccess redirecting from https://w3id.org/objectcore/<ANYTHING> to https://n4o-rse.github.io/OCMDP/<ANYTHING>