### PR TITLE
PrOM folder addition

### DIFF
--- a/PrOM/.htaccess
+++ b/PrOM/.htaccess
@@ -1,0 +1,48 @@
+Options +FollowSymLinks
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .nt
+AddType application/ld+json .jsonld
+# Rewrite engine setup
+RewriteEngine On
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+# Placed before HTML to support serving JSON-LD from a browser (e.g., JSON Playground)
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://prom-o.codeberg.page/PrOM/widoco/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*|\*/\*)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://prom-o.codeberg.page/PrOM/widoco/index-en.html [R=303,NE,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf+xml*
+RewriteRule ^$ https://prom-o.codeberg.page/PrOM/widoco/ontology.owl [R=303,NE,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} ^.*application/n-triples*
+RewriteRule ^$ https://prom-o.codeberg.page/PrOM/widoco/ontology.nt [R=303,NE,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.*
+RewriteRule ^$ https://prom-o.codeberg.page/PrOM/widoco/ontology.ttl [R=303,NE,L]
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^$ https://prom-o.codeberg.page/PrOM/widoco/406.html [R=406,L]
+
+# Default response : ttl
+RewriteRule ^$ https://prom-o.codeberg.page/PrOM/widoco/ontology.ttl [R=303,NE,L] 
+
+
+

--- a/PrOM/README.md
+++ b/PrOM/README.md
@@ -1,0 +1,8 @@
+# PrOM: Provenance Ontology for Questionnaire Metadata
+
+Provenance Ontology for Questionnaire Metadata (**PrOM**) is a domain-specific ontology developed to formally represent the provenance and evolution of metadata in longitudinal survey research. In large-scale studies, questionnaires frequently evolve across successive waves to accommodate emerging research priorities, revised methodological protocols, or technical refinements. Such modifications may vary in scope, ranging from minor textual revisions to extensive restructuring of questions or response categories. **PrOM** provides a structured, machine-readable, and interoperable framework to capture and document these evolutionary changes.
+
+
+# Maintainers
+
+* Julia Matela <julia.matela@hs-wismar.de>, @matjulia


### PR DESCRIPTION
This pull request adds the 'PrOM' folder under the 'perma-id' namespace in the w3id.org repository. 

The folder includes:
- README.md with basic information and contact details
- .htaccess file for URL redirection

Purpose:  
To enable permanent, resolvable URLs for the PrOM project as part of w3id.org. 

No existing content was modified; this is an addition only.

Please review and merge if everything is in order.