### PR TITLE
Add w3id for Signal Description Ontology

### DIFF
--- a/signal-description-ontology/.htaccess
+++ b/signal-description-ontology/.htaccess
@@ -1,0 +1,44 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .jsonld
+# Rewrite engine setup
+RewriteEngine On
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+# Placed before HTML to support serving JSON-LD from a browser (e.g., JSON Playground)
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://lexebner.github.io/sdo/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://lexebner.github.io/sdo/index.html [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://lexebner.github.io/sdo/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://lexebner.github.io/sdo/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ https://lexebner.github.io/sdo/ontology.ttl [R=303,L]
+
+# Default response
+# ---------------------------
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^$ https://lexebner.github.io/sdo/ontology.owl [R=303,L]

--- a/signal-description-ontology/.htaccess
+++ b/signal-description-ontology/.htaccess
@@ -37,8 +37,3 @@ RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle
 RewriteRule ^$ https://lexebner.github.io/sdo/ontology.ttl [R=303,L]
-
-# Default response
-# ---------------------------
-# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
-RewriteRule ^$ https://lexebner.github.io/sdo/ontology.owl [R=303,L]

--- a/signal-description-ontology/README.md
+++ b/signal-description-ontology/README.md
@@ -1,0 +1,23 @@
+# Signal Description Ontology
+
+This directory contains configuration for the [w3id.org](https://w3id.org) permanent identifier:
+
+**https://w3id.org/signal-description-ontology/**
+
+## Redirects
+
+The `.htaccess` file in this folder defines the following redirects:
+
+Requests from `https://w3id.org/signal-description-ontology/` to resources hosted at [https://lexebner.github.io/sdo/](https://lexebner.github.io/sdo/)
+
+- index.html
+- ontology.(ttl|owl|jsonld|nt)
+
+## Maintainers
+
+- **Name:** Alexander Ebner 
+- **GitHub:** [@lexEbner](https://github.com/lexEbner) 
+
+## Acknowledgements
+
+This permanent identifier is provided via [w3id.org](https://w3id.org), a community service for stable Web identifiers.


### PR DESCRIPTION
I want to create a w3id for my ontology to use for the URIs and the documentation.
The documentation is hosted at GitHub pages and it hosts the ontology in the formats (ttl|owl|jsonld|nt).