### PR TITLE
GNSS-DCAT-AP

### DIFF
--- a/gnss-dcat-ap/.htaccess
+++ b/gnss-dcat-ap/.htaccess
@@ -1,0 +1,57 @@
+Header set Access-Control-Allow-Origin *
+Options -MultiViews
+Options +FollowSymLinks
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
+AddType application/json+ld .json
+AddType application/json .json
+
+RewriteEngine on
+SetEnvIf Accept ^.+$ SYNTAX=other
+SetEnvIf Accept ^.*application/rdf\+xml.* SYNTAX=rdf
+SetEnvIf Accept ^.*text/turtle.* SYNTAX=ttl
+SetEnvIf Accept ^.*application/json-ld.* SYNTAX=json
+SetEnvIf Accept ^.*application/n-triples.* SYNTAX=nt
+SetEnvIf Accept ^.*text/html.* SYNTAX=html
+SetEnvIf Accept ^\*/\*$ SYNTAX=ttl
+SetEnvIf Request_URI ^.*$ ROOT_URL=https://gnss.be/vocab/latest
+
+#####     GNSS-DCAT-AP     #####
+
+# Latest specification
+RewriteCond %{HTTP:Accept} application/rdf\+xml [NC]
+RewriteRule ^(.+)$ %{ENV:ROOT_URL}/$1.rdf [R=303,L]
+
+RewriteCond %{HTTP:Accept} application/ld\+json [NC]
+RewriteRule ^(.+)$ %{ENV:ROOT_URL}/$1.json [R=303,L]
+
+RewriteCond %{HTTP:Accept} application/json\+ld [NC]
+RewriteRule ^(.+)$ %{ENV:ROOT_URL}/$1.json [R=303,L]
+
+RewriteCond %{HTTP:Accept} application/json [NC]
+RewriteRule ^(.+)$ %{ENV:ROOT_URL}/$1.json [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/turtle [NC]
+RewriteRule ^(.+)$ %{ENV:ROOT_URL}/$1.ttl [R=303,L]
+
+RewriteCond %{HTTP:Accept} text/html [NC]
+RewriteRule ^(.+)$ %{ENV:ROOT_URL}/$1.html [R=303,L]
+
+# Serve index.html for root path
+RewriteCond %{HTTP:Accept} text/html [NC]
+RewriteRule ^$ %{ENV:ROOT_URL}/index.html [L]
+
+# ===== Redirect to 406.html for unsupported Accept types =====
+RewriteCond %{HTTP:Accept} !application/rdf\+xml [NC]
+RewriteCond %{HTTP:Accept} !application/ld\+json [NC]
+RewriteCond %{HTTP:Accept} !application/json\+ld [NC]
+RewriteCond %{HTTP:Accept} !application/json [NC]
+RewriteCond %{HTTP:Accept} !text/turtle [NC]
+RewriteCond %{HTTP:Accept} !text/html [NC]
+RewriteRule ^(.*)$ %{ENV:ROOT_URL}/406.html [R=406,L]
+

--- a/gnss-dcat-ap/README.md
+++ b/gnss-dcat-ap/README.md
@@ -1,0 +1,20 @@
+# gnss-dcat-ap
+
+This namespace [w3id.org/gnss-dcat-ap](https://w3id.org/gnss-dcat-ap) provides a persistent URI namespace for the GNSS-DCAT-AP specification and related controlled vocabularies.
+
+## Description
+This namespace is used for the overall specification and the associated controlled vocabularies for the GNSS-DCAT-AP. See [w3id.org/gnss-dcat-ap](https://w3id.org/gnss-dcat-ap) for full details.
+
+## Contacts 
+
+**Andras Fabian**
+ORCID: [0000-0002-9855-0494](https://orcid.org/0000-0002-9855-0494)
+**Anna Miglio**
+ORCID: [0000-0001-7316-4952](https://orcid.org/0000-0001-7316-4952)
+**Carine Bruyninx**
+ORCID: [0000-0001-6492-3945](https://orcid.org/0000-0001-6492-3945)
+
+
+[M3G](https://www.gnss-metadata.eu) <m3g@oma.be>
+[GNSS.BE](https://www.gnss.be) <gnss@oma.be>
+[EPNCB](https://epncb.oma.be) <epncb@oma.be>

--- a/gnss-dcat-ap/README.md
+++ b/gnss-dcat-ap/README.md
@@ -9,8 +9,10 @@ This namespace is used for the overall specification and the associated controll
 
 **Andras Fabian**
 ORCID: [0000-0002-9855-0494](https://orcid.org/0000-0002-9855-0494)
+GitHub: [@andrasfabian12](https://github.com/andrasfabian12)
 **Anna Miglio**
 ORCID: [0000-0001-7316-4952](https://orcid.org/0000-0001-7316-4952)
+GitHub: [@ROB-GNSS](https://github.com/ROB-GNSS)
 **Carine Bruyninx**
 ORCID: [0000-0001-6492-3945](https://orcid.org/0000-0001-6492-3945)
 


### PR DESCRIPTION
Add Persistent identifier (/gnss-dcat-ap) for the latest version of the GNSS-DCAT-AP Controlled vocabulary.

