### PR TITLE
Add permanent identifier for Agroforestry ontology

### DIFF
--- a/afy/.htaccess
+++ b/afy/.htaccess
@@ -1,0 +1,74 @@
+# Turn off MultiViews 
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
+
+RewriteEngine on
+
+# Rewrite rule for latest version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://agroforesterie.github.io/afy/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://agroforesterie.github.io/afy/ontology.json [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://agroforesterie.github.io/afy/ontology.xml [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://agroforesterie.github.io/afy/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle 
+RewriteRule ^$ https://agroforesterie.github.io/afy/ontology.ttl [R=303,L]
+
+
+# Rewrite rules for any other version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(.+)$ https://agroforesterie.github.io/afy/$1/index-en.html [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(.+)$ https://agroforesterie.github.io/afy/$1/ontology.json [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(.+)$ https://agroforesterie.github.io/afy/$1/ontology.xml [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(.+)$ https://agroforesterie.github.io/afy/$1/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle 
+RewriteRule ^(.+)$ https://agroforesterie.github.io/afy/$1/ontology.ttl [R=303,L]
+
+
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^(.*)$ https://agroforesterie.github.io/afy/406.html [R=406,L]
+# Default response
+# ---------------------------
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^$ https://agroforesterie.github.io/afy/ontology.xml [R=303,L]

--- a/afy/README.md
+++ b/afy/README.md
@@ -1,0 +1,29 @@
+# AFY: Ontology of agroforestry systems. 
+==========================================
+
+# Description and publication 
+
+This project involves building an ontology to describe agroforestry systems.  
+
+
+## Persistent URI 
+https://w3id.org/afy is a persistent URI namespace for **Ontology of agroforestry systems. (AFY)** Ontology resources.
+
+
+## License
+The AFY ontology is licensed under Creative Commons 4.0 International. 
+
+## Contacts
+
+* Our Github address [AGROFORESTERIE](https://github.com/agroforesterie)
+
+**Raphaël Conde Salazar (University of Montpellier)** 
+ORCID: [0000-0002-6926-5299](https://orcid.org/0000-0002-6926-5299)   
+[AGROFORESTERIE](https://github.com/AGROFORESTERIE)
+<raphaelcs@free.fr>
+
+**Isabelle Mougenot (University of Montpellier)**  
+ORCID: [0000-0002-1287-3269](https://orcid.org/0000-0002-1287-3269) 
+
+**Alexia Stokes (University of Montpellier)**  
+ORCID: [0000-0002-2276-0911](https://orcid.org/0000-0002-2276-0911)


### PR DESCRIPTION
Hello,

I would like to add a permanent identifier for my ontology Agroforestry, which describes agroforestry systems and landscape management.
The goal is to provide a stable and persistent URL for referencing this ontology in semantic web and linked data applications.

Thank you for maintaining this great service!

Best regards,
Raphaël Conde Salazar