### PR TITLE
Add permanent identifier for HM-Ontology (hydromet/hm-ontology)

### DIFF
--- a/hmontology/.htaccess
+++ b/hmontology/.htaccess
@@ -1,0 +1,16 @@
+Options +FollowSymLinks
+RewriteEngine On
+
+# Redirect to JSON-LD if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/latest.jsonld [R=303,L]
+
+# Redirect to Turtle if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/n-triples [OR]
+RewriteCond %{HTTP_ACCEPT} application/n-quads
+RewriteRule ^$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/latest.ttl [R=303,L]
+
+# Default: send to HTML documentation page
+RewriteRule ^$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/index.html [R=303,L]

--- a/hmontology/README.md
+++ b/hmontology/README.md
@@ -8,4 +8,4 @@ Maintainers:
 Ontology homepage:  
 https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/
 
-More info: Developed as part of the NFDI4Earth project to support FAIR data principles for hydrological datasets.
+More info: Developed as part of the [NFDI4Earth](https://www.nfdi4earth.de/) project to support FAIR data principles for hydrological datasets.

--- a/hmontology/README.md
+++ b/hmontology/README.md
@@ -1,0 +1,11 @@
+# HM-Ontology
+
+Permanent identifier for the HM-Ontology, a lightweight, domain-specific ontology describing hydrological concepts, variables, and relationships.
+
+Maintainers:  
+- Shamila Herath (shamilasri40@gmail.com)
+
+Ontology homepage:  
+https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/
+
+More info: Developed as part of the NFDI4Earth project to support FAIR data principles for hydrological datasets.


### PR DESCRIPTION
## Summary
This PR registers a permanent IRI namespace for the HM-Ontology under:

`https://w3id.org/hydromet/hm-ontology/`

The HM-Ontology is a lightweight, domain-specific ontology developed to describe hydrological concepts, variables, and relationships in a semantically consistent and machine-readable way. It supports the FAIR principles for hydrological data by enabling semantic annotation, RDF transformation, and integration into knowledge graphs.

## Context
This ontology is developed as part of the NFDI4Earth project, focusing on transforming conventional hydrology datasets (e.g., CSV) into semantically enriched RDF knowledge graphs, allowing better interoperability, SPARQL querying, and integration with other datasets using Semantic Web technologies.

It:
- Links to existing vocabularies (e.g., SOSA, QUDT, EnvThes, Schema.org).
- Supports semantic transformation of datasets such as LamaH-CE.
- Enables intelligent querying and integration with question-answering systems.

## Technical details
This PR includes:
- `.htaccess` with 303 redirects and content negotiation for JSON-LD, Turtle, and HTML representations hosted at:
  `https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/`
- `README.md` describing the namespace and maintainers.

Maintainer: Shamila Herath (shamilasri40@gmail.com)
