### PR TITLE
fix(routing): update .htaccess redirects to new spec filenames

### DIFF
--- a/health-ri/.htaccess
+++ b/health-ri/.htaccess
@@ -41,7 +41,7 @@ RedirectMatch 302 ^/health-ri/ontology(/ttl)?/?$ https://raw.githubusercontent.c
 RedirectMatch 302 ^/health-ri/ontology/vpp/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/health-ri-ontology.vpp
 RedirectMatch 302 ^/health-ri/ontology/json/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/health-ri-ontology.json
 RedirectMatch 302 ^/health-ri/ontology/(doc|documentation)/?$ https://health-ri.github.io/semantic-interoperability/ontology/documentation/
-RedirectMatch 302 ^/health-ri/ontology/(spec|specification)/?$ https://health-ri.github.io/semantic-interoperability/ontology/specification.html
+RedirectMatch 302 ^/health-ri/ontology/(spec|specification)/?$ https://health-ri.github.io/semantic-interoperability/ontology/specification-ontology.html
 
 ## Versioned ontology files (ttl, vpp, json, documentation.md, specification.html)
 # Matches semantic versions like v1.2.3 and redirects to the corresponding static files
@@ -65,7 +65,7 @@ RedirectMatch 302 ^/health-ri/semantic-interoperability/mappings/tsv/?$ https://
 
 ## Latest vocabulary files (ttl and specification.html)
 RedirectMatch 302 ^/health-ri/mapping-vocabulary(/ttl)?/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/vocabulary/latest/health-ri-vocabulary.ttl
-RedirectMatch 302 ^/health-ri/mapping-vocabulary/(spec|specification)/?$ https://health-ri.github.io/semantic-interoperability/method/specification.html
+RedirectMatch 302 ^/health-ri/mapping-vocabulary/(spec|specification)/?$ https://health-ri.github.io/semantic-interoperability/method/specification-vocabulary.html
 
 ## Versioned vocabulary files (ttl and specification.html)
 # Matches semantic versions like v1.2.3 and redirects to the corresponding static files


### PR DESCRIPTION
- change ontology redirect from `specification.html` → `specification-ontology.html`
- change mapping vocabulary redirect from `specification.html` → `specification-vocabulary.html`

Ensures external users are redirected to the correct renamed spec files.