### PR TITLE
Redirect to catena-X odrl.jsonld

### DIFF
--- a/catenax/.htaccess
+++ b/catenax/.htaccess
@@ -162,6 +162,9 @@ RewriteRule ^credentials/v1.0.0(.*)$ https://eclipse-tractusx.github.io/tractusx
 # Redirect to published 2025/9 context until it is properly released
 RewriteRule ^2025/9/policy/context.jsonld https://raw.githubusercontent.com/catenax-eV/cx-odrl-profile/refs/heads/main/schema/context/context.jsonld [R=302,L]
 
+# Redirect to published 2025/9 context until it is properly released
+RewriteRule ^2025/9/policy/odrl.jsonld https://raw.githubusercontent.com/catenax-eV/cx-odrl-profile/refs/heads/main/schema/context/odrl.jsonld [R=302,L]
+
 # Redirect to published 2025/9 overarching schemas until they are properly released
 RewriteRule ^2025/9/policy/schema/(.+)$ https://raw.githubusercontent.com/catenax-eV/cx-odrl-profile/refs/heads/main/schema/$1 [R=302,L]
 


### PR DESCRIPTION
As we limited the allowed scope of odrl in this file https://github.com/catenax-eV/cx-odrl-profile/blob/main/schema/context/odrl.jsonld and thus need to reference this one in the constraints in CX-0152. 

New rule and sequence was tested in https://htaccess.madewithlove.com/ . Please remove in the "url that you are applying the rules to" /catenax if you test.