### PR TITLE
Add CoSMO ontology redirects

### DIFF
--- a/CoSMO/.htaccess
+++ b/CoSMO/.htaccess
@@ -1,0 +1,13 @@
+Options +FollowSymLinks
+RewriteEngine On
+RewriteBase /
+
+# Ontologia CoSMO
+RewriteRule ^ontology$ https://raw.githubusercontent.com/camila875/CoSMO/main/CoSMO.owl [R=302,L]
+RewriteRule ^ontology.ttl$ https://raw.githubusercontent.com/camila875/CoSMO/main/CoSMO.ttl [R=302,L]
+
+# Documentação
+RewriteRule ^doc$ https://camila875.github.io/CoSMO/ [R=302,L]
+
+# Default (se alguém acessar só /CoSMO)
+RewriteRule ^$ https://camila875.github.io/CoSMO/ [R=302,L]

--- a/CoSMO/README.md
+++ b/CoSMO/README.md
@@ -1,0 +1,18 @@
+# CoSMO w3id
+
+This folder provides permanent URLs (w3id) for the CoSMO ontology.
+
+## Purpose
+
+The CoSMO ontology (Consent in Social Media Ontology) is designed to formally represent knowledge about the consent of individuals in digital social media, focusing on data protection. This w3id ensures stable, persistent URLs so the ontology can be reliably referenced in research, ontologies, applications, and tools such as Protégé.
+
+## Permanent URLs
+
+- **Ontology (OWL):** https://w3id.org/CoSMO/ontology → CoSMO.owl  
+- **Ontology (Turtle):** https://w3id.org/CoSMO/ontology.ttl → CoSMO.ttl  
+- **Documentation / GitHub Pages:** https://w3id.org/CoSMO/doc
+
+## Maintainer
+
+- Name: Camila Pereira  
+- GitHub ID: camila875  


### PR DESCRIPTION
This PR adds a new folder CoSMO with a .htaccess file
to provide permanent URLs for the CoSMO ontology:
- https://w3id.org/CoSMO/ontology → CoSMO.owl
- https://w3id.org/CoSMO/ontology.ttl → CoSMO.ttl
- https://w3id.org/CoSMO/doc → documentation (GitHub Pages)
