### PR TITLE
https://w3id.org/archlink/branches/ redirection

### DIFF
--- a/archlink/branches/.htaccess
+++ b/archlink/branches/.htaccess
@@ -1,0 +1,11 @@
+# https://w3id.org/archlink/branches/ redirects to https://w3id.org/archlink/terms/conservationthesaurus
+#
+# ## Contact
+# This space is administered by:  
+#
+# Lasse Mempel-Länger
+# GitHub username: LasseMempel
+# email: lasse.mempellaenger@leiza.de
+
+RewriteEngine on
+RewriteRule ^ https://w3id.org/archlink/terms/conservationthesaurus [R=303,L]


### PR DESCRIPTION
https://w3id.org/archlink/branches/ redirects to https://w3id.org/archlink/terms/conservationthesaurus
This allows the publication of seperate branches of our vocabulary with own Concept Scheme URIs, while still leading to the base thesaurus URI.