### PR TITLE
Add redirect for PODS 03 ontology

### DIFF
--- a/pods/complete_03/.htaccess
+++ b/pods/complete_03/.htaccess
@@ -1,0 +1,1 @@
+Redirect 302 /pods/complete_03 https://github.com/Vlauro/PODS/blob/main/PODS%200.3

--- a/pods/complete_03/README.md
+++ b/pods/complete_03/README.md
@@ -1,0 +1,10 @@
+# PODS-03 Ontology
+
+Temporary identifier for the PODS-03 ontology.
+Full and modular version of the PODS ontology for comprehensive semantic representation of photogrammetric workflows. Content: Includes the entire set of PODS classes (F1–F5 and sub-classes), properties (Y1–Y95), and alignments with reference ontologies such as CIDOC CRM, CRMDig, SKOS, QUDT, OWL-Time. Status: Designed for completeness, academic use, and formal reasoning over all phases of the survey process (acquisition, processing, modelling, exporting).
+
+**Redirects to:**  
+https://github.com/Vlauro/PODS/blob/main/PODS%200.3
+
+**Maintainer:**  
+Vittorio Lauro — [vittorio.lauro@unito.it]


### PR DESCRIPTION
This PR adds a temporary redirect for the PODS 03 ontology to the corresponding file hosted on GitHub.