### PR TITLE
Add redirect for jelly-cli install script

### DIFF
--- a/jelly/.htaccess
+++ b/jelly/.htaccess
@@ -1,5 +1,10 @@
 RewriteEngine on
 
+AddType application/x-sh .sh
+
+# Install script for jelly-cli
+RewriteRule ^setup-cli.sh$ https://raw.githubusercontent.com/Jelly-RDF/cli/main/install.sh [R=302,L]
+
 # Redirect by default to the dev version of the docs
 RewriteRule ^$ https://jelly-rdf.github.io/dev/ [R=302,L]
 


### PR DESCRIPTION
Issue: https://github.com/Jelly-RDF/cli/issues/172

This adds a redirect for the [jelly-cli](https://github.com/Jelly-RDF/cli) installation script. I tested this on a local Apache instance, it works.

You can review the install script this points to here: https://github.com/Jelly-RDF/cli/blob/main/install.sh