### PR TITLE
Bugfix

### DIFF
--- a/RoBivaL/FDOProfile/.htaccess
+++ b/RoBivaL/FDOProfile/.htaccess
@@ -1,4 +1,4 @@
 RewriteEngine on
 RewriteRule ^$ https://github.com/cbacke/RoBivaL/tree/main/FDOProfile/ [R=303,L]
-RewriteRule ^([^/]+)/?$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDOProfile/$1.ttl [R=303,L]
 RewriteRule ^([^/]+)\.ttl$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDOProfile/$1.ttl [R=303,L]
+RewriteRule ^([^/]+)/?$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDOProfile/$1.ttl [R=303,L]

--- a/RoBivaL/FDORecord/Payload/Run/.htaccess
+++ b/RoBivaL/FDORecord/Payload/Run/.htaccess
@@ -1,4 +1,4 @@
 RewriteEngine on
 RewriteRule ^$ https://github.com/cbacke/RoBivaL/tree/main/FDORecord/Payload/Run/ [R=303,L]
-RewriteRule ^([^/]+)/?$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDORecord/Payload/Run/$1.ttl [R=303,L]
 RewriteRule ^([^/]+)\.ttl$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDORecord/Payload/Run/$1.ttl [R=303,L]
+RewriteRule ^([^/]+)/?$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDORecord/Payload/Run/$1.ttl [R=303,L]

--- a/RoBivaL/FDORecord/Specification/ExperimentParameter/.htaccess
+++ b/RoBivaL/FDORecord/Specification/ExperimentParameter/.htaccess
@@ -1,4 +1,4 @@
 RewriteEngine on
 RewriteRule ^$ https://github.com/cbacke/RoBivaL/tree/main/FDORecord/Specification/ExperimentParameter/ [R=303,L]
-RewriteRule ^([^/]+)/?$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDORecord/Specification/ExperimentParameter/$1.ttl [R=303,L]
 RewriteRule ^([^/]+)\.ttl$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDORecord/Specification/ExperimentParameter/$1.ttl [R=303,L]
+RewriteRule ^([^/]+)/?$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDORecord/Specification/ExperimentParameter/$1.ttl [R=303,L]

--- a/RoBivaL/FDORecord/Specification/ExperimentType/.htaccess
+++ b/RoBivaL/FDORecord/Specification/ExperimentType/.htaccess
@@ -1,4 +1,4 @@
 RewriteEngine on
 RewriteRule ^$ https://github.com/cbacke/RoBivaL/tree/main/FDORecord/Specification/ExperimentType/ [R=303,L]
-RewriteRule ^([^/]+)/?$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDORecord/Specification/ExperimentType/$1.ttl [R=303,L]
 RewriteRule ^([^/]+)\.ttl$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDORecord/Specification/ExperimentType/$1.ttl [R=303,L]
+RewriteRule ^([^/]+)/?$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDORecord/Specification/ExperimentType/$1.ttl [R=303,L]

--- a/RoBivaL/FDORecord/Specification/Hardware/.htaccess
+++ b/RoBivaL/FDORecord/Specification/Hardware/.htaccess
@@ -1,4 +1,4 @@
 RewriteEngine on
 RewriteRule ^$ https://github.com/cbacke/RoBivaL/tree/main/FDORecord/Specification/Hardware/ [R=303,L]
-RewriteRule ^([^/]+)/?$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDORecord/Specification/Hardware/$1.ttl [R=303,L]
 RewriteRule ^([^/]+)\.ttl$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDORecord/Specification/Hardware/$1.ttl [R=303,L]
+RewriteRule ^([^/]+)/?$ https://raw.githubusercontent.com/cbacke/RoBivaL/refs/heads/main/FDORecord/Specification/Hardware/$1.ttl [R=303,L]


### PR DESCRIPTION
The more specific pattern must come first. Otherwise, the more general pattern is always applied, leading to non-existing target URLs.