### PR TITLE
Add testo redirects

### DIFF
--- a/testo/.htaccess
+++ b/testo/.htaccess
@@ -1,0 +1,48 @@
+Header set Access-Control-Allow-Origin *
+Options -MultiViews
+
+RewriteEngine on
+RewriteRule ^ - [E=ONTO:testo]
+RewriteRule ^ - [E=ONTO_IRI:https://w3id.org/%{ENV:ONTO}/]
+#RewriteRule ^ - [E=WEBSITE:index.html]
+RewriteRule ^ - [E=WEBSITE:https://micheldumontier.github.com/ontostart/]
+RewriteRule ^ - [E=DOCS:https://ontostart.github.io/docs/]
+
+RewriteRule ^ - [E=VERSIONS:versions]
+RewriteRule ^ - [E=LATEST:%{ENV:VERSIONS}/latest]
+#RewriteRule ^ - [E=FILE_IRI:http://localhost:8080/versions/]
+RewriteRule ^ - [E=FILE_IRI:https://raw.githubusercontent.com/micheldumontier/ontostart/refs/heads/main/%{ENV:VERSIONS}/]
+
+RewriteBase /
+
+# HTML documentation
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^$ %{ENV:WEBSITE} [R=303,L]
+RewriteRule ^docs/(.*)$ %{ENV:DOCS}/$1 [R=303,L]
+RewriteRule ^ontology$ %{ENV:LATEST}/%{ENV:ONTO}.ttl [R=303,L]
+RewriteRule ^versions/(([0-9]+\.[0-9]+\.[0-9]+)|latest)$ %{ENV:VERSIONS}/$1/ [R=303,L,NE]
+
+# Redirects for RDF/XML files
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/xml
+RewriteCond %{HTTP_ACCEPT} application/owl\+xml
+RewriteRule ^$ %{ENV:LATEST}/%{ENV:ONTO}.owl [R=303,L]
+RewriteRule ^versions/(([0-9]+\.[0-9]+\.[0-9]+)|latest)$ %{ENV:VERSIONS}/$1/%{ENV:ONTO}.owl [R=303,L,NE]
+
+# Redirects for Turtle files
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/ttl [OR]
+RewriteCond %{HTTP_ACCEPT} application/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^$ %{ENV:LATEST}/%{ENV:ONTO}.ttl [R=303,L]
+RewriteRule ^versions/(([0-9]+\.[0-9]+\.[0-9]+)|latest)$ %{ENV:VERSIONS}/$1/%{ENV:ONTO}.ttl [R=303,L,NE]
+
+# Redirect for JSON-LD files
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ %{ENV:LATEST}/%{ENV:ONTO}.jsonld [R=303,L]
+RewriteRule ^versions/(([0-9]+\.[0-9]+\.[0-9]+)|latest)$ %{ENV:VERSIONS}/$1/%{ENV:ONTO}.jsonld [R=303,L,NE]
+
+# Redirect for N-triples
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ %{ENV:LATEST}/%{ENV:ONTO}.nt [R=303,L]
+RewriteRule ^versions/(([0-9]+\.[0-9]+\.[0-9]+)|latest)$ %{ENV:VERSIONS}/$1/%{ENV:ONTO}.nt [R=303,L,NE]


### PR DESCRIPTION
This PR adds `testo/.htaccess` with redirects for the `testo` namespace.