### PR TITLE
Add ID for OntoEvents ontology

### DIFF
--- a/OntoEvents/.htaccess
+++ b/OntoEvents/.htaccess
@@ -1,0 +1,13 @@
+RewriteEngine On
+RewriteBase /OntoEvents/
+
+# Content negotiation (RDF/XML)
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://raw.githubusercontent.com/fcarrillo-brenes/OntoEvents/refs/heads/main/eventsv2.rdf [R=303,L]
+
+# Default: show the GitHub repo (HTML view)
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^$ https://github.com/fcarrillo-brenes/OntoEvents [R=303,L]
+
+# Fallback: if no Accept header, go to the repo
+RewriteRule ^$ https://github.com/fcarrillo-brenes/OntoEvents [R=303,L]

--- a/OntoEvents/README.md
+++ b/OntoEvents/README.md
@@ -1,0 +1,15 @@
+# OntoEvents
+
+OntoEvents is an ontology for representing events, their participants, temporal properties, and contextual information extracted from text sources such as Twitter posts and news articles.  
+
+
+## Features
+- Classes for events, subevents, subjects, objects, and extracted entities.
+- Properties for linking subjects, predicates, and objects in event triples.
+- Support for temporal data (date, hour, timestamp) using W3C Time Ontology.
+- Contextualization of events within tweets (using named graphs).
+
+## Maintainers
+- Francisco Carrillo  
+  [@fcarrillo-brenes](https://github.com/fcarrillo-brenes)  
+  ✉️ fcarrillob2022@cic.ipn.mx


### PR DESCRIPTION
Hi,

I would like to register the permanent identifier w3id.org/OntoEvents for my ontology OntoEvents.

Repository: https://github.com/fcarrillo-brenes/OntoEvents

Ontology file: eventsv2.rdf

Purpose: OntoEvents is an ontology for representing events, their participants, temporal information, and contextual data extracted from textual sources such as social media posts and news articles.

Maintainer: Francisco Carrillo-Brenes (@fcarrillo-brenes)

This PR adds the folder OntoEvents/ with an .htaccess file to redirect to the ontology in GitHub with content negotiation.

Thanks!