### PR TITLE
Add new namespace ExperimentalResearchOntology

### DIFF
--- a/ExperimentalResearchOntology/.htaccess
+++ b/ExperimentalResearchOntology/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine on
+RewriteRule ^$ https://raw.githubusercontent.com/cbacke/ExperimentalResearchOntology/refs/heads/main/ero.ttl [R=303,L]
+RewriteRule ^(alias|core|util)$ https://raw.githubusercontent.com/cbacke/ExperimentalResearchOntology/refs/heads/main/ero.ttl [R=303,L]

--- a/ExperimentalResearchOntology/README.md
+++ b/ExperimentalResearchOntology/README.md
@@ -1,0 +1,15 @@
+# Experimental Research Ontology
+
+## Description
+
+This namespace provides a permanent [IRI](https://www.rfc-editor.org/rfc/rfc3987) for the Experimental Research Ontology (ERO).
+
+## Maintainers
+
+### Christian Backe
+
+- Name: Christian Backe
+- Affiliation: [DFKI Robotics Innovation Center](https://robotik.dfki-bremen.de/en/about-us/dfki-robotics-innovation-center/), Bremen, Germany
+- Email: christian.backe@dfki.de
+- GitHub: [cbacke](https://github.com/cbacke)
+- ORCID: [0009-0002-7114-0687](https://orcid.org/0009-0002-7114-0687)


### PR DESCRIPTION
This namespace provides a permanent IRI for the Experimental Research Ontology (ERO).