### PR TITLE
chore(dspace): redirect 2025-1 to now published release 2025-1

### DIFF
--- a/dspace/.htaccess
+++ b/dspace/.htaccess
@@ -29,11 +29,11 @@ RewriteRule ^2024/1/common/([\w.-]+shapes?.ttl) https://international-data-space
 
 # Rules controlling links explicitly for release /2025-1/ pointing to EDWG
 ## Redirect main JSON-LD context
-RewriteRule ^2025/1/context.jsonld https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/HEAD/message/schema/dspace.jsonld [R=302,L,QSA]
-RewriteRule ^2025/1/odrl-profile.jsonld https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/HEAD/message/schema/odrl.jsonld [R=302,L,QSA]
+RewriteRule ^2025/1/context.jsonld https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1/message/schema/dspace.jsonld [R=302,L,QSA]
+RewriteRule ^2025/1/odrl-profile.jsonld https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1/message/schema/odrl.jsonld [R=302,L,QSA]
 
 ## Redirect JSON Schemas
-RewriteRule ^2025/1/(catalog|negotiation|transfer|common)/([\w.-]+schema.json) https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/HEAD/message/schema/$2 [R=302,L,QSA]
+RewriteRule ^2025/1/(catalog|negotiation|transfer|common)/([\w.-]+schema.json) https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1/message/schema/$2 [R=302,L,QSA]
 
 # Redirect to repository
 RewriteRule ^.*$ https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocol [R=302,L,QSA]

--- a/dspace/README.md
+++ b/dspace/README.md
@@ -40,11 +40,11 @@ Find more information at [https://internationaldataspaces.org/](https://internat
 
 3. Links for the 2025-1 release version:
 
-* https://w3id.org/dspace/2025/1/context.jsonld --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/HEAD/message/schema/dspace.jsonld
-* https://w3id.org/dspace/2025/1/odrl-profile.jsonld --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/HEAD/message/schema/odrl.jsonld
-* https://w3id.org/dspace/2025/1/catalog/catalog-schema.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/HEAD/message/schema/catalog-schema.json
-* https://w3id.org/dspace/2025/1/catalog/dataset-schema.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/HEAD/message/schema/dataset-schema.json
-* https://w3id.org/dspace/2025/1/negotiation/contract-schema.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/HEAD/message/schema/contract-schema.json
+* https://w3id.org/dspace/2025/1/context.jsonld --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1/message/schema/dspace.jsonld
+* https://w3id.org/dspace/2025/1/odrl-profile.jsonld --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1/message/schema/odrl.jsonld
+* https://w3id.org/dspace/2025/1/catalog/catalog-schema.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1/message/schema/catalog-schema.json
+* https://w3id.org/dspace/2025/1/catalog/dataset-schema.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1/message/schema/dataset-schema.json
+* https://w3id.org/dspace/2025/1/negotiation/contract-schema.json --> https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1/message/schema/contract-schema.json
 
 4. Version-independent links:
 


### PR DESCRIPTION
The release of Dataspace Protocol 2025-1 is finalized. The final PR executing on the decision to release is pending [1]. This one should be reviewed and merged soon afterwards.

Closes [2]

[1] https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocol/pull/223
[2] https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocol/issues/197