### PR TITLE
Handle IDs changed in the Clavis Aethiopica

### DIFF
--- a/malke/.htaccess
+++ b/malke/.htaccess
@@ -2,4 +2,11 @@ Header set Access-Control-Allow-Origin *
 Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
 Options +FollowSymLinks
 RewriteEngine on
+# Moved IDs
+RewriteRule 0285 6392
+RewriteRule 0347 6391
+RewriteRule 0355 6378
+RewriteRule 0377 6390
+RewriteRule 2005 2003
+# Universal
 RewriteRule (.*) https://malkeagubae.com/works/$1 [R=301,L]


### PR DESCRIPTION
This is to handle specific redirects for doublets which were removed from the Clavis Aethiopica (see https://github.com/BetaMasaheft/Documentation/issues/3046).

It also deals with the issue raised in https://github.com/BetaMasaheft/Documentation/issues/2653.