### PR TITLE
feat(w3id): add redirects for Health-RI Mapping Vocabulary (latest & versioned)

### DIFF
--- a/health-ri/.htaccess
+++ b/health-ri/.htaccess
@@ -58,3 +58,16 @@ RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/(spec|specifica
 ## Latest SSSOM mappings files (ttl, tsv)
 RedirectMatch 302 ^/health-ri/semantic-interoperability/mappings(/ttl)?/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/mappings/health-ri-mappings.ttl
 RedirectMatch 302 ^/health-ri/semantic-interoperability/mappings/tsv/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/mappings/health-ri-mappings.tsv
+
+# --------------------------------------------------------------------------------------------------------------
+# MAPPING VOCABULARY FILES
+# --------------------------------------------------------------------------------------------------------------
+
+## Latest vocabulary files (ttl and specification.html)
+RedirectMatch 302 ^/health-ri/mapping-vocabulary(/ttl)?/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/vocabulary/latest/health-ri-vocabulary.ttl
+RedirectMatch 302 ^/health-ri/mapping-vocabulary/(spec|specification)/?$ https://health-ri.github.io/semantic-interoperability/method/specification.html
+
+## Versioned vocabulary files (ttl and specification.html)
+# Matches semantic versions like v1.2.3 and redirects to the corresponding static files
+RedirectMatch 302 ^/health-ri/mapping-vocabulary/v([0-9]+\.[0-9]+\.[0-9]+)(/ttl)?/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/vocabulary/versioned/health-ri-vocabulary-v$1.ttl
+RedirectMatch 302 ^/health-ri/mapping-vocabulary/v([0-9]+\.[0-9]+\.[0-9]+)/(spec|specification)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/vocabulary/versioned/documentations/specification-v$1.html


### PR DESCRIPTION
* Add latest TTL redirect: `/health-ri/mapping-vocabulary[/ttl]` → `vocabulary/latest/health-ri-vocabulary.ttl`
* Add latest spec redirect: `/health-ri/mapping-vocabulary/(spec|specification)` → site `method/specification.html`
* Add versioned TTL redirect: `/health-ri/mapping-vocabulary/vX.Y.Z[/ttl]` → `vocabulary/versioned/health-ri-vocabulary-v$1.ttl`
* Add versioned spec redirect: `/health-ri/mapping-vocabulary/vX.Y.Z/(spec|specification)` → `vocabulary/versioned/documentations/specification-v$1.html`