### PR TITLE
Add new w3id for dh.aks.ac.kr 

### DIFF
--- a/dh.aks.ac.kr/.htaccess
+++ b/dh.aks.ac.kr/.htaccess
@@ -1,0 +1,14 @@
+# dh.aks.ac.kr
+#
+# https://w3id.org/dh.aks.ac.kr/ redirects to https://dh.aks.ac.kr/
+#
+# ## Contact
+# This space is administered by:
+#
+# Dong Shin SEO
+# oriental.neo@gmail.com
+# GitHub username: dongshins
+
+RewriteEngine on
+RewriteRule ^$ https://dh.aks.ac.kr/ [R=301,L]
+RewriteRule ^(.*)$ https://dh.aks.ac.kr/$1 [R=301,L]

--- a/dh.aks.ac.kr/README.md
+++ b/dh.aks.ac.kr/README.md
@@ -1,0 +1,7 @@
+Persistent identifier for the DH host address at the Academy of Korean Studies 
+
+This w3id is maintained by:
+
+Dong Shin SEO 
+* oriental.neo@gmail.com  
+* GitHub: [@dongshins](https://github.com/dongshins)


### PR DESCRIPTION
This pull request adds a new persistent identifier for https://w3id.org/dh.aks.ac.kr/.

# Redirect Information

The identifier redirects permanently (HTTP 301) to the address of the current DH host at the Academy of Korean Studies at:
→ https://dh.aks.ac.kr/

The `.htaccess` file uses Apache rewrite rules to handle:
- Base path redirection:
  → https://w3id.org/dh.aks.ac.kr/ → https://dh.aks.ac.kr/
- Subpath redirection:
  → https://w3id.org/dh.aks.ac.kr/something → https://dh.aks.ac.kr/something

# Maintainer Contact

This w3id is maintained by:

Dongshin SEO  
📧 oriental.neo@gmail.com  
🐙 GitHub: @dongshins

All files are placed under the `dh.aks.ac.kr/` directory, following w3id.org conventions.
