### PR TITLE
Add permanent identifiers for Solid CRDT Sync framework

### DIFF
--- a/solid-crdt-sync/.htaccess
+++ b/solid-crdt-sync/.htaccess
@@ -1,0 +1,17 @@
+# https://w3id.org/solid-crdt-sync/
+# Redirects for Solid CRDT Sync vocabulary and mapping files
+#
+# Contact:
+# Klas Kalaß
+# habbatical@gmail.com
+# GitHub username: kkalass
+
+RewriteEngine on
+
+# Vocabulary redirects to GitHub Pages
+RewriteRule ^vocab/(.+)$ https://kkalass.github.io/solid_crdt_sync/vocab/$1 [R=302,L]
+RewriteRule ^vocab/?$ https://kkalass.github.io/solid_crdt_sync/vocab/ [R=302,L]
+
+# Mappings redirects to GitHub Pages  
+RewriteRule ^mappings/(.+)$ https://kkalass.github.io/solid_crdt_sync/mappings/$1 [R=302,L]
+RewriteRule ^mappings/?$ https://kkalass.github.io/solid_crdt_sync/mappings/ [R=302,L]

--- a/solid-crdt-sync/README.md
+++ b/solid-crdt-sync/README.md
@@ -1,0 +1,16 @@
+# /solid-crdt-sync/
+
+Permanent identifiers for the Solid CRDT Sync framework vocabulary and mapping files.
+
+[https://w3id.org/solid-crdt-sync/vocab/](https://w3id.org/solid-crdt-sync/vocab/) redirects to the vocabulary files at [https://kkalass.github.io/solid_crdt_sync/vocab/](https://kkalass.github.io/solid_crdt_sync/vocab/).
+
+[https://w3id.org/solid-crdt-sync/mappings/](https://w3id.org/solid-crdt-sync/mappings/) redirects to the mapping files at [https://kkalass.github.io/solid_crdt_sync/mappings/](https://kkalass.github.io/solid_crdt_sync/mappings/).
+
+The Solid CRDT Sync framework enables synchronization of RDF data to Solid Pods using CRDT (Conflict-free Replicated Data Types) for local-first, interoperable applications. These permanent identifiers provide stable IRIs for the framework's vocabularies (`crdt:`, `algo:`, `sync:`, `idx:`, `mc:`) and merge contract mappings.
+
+## Contact
+
+This space is administered by **Klas Kalaß**.  
+
+habbatical@gmail.com  
+GitHub username: [kkalass](https://github.com/kkalass)


### PR DESCRIPTION
## Request Summary

  This PR adds permanent identifiers for the Solid CRDT Sync framework vocabularies and
  mappings:

  - **https://w3id.org/solid-crdt-sync/vocab/** - RDF vocabularies (crdt:, algo:, sync:,
  idx:, mc: namespaces)
  - **https://w3id.org/solid-crdt-sync/mappings/** - CRDT merge contract mappings

  ## Project Description

  Solid CRDT Sync is both a specification and Dart library for synchronizing RDF data to
  Solid Pods using Conflict-free Replicated Data Types (CRDTs). The framework enables
  local-first, interoperable applications following semantic web standards.

  ## Technical Details

  - Redirects to existing GitHub Pages deployment at `kkalass.github.io/solid_crdt_sync/`
  - Simple .htaccess configuration with clean URL patterns
  - Vocabularies define CRDT algorithms, synchronization mechanics, and merge strategies
  - Mappings provide reusable CRDT merge contracts for applications

  ## Justification

  These permanent identifiers are needed for:
  - Stable vocabulary namespace URIs in RDF applications
  - Long-term interoperability as the framework evolves
  - Citation in academic and production contexts
  - Supporting multiple future implementations of the specification

  ## Links

  - **GitHub Repository:** https://github.com/kkalass/solid_crdt_sync
  - **Documentation:** https://kkalass.github.io/solid_crdt_sync/
  - **Specification:**
  https://github.com/kkalass/solid_crdt_sync/blob/main/spec/SPECIFICATION.md

  ## Contact

  Klas Kalaß ([@kkalass](https://github.com/kkalass))
  habbatical@gmail.com