### PR TITLE
redirection to raw branch ttls

### DIFF
--- a/archlink/branches/.htaccess
+++ b/archlink/branches/.htaccess
@@ -1,4 +1,4 @@
-# https://w3id.org/archlink/branches/<ANYTHING> redirects to https://lassemempel.github.io/conservationbranches/<ANYTHING>
+# https://w3id.org/archlink/branches/<ANYTHING> redirects to https://raw.githubusercontent.com/LasseMempel/conservationbranches/refs/heads/master/<ANYTHING>.ttl
 #
 # ## Contact
 # This space is administered by:  
@@ -8,4 +8,4 @@
 # email: lasse.mempellaenger@leiza.de
 
 RewriteEngine on
-RewriteRule ^(.*)$ https://lassemempel.github.io/conservationbranches/$1 [R=303,L]
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/LasseMempel/conservationbranches/refs/heads/master/$1.ttl [R=303,L]


### PR DESCRIPTION
https://w3id.org/archlink/branches/<ANYTHING> now redirects to 
https://raw.githubusercontent.com/LasseMempel/conservationbranches/refs/heads/master/<ANYTHING>.ttl