### PR TITLE
feat(tractusx-trust): add initial tractusx-trust with context

### DIFF
--- a/tractusx-trust/.htaccess
+++ b/tractusx-trust/.htaccess
@@ -1,0 +1,19 @@
+#
+# Tractus-X Trust Namespace Forwarding Rules
+# tested with https://htaccess.madewithlove.com/
+#
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType application/ld+json .jsonld
+# Rewrite engine setup
+RewriteEngine On
+#Change the path to the folder here
+RewriteBase /
+
+# Rewrite rule to resolve policy context
+RewriteRule ^0.8(.*)$ https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/0.8.1/specifications/context.json [R=302,L]
+
+# Rewrite rule to default to the last release with said namespace
+RewriteRule ^(.*)$ https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol/releases/tag/0.8.1 [R=303,L]

--- a/tractusx-trust/README.md
+++ b/tractusx-trust/README.md
@@ -1,0 +1,11 @@
+# Tractus-X Trust Namespace
+
+This namespace was used in specification drafts for a protocol for the exchange of verifiable credentials. The project
+was soon moved to the EDWG and the [dspace-dcp](../dspace-dcp) namespace. However, there's still systems out there
+that use payloads including `tractusx-trust` for compatibility reasons. The namespace is registered mainly to prevent
+someone else squatting on it.
+
+Contact:
+
+- James Marino <jim.marino@gmail.com> (https://github.com/jimmarino)
+- Arno Weiß <arno.weiss@sap.com> (https://github.com/arnoweiss)


### PR DESCRIPTION
This PR adds the tractusx-trust namespace. Even though it's legacy, leaving it unclaimed would pose a security risk implementing the old specs.