### PR TITLE
Add redirect to foodhkg

### DIFF
--- a/foodhkg/.htaccess
+++ b/foodhkg/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine On
+
+RewriteRule ^$ https://maastrichtu-ids.github.io/food-claims-kg/ [R=303,L]

--- a/foodhkg/README.md
+++ b/foodhkg/README.md
@@ -9,4 +9,5 @@ evidence, designed to support personalised nutrition and health applications.
 
 ## Contact
 
-- Remzi Celebi <remzi.celebi@maastrichtuniversity.nl>
+- Remzi Celebi <remzi.celebi@maastrichtuniversity.nl> GitHub: <https://github.com/rcelebi>
+- Ensar Emir EROL <ensar.erol@maastrichtuniversity.nl> GitHub: <https://github.com/ensaremirerol>

--- a/foodhkg/README.md
+++ b/foodhkg/README.md
@@ -1,0 +1,12 @@
+# Knowledge Graph for Food Health Claims
+
+FoodKG is a structured knowledge graph curated from 260 authorised EU food
+health claims, covering ingredients, effects, target populations, and scientific
+evidence, designed to support personalised nutrition and health applications.
+
+<https://w3id.org/foodhkg> ->
+<https://maastrichtu-ids.github.io/food-claims-kg/>
+
+## Contact
+
+- Remzi Celebi <remzi.celebi@maastrichtuniversity.nl>


### PR DESCRIPTION
This pull request introduces initial setup and documentation for the Food Health Claims Knowledge Graph (foodhkg) project. It adds a redirect rule to the project and provides a README with a project overview and contact information.

* Added a `README.md` file in the `foodhkg` directory describing the FoodKG project, its purpose, and contact details.

* Created a `.htaccess` file in the `foodhkg` directory to redirect visitors to the project's GitHub Pages site.
