### PR TITLE
Add w3id.org/cerif2

### DIFF
--- a/cerif2/.htaccess
+++ b/cerif2/.htaccess
@@ -1,0 +1,3 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^(.*)$ https://cerif2.eu/$1 [R=302,L]

--- a/cerif2/README.md
+++ b/cerif2/README.md
@@ -1,0 +1,8 @@
+## Common European Research Information Format (CERIF) version 2
+
+Developed and maintained by euroCRIS (https://eurocris.org/) 
+
+Contacts
+
+* Jan Dvořák <jan.dvorak@eurocris.org>
+* the euroCRIS Secretariat <eurocris@eurocris.org>


### PR DESCRIPTION
For an updated version of CERIF, the Common European Research Information Format, we need a new prefix: `cerif2`.
We’ve got a very basic website running at https://cerif2.eu/ where we suggest the forwarding leads.