### PR TITLE
cast-onto the ontology for casting field 

### DIFF
--- a/cast-onto/.htaccess
+++ b/cast-onto/.htaccess
@@ -1,0 +1,6 @@
+Options +FollowSymLinks
+RewriteEngine On
+
+# Placeholder redirect for cast-onto
+RewriteRule ^$ https://github.com/ziyuuuuuu [R=302,L]
+RewriteRule (.*) https://github.com/ziyuuuuuu [R=302,L]

--- a/cast-onto/README.md
+++ b/cast-onto/README.md
@@ -1,0 +1,9 @@
+# cast-onto
+
+Reserved permanent identifier under **https://w3id.org/cast-onto**.
+
+Currently redirects to a placeholder (GitHub profile).  
+Will be updated with the real ontology resources later.
+
+**Maintainer:**  
+- Ziyu Li (GitHub: [@ziyuuuuuu](https://github.com/ziyuuuuuu))


### PR DESCRIPTION
This PR reserves the permanent identifier https://w3id.org/cast-onto
Currently points to a placeholder (GitHub profile).
Maintainer: Ziyu Li (@ziyuuuuuu)