### PR TITLE
Add namespace for ofco ontology

### DIFF
--- a/ofco/.htaccess
+++ b/ofco/.htaccess
@@ -1,6 +1,6 @@
 RewriteEngine On
 
-# maintener github username: @Orphanet
+# maintainer github username: @Orphanet
 
 # RDF/XML
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]


### PR DESCRIPTION
This PR creates a new namespace for the Orphanet Functioning Ontology (OFCO) under:
https://w3id.org/ofco
Details :
Ontology IRI: https://w3id.org/ofco/
Namespace prefix: ofco
Maintainers:
Marc Hanauer (Inserm, Orphanet)
Ana Rath (Inserm, Orphanet)
Rami Nadji (Inserm, Orphanet)

Purpose
.htaccess file provides redirections to ontology resources hosted on GitHub:

RDF/XML → ofco.owl
Default (HTML documentation) → GitHub Pages

This ensures persistent and resolvable identifiers for OFCO classes and properties, e.g.:
https://w3id.org/ofco#hasORPHANETDBInternalReference
https://w3id.org/ofco#hasICFcode
