### PR TITLE
Add new w3id for dongshin.seo

### DIFF
--- a/dongshin.seo/.htaccess
+++ b/dongshin.seo/.htaccess
@@ -1,0 +1,14 @@
+# dongshin.seo
+#
+# https://w3id.org/dongshin.seo/ redirects to https://dh.aks.ac.kr/~dongshin/
+#
+# ## Contact
+# This space is administered by:
+#
+# Dongshin SEO
+# oriental.neo@gmail.com
+# GitHub username: dongshins
+
+RewriteEngine on
+RewriteRule ^$ https://dh.aks.ac.kr/~dongshin/ [R=302,L]
+RewriteRule ^(.*)$ https://dh.aks.ac.kr/~dongshin/$1 [R=302,L]

--- a/dongshin.seo/.htaccess
+++ b/dongshin.seo/.htaccess
@@ -5,7 +5,7 @@
 # ## Contact
 # This space is administered by:
 #
-# Dongshin SEO
+# Dong Shin SEO
 # oriental.neo@gmail.com
 # GitHub username: dongshins
 

--- a/dongshin.seo/.htaccess
+++ b/dongshin.seo/.htaccess
@@ -10,5 +10,5 @@
 # GitHub username: dongshins
 
 RewriteEngine on
-RewriteRule ^$ https://dh.aks.ac.kr/~dongshin/ [R=302,L]
-RewriteRule ^(.*)$ https://dh.aks.ac.kr/~dongshin/$1 [R=302,L]
+RewriteRule ^$ https://dh.aks.ac.kr/~dongshin/ [R=301,L]
+RewriteRule ^(.*)$ https://dh.aks.ac.kr/~dongshin/$1 [R=301,L]

--- a/dongshin.seo/README.md
+++ b/dongshin.seo/README.md
@@ -6,4 +6,4 @@ This w3id is maintained by:
 
 Dongshin SEO  
 * oriental.neo@gmail.com  
-* GitHub: @dongshins
+* GitHub: [@dongshins](https://github.com/dongshins)

--- a/dongshin.seo/README.md
+++ b/dongshin.seo/README.md
@@ -1,1 +1,1 @@
-Persistent identifiers for Dong Shin SEO 
+Persistent identifiers for Dong Shin SEO. 

--- a/dongshin.seo/README.md
+++ b/dongshin.seo/README.md
@@ -1,6 +1,7 @@
 Persistent identifier for Dong Shin SEO 
 
 This w3id is maintained by:
+
 Dong Shin SEO 
 * oriental.neo@gmail.com  
 * GitHub: [@dongshins](https://github.com/dongshins)

--- a/dongshin.seo/README.md
+++ b/dongshin.seo/README.md
@@ -1,1 +1,9 @@
 Persistent identifiers for Dong Shin SEO. 
+
+# Maintainer Contact
+
+This w3id is maintained by:
+
+Dongshin SEO  
+📧 oriental.neo@gmail.com  
+🐙 GitHub: @dongshins

--- a/dongshin.seo/README.md
+++ b/dongshin.seo/README.md
@@ -5,5 +5,5 @@ Persistent identifiers for Dong Shin SEO.
 This w3id is maintained by:
 
 Dongshin SEO  
-📧 oriental.neo@gmail.com  
-🐙 GitHub: @dongshins
+* oriental.neo@gmail.com  
+* GitHub: @dongshins

--- a/dongshin.seo/README.md
+++ b/dongshin.seo/README.md
@@ -1,9 +1,6 @@
 Persistent identifier for Dong Shin SEO 
 
-# Maintainer Contact
-
 This w3id is maintained by:
-
 Dong Shin SEO 
 * oriental.neo@gmail.com  
 * GitHub: [@dongshins](https://github.com/dongshins)

--- a/dongshin.seo/README.md
+++ b/dongshin.seo/README.md
@@ -1,0 +1,1 @@
+Persistent identifiers for Dong Shin SEO 

--- a/dongshin.seo/README.md
+++ b/dongshin.seo/README.md
@@ -1,4 +1,4 @@
-Persistent identifiers for Dong Shin SEO. 
+Persistent identifier for Dong Shin SEO 
 
 # Maintainer Contact
 

--- a/dongshin.seo/README.md
+++ b/dongshin.seo/README.md
@@ -4,6 +4,6 @@ Persistent identifiers for Dong Shin SEO.
 
 This w3id is maintained by:
 
-Dongshin SEO  
+Dong Shin SEO 
 * oriental.neo@gmail.com  
 * GitHub: [@dongshins](https://github.com/dongshins)


### PR DESCRIPTION
This pull request adds a new persistent identifier for https://w3id.org/dongshin.seo/.

# Redirect Information

The identifier redirects permanently (HTTP 301) to the personal webpage of Dongshin Seo at:
→ https://dh.aks.ac.kr/~dongshin/

The `.htaccess` file uses Apache rewrite rules to handle:
- Base path redirection:
  → https://w3id.org/dongshin.seo/ → https://dh.aks.ac.kr/~dongshin/
- Subpath redirection:
  → https://w3id.org/dongshin.seo/something → https://dh.aks.ac.kr/~dongshin/something

# Maintainer Contact

This w3id is maintained by:

Dongshin SEO  
📧 oriental.neo@gmail.com  
🐙 GitHub: @dongshins

All files are placed under the `dongshin.seo/` directory, following w3id.org conventions.
