### PR TITLE
New `dataspaces` namespace

### DIFF
--- a/dataspaces/.htaccess
+++ b/dataspaces/.htaccess
@@ -1,0 +1,11 @@
+# Turn off MultiViews
+Options -MultiViews
+Options +FollowSymLinks
+
+Header set Access-Control-Allow-Origin *
+
+# Rewrite engine setup
+RewriteEngine On
+
+# Redirect *anything* to the GitHub repository for now
+RewriteRule ^.*$ https://github.com/Fraunhofer-FIT-DSAI/ds-tcat-ap [R=303]

--- a/dataspaces/README.md
+++ b/dataspaces/README.md
@@ -1,0 +1,25 @@
+# Dataspaces Tool Catalog Application Profile (DS-TCAT-AP) and Semantic Models
+
+- This repository has been created to develop ontologies, controlled vocabularies, and semantic application profiles for dataspaces.
+- Currently, it primarily hosts the Application Profile (DS-TCAT-AP) for the [DSSC](https://dssc.eu/)
+Dataspaces Toolbox, which is currently available at https://toolbox.dssc.eu/.
+
+## Persistent Identifier (PID)
+
+Namespace: `https://w3id.org/dataspaces/`
+
+## Redirection
+
+Currently, every url staring with `https://w3id.org/dataspaces/` is redirected to the GitHub repository `https://github.com/Fraunhofer-FIT-DSAI/ds-tcat-ap`.
+
+## Maintainer
+
+Rohit A. Deshmukh - rohit.deshmukh@fit.fraunhofer.de - @rohitadeshmukh13
+
+## Ongoing/Future work
+
+**Specific Models**:
+- DS-TCAT-AP: `https://w3id.org/dataspaces/ap/ds-tcat-ap/`
+- DSSC Ontology: `https://w3id.org/dataspaces/ont/dssc/`
+- TCAT Ontology: `https://w3id.org/dataspaces/ont/tcat/`
+- DS-TCAT Ontology: `https://w3id.org/dataspaces/ont/ds-tcat/`


### PR DESCRIPTION
- This PR proposes the creation of the `dataspaces` namespace for dataspace ontologies, controlled vocabularies, and application profiles.
- Currently, it redirects to the GitHub repository: `https://github.com/Fraunhofer-FIT-DSAI/ds-tcat-ap`.
- We are currently developing the Application Profile `DS-TCAT-AP` for the [DSSC](https://dssc.eu/)
Dataspaces Toolbox, which can be accessed at https://toolbox.dssc.eu/.
- The redirection rules will be updates as new resources and documentation become available.