### PR TITLE
Assets for DGGRS registry

### DIFF
--- a/dggrs/.htaccess
+++ b/dggrs/.htaccess
@@ -1,7 +1,6 @@
 # Rewrite engine setup
 RewriteEngine On
 
-
 # Rewrite rule to serve HTML content of the page
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
@@ -9,25 +8,7 @@ RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 RewriteRule ^$ https://geoplegma.github.io/dggrs-registry/ [R=303,L]
 
-
-## Rewrite rule to serve RDF/XML content if requested
-#RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
-#RewriteCond %{HTTP_ACCEPT} application/owl\+xml
-#RewriteRule ^$ https://geoplegma.github.io/dggrs-registry/index.owl [R=303,L]
-#
-#
-#
-## Rewrite rule to serve JSON-LD content if requested
-#RewriteCond %{HTTP_ACCEPT} application/ld\+json 
-#RewriteRule ^$ https://geoplegma.github.io/dggrs-registry/index.jsonld [R=303,L]
-#
-#
-## Rewrite rule to serve TURTLE if requested
-#RewriteCond %{HTTP_ACCEPT} text/turtle
-#RewriteRule ^$ https://geoplegma.github.io/dggrs-registry/index.ttl [R=303,L]
-
-
 # Choose the default response for core ontology
 # --------------------------------------------
 # Default Rule
-RewriteRule ^$ https://geoplegma.github.io/dggrs-registry/index.ttl [R=303,L]
+RewriteRule ^$ https://geoplegma.github.io/dggrs-registry/dggrs-ontology.ttl [R=303,L]

--- a/dggrs/.htaccess
+++ b/dggrs/.htaccess
@@ -1,0 +1,33 @@
+# Rewrite engine setup
+RewriteEngine On
+
+
+# Rewrite rule to serve HTML content of the page
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://geoplegma.github.io/dggrs-registry/ [R=303,L]
+
+
+## Rewrite rule to serve RDF/XML content if requested
+#RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+#RewriteCond %{HTTP_ACCEPT} application/owl\+xml
+#RewriteRule ^$ https://geoplegma.github.io/dggrs-registry/index.owl [R=303,L]
+#
+#
+#
+## Rewrite rule to serve JSON-LD content if requested
+#RewriteCond %{HTTP_ACCEPT} application/ld\+json 
+#RewriteRule ^$ https://geoplegma.github.io/dggrs-registry/index.jsonld [R=303,L]
+#
+#
+## Rewrite rule to serve TURTLE if requested
+#RewriteCond %{HTTP_ACCEPT} text/turtle
+#RewriteRule ^$ https://geoplegma.github.io/dggrs-registry/index.ttl [R=303,L]
+
+
+# Choose the default response for core ontology
+# --------------------------------------------
+# Default Rule
+RewriteRule ^$ https://geoplegma.github.io/dggrs-registry/index.ttl [R=303,L]

--- a/dggrs/README.md
+++ b/dggrs/README.md
@@ -3,7 +3,7 @@ Discrete Global Grid Reference System Registry
 
 
 Ontologies:
-* https://w3id.org/dggrs/ontology (namespace: https://w3id.org/dggrs)
+* https://w3id.org/dggrs/ (namespace: https://w3id.org/dggrs)
 
 Registry:
 * https://w3id.org/dggrs/system (namespace: https://w3id.org/dggrs/system)

--- a/dggrs/README.md
+++ b/dggrs/README.md
@@ -1,0 +1,16 @@
+Discrete Global Grid Reference System Registry
+===============================================
+
+
+Ontologies:
+* https://w3id.org/dggrs/ontology (namespace: https://w3id.org/dggrs)
+
+Registry:
+* https://w3id.org/dggrs/system (namespace: https://w3id.org/dggrs/system)
+* https://w3id.org/dggrs/implement (namespace: https://w3id.org/dggrs/implement)
+
+References:
+* https://github.com/GeoPlegma/GeoPlegma
+
+Contacts: 
+* Luís Moreira de Sousa [ldesousa](https://github.com/ldesousa)

--- a/dggrs/implement/.htaccess
+++ b/dggrs/implement/.htaccess
@@ -1,0 +1,12 @@
+# Rewrite rule to serve HTML content for Geocs extension
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://geoplegma.github.io/dggrs-registry/doc/implement/index-en.html [R=303,L]
+
+
+# Choose the default response for the registry
+# --------------------------------------------
+# Default Rule
+RewriteRule ^$ https://geoplegma.github.io/dggrs-registry/implement.ttl [R=303,L]

--- a/dggrs/system/.htaccess
+++ b/dggrs/system/.htaccess
@@ -3,7 +3,7 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://geoplegma.github.io/dggrs-ontology/doc/system/index-en.html [R=303,L]
+RewriteRule ^$ https://geoplegma.github.io/dggrs-registry/doc/system/index-en.html [R=303,L]
 
 
 # Choose the default response for the Registry 

--- a/dggrs/system/.htaccess
+++ b/dggrs/system/.htaccess
@@ -1,0 +1,12 @@
+# Rewrite rule to serve HTML content for Geocs extension
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://geoplegma.github.io/dggrs-ontology/doc/system/index-en.html [R=303,L]
+
+
+# Choose the default response for the Registry 
+# --------------------------------------------
+# Default Rule
+RewriteRule ^$ https://geoplegma.github.io/dggrs-registry/system.ttl [R=303,L]


### PR DESCRIPTION
This DGGRS registry is meant to support development in the [GeoPlegma](https://github.com/GeoPlegma) project. But more widely to become a web-based reference for DGGS development.

The DGGRS registry is also related to the [CRS ontology](https://opengeospatial.github.io/ontology-crs/) in development within the OGC.