### PR TITLE
Adding rewrite rules for worldstatesmen.org.

### DIFF
--- a/worldstatesmen/.htaccess
+++ b/worldstatesmen/.htaccess
@@ -1,0 +1,30 @@
+# Example
+#
+# https://w3id.org/worldstatesmen/Afghanistan redirects to https://www.worldstatesmen.org/Afghanistan.htm
+# https://w3id.org/worldstatesmen/US_Mayors/Akron redirects to https://www.worldstatesmen.org/US_Mayors.html#Akron
+# 
+# ## Contact
+# This space is administered by:
+#
+# Clair Kronk
+# Clair.Kronk@mountsinai.org
+# GitHub username: Superraptor
+
+# Examples tested using:
+# https://htaccess.madewithlove.com/
+# (20 July 2025)
+
+RewriteEngine On
+RewriteBase /
+
+# Necessary because some pages end with .htm as their extension
+RewriteRule ^(Afghanistan|Kazakhstan|Albania|Portugal|New\_Zealand|Iraq|Myanmar|Latvia|Lesotho|Netherlands|Lebanon|Palau|Moldova|India|Macedonia|Mongolia|Reunion|Malawi|Kenya|Guyana|Kiribati|Liberia|Micronesia|Korea\_South|Poland|Indonesia)$ https://www.worldstatesmen.org/$1.htm [R=301,NE,L]
+
+# Necessary because some pages end with .htm as their extension
+RewriteRule ^(Afghanistan|Kazakhstan|Albania|Portugal|New\_Zealand|Iraq|Myanmar|Latvia|Lesotho|Netherlands|Lebanon|Palau|Moldova|India|Macedonia|Mongolia|Reunion|Malawi|Kenya|Guyana|Kiribati|Liberia|Micronesia|Korea\_South|Poland|Indonesia)/([A-Za-z0-9\_\-]{1,80})$ https://www.worldstatesmen.org/$1.htm#$2 [R=301,NE,L]
+
+# Redirect URLs of the form /worldstatesmen/$1
+RewriteRule ^([A-Za-z0-9\_\-]{1,80})$ https://www.worldstatesmen.org/$1.html [R=301,NE,L]
+
+# Redirect URLs of the form /worldstatesmen/$1/$2
+RewriteRule ^([A-Za-z0-9\_\-]{1,80})/([A-Za-z0-9_\-]{1,80})$ https://www.worldstatesmen.org/$1.html#$2 [R=301,NE,L]

--- a/worldstatesmen/README.md
+++ b/worldstatesmen/README.md
@@ -1,4 +1,4 @@
-# Gaycities
+# worldstatesmen
 
 [Website](hhttps://www.worldstatesmen.org/) that is called "an online encyclopedia of the leaders of nations and territories". `.htaccess` file created by Clair Kronk for use at lgbtDB.
 

--- a/worldstatesmen/README.md
+++ b/worldstatesmen/README.md
@@ -1,0 +1,9 @@
+# Gaycities
+
+[Website](hhttps://www.worldstatesmen.org/) that is called "an online encyclopedia of the leaders of nations and territories". `.htaccess` file created by Clair Kronk for use at lgbtDB.
+
+## Contact
+This space is administered by:
+* Clair Kronk
+* Clair.Kronk@mountsinai.org
+* GitHub username: Superraptor


### PR DESCRIPTION
Added rewrite rules. Unfortunately, seemingly at random, a small number of pages end in ".htm" instead of ".html". I documented all of those in separate rewrite rules that trigger first; this required investigating the page here (https://www.worldstatesmen.org/CONTENTS.html) and finding all links ending with ".htm". Tested and ready for action!