### PR TITLE
fix(tractusx-trust): path

### DIFF
--- a/tractusx-trust/.htaccess
+++ b/tractusx-trust/.htaccess
@@ -13,7 +13,7 @@ RewriteEngine On
 RewriteBase /
 
 # Rewrite rule to resolve policy context
-RewriteRule ^0.8(.*)$ https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/0.8.1/specifications/context.json [R=302,L]
+RewriteRule ^v0.8(.*)$ https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/0.8.1/specifications/context.json [R=302,L]
 
 # Rewrite rule to default to the last release with said namespace
 RewriteRule ^(.*)$ https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol/releases/tag/0.8.1 [R=303,L]


### PR DESCRIPTION
stupid mistake - sorry

It's referenced to here:
https://github.com/eclipse-edc/Connector/blob/d831c31e9e14ab72807b5a045f4c7ad7816aab2e/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/iam/identitytrust/spi/DcpConstants.java#L22