### PR TITLE
feat(routing): add content negotiation and ontology file redirections to .htaccess:

### DIFF
--- a/health-ri/.htaccess
+++ b/health-ri/.htaccess
@@ -1,31 +1,78 @@
 Options -MultiViews
 RewriteEngine on
 
-# RESOURCES' VERSIONING ----------------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------------------------------------
+# CONTENT NEGOTIATION FOR /ontology
+# --------------------------------------------------------------------------------------------------------------
+
+# Redirect to HTML spec if no RDF content type is requested
+RewriteCond %{REQUEST_URI} ^/health-ri/ontology/?$
+RewriteCond %{HTTP_ACCEPT} !text/turtle
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml
+RewriteCond %{HTTP_ACCEPT} !application/ld\+json
+RewriteRule ^health-ri/ontology/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/documentations/specification.html [R=303,L]
+
+# Serve TTL if Turtle is requested
+RewriteCond %{REQUEST_URI} ^/health-ri/ontology/?$
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^health-ri/ontology/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/health-ri-ontology.ttl [R=303,L]
+
+# --------------------------------------------------------------------------------------------------------------
+# RESOURCES' VERSIONING
+# --------------------------------------------------------------------------------------------------------------
 
 ## Latest release
-RedirectMatch 302 ^/health-ri/metadata/releases/(latest|current)/?$  https://github.com/Health-RI/health-ri-metadata/releases/latest
+RedirectMatch 302 ^/health-ri/metadata/releases/(latest|current)/?$ https://github.com/Health-RI/health-ri-metadata/releases/latest
 
 ## All releases
-RedirectMatch 302 ^/health-ri/metadata/releases/?$  https://github.com/Health-RI/health-ri-metadata/releases
+RedirectMatch 302 ^/health-ri/metadata/releases/?$ https://github.com/Health-RI/health-ri-metadata/releases
 
 ## Specific release
-RedirectMatch 302 ^/health-ri/metadata/releases/(.+)/?$  https://github.com/Health-RI/health-ri-metadata/releases/tag/$1
+RedirectMatch 302 ^/health-ri/metadata/releases/(.+)/?$ https://github.com/Health-RI/health-ri-metadata/releases/tag/$1
 
-# RESOURCES' HOMEPAGES ----------------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------------------------------------
+# RESOURCES' HOMEPAGES
+# --------------------------------------------------------------------------------------------------------------
 
-# Health-RI Metadata Schema
-RedirectMatch 302 ^/health-ri/metadata/?$  https://github.com/Health-RI/health-ri-metadata/
-RedirectMatch 302 ^/health-ri/metadata/(git|repo)/?$  https://github.com/Health-RI/health-ri-metadata/
+## Health-RI Metadata Schema
+RedirectMatch 302 ^/health-ri/metadata/?$ https://github.com/Health-RI/health-ri-metadata/
+RedirectMatch 302 ^/health-ri/metadata/(git|repo)/?$ https://github.com/Health-RI/health-ri-metadata/
 
-# Health-RI Semantic Interoperability
-RedirectMatch 302 ^/health-ri/semantic-interoperability/?$  https://health-ri.github.io/semantic-interoperability/
-RedirectMatch 302 ^/health-ri/semantic-interoperability/git/?$  https://github.com/Health-RI/semantic-interoperability/
+## Health-RI Semantic Interoperability
+RedirectMatch 302 ^/health-ri/semantic-interoperability/?$ https://health-ri.github.io/semantic-interoperability/
+RedirectMatch 302 ^/health-ri/semantic-interoperability/git/?$ https://github.com/Health-RI/semantic-interoperability/
 
-# GENERAL REDIRECTIONS ----------------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------------------------------------
+# GENERAL REDIRECTIONS
+# --------------------------------------------------------------------------------------------------------------
 
 # Redirect the root /health-ri path to the official website
 RedirectMatch 302 ^/health-ri/?$ https://www.health-ri.nl/
+
+# --------------------------------------------------------------------------------------------------------------
+# ONTOLOGY FILES
+# --------------------------------------------------------------------------------------------------------------
+
+## Latest ontology files (ttl, vpp, json, documentation.md, specification.html)
+RewriteCond %{REQUEST_URI} ^/health-ri/ontology/(ttl|vpp|json|doc|documentation|spec|specification)/?$
+RewriteRule ^health-ri/ontology/(ttl|vpp|json)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/health-ri-ontology.%1 [R=302,L]
+RewriteRule ^health-ri/ontology/(doc|documentation)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/documentations/documentation.md [R=302,L]
+RewriteRule ^health-ri/ontology/(spec|specification)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/documentations/specification.html [R=302,L]
+
+## Default TTL redirection for /ontology/
+RedirectMatch 302 ^/health-ri/ontology/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/health-ri-ontology.ttl
+
+## Versioned ontology files
+RewriteRule ^health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/(ttl|vpp|json)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/health-ri-ontology/v$1/$2 [R=302,L]
+RewriteRule ^health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/(doc|documentation)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/documentations/documentation-v$1.md [R=302,L]
+RewriteRule ^health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/(spec|specification)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/documentations/specification-v$1.html [R=302,L]
+RewriteRule ^health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/health-ri-ontology/v$1 [R=302,L]
+
+# --------------------------------------------------------------------------------------------------------------
+# FALLBACKS OR LEGACY (commented out)
+# --------------------------------------------------------------------------------------------------------------
 
 # (REMOVED) Redirect everything else to the corresponding GitHub repository
 # RewriteRule ^(.*)$ https://github.com/Health-RI/$1 [R=302,L]


### PR DESCRIPTION
Add to .htaccess:

- Introduced Accept header-based content negotiation for /ontology:
  - Redirects to TTL if 'text/turtle' is requested
  - Redirects to HTML specification if no RDF type is requested
- Added RewriteRules for latest and versioned ontology resources (ttl, vpp, json, doc, spec)
- Improved support for optional trailing slashes on all ontology-related routes
- Reorganized and commented sections for clarity:
  - Content Negotiation
  - Resource Versioning
  - Resource Homepages
  - General Redirections
  - Ontology Files
  - Fallbacks