### PR TITLE
Add permanent prefix for GAIDeT

### DIFF
--- a/gaidet/.htaccess
+++ b/gaidet/.htaccess
@@ -1,6 +1,14 @@
 Options +FollowSymLinks
 RewriteEngine On
 
-# Redirect everything under /gaidet/ to GitHub Pages
+# Redirect base GAIDeT namespace to the project homepage
 RewriteRule ^$ https://panbibliotekar.github.io/gaidet-declaration/ [R=302,L]
-RewriteRule (.*) https://panbibliotekar.github.io/gaidet-declaration/$1 [R=302,L]
+
+# Redirect OWL ontology
+RewriteRule ^gaidet.owl$ https://raw.githubusercontent.com/panbibliotekar/gaidet-declaration/main/gaidet.owl [R=302,L]
+
+# Redirect YAML source
+RewriteRule ^terms.yml$ https://raw.githubusercontent.com/panbibliotekar/gaidet-declaration/main/_data/terms.yml [R=302,L]
+
+# Fallback: redirect any other request under /gaidet/ to project homepage
+RewriteRule (.*) https://panbibliotekar.github.io/gaidet-declaration/ [R=302,L]

--- a/gaidet/.htaccess
+++ b/gaidet/.htaccess
@@ -1,0 +1,6 @@
+Options +FollowSymLinks
+RewriteEngine On
+
+# Redirect everything under /gaidet/ to GitHub Pages
+RewriteRule ^$ https://panbibliotekar.github.io/gaidet-declaration/ [R=302,L]
+RewriteRule (.*) https://panbibliotekar.github.io/gaidet-declaration/$1 [R=302,L]

--- a/gaidet/README.md
+++ b/gaidet/README.md
@@ -1,6 +1,23 @@
-# GAIDeT
+# GAIDeT – Generative AI Delegation Taxonomy
 
-Permanent identifier for the Generative AI Delegation Taxonomy (GAIDeT).
+**Permanent identifier: https://w3id.org/gaidet/**
 
-Maintainers:  
-- Serhii Nazarovets (@panbibliotekar)  
+GAIDeT (Generative AI Delegation Taxonomy) is a taxonomy and ontology designed to help researchers transparently disclose which research and writing tasks were delegated to generative AI tools. It complements existing frameworks such as **CRediT (Contributor Roles Taxonomy)** and **CRO (Contributor Role Ontology)** by providing a structured way to represent AI involvement in the research workflow.
+
+The taxonomy is available in several formats:
+- **Human-readable YAML** – primary source with bilingual (English/Ukrainian) labels.
+- **Machine-readable OWL ontology** – interoperable with CRO and CRediT.
+- **Interactive web tool** – [GAIDeT Declaration Generator](https://panbibliotekar.github.io/gaidet-declaration/) for creating ready-to-use disclosure statements.
+
+## Citation
+
+Suchikova, Y., Tsybuliak, N., Teixeira da Silva, J. A., & Nazarovets, S. (2025).  
+*GAIDeT (Generative AI Delegation Taxonomy): A taxonomy for humans to delegate tasks to generative artificial intelligence in scientific research and publishing.*  
+**Accountability in Research.** https://doi.org/10.1080/08989621.2025.2544331
+
+## Maintainers
+- Serhii Nazarovets (@panbibliotekar) – serhii.nazarovets@gmail.com  
+- Yana Suchikova – yanasuchikova@gmail.com  
+
+## License
+MIT License © 2025 Yana Suchikova, Natalia Tsybuliak, Jaime A. Teixeira da Silva, Serhii Nazarovets

--- a/gaidet/README.md
+++ b/gaidet/README.md
@@ -1,0 +1,6 @@
+# GAIDeT
+
+Permanent identifier for the Generative AI Delegation Taxonomy (GAIDeT).
+
+Maintainers:  
+- Serhii Nazarovets (@panbibliotekar)  

--- a/gaidet/README.md
+++ b/gaidet/README.md
@@ -16,8 +16,7 @@ Suchikova, Y., Tsybuliak, N., Teixeira da Silva, J. A., & Nazarovets, S. (2025).
 **Accountability in Research.** https://doi.org/10.1080/08989621.2025.2544331
 
 ## Maintainers
-- Serhii Nazarovets (@panbibliotekar) – serhii.nazarovets@gmail.com  
-- Yana Suchikova – yanasuchikova@gmail.com  
+- Serhii Nazarovets (@panbibliotekar) – serhii.nazarovets@gmail.com
 
 ## License
 MIT License © 2025 Yana Suchikova, Natalia Tsybuliak, Jaime A. Teixeira da Silva, Serhii Nazarovets


### PR DESCRIPTION
### Request for new prefix: /gaidet/

**Maintainers:**
- Serhii Nazarovets (@panbibliotekar) – serhii.nazarovets@gmail.com

**Purpose:**
GAIDeT (Generative AI Delegation Taxonomy) is a taxonomy and ontology that enables transparent disclosure of which research and writing tasks are delegated to generative AI tools.  
It complements CRediT (Contributor Roles Taxonomy) and CRO (Contributor Role Ontology) by adding structured, machine-readable roles for AI involvement.

**Redirects:**
- https://w3id.org/gaidet/ → https://panbibliotekar.github.io/gaidet-declaration/
- https://w3id.org/gaidet/gaidet.owl → OWL ontology in the GitHub repository
- https://w3id.org/gaidet/terms.yml → YAML source file for the taxonomy

**License:**
MIT License © 2025 Yana Suchikova, Natalia Tsybuliak, Jaime A. Teixeira da Silva, Serhii Nazarovets