### PR TITLE
Add /cSite redirect for CSite ontology

### DIFF
--- a/cSite/.htaccess
+++ b/cSite/.htaccess
@@ -1,0 +1,15 @@
+RewriteEngine On
+
+# Root redirect to GitHub Pages site
+RewriteRule ^$ https://digiconstructlab-tu-delft.github.io/cSiteOntology/ [R=302,L]
+
+# Ontology serializations
+RewriteRule ^ontology.ttl$ https://digiconstructlab-tu-delft.github.io/cSiteOntology/ontology.ttl [R=302,L]
+RewriteRule ^ontology.owl$ https://digiconstructlab-tu-delft.github.io/cSiteOntology/ontology.owl [R=302,L]
+RewriteRule ^ontology.jsonld$ https://digiconstructlab-tu-delft.github.io/cSiteOntology/ontology.jsonld [R=302,L]
+
+# Redirect resource folder (e.g., images, CSS, JS)
+RewriteRule ^resources/(.*)$ https://digiconstructlab-tu-delft.github.io/cSiteOntology/resources/$1 [R=302,L]
+
+# Redirect modular documentation sections
+RewriteRule ^sections/(.*)$ https://digiconstructlab-tu-delft.github.io/cSiteOntology/sections/$1 [R=302,L]

--- a/cSite/README.md
+++ b/cSite/README.md
@@ -1,0 +1,36 @@
+# CSite Ontology
+
+This W3ID provides a persistent URI namespace for the **CSite Ontology** developed under the [DigiConstructLab at TU Delft](https://github.com/DigiConstructLab-TU-Delft). The ontology supports semantic integration of spatial, resource, activity, and document data in construction control environments — including live digital twin dashboards.
+
+The primary URI for the ontology is:
+
+📌 https://w3id.org/cSite
+
+## 🔁 Redirects
+
+| Path               | Redirect Target                                                                 |
+|--------------------|----------------------------------------------------------------------------------|
+| `/cSite`           | Main ontology documentation (GitHub Pages site)                                 |
+| `/cSite/ontology.ttl` | Turtle serialization of the ontology                                         |
+| `/cSite/ontology.owl` | RDF/XML serialization of the ontology                                        |
+| `/cSite/ontology.jsonld` | JSON-LD serialization of the ontology                                    |
+| `/cSite/resources/*`   | Images and assets for visualizing the ontology                              |
+| `/cSite/sections/*`    | Modular HTML documentation sections (abstract, usage, alignment, etc.)      |
+
+## 📚 Ontology Repository
+
+The ontology is maintained publicly at:  
+👉 https://github.com/DigiConstructLab-TU-Delft/cSiteOntology
+
+## 👤 Maintainer
+
+**Name**: Ranjith Kuttantharappel Soman  
+**Affiliation**: Assistant Professor, TU Delft  
+**Contact**: ranjithsomantudelft@gmail.com  
+**GitHub**: [@rkuttantharapp](https://github.com/rkuttantharapp)
+
+For questions or suggestions, feel free to raise an issue on the GitHub repository.
+
+## 🛠 License
+
+This ontology and its associated documentation are licensed under the [Creative Commons Attribution 4.0 International License (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
This PR adds a W3ID redirect for the CSite Ontology, developed by the [DigiConstructLab at TU Delft](https://github.com/DigiConstructLab-TU-Delft). The ontology supports semantic modeling of construction site production control, including spatial, activity, resource, and document integration for digital twin applications.

 Maintainer

Name: Ranjith Kuttantharappel Soman
Affiliation: Assistant Professor, TU Delft
Email: ranjithsomantudelft@gmail.com

 Redirect Details
 W3ID Path
Target Redirect URL
/cSite
https://digiconstructlab-tu-delft.github.io/cSiteOntology/
/cSite/ontology.ttl
https://digiconstructlab-tu-delft.github.io/cSiteOntology/ontology.ttl
/cSite/ontology.owl
https://digiconstructlab-tu-delft.github.io/cSiteOntology/ontology.owl
/cSite/ontology.jsonld
https://digiconstructlab-tu-delft.github.io/cSiteOntology/ontology.jsonld
/cSite/resources/*
https://digiconstructlab-tu-delft.github.io/cSiteOntology/resources/
/cSite/sections/*
https://digiconstructlab-tu-delft.github.io/cSiteOntology/sections/
