### PR TITLE
changed ols redirection for handling error at ebispot/ols4

### DIFF
--- a/emi/.htaccess
+++ b/emi/.htaccess
@@ -38,8 +38,8 @@ RewriteCond %{HTTP_ACCEPT} \*/turtle
 RewriteRule ^$ https://raw.githubusercontent.com/earth-metabolome-initiative/earth_metabolome_ontology/refs/heads/main/docs/ontology.ttl [R=303,L]
 
 # Rewrite rule to serve TTL content for the EBI-OLS service 
-RewriteCond %{REQUEST_URI} ols
-RewriteRule ols/?$ https://raw.githubusercontent.com/earth-metabolome-initiative/earth_metabolome_ontology/refs/heads/main/emi-ols.ttl [R=301,L]
+RewriteCond %{REQUEST_URI} ols\.ttl$
+RewriteRule ols\.ttl$/?$ https://raw.githubusercontent.com/earth-metabolome-initiative/earth_metabolome_ontology/refs/heads/main/emi-ols.ttl [R=301,L]
 
 # Rewrite rule to serve TTL content for the NPClassifier taxonomy
 RewriteCond %{REQUEST_URI} npc


### PR DESCRIPTION
ols changed to ols.ttl. helps in recognition of content type. See also here for context: https://github.com/EBISPOT/ols4/issues/814