### PR TITLE
Fix hmontology term redirects and tighten content negotiation

### DIFF
--- a/hmontology/.htaccess
+++ b/hmontology/.htaccess
@@ -20,7 +20,7 @@ RewriteRule ^$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/index.h
 
 # ---------- Terms ----------
 # Map /hmontology/<term> (with or without trailing slash) to backend /<term>/
-RewriteRule ^([^/]+?)/?$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/%1/ [R=303,L]
+RewriteRule ^([^/]+?)/?$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/$1/ [R=303,L]
 
 # (Optional) handle deeper paths if you ever add them later
 RewriteRule ^(.+)$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/$1 [R=303,L]


### PR DESCRIPTION
## Summary
This PR fixes term-level redirects under `https://w3id.org/hmontology/` and restricts content negotiation to the formats we currently publish.

## Changes
- Corrected RewriteRule backreference from `%1` to `$1` so term IRIs like
  `https://w3id.org/hmontology/AirTemperature2m` 303 to
  `https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/AirTemperature2m/`.
- Limited conneg to JSON-LD (`latest.jsonld`) and Turtle (`latest.ttl`).
- Default fallback remains the human-readable HTML (`index.html`).

## Notes
We will add rules for RDF/XML and other serializations once those representations are available.