### PR TITLE
Updated contact persons

### DIFF
--- a/xfsc/README.md
+++ b/xfsc/README.md
@@ -4,8 +4,9 @@ XFSC
 This W3ID provides a persistent URI namespace for the XFSC resources.
 
 Redirections:
-* `/catalogue` to [Federated Catalogue](https://gitlab.com/gaia-x/data-infrastructure-federation-services/cat/)
+* `/catalogue` to [Federated Catalogue](https://github.com/eclipse-xfsc/federated-catalogue/)
 
 Contacts:
-* [Philipp Hertweck](https://github.com/phertweck/) <philipp.hertweck@iosb.fraunhofer.de>
-* [Christoph Lange](https://gitlab.com/langec) <christoph.lange-bever@fit.fraunhofer.de>
+* [Lauresha Toska](https://github.com/lmemeti) <lauresha.toska@eco.de> (Eclipse XFSC project lead)
+* [Christoph Lange](https://github.com/clange) <christoph.lange-bever@fit.fraunhofer.de> (coordinator of the XFSC Catalogue development community)
+* [Philipp Hertweck](https://github.com/phertweck/) <philipp.hertweck@iosb.fraunhofer.de> (member of the XFSC Catalogue development team)


### PR DESCRIPTION
I updated the links to point to GitHub rather than the former GitLab home of the project, in line with https://github.com/perma-id/w3id.org/pull/5117. In particular, my identity is https://github.com/clange as well as https://gitlab.com/langec.