### PR TITLE
Changes redirection rules to reflect format change from .owl to .ttl to correctly reflect the used Turtle syntax

### DIFF
--- a/hsu-aut/DINEN61360/.htaccess
+++ b/hsu-aut/DINEN61360/.htaccess
@@ -4,13 +4,13 @@ RewriteEngine on
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
-RewriteRule ^(\d\.\d\.\d)/?$ https://raw.githubusercontent.com/hsu-aut/IndustrialStandard-ODP-DINEN61360/v$1/DINEN61360.owl [R=303,NC,L]
+RewriteRule ^(\d\.\d\.\d)/?$ https://raw.githubusercontent.com/hsu-aut/IndustrialStandard-ODP-DINEN61360/v$1/DINEN61360.ttl [R=303,NC,L]
 
 # Redirect ontology IRI (without version) to the current main branch version
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
-RewriteRule ^/?$ https://raw.githubusercontent.com/hsu-aut/IndustrialStandard-ODP-DINEN61360/master/DINEN61360.owl [R=303,NC,L]
+RewriteRule ^/?$ https://raw.githubusercontent.com/hsu-aut/IndustrialStandard-ODP-DINEN61360/master/DINEN61360.ttl [R=303,NC,L]
 
 # Redirect HTML requests to the main repository page
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)

--- a/hsu-aut/cask/.htaccess
+++ b/hsu-aut/cask/.htaccess
@@ -4,13 +4,13 @@ RewriteEngine on
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
-RewriteRule ^(\d\.\d\.\d)/?$ https://raw.githubusercontent.com/CaSkade-Automation/CaSk/v$1/cask.owl [R=303,NC,L]
+RewriteRule ^(\d\.\d\.\d)/?$ https://raw.githubusercontent.com/CaSkade-Automation/CaSk/v$1/cask.ttl [R=303,NC,L]
 
 # Redirect ontology IRI (withouth version) to the current main branch version
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
-RewriteRule ^/?$ https://raw.githubusercontent.com/CaSkade-Automation/CaSk/main/cask.owl [R=303,NC,L]
+RewriteRule ^/?$ https://raw.githubusercontent.com/CaSkade-Automation/CaSk/main/cask.ttl [R=303,NC,L]
 
 # Redirect HTML requests to the main repository page
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)

--- a/hsu-aut/css/.htaccess
+++ b/hsu-aut/css/.htaccess
@@ -4,13 +4,13 @@ RewriteEngine on
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
-RewriteRule ^(\d\.\d\.\d)/?$ https://raw.githubusercontent.com/CaSkade-Automation/CSS/v$1/CSS-Ontology.owl [R=303,NC,L]
+RewriteRule ^(\d\.\d\.\d)/?$ https://raw.githubusercontent.com/CaSkade-Automation/CSS/v$1/CSS-Ontology.ttl [R=303,NC,L]
 
 # Redirect ontology IRI (withouth version) to the current main branch version
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
-RewriteRule ^/?$ https://raw.githubusercontent.com/CaSkade-Automation/CSS/main/CSS-Ontology.owl [R=303,NC,L]
+RewriteRule ^/?$ https://raw.githubusercontent.com/CaSkade-Automation/CSS/main/CSS-Ontology.ttl [R=303,NC,L]
 
 # Redirect HTML requests to the main repository page
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)


### PR DESCRIPTION
This update adjusts the redirection rules for some ontologies to reflect a format change from .owl to .ttl., since the ontologies have always been written in Turtle syntax. There are no changes to the ontology content itself — only the file extension was corrected to accurately reflect the format being used. 