### PR TITLE
chore(dspace-dcp): redirect v1.0 to now published release v1.0

### DIFF
--- a/dspace-dcp/.htaccess
+++ b/dspace-dcp/.htaccess
@@ -6,11 +6,11 @@ RewriteEngine On
 ## Redirect main JSON-LD context for v0.8
 RewriteRule ^v0.8$ https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/0.8.1/specifications/context.jsonld [R=302,L]
 
-## Redirect main JSON-LD context for v1.0 (to HEAD before v1.0 release)
-RewriteRule ^v1.0/dcp.jsonld$ https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/HEAD/resources/context/dcp.jsonld [R=302,L]
+## Redirect main JSON-LD context for v1.0
+RewriteRule ^v1.0/dcp.jsonld$ https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0/resources/context/dcp.jsonld [R=302,L]
 
-## Redirect JSON Schemas for 1.0 (to HEAD before v1.0 release)
-RewriteRule ^v1.0/(presentation|issuance|common)/([\w.-]+schema.json) https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/HEAD/resources/$1/$2 [R=302,L]
+## Redirect JSON Schemas for 1.0
+RewriteRule ^v1.0/(presentation|issuance|common)/([\w.-]+schema.json) https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0/resources/$1/$2 [R=302,L]
 
 # Redirect to GH pages
 RewriteRule ^.*$ https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol [R=302,L]


### PR DESCRIPTION
The Eclipse DCP is about to publish its v1.0. 

That's why the redirects should point to the stable release instead of the repo HEAD. Should be merged only after [1]


[1] https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol/pull/245

