### PR TITLE
fix: remove # in redirects as that does not work

### DIFF
--- a/trustenvelope/.htaccess
+++ b/trustenvelope/.htaccess
@@ -18,14 +18,11 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^ontology$ https://spec.knows.idlab.ugent.be/trustenvelope/latest/#vocabulary [R=302,L]
+RewriteRule ^ontology$ https://github.com/KNowledgeOnWebScale/TrustEnvelope/blob/main/trustenvelope.ttl [R=302,L]
 
 # Examples
-RewriteRule ^example$ https://github.com/KNowledgeOnWebScale/TrustEnvelope#example  [R=302,L]
-
 ## Age verification 
-RewriteRule ^example/age-verification$ https://spec.knows.idlab.ugent.be/trustenvelope/latest/#age-verification  [R=302,L]
+RewriteRule ^example/age-verification$ https://github.com/KNowledgeOnWebScale/TrustEnvelope/blob/main/Age-verification.md  [R=302,L]
 
 ## Cargo Monitoring
-
-RewriteRule ^example/cargo-monitoring$ https://spec.knows.idlab.ugent.be/trustenvelope/latest/#cargo-monitoring  [R=302,L]
+RewriteRule ^example/cargo-monitoring$ https://github.com/KNowledgeOnWebScale/TrustEnvelope/blob/main/Cargo-monitoring.md  [R=302,L]

--- a/trustenvelope/README.md
+++ b/trustenvelope/README.md
@@ -9,9 +9,8 @@ A Trust Envelope is a data package that explicitly embeds trust using cryptograp
 | w3id                      | Description                              | URL                                                                                    |
 | ------------------------- | ---------------------------------------- | -------------------------------------------------------------------------------------- |
 | /                         | Main specification of Trust Envelope     | https://spec.knows.idlab.ugent.be/trustenvelope/latest/                                |
-| /example                  | Example                                  | https://github.com/KNowledgeOnWebScale/TrustEnvelope#example                           |
-| /example/age-verification | Age Verification Example Materialization | https://spec.knows.idlab.ugent.be/trustenvelope/latest/#age-verification               |
-| /example/cargo-monitoring | Cargo Monitoring Example Materialization | https://spec.knows.idlab.ugent.be/trustenvelope/latest/#cargo-monitoring               |
+| /example/age-verification | Age Verification Example Materialization | https://github.com/KNowledgeOnWebScale/TrustEnvelope/blob/main/Age-verification.md     |
+| /example/cargo-monitoring | Cargo Monitoring Example Materialization | https://github.com/KNowledgeOnWebScale/TrustEnvelope/blob/main/Cargo-monitoring.md     |
 | /ontology                 | Trust Envelope Ontology                  | https://cdn.jsdelivr.net/gh/KNowledgeOnWebScale/TrustEnvelope@master/trustenvelope.ttl |
 
 ## Contacts


### PR DESCRIPTION
fragments are only handled in browser, thus this was translated to its unicode variant `%23`, leading to 404s