### PR TITLE
Update solid-crdt-sync redirects to point to locorda.dev

### DIFF
--- a/solid-crdt-sync/.htaccess
+++ b/solid-crdt-sync/.htaccess
@@ -1,5 +1,5 @@
 # https://w3id.org/solid-crdt-sync/
-# Redirects for Solid CRDT Sync vocabulary and mapping files
+# Redirects for Locorda vocabulary and mapping files (formerly Solid CRDT Sync)
 #
 # Contact:
 # Klas Kalaß
@@ -8,10 +8,10 @@
 
 RewriteEngine on
 
-# Vocabulary redirects to GitHub Pages
-RewriteRule ^vocab/(.+)$ https://kkalass.github.io/solid_crdt_sync/vocab/$1 [R=302,L]
-RewriteRule ^vocab/?$ https://kkalass.github.io/solid_crdt_sync/vocab/ [R=302,L]
+# Vocabulary redirects to locorda.dev
+RewriteRule ^vocab/(.+)$ https://locorda.dev/vocab/$1 [R=302,L]
+RewriteRule ^vocab/?$ https://locorda.dev/vocab/ [R=302,L]
 
-# Mappings redirects to GitHub Pages  
-RewriteRule ^mappings/(.+)$ https://kkalass.github.io/solid_crdt_sync/mappings/$1 [R=302,L]
-RewriteRule ^mappings/?$ https://kkalass.github.io/solid_crdt_sync/mappings/ [R=302,L]
+# Mappings redirects to locorda.dev
+RewriteRule ^mappings/(.+)$ https://locorda.dev/mappings/$1 [R=302,L]
+RewriteRule ^mappings/?$ https://locorda.dev/mappings/ [R=302,L]

--- a/solid-crdt-sync/README.md
+++ b/solid-crdt-sync/README.md
@@ -1,16 +1,16 @@
 # /solid-crdt-sync/
 
-Permanent identifiers for the Solid CRDT Sync framework vocabulary and mapping files.
+Permanent identifiers for the Locorda Sync framework (formerly Solid CRDT Sync) vocabulary and mapping files.
 
-[https://w3id.org/solid-crdt-sync/vocab/](https://w3id.org/solid-crdt-sync/vocab/) redirects to the vocabulary files at [https://kkalass.github.io/solid_crdt_sync/vocab/](https://kkalass.github.io/solid_crdt_sync/vocab/).
+[https://w3id.org/solid-crdt-sync/vocab/](https://w3id.org/solid-crdt-sync/vocab/) redirects to the vocabulary files at [https://locorda.dev/vocab/](https://locorda.dev/vocab/).
 
-[https://w3id.org/solid-crdt-sync/mappings/](https://w3id.org/solid-crdt-sync/mappings/) redirects to the mapping files at [https://kkalass.github.io/solid_crdt_sync/mappings/](https://kkalass.github.io/solid_crdt_sync/mappings/).
+[https://w3id.org/solid-crdt-sync/mappings/](https://w3id.org/solid-crdt-sync/mappings/) redirects to the mapping files at [https://locorda.dev/mappings/](https://locorda.dev/mappings/).
 
-The Solid CRDT Sync framework enables synchronization of RDF data to Solid Pods using CRDT (Conflict-free Replicated Data Types) for local-first, interoperable applications. These permanent identifiers provide stable IRIs for the framework's vocabularies (`crdt:`, `algo:`, `sync:`, `idx:`, `mc:`) and merge contract mappings.
+The Locorda Sync framework enables synchronization of RDF data to Solid Pods (and potentially other passive data stores) using CRDT (Conflict-free Replicated Data Types) for local-first, interoperable applications. These permanent identifiers provide stable IRIs for the framework's vocabularies (`crdt:`, `algo:`, `sync:`, `idx:`, `mc:`) and merge contract mappings.
 
 ## Contact
 
-This space is administered by **Klas Kalaß**.  
+This space is administered by **Klas Kalaß**.
 
-habbatical@gmail.com  
+habbatical@gmail.com
 GitHub username: [kkalass](https://github.com/kkalass)


### PR DESCRIPTION
# Request Summary
This PR updates the permanent identifiers for the Solid CRDT Sync framework to redirect to the new Locorda domain:

- https://w3id.org/solid-crdt-sync/vocab/ - Now redirects to locorda.dev/vocab/
- https://w3id.org/solid-crdt-sync/mappings/ - Now redirects to locorda.dev/mappings/

## Changes Made
- Updated .htaccess redirect rules from `kkalass.github.io/solid_crdt_sync/` to `locorda.dev`
- Updated project references to "Locorda Sync (formerly Solid CRDT Sync)"
- Maintained existing w3id.org namespace for backward compatibility

## Project Evolution
The Solid CRDT Sync framework has evolved into Locorda, a more general synchronization framework that supports not only Solid Pods but potentially other passive data stores. The framework continues to use CRDT (Conflict-free Replicated Data Types) for local-first, interoperable applications.

## Technical Details
- Simple .htaccess rule updates with same URL patterns
- Preserves existing vocabulary namespaces (`crdt:`, `algo:`, `sync:`, `idx:`, `mc:`)
- Maintains compatibility for existing applications using these IRIs
- Clean migration path from GitHub Pages to dedicated domain

## Justification
These updates are needed for:
- Improved branding and project identity under Locorda
- Better long-term sustainability with dedicated domain
- Continued stable vocabulary namespace URIs for existing applications
- Professional hosting for production and academic use

## Links
- New site: https://locorda.dev
- Original GitHub Repository: https://github.com/kkalass/solid_crdt_sync

## Contact
Klas Kalaß (@kkalass)
habbatical@gmail.com