### PR TITLE
Enhance hmontology namespace to redirect individual ontology terms

### DIFF
--- a/hmontology/.htaccess
+++ b/hmontology/.htaccess
@@ -1,16 +1,24 @@
 Options +FollowSymLinks
 RewriteEngine On
 
-# Redirect to JSON-LD if requested
+# ---------- Ontology root (content negotiation) ----------
+# JSON(-LD)
 RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
 RewriteCond %{HTTP_ACCEPT} application/json
 RewriteRule ^$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/latest.jsonld [R=303,L]
 
-# Redirect to Turtle if requested
+# Turtle / N-Triples / N-Quads
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/n-triples [OR]
 RewriteCond %{HTTP_ACCEPT} application/n-quads
 RewriteRule ^$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/latest.ttl [R=303,L]
 
-# Default: send to HTML documentation page
+# Default (human-readable HTML)
 RewriteRule ^$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/index.html [R=303,L]
+
+# ---------- Terms ----------
+# Map /hmontology/<term> (with or without trailing slash) to backend /<term>/
+RewriteRule ^([^/]+?)/?$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/%1/ [R=303,L]
+
+# (Optional) handle deeper paths if you ever add them later
+RewriteRule ^(.+)$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/$1 [R=303,L]

--- a/hmontology/.htaccess
+++ b/hmontology/.htaccess
@@ -7,13 +7,15 @@ RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
 RewriteCond %{HTTP_ACCEPT} application/json
 RewriteRule ^$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/latest.jsonld [R=303,L]
 
-# Turtle / N-Triples / N-Quads
-RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
-RewriteCond %{HTTP_ACCEPT} application/n-triples [OR]
-RewriteCond %{HTTP_ACCEPT} application/n-quads
+# Turtle only (do not match n-triples/n-quads here)
+RewriteCond %{HTTP_ACCEPT} text/turtle
 RewriteRule ^$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/latest.ttl [R=303,L]
 
-# Default (human-readable HTML)
+# (Optional) RDF/XML — This will be activated later when we add RDF/XML
+# RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+# RewriteRule ^$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/latest.rdf [R=303,L]
+
+# Default to human-readable HTML
 RewriteRule ^$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/index.html [R=303,L]
 
 # ---------- Terms ----------


### PR DESCRIPTION
## Summary
This PR updates the `.htaccess` for the `hmontology` namespace to ensure that individual ontology term IRIs (e.g., `https://w3id.org/hmontology/hasDominantGeologicalClass`) redirect correctly to their corresponding term pages in the current hosting location.

## Changes
- Added rewrite rules to handle subpaths and redirect them either to:
  - The matching term page (`/<term>/`) on the backend site, or
  - A section (`#<term>`) of the main ontology HTML page, depending on hosting structure.
- Preserved existing content negotiation and 303 redirects for the ontology root.

## Context
Previously, only the base namespace (`https://w3id.org/hmontology/`) redirected to the ontology’s main HTML page or RDF serializations.  
Requests to term IRIs did not resolve as intended, impacting linked data usability.

Maintainer: Shamila Herath (shamilasri40@gmail.com)
