### PR TITLE
rdf-tensor: add ontology files in RDF/XML, JSON-LD

### DIFF
--- a/rdf-tensor/.htaccess
+++ b/rdf-tensor/.htaccess
@@ -4,20 +4,33 @@ RewriteEngine on
 
 AddType text/turtle .ttl
 AddType application/n-triples .nt
+AddType application/rdf+xml .rdf
+AddType application/ld+json .jsonld
 AddType application/x-jelly-rdf .jelly
 
 # Ontology files -- explicit file extension
-RewriteRule ^([a-z]+)\.(ttl|nt|jelly)([#?].*)?$ https://github.com/RDF-tensor/jena-datatensor/releases/download/dev/$1.$2 [R=302,L]
+RewriteRule ^([a-z]+)\.(ttl|nt|jsonld|rdf|jelly)([#?].*)?$ https://github.com/RDF-tensor/jena-datatensor/releases/download/dev/$1.$2 [R=302,L]
 
 # Ontology files -- content negotiation
+# N-Triples
 RewriteCond %{HTTP_ACCEPT} application/n-triples
 RewriteRule ^(datatypes|functions|aggregates)/?([#?].*)?$ https://github.com/RDF-tensor/jena-datatensor/releases/download/dev/$1.nt [R=302,L]
 
+# Turtle
 RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle
 RewriteRule ^(datatypes|functions|aggregates)/?([#?].*)?$ https://github.com/RDF-tensor/jena-datatensor/releases/download/dev/$1.ttl [R=302,L]
 
+# JSON-LD
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(datatypes|functions|aggregates)/?([#?].*)?$ https://github.com/RDF-tensor/jena-datatensor/releases/download/dev/$1.jsonld [R=302,L]
+
+# RDF/XML
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(datatypes|functions|aggregates)/?([#?].*)?$ https://github.com/RDF-tensor/jena-datatensor/releases/download/dev/$1.rdf [R=302,L]
+
+# Jelly
 RewriteCond %{HTTP_ACCEPT} application/x-jelly-rdf
 RewriteRule ^(datatypes|functions|aggregates)/?([#?].*)?$ https://github.com/RDF-tensor/jena-datatensor/releases/download/dev/$1.jelly [R=302,L]
 

--- a/rdf-tensor/README.md
+++ b/rdf-tensor/README.md
@@ -16,6 +16,12 @@ An extension of RDF and SPARQL to process multi-dimensional arrays of numerical 
 - https://w3id.org/rdf-tensor/aggregates.ttl
 - https://w3id.org/rdf-tensor/functions.ttl
 - https://w3id.org/rdf-tensor/datatypes.ttl
+- https://w3id.org/rdf-tensor/aggregates.jsonld
+- https://w3id.org/rdf-tensor/functions.jsonld
+- https://w3id.org/rdf-tensor/datatypes.jsonld
+- https://w3id.org/rdf-tensor/aggregates.rdf
+- https://w3id.org/rdf-tensor/functions.rdf
+- https://w3id.org/rdf-tensor/datatypes.rdf
 - https://w3id.org/rdf-tensor/aggregates.jelly
 - https://w3id.org/rdf-tensor/functions.jelly
 - https://w3id.org/rdf-tensor/datatypes.jelly


### PR DESCRIPTION
Adds support for content negotiation and explicit URLs for JSON-LD and RDF/XML. Follow-up of: https://github.com/RDF-tensor/jena-datatensor/pull/8

Tested on a local Apache instance, it works.