### PR TITLE
Add CSRO project

### DIFF
--- a/CSRO/.htaccess
+++ b/CSRO/.htaccess
@@ -1,0 +1,5 @@
+# Redirect https://w3id.org/csro to your GitHub repository
+Redirect 302 /csro https://github.com/fortiss/CSRO
+
+# Redirect https://w3id.org/csro/ontology to the ontology file
+Redirect 302 /csro/ontology https://github.com/fortiss/CSRO/raw/main/csro.ttl

--- a/CSRO/README.md
+++ b/CSRO/README.md
@@ -1,0 +1,11 @@
+# CSRO
+
+Container Security Risk Ontology (CSRO) is an ontology for security risk assessment in containerized environments. Its main purpose is to provide a formal, extensible framework for modeling security assumptions, risk factors, calculation rules, and standards relevant to containers. CSRO supports automated reasoning and risk analysis, bridging the gap between static documentation and dynamic security engineering needs.
+
+This artifact was created with the needs of domain experts, the assurance and security community, and the Semantic Web community in mind.
+
+The ontology has been created by Yannick Landeck, scientific researcher at the fortiss Research Institute of the Free State of Bavaria for software-intensive systems.
+
+# Author & Maintainer
+
+- [Yannick Landeck](https://www.fortiss.org/en/results/scientific-publications/author/yannick-landeck) (GitHub: [YannickLand](https://github.com/YannickLand))


### PR DESCRIPTION
Create .htaccess and README.md for w3id.org persistent identifier registration of the Container Security Risk Ontology (CSRO) project.