### PR TITLE
Fixed `%RewriteCond` statements

### DIFF
--- a/emmo/.htaccess
+++ b/emmo/.htaccess
@@ -50,8 +50,7 @@ RewriteRule ^emmo-lite/?$ https://raw.githubusercontent.com/emmo-repo/EMMO-LITE/
 ##########################################################################
 
 # Rule 1:
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^domain/characterisation-methodology/chameo/?$ https://emmo-repo.github.io/domain-characterisation-methodology/chameo.html [R=303,NE,L]
 RewriteRule ^domain/characterisation-methodology/chameo/?$ https://emmo-repo.github.io/domain-characterisation-methodology/chameo.ttl [R=303,NE,L]
 
@@ -66,8 +65,7 @@ RewriteRule ^domain/characterisation-methodology/chameo/latest/?$ https://raw.gi
 RewriteRule ^domain/characterisation-methodology/chameo/source/?$ https://raw.githubusercontent.com/emmo-repo/domain-characterisation-methodology/master/chameo.ttl [R=303,NE,L]
 
 # Rule 3
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^domain/characterisation-methodology/chameo/(dev|[0-9][^/]*)/?$ https://emmo-repo.github.io/domain-characterisation-methodology/versions/$1/chameo.html [R=303,NE,L]
 RewriteRule ^domain/characterisation-methodology/chameo/(dev|[0-9][^/]*)/?$ https://emmo-repo.github.io/domain-characterisation-methodology/versions/$1/chameo.ttl [R=303,NE,L]
 
@@ -86,12 +84,10 @@ RewriteRule ^domain/characterisation-methodology/chameo/(dev|[0-9][^/]*)/source/
 # Alias:    https://w3id.org/emmo/application/{DOMAIN}/{VERSION}/
 # Redirect to GitHub Pages
 # If the request appears coming from a browser, redirect to the html documentation otherwise redirect to squashed ontology of given version
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^domain/(domain-)?([^/]+)/(dev|[0-9][^/]*)/?$ https://emmo-repo.github.io/domain-$2/versions/$3/$2.html [R=303,NE,L]
 RewriteRule ^domain/(domain-)?([^/]+)/(dev|[0-9][^/]*)/?$ https://emmo-repo.github.io/domain-$2/versions/$3/$2.ttl [R=303,NE,L]
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^application/(application-)?([^/]+)/(dev|[0-9][^/]*)/?$ https://emmo-repo.github.io/application-$2/versions/$3/$2.html [R=303,NE,L]
 RewriteRule ^application/(application-)?([^/]+)/(dev|[0-9][^/]*)/?$ https://emmo-repo.github.io/application-$2/versions/$3/$2.ttl [R=303,NE,L]
 
@@ -134,12 +130,10 @@ RewriteRule ^application/(application-)?([^/]+)/(dev|[0-9][^/]*)/([^0-9].*[^/])/
 # Rule 4a': https://w3id.org/emmo/application/{DOMAIN}
 # Redirect to GitHub Pages
 # If the request appears coming from a browser, redirect to html documentation otherwise to squashed turtle file.
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^domain/(domain-)?([^/]+)/?$ https://emmo-repo.github.io/domain-$2/$2.html [R=303,NE,L]
 RewriteRule ^domain/(domain-)?([^/]+)/?$ https://emmo-repo.github.io/domain-$2/$2.ttl [R=303,NE,L]
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^application/(application-)?([^/]+)/?$ https://emmo-repo.github.io/application-$2/$2.html [R=303,NE,L]
 RewriteRule ^application/(application-)?([^/]+)/?$ https://emmo-repo.github.io/application-$2/$2.ttl [R=303,NE,L]
 
@@ -205,8 +199,7 @@ RewriteRule ^application/(application-)?([^/]+)/([^0-9].*[^/])/?$ https://raw.gi
 # Alias:   https://w3id.org/emmo/{VERSION}/
 # Redirect to specified version branch
 # If the request appears coming from a browser, redirect to html documentation otherwise to squashed turtle file for given version.
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^(dev|[0-9][^/]*)/?$ https://emmo-repo.github.io/versions/$1/emmo.html [R=303,NE,L]
 RewriteRule ^(dev|[0-9][^/]*)/?$ https://emmo-repo.github.io/versions/$1/emmo.ttl [R=303,NE,L]
 #
@@ -262,8 +255,7 @@ RewriteRule ^(dev|[0-9][^/]*)/([^0-9].*[^/])/?$ https://raw.githubusercontent.co
 # Alias:   https://w3id.org/emmo/
 # Redirect to GitHub Pages
 # If the request appears coming from a browser, redirect to html documentation otherwise to squashed turtle file.
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^$ https://emmo-repo.github.io/emmo.html [R=303,NE,L]
 RewriteRule ^$ https://emmo-repo.github.io/emmo.ttl [R=303,NE,L]
 #


### PR DESCRIPTION
Removed all

    %RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml

statements, since these are unintentional matched when opening an ontology from URL in Protege.
