### PR TITLE
football-cdf redirection

### DIFF
--- a/football-cdf/.htaccess
+++ b/football-cdf/.htaccess
@@ -1,0 +1,4 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ https://semsys.ai.wu.ac.at/football-cdf/ [R=302,L]
+RewriteRule ^(.*)$ https://semsys.ai.wu.ac.at/football-cdf/$1 [R=302,L]

--- a/football-cdf/readme.md
+++ b/football-cdf/readme.md
@@ -1,0 +1,8 @@
+Football Common Data Format (Football-CDF) Ontology
+===
+
+The aim of this irectory is to provide permanent URLs for resources created created in the context of the Football Common Data Format (football-cdf) ontology. This is a proposed ontology serialization of the Football Common Data Format developed as a community effort between representation of academic, practitioners, and regulator in football data analytics [The Common Data Format (CDF):  A Standardized Format for Match-Data in Football (Soccer)](https://arxiv.org/abs/2505.15820)
+
+* Contacts: 
+    * [Fajar J. Ekaputra](mailto:fajar.ekaputra@wu.ac.at)
+    * [Gregor Käfer](mailto:gregor.kaefer@wu.ac.at)


### PR DESCRIPTION
The aim of this directory is to provide permanent URLs for resources created created in the context of the Football Common Data Format (football-cdf) ontology