### PR TITLE
feat(factoryx): add initial factoryx namespace

### DIFF
--- a/factoryx/.htaccess
+++ b/factoryx/.htaccess
@@ -1,0 +1,21 @@
+#
+# Factory-X Namespace Forwarding Rules
+# tested with https://htaccess.madewithlove.com/
+#
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType application/ld+json .jsonld
+
+# Rewrite engine setup
+RewriteEngine On
+#Change the path to the folder here
+RewriteBase /
+
+# Policy json-ld context resolution
+RewriteRule ^policy/v1.0(.*)$ https://raw.githubusercontent.com/factory-x-contributions/factoryx-edc/refs/heads/main/edc-extensions/fx-json-ld-core/src/main/resources/document/fx-policy-v1.jsonld [R=302,L]
+
+# Credential json-ld context resolution
+RewriteRule ^credentials/v1.0(.*)$ https://raw.githubusercontent.com/factory-x-contributions/factoryx-edc/refs/heads/main/edc-extensions/fx-json-ld-core/src/main/resources/document/fx-credentials-v1.jsonld [R=302,L]
+

--- a/factoryx/README.md
+++ b/factoryx/README.md
@@ -1,0 +1,9 @@
+## Factory-X
+
+Factory-X is a Dataspace similar to [Catena-X](../catenax/README.md) that uses W3C VCs and ODRL Policy objects to
+facilitate trust between participants. All relevant protocols serving those payloads use JSON-LD, so the relevant
+redirects will mostly facilitate access to JSON-LD contexts and JSON schemas.
+
+Contact:
+
+- Arno Weiß <arno.weiss@sap.com> (arnoweiss)


### PR DESCRIPTION
## Background

Factory-X is a dataspace aimed at interoperable data exchange between organizations in the automation industry. Some aspects of the chosen technology stack require the maintenance of IDs redirecting to json-ld contexts and json schemas. This namespace will be used for precisely that.

## Future Work

- Add more contacts to distribute governance
- Move redirect targets away from (1) github raw and (2) the factoryx-edc repo to something not ratelimited.

## Notes

All preconditions met. PR is ready for review.