### PR TITLE
Update .htaccess

### DIFF
--- a/hector/.htaccess
+++ b/hector/.htaccess
@@ -1,24 +1,23 @@
+# Allow all (*) origins to access the resource on the server
+Header set Access-Control-Allow-Origin *
+
+# Allow following symbolic links / symlinks / softlinks
+Options +FollowSymLinks
+
 # Turn off MultiViews
 Options -MultiViews
 
-# JSON-LD MIME type
-AddType application/ld+json .json
-
 RewriteEngine on
-
-# Set environment variables for URLs
-RewriteRule ^ - [E=REPO_URL:https://github.com/docuracy/hector]
-RewriteRule ^ - [E=GITHUB_PAGES_URL:https://docuracy.github.io/hector/]
 
 # ---------------------------
 # Canonical redirects
 # ---------------------------
 
 # Redirect /about (with or without trailing slash) to GitHub repo
-RewriteRule ^about/?$ ${ENV:REPO_URL} [R=303,L]
+RewriteRule ^about/?$ https://github.com/docuracy/hector [R=303,L]
 
 # Redirect /context (with or without trailing slash) to JSON-LD context
-RewriteRule ^context/?$ ${ENV:GITHUB_PAGES_URL}context/hector.jsonld [R=303,L]
+RewriteRule ^context/?$ https://docuracy.github.io/hector/context/hector.jsonld [R=303,L]
 
 # ---------------------------
 # Content negotiation for ontology
@@ -26,15 +25,16 @@ RewriteRule ^context/?$ ${ENV:GITHUB_PAGES_URL}context/hector.jsonld [R=303,L]
 
 # Serve RDF/XML if explicitly requested
 #RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-#RewriteRule ^(.*)$ ${ENV:GITHUB_PAGES_URL}$1/ontology.owl [R=303,L]
+#RewriteRule ^(.*)$ https://docuracy.github.io/hector/$1/ontology.owl [R=303,L]
 
 # Serve JSON-LD if explicitly requested
-RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
-RewriteRule ^(.*)$ ${ENV:GITHUB_PAGES_URL}$1/ontology.json [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/json [OR]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(.*)$ https://docuracy.github.io/hector/$1/ontology.json [R=303,L]
 
 # ---------------------------
 # SPA fallback
 # ---------------------------
 
 # Anything under / not matched above goes to SPA
-RewriteRule ^(.*)$ ${ENV:GITHUB_PAGES_URL}index.html?path=$1 [R=303,L]
+RewriteRule ^(.*)$ https://docuracy.github.io/hector/index.html?path=$1 [R=303,L]


### PR DESCRIPTION
Remove unused environment variables and AddType directives

Environment variables were not processed as expected. `AddType` directives are only relevant for the file server, not for w3id redirection.