### PR TITLE
MoRe-SFB1475: additional redirects to new vocabulary

### DIFF
--- a/MoRe-SFB1475/.htaccess
+++ b/MoRe-SFB1475/.htaccess
@@ -2,11 +2,17 @@ RewriteEngine On
 
 # Redirect to website for the root URI
 RewriteRule	  ^$ https://sfb1475.ruhr-uni-bochum.de/ [R=302,L]
-# Redirect to vocabulary overview
+# Redirect to "Conceptual Thesaurus" vocabulary overview
 RewriteRule   ^CT/?$	https://metaphors.skosmos.ub.rub.de/ct/en/ [R=303,L,QSA]
-
+# Resolve conceptScheme URI
+RewriteRule   ^CT/concepts$	https://metaphors.skosmos.ub.rub.de/ct/ [R=303,L,QSA]
 # Redirect individual concepts
 RewriteRule   ^CT/concepts/(.+)$ https://metaphors.skosmos.ub.rub.de/ct/en/page/$1 [R=303,L,QSA]
+
+# Redirect to "Metaphor Identification Tagset" vocabulary
+RewriteRule   ^MITS$	https://metaphors.skosmos.ub.rub.de/mits/ [R=303,L,QSA]
+# Redirect to individual MITS concepts
+RewriteRule   ^MITS/(.+)$	https://metaphors.skosmos.ub.rub.de/mits/en/page/$1 [R=303,L,QSA]
 
 # Redirect to utility software repo
 RewriteRule   ^waps-annotation-migrator/?$   https://gitlab.ruhr-uni-bochum.de/sfb-1475-inf/waps-annotation-migrator/  [R=303,L]

--- a/MoRe-SFB1475/README.md
+++ b/MoRe-SFB1475/README.md
@@ -9,6 +9,7 @@ The namespace currently only contains the project website, the conceptual thesau
 * **`/MoRe-SFB1475/`** redirects to the project website
 * **`/MoRe-SFB1475/CT/`** is the entry point to the thesaurus
 * **`/MoRe-SFB1475/CT/concepts/`** is used for the individual concepts
+* **`/MoRe-SFB1475/MITS`** is the entry point to a small controlled vocabulary, the "Metaphor Identification Tagset"
 * **`/MoRe-SFB1475/waps-annotation-migrator`** utility software
 * **`/MoRe-SFB1475/repo/util/`** (image) resources used inside our textual data 
 


### PR DESCRIPTION
This PR creates new redirects for a small controlled vocabulary. It also adds one redirect for an existing vocabulary, so that its conceptScheme URI resolves correctly. 