### PR TITLE
Add new namespace RoBivaL

### DIFF
--- a/RoBivaL/.htaccess
+++ b/RoBivaL/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine on
+RewriteRule ^$ https://github.com/cbacke/RoBivaL/ [R=303,L]

--- a/RoBivaL/FDOProfile/.htaccess
+++ b/RoBivaL/FDOProfile/.htaccess
@@ -1,0 +1,4 @@
+RewriteEngine on
+RewriteRule ^$ https://github.com/cbacke/RoBivaL/tree/main/FDOProfile/ [R=303,L]
+RewriteRule ^([^/]+)/?$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDOProfile/$1.ttl [R=303,L]
+RewriteRule ^([^/]+)\.ttl$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDOProfile/$1.ttl [R=303,L]

--- a/RoBivaL/FDORecord/.htaccess
+++ b/RoBivaL/FDORecord/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine on
+RewriteRule ^$ https://github.com/cbacke/RoBivaL/tree/main/FDORecord/ [R=303,L]

--- a/RoBivaL/FDORecord/Payload/.htaccess
+++ b/RoBivaL/FDORecord/Payload/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine on
+RewriteRule ^$ https://github.com/cbacke/RoBivaL/tree/main/FDORecord/Payload/ [R=303,L]

--- a/RoBivaL/FDORecord/Payload/Run/.htaccess
+++ b/RoBivaL/FDORecord/Payload/Run/.htaccess
@@ -1,0 +1,4 @@
+RewriteEngine on
+RewriteRule ^$ https://github.com/cbacke/RoBivaL/tree/main/FDORecord/Payload/Run/ [R=303,L]
+RewriteRule ^([^/]+)/?$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDORecord/Payload/Run/$1.ttl [R=303,L]
+RewriteRule ^([^/]+)\.ttl$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDORecord/Payload/Run/$1.ttl [R=303,L]

--- a/RoBivaL/FDORecord/Specification/.htaccess
+++ b/RoBivaL/FDORecord/Specification/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine on
+RewriteRule ^$ https://github.com/cbacke/RoBivaL/tree/main/FDORecord/Specification/ [R=303,L]

--- a/RoBivaL/FDORecord/Specification/ExperimentParameter/.htaccess
+++ b/RoBivaL/FDORecord/Specification/ExperimentParameter/.htaccess
@@ -1,0 +1,4 @@
+RewriteEngine on
+RewriteRule ^$ https://github.com/cbacke/RoBivaL/tree/main/FDORecord/Specification/ExperimentParameter/ [R=303,L]
+RewriteRule ^([^/]+)/?$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDORecord/Specification/ExperimentParameter/$1.ttl [R=303,L]
+RewriteRule ^([^/]+)\.ttl$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDORecord/Specification/ExperimentParameter/$1.ttl [R=303,L]

--- a/RoBivaL/FDORecord/Specification/ExperimentType/.htaccess
+++ b/RoBivaL/FDORecord/Specification/ExperimentType/.htaccess
@@ -1,0 +1,4 @@
+RewriteEngine on
+RewriteRule ^$ https://github.com/cbacke/RoBivaL/tree/main/FDORecord/Specification/ExperimentType/ [R=303,L]
+RewriteRule ^([^/]+)/?$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDORecord/Specification/ExperimentType/$1.ttl [R=303,L]
+RewriteRule ^([^/]+)\.ttl$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDORecord/Specification/ExperimentType/$1.ttl [R=303,L]

--- a/RoBivaL/FDORecord/Specification/Hardware/.htaccess
+++ b/RoBivaL/FDORecord/Specification/Hardware/.htaccess
@@ -1,0 +1,4 @@
+RewriteEngine on
+RewriteRule ^$ https://github.com/cbacke/RoBivaL/tree/main/FDORecord/Specification/Hardware/ [R=303,L]
+RewriteRule ^([^/]+)/?$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDORecord/Specification/Hardware/$1.ttl [R=303,L]
+RewriteRule ^([^/]+)\.ttl$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDORecord/Specification/Hardware/$1.ttl [R=303,L]

--- a/RoBivaL/README.md
+++ b/RoBivaL/README.md
@@ -1,0 +1,36 @@
+# RoBivaL
+
+## Description
+
+This namespace provides permanent [IRIs](https://www.rfc-editor.org/rfc/rfc3987) for data from the [RoBivaL project](https://robotik.dfki-bremen.de/en/research/projects/robival).
+The data is modeled as a network of [RDF](https://www.w3.org/RDF/) nodes which are published as [FDOs](https://fairdo.org/).
+These are intended as a substitute for a previous [monolithic version of the RoBivaL data corpus](https://doi.org/10.5281/zenodo.8424932).
+
+The namespace is divided into multiple levels reflecting the hierarchical design of the RoBivaL data model.
+
+```txt
+RoBivaL/
+    FDOProfile/
+        ${FDO_PROFILE_NAME}
+    FDORecord/
+        Payload/
+            Run/
+                ${RUN_NAME}
+        Specification/
+            ExperimentParameter/
+                ${EXPERIMENT_PARAMETER_NAME}
+            ExperimentType/
+                ${EXPERIMENT_TYPE_NAME}
+            Hardware/
+                ${HARDWARE_NAME}
+```
+
+## Maintainers
+
+### Christian Backe
+
+- Name: Christian Backe
+- Affiliation: [DFKI Robotics Innovation Center](https://robotik.dfki-bremen.de/en/about-us/dfki-robotics-innovation-center/), Bremen, Germany
+- Email: christian.backe@dfki.de
+- GitHub: [cbacke](https://github.com/cbacke)
+- ORCID: [0009-0002-7114-0687](https://orcid.org/0009-0002-7114-0687)


### PR DESCRIPTION
This namespace provides permanent IRIs for data from the [RoBivaL project](https://robotik.dfki-bremen.de/en/research/projects/robival). The data is modeled as a network of RDF nodes. The namespace is divided into multiple levels reflecting the hierarchical design of the RoBivaL data model.