### PR TITLE
created \comptox namespace

### DIFF
--- a/comptox/.htaccess
+++ b/comptox/.htaccess
@@ -1,0 +1,27 @@
+# # /comptox/
+#
+# All requests are redirected to the main turtle file on the github repo  https://github.com/SAWGraph/comptox
+
+#
+# ## Contact
+# This space is administered by:
+#
+# Katrina Schweikert
+# Github username: kschweikert
+#
+# Torsten Hahmann
+# Github username: thahmann
+
+
+# Turn off MultiViews
+Options -MultiViews
+
+RewriteEngine on
+
+# Default response
+# -----------------------------
+
+# Rewrite rule for all other request to point back to the main github repo 
+RewriteRule ^(.*) https://raw.githubusercontent.com/SAWGraph/comptox-ontology/refs/heads/main/v0/pfas.ttl [R=303,L,NE]
+
+

--- a/comptox/README.md
+++ b/comptox/README.md
@@ -1,0 +1,1 @@
+Home of the ontology for chemicals (primarily contaminants like PFAS) and their identifiers and properties from EPA's Comptox dashboard.


### PR DESCRIPTION
create new namespace to host chemicals as identified and described by EPA's CompTox dashboard