### PR TITLE
Add OntoCrime namespace

### DIFF
--- a/Ontocrime/.htaccess
+++ b/Ontocrime/.htaccess
@@ -1,0 +1,20 @@
+# Always use HTTPS
+RewriteEngine On
+RewriteCond %{HTTPS} off
+RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+
+# Redirect root to ontology README
+RewriteRule ^$ https://github.com/fcarrillo-brenes/Ontocrime [R=302,L]
+
+# Redirect ontology files
+RewriteRule ^ontology/?$ https://raw.githubusercontent.com/fcarrillo-brenes/Ontocrime/main/crimev5.rdf [R=302,L]
+
+# Content negotiation for different formats
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^ontology$ https://raw.githubusercontent.com/fcarrillo-brenes/Ontocrime/main/crimev5.rdf [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^ontology$ https://raw.githubusercontent.com/fcarrillo-brenes/Ontocrime/main/crimev5.ttl [R=302,L]
+
+# Default redirect to RDF
+RewriteRule ^ontology$ https://raw.githubusercontent.com/fcarrillo-brenes/Ontocrime/main/crimev5.rdf [R=302,L]

--- a/Ontocrime/README.md
+++ b/Ontocrime/README.md
@@ -1,0 +1,16 @@
+# OntoCrime
+
+Persistent URI namespace for the **OntoCrime ontology**, an ontology for modeling and publishing crime-related data as Linked Data.
+
+## Homepage
+- https://github.com/fcarrillo-brenes/Ontocrime
+
+## Ontology files
+- RDF/XML: https://raw.githubusercontent.com/fcarrillo-brenes/Ontocrime/main/crimev5.rdf
+- (Optional) Turtle: https://raw.githubusercontent.com/fcarrillo-brenes/Ontocrime/main/crimev5.ttl
+- (Optional) JSON-LD: https://raw.githubusercontent.com/fcarrillo-brenes/Ontocrime/main/crimev5.jsonld
+
+## Maintainers
+- Francisco Carrillo  
+  [@fcarrillo-brenes](https://github.com/fcarrillo-brenes)  
+  ✉️ fcarrillob2022@cic.ipn.mx


### PR DESCRIPTION
This pull request adds a new persistent namespace for OntoCrime.

OntoCrime is an ontology for modeling and publishing crime-related data as Linked Data.
The namespace will provide stable and persistent URIs for crime datasets and knowledge graph projects.

Changes included:
- Created the /ontocrime/ directory.
- Added .htaccess with content negotiation for RDF/XML (and optional TTL, JSON-LD).
- Added README.md describing the namespace and maintainers.

Maintainer:
- Francisco Carrillo (fcarrillob2022@cic.ipn.mx)
  GitHub: https://github.com/fcarrillo-brenes

Please review and let me know if further adjustments are needed.
