### PR TITLE
refactor(.htaccess): remove content negotiation, simplify ontology redirects, and add mappings redirects

### DIFF
--- a/health-ri/.htaccess
+++ b/health-ri/.htaccess
@@ -1,23 +1,4 @@
 Options -MultiViews
-RewriteEngine on
-
-# --------------------------------------------------------------------------------------------------------------
-# CONTENT NEGOTIATION FOR /ontology
-# --------------------------------------------------------------------------------------------------------------
-
-# Redirect to HTML spec if no RDF content type is requested
-RewriteCond %{REQUEST_URI} ^/health-ri/ontology/?$
-RewriteCond %{HTTP_ACCEPT} !text/turtle
-RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml
-RewriteCond %{HTTP_ACCEPT} !application/ld\+json
-RewriteRule ^health-ri/ontology/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/documentations/specification.html [R=303,L]
-
-# Serve TTL if Turtle is requested
-RewriteCond %{REQUEST_URI} ^/health-ri/ontology/?$
-RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
-RewriteCond %{HTTP_ACCEPT} text/\* [OR]
-RewriteCond %{HTTP_ACCEPT} \*/turtle
-RewriteRule ^health-ri/ontology/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/health-ri-ontology.ttl [R=303,L]
 
 # --------------------------------------------------------------------------------------------------------------
 # RESOURCES' VERSIONING
@@ -56,7 +37,7 @@ RedirectMatch 302 ^/health-ri/?$ https://www.health-ri.nl/
 # --------------------------------------------------------------------------------------------------------------
 
 ## Latest ontology files (ttl, vpp, json, documentation.html, specification.html)
-RedirectMatch 302 ^/health-ri/ontology/ttl/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/health-ri-ontology.ttl
+RedirectMatch 302 ^/health-ri/ontology(/ttl)?/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/health-ri-ontology.ttl
 RedirectMatch 302 ^/health-ri/ontology/vpp/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/health-ri-ontology.vpp
 RedirectMatch 302 ^/health-ri/ontology/json/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/health-ri-ontology.json
 RedirectMatch 302 ^/health-ri/ontology/(doc|documentation)/?$ https://health-ri.github.io/semantic-interoperability/ontology/documentation/
@@ -64,12 +45,16 @@ RedirectMatch 302 ^/health-ri/ontology/(spec|specification)/?$ https://health-ri
 
 ## Versioned ontology files (ttl, vpp, json, documentation.md, specification.html)
 # Matches semantic versions like v1.2.3 and redirects to the corresponding static files
-RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/health-ri-ontology-v$1.ttl
-RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/(ttl)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/health-ri-ontology-v$1.ttl
-RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/(vpp)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/health-ri-ontology-v$1.vpp
-RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/(json)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/health-ri-ontology-v$1.json
+RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)(/ttl)?/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/health-ri-ontology-v$1.ttl
+RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/vpp/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/health-ri-ontology-v$1.vpp
+RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/json/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/health-ri-ontology-v$1.json
 RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/(doc|documentation)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/documentations/documentation-v$1.md
 RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/(spec|specification)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/documentations/specification-v$1.html
 
-## Default TTL redirection for /ontology/
-RedirectMatch 302 ^/health-ri/ontology/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/health-ri-ontology.ttl
+# --------------------------------------------------------------------------------------------------------------
+# SSSOM MAPPINGS FILES
+# --------------------------------------------------------------------------------------------------------------
+
+## Latest SSSOM mappings files (ttl, tsv)
+RedirectMatch 302 ^/health-ri/semantic-interoperability/mappings(/ttl)?/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/mappings/health-ri-mappings.ttl
+RedirectMatch 302 ^/health-ri/semantic-interoperability/mappings/tsv/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/mappings/health-ri-mappings.tsv


### PR DESCRIPTION
refactor(.htaccess): remove content negotiation, simplify ontology redirects, and add mappings redirects

- dropped RewriteEngine and all content negotiation logic for /ontology
- unified latest ontology redirect with optional /ttl segment
- simplified versioned ontology redirects (ttl, vpp, json)
- removed redundant default TTL redirect
- added new redirects for SSSOM mappings (ttl, tsv)