### PR TITLE
emi/npc subdomain

### DIFF
--- a/emi/npc/.htaccess
+++ b/emi/npc/.htaccess
@@ -1,0 +1,76 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
+
+RewriteEngine on
+
+# Rewrite rule for latest version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://www.earthmetabolome.org/earth_metabolome_ontology/docs-npc/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://raw.githubusercontent.com/earth-metabolome-initiative/earth_metabolome_ontology/refs/heads/main/docs/docs-npc/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://raw.githubusercontent.com/earth-metabolome-initiative/earth_metabolome_ontology/refs/heads/main/docs/docs-npc/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://raw.githubusercontent.com/earth-metabolome-initiative/earth_metabolome_ontology/refs/heads/main/docs/docs-npc/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ https://raw.githubusercontent.com/earth-metabolome-initiative/earth_metabolome_ontology/refs/heads/main/docs/docs-npc/ontology.ttl [R=303,L]
+
+
+## We will have to better handle the EMI ontology versions in the future.
+
+# # Rewrite rules for any other version.
+# RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+# RewriteCond %{HTTP_ACCEPT} text/html [OR]
+# RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+# RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+# RewriteRule ^(.+)$ https://dgarijo.github.io/example/release/$1/index-en.html [R=303,L]
+
+# # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+# RewriteCond %{HTTP_ACCEPT} application/ld\+json
+# RewriteRule ^(.+)$ https://dgarijo.github.io/example/release/$1/ontology.json [R=303,L]
+
+# # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+# RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+# RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+# RewriteRule ^(.+)$ https://dgarijo.github.io/example/release/$1/ontology.owl [R=303,L]
+
+# # Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+# RewriteCond %{HTTP_ACCEPT} application/n-triples
+# RewriteRule ^(.+)$ https://dgarijo.github.io/example/release/$1/ontology.nt [R=303,L]
+
+# # Rewrite rule to serve TTL content from the vocabulary URI if requested
+# RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+# RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+# RewriteCond %{HTTP_ACCEPT} \*/turtle
+# RewriteRule ^(.+)$ https://dgarijo.github.io/example/release/$1/ontology.ttl [R=303,L]
+
+
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/earth-metabolome-initiative/earth_metabolome_ontology/refs/heads/main/docs/docs-npc/406.html [R=406,L]
+# Default response
+# ---------------------------
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^$ https://raw.githubusercontent.com/earth-metabolome-initiative/earth_metabolome_ontology/refs/heads/main/docs/docs-npc/ontology.owl [R=303,L]

--- a/emi/npc/README.md
+++ b/emi/npc/README.md
@@ -1,0 +1,25 @@
+## Earth Metabolome Initiative
+
+This permanent w3id is meant to share vocabularies and ontologies related to the Natural Products taxonomy (NPC) used by the Earth Metabolome Initiative.
+
+https://w3id.org/emi/npc redirects to https://www.earthmetabolome.org/earth_metabolome_ontology/docs-npc/index-en.html
+
+
+## Contacts 
+
+- Pierre-Marie Allard
+    - Email: pierre-marie.allard@unifr.ch
+    - GitHub: @oolonek
+- Emmanuel Defossez
+    - Email: emmanuel.defossez@unine.ch
+    - GitHub: @Edefossez
+- Tarcisio Mendes de Farias
+    - Email: tarcisio.mendes@sib.swiss
+    - Github: @tarcisiotmf
+- Disha Tandon
+    - Email: dishatandon.vit@gmail.com
+    - GitHub: @mdrishti
+
+- Earth Metabolome Initiative data stewardship team (data@earthmetabolome.org)
+
+


### PR DESCRIPTION
Adds the `npc` subdomain to `w3id.org/emi`