### PR TITLE
Fix, simplify, and improve ontology file redirections in health-ri's .htaccess

### DIFF
--- a/health-ri/.htaccess
+++ b/health-ri/.htaccess
@@ -55,24 +55,21 @@ RedirectMatch 302 ^/health-ri/?$ https://www.health-ri.nl/
 # ONTOLOGY FILES
 # --------------------------------------------------------------------------------------------------------------
 
-## Latest ontology files (ttl, vpp, json, documentation.md, specification.html)
-RewriteCond %{REQUEST_URI} ^/health-ri/ontology/(ttl|vpp|json|doc|documentation|spec|specification)/?$
-RewriteRule ^health-ri/ontology/(ttl|vpp|json)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/health-ri-ontology.%1 [R=302,L]
-RewriteRule ^health-ri/ontology/(doc|documentation)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/documentations/documentation.md [R=302,L]
-RewriteRule ^health-ri/ontology/(spec|specification)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/documentations/specification.html [R=302,L]
+## Latest ontology files (ttl, vpp, json, documentation.html, specification.html)
+RedirectMatch 302 ^/health-ri/ontology/ttl/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/health-ri-ontology.ttl
+RedirectMatch 302 ^/health-ri/ontology/vpp/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/health-ri-ontology.vpp
+RedirectMatch 302 ^/health-ri/ontology/json/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/health-ri-ontology.json
+RedirectMatch 302 ^/health-ri/ontology/(doc|documentation)/?$ https://health-ri.github.io/semantic-interoperability/ontology/documentation/
+RedirectMatch 302 ^/health-ri/ontology/(spec|specification)/?$ https://health-ri.github.io/semantic-interoperability/ontology/specification.html
+
+## Versioned ontology files (ttl, vpp, json, documentation.md, specification.html)
+# Matches semantic versions like v1.2.3 and redirects to the corresponding static files
+RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/health-ri-ontology-v$1.ttl
+RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/(ttl)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/health-ri-ontology-v$1.ttl
+RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/(vpp)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/health-ri-ontology-v$1.vpp
+RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/(json)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/health-ri-ontology-v$1.json
+RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/(doc|documentation)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/documentations/documentation-v$1.md
+RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/(spec|specification)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/documentations/specification-v$1.html
 
 ## Default TTL redirection for /ontology/
 RedirectMatch 302 ^/health-ri/ontology/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/health-ri-ontology.ttl
-
-## Versioned ontology files
-RewriteRule ^health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/(ttl|vpp|json)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/health-ri-ontology/v$1/$2 [R=302,L]
-RewriteRule ^health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/(doc|documentation)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/documentations/documentation-v$1.md [R=302,L]
-RewriteRule ^health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/(spec|specification)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/documentations/specification-v$1.html [R=302,L]
-RewriteRule ^health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/health-ri-ontology/v$1 [R=302,L]
-
-# --------------------------------------------------------------------------------------------------------------
-# FALLBACKS OR LEGACY (commented out)
-# --------------------------------------------------------------------------------------------------------------
-
-# (REMOVED) Redirect everything else to the corresponding GitHub repository
-# RewriteRule ^(.*)$ https://github.com/Health-RI/$1 [R=302,L]


### PR DESCRIPTION
refactor(routing): fix, simplify, and improve ontology file redirections in .htaccess

- Replaced RewriteRule-based redirections with RedirectMatch for clarity and maintainability
- Updated latest ontology file redirects (ttl, vpp, json, doc, spec)
- Added clean support for versioned ontology files using semantic version capture (vX.Y.Z)
- Changed doc/spec redirects to use GitHub Pages for proper HTML rendering
- Removed obsolete RewriteRule-based versioned redirect logic