### PR TITLE
SensorThings API Ontology

### DIFF
--- a/stapi/.htaccess
+++ b/stapi/.htaccess
@@ -1,0 +1,5 @@
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^.*$ https://cdn.jsdelivr.net/gh/rdf-connect/sensorthings-api-fetcher-ts@main/ontology/stapi.ttl [R=303,L]

--- a/stapi/README.md
+++ b/stapi/README.md
@@ -1,0 +1,19 @@
+SensorThings API Ontology
+===
+
+
+This W3ID provides a persistent URI namespace for the [SensorThings API](https://www.ogc.org/standards/sensorthings/) ontology.
+
+## Vocabulary
+
+https://w3id.org/stapi
+
+## Contact
+Ruben Dedecker 
+
+Email: ruben.dedecker@ugent.be
+
+Github handle: @dexagod
+
+## Issues 
+Any issues can be reported [here](https://github.com/rdf-connect/sensorthings-api-fetcher-ts/issues).


### PR DESCRIPTION
Hi

I would like to add the ontology we created for the [SensorThings API](https://www.ogc.org/standards/sensorthings/).


Kind regards

Ruben