### PR TITLE
Update hmontology namespace: new hosting location and README maintainer info

### DIFF
--- a/hmontology/.htaccess
+++ b/hmontology/.htaccess
@@ -5,22 +5,22 @@ RewriteEngine On
 # JSON(-LD)
 RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
 RewriteCond %{HTTP_ACCEPT} application/json
-RewriteRule ^$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/latest.jsonld [R=303,L]
+RewriteRule ^$ https://nfdi4earth.pages.rwth-aachen.de/knowledgehub/hydro-knowledge-graph/latest.jsonld [R=303,L]
 
 # Turtle only (do not match n-triples/n-quads here)
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/latest.ttl [R=303,L]
+RewriteRule ^$ https://nfdi4earth.pages.rwth-aachen.de/knowledgehub/hydro-knowledge-graph/latest.ttl [R=303,L]
 
 # (Optional) RDF/XML — This will be activated later when we add RDF/XML
 # RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-# RewriteRule ^$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/latest.rdf [R=303,L]
+# RewriteRule ^$ https://nfdi4earth.pages.rwth-aachen.de/knowledgehub/hydro-knowledge-graph/latest.rdf [R=303,L]
 
 # Default to human-readable HTML
-RewriteRule ^$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/index.html [R=303,L]
+RewriteRule ^$ https://nfdi4earth.pages.rwth-aachen.de/knowledgehub/hydro-knowledge-graph/index.html [R=303,L]
 
 # ---------- Terms ----------
 # Map /hmontology/<term> (with or without trailing slash) to backend /<term>/
-RewriteRule ^([^/]+?)/?$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/$1/ [R=303,L]
+RewriteRule ^([^/]+?)/?$ https://nfdi4earth.pages.rwth-aachen.de/knowledgehub/hydro-knowledge-graph/$1/ [R=303,L]
 
-# (Optional) handle deeper paths if you ever add them later
-RewriteRule ^(.+)$ https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/$1 [R=303,L]
+# (Optional) handle deeper paths if we ever add them later
+RewriteRule ^(.+)$ https://nfdi4earth.pages.rwth-aachen.de/knowledgehub/hydro-knowledge-graph/$1 [R=303,L]

--- a/hmontology/README.md
+++ b/hmontology/README.md
@@ -3,10 +3,10 @@
 Permanent identifier for the HM-Ontology, a lightweight, domain-specific ontology describing hydrological concepts, variables, and relationships.
 
 Maintainers:  
-- [Shamila Herath](https://github.com/shamilasudalshana) (shamilasri40@gmail.com)
-- [Auriol Degbelo](https://github.com/aurioldegbelo) (auriol.degbelo@tu-dresden.de)
+- [Shamila Herath](https://github.com/shamilasudalshana) 
+- [Auriol Degbelo](https://github.com/aurioldegbelo) 
 
 Ontology homepage:  
-https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/
+[https://nfdi4earth.pages.rwth-aachen.de/knowledgehub/hydro-knowledge-graph/](https://nfdi4earth.pages.rwth-aachen.de/knowledgehub/hydro-knowledge-graph/)
 
 More info: Developed as part of the [NFDI4Earth](https://www.nfdi4earth.de/) project to support FAIR data principles for hydrological datasets.


### PR DESCRIPTION
## Summary
This PR updates the `hmontology` namespace configuration to reflect a new hosting location and revised maintainer information.

## Changes
- **.htaccess**: Updated redirect targets from  
  `https://hydro-knowledge-graph-f48785.pages.rwth-aachen.de/`  
  to  
  `https://nfdi4earth.pages.rwth-aachen.de/knowledgehub/hydro-knowledge-graph/`  
  while keeping content negotiation (JSON-LD, Turtle, HTML) and term redirects intact.
- **README.md**: Replaced maintainer email addresses with GitHub profile links to reduce exposure to spam. Ontology homepage link updated to the new hosting location.

## Context
The HM-Ontology continues to be maintained as part of the [NFDI4Earth](https://www.nfdi4earth.de/) project. These changes ensure that the permanent IRI `https://w3id.org/hmontology/` resolves correctly to the ontology’s new home, and that maintainer contact details remain current.
