### PR TITLE
Adding Core Activity Ontology

### DIFF
--- a/core-activity-ontology/.htaccess
+++ b/core-activity-ontology/.htaccess
@@ -2,7 +2,7 @@ Options +FollowSymLinks
 RewriteEngine On
 
 # Redirect ontology namespace
-RewriteRule ^$ https://activity-knowledge-project.github.io/CAO/v1/index.html [R=303,L]
+RewriteRule ^$ https://activity-knowledge-project.github.io/CAO/index.html [R=303,L]
 
 # Redirect ontology file (TTL)
-RewriteRule ^ontology$ https://activity-knowledge-project.github.io/CAO/v1/core-activity-ontology.ttl [R=303,L]
+RewriteRule ^ontology$ https://activity-knowledge-project.github.io/CAO/core-activity-ontology.ttl [R=303,L]

--- a/core-activity-ontology/.htaccess
+++ b/core-activity-ontology/.htaccess
@@ -2,7 +2,7 @@ Options +FollowSymLinks
 RewriteEngine On
 
 # Redirect ontology namespace
-RewriteRule ^$ https://activity-knowledge-project.github.io/ontology/v1/index.html [R=303,L]
+RewriteRule ^$ https://activity-knowledge-project.github.io/CAO/v1/index.html [R=303,L]
 
 # Redirect ontology file (TTL)
-RewriteRule ^ontology$ https://activity-knowledge-project.github.io/ontology/v1/core-activity-ontology.ttl [R=303,L]
+RewriteRule ^ontology$ https://activity-knowledge-project.github.io/CAO/v1/core-activity-ontology.ttl [R=303,L]

--- a/core-activity-ontology/.htaccess
+++ b/core-activity-ontology/.htaccess
@@ -1,0 +1,8 @@
+Options +FollowSymLinks
+RewriteEngine On
+
+# Redirect ontology namespace
+RewriteRule ^$ https://activity-knowledge-project.github.io/ontology/v1/index.html [R=303,L]
+
+# Redirect ontology file (TTL)
+RewriteRule ^ontology$ https://activity-knowledge-project.github.io/ontology/v1/core-activity-ontology.ttl [R=303,L]

--- a/core-activity-ontology/README.md
+++ b/core-activity-ontology/README.md
@@ -5,3 +5,7 @@ The Core Activity Ontology is derived from the Activity Theory and aims at repre
 Serge Sonfack Sounchio
 
 Email: sss.sounchio@gmail.com
+
+Github: https://github.com/sonfack
+
+Project Github: https://github.com/activity-knowledge-project

--- a/core-activity-ontology/README.md
+++ b/core-activity-ontology/README.md
@@ -1,0 +1,7 @@
+# Core Activity Ontology (CAO)
+The Core Activity Ontology is derived from the Activity Theory and aims at representing knowledge about activities carried out within an organization., This ontology defines core concepts and their relations to represent activity knowledge within an organization.
+
+## contact
+Serge Sonfack Sounchio
+
+Email: sss.sounchio@gmail.com

--- a/core-activity-ontology/README.md
+++ b/core-activity-ontology/README.md
@@ -1,5 +1,5 @@
 # Core Activity Ontology (CAO)
-The Core Activity Ontology is derived from the Activity Theory and aims at representing knowledge about activities carried out within an organization., This ontology defines core concepts and their relations to represent activity knowledge within an organization.
+The Core Activity Ontology is derived from the Activity Theory and aims at representing knowledge about activities carried out within an organization. This ontology defines core concepts and their relations to represent activity knowledge within an organization.
 
 ## contact
 Serge Sonfack Sounchio


### PR DESCRIPTION
The Core Activity Ontology was created in the Activity Knowledge management project and is hosted on https://github.com/activity-knowledge-project/CAO/blob/main/v1/core_activity_ontology.ttl

The link for its URL is activity-knowledge-project.github.io 