### PR TITLE
Add LivePublication interface-schemas persistent identifiers

### DIFF
--- a/livepublication/interface-schemas/.htaccess
+++ b/livepublication/interface-schemas/.htaccess
@@ -1,0 +1,120 @@
+# w3id Persistent Identifiers for LivePublication Interface Schemas
+#
+# Maintainer: Augustus Ellerm <aell854@UoA.auckland.ac.nz>
+# Repository: https://github.com/GusEllerm/livepub-interface-schemas
+# Production: https://livepublication.org/interface-schemas/
+#
+# These rules provide persistent identifiers for all interface schemas,
+# including current modules (dpc, dsc, lp-dscdpc) and future additions.
+# Uses patterns to reduce the need for per-module w3id updates.
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# ==============================================================================
+# 1. NESTED PROFILE CONTEXTS (Immutable)
+# ==============================================================================
+# Pattern (relative to this dir):
+#   contexts/{profile}/v{N}.jsonld
+#
+# Example:
+#   /livepublication/interface-schemas/contexts/lp-dscdpc/v1.jsonld
+# → https://livepublication.org/interface-schemas/contexts/lp-dscdpc/v1.jsonld
+#
+# These are merged/profile contexts (like lp-dscdpc) that don't correspond
+# to a single module. This rule must go BEFORE module rules so it wins.
+
+RewriteRule ^contexts/([A-Za-z0-9_-]+)/(v[0-9.]+\.jsonld)$ \
+  https://livepublication.org/interface-schemas/contexts/$1/$2 [R=302,L]
+
+# ==============================================================================
+# 2. MODULE VERSIONED CONTEXTS (Immutable)
+# ==============================================================================
+# Pattern (relative to this dir):
+#   {module}/contexts/v{N}.jsonld
+#
+# Example:
+#   /livepublication/interface-schemas/dpc/contexts/v1.jsonld
+# → https://livepublication.org/interface-schemas/dpc/contexts/v1.jsonld
+#
+# Each versioned context is immutable once published.
+
+RewriteRule ^([A-Za-z0-9_-]+)/contexts/(v[0-9.]+\.jsonld)$ \
+  https://livepublication.org/interface-schemas/$1/contexts/$2 [R=302,L]
+
+# ==============================================================================
+# 3. MODULE BASE WITH CONTENT NEGOTIATION
+# ==============================================================================
+# Pattern (relative to this dir):
+#   {module}
+#
+# Behavior:
+# - If client requests Turtle (Accept: text/turtle), send them the vocabulary
+#   in Turtle form: terms.ttl
+# - Otherwise send them the human-readable landing page index.html
+#
+# Example:
+#   GET /livepublication/interface-schemas/dpc
+#   Accept: text/turtle
+# → https://livepublication.org/interface-schemas/dpc/terms.ttl
+#
+#   GET /livepublication/interface-schemas/dpc
+#   (no special Accept)
+# → https://livepublication.org/interface-schemas/dpc/index.html
+
+# Turtle request → terms.ttl
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^([A-Za-z0-9_-]+)/?$ \
+  https://livepublication.org/interface-schemas/$1/terms.ttl [R=302,L,NE]
+
+# Default → index.html
+RewriteRule ^([A-Za-z0-9_-]+)/?$ \
+  https://livepublication.org/interface-schemas/$1/index.html [R=302,L,NE]
+
+# ==============================================================================
+# 4. SPECIFIC ARTIFACTS
+# ==============================================================================
+# Direct lookups of specific published resources.
+#
+#   {module}/terms.ttl      → vocabulary (RDF/Turtle)
+#   {module}/shapes.ttl     → SHACL shapes in Turtle
+#   {module}/index.html     → human landing page
+#
+# All of these are public, static, and version-controlled in
+# https://github.com/GusEllerm/livepub-interface-schemas
+
+RewriteRule ^([A-Za-z0-9_-]+)/terms\.ttl$ \
+  https://livepublication.org/interface-schemas/$1/terms.ttl [R=302,L,NE]
+
+RewriteRule ^([A-Za-z0-9_-]+)/shapes\.ttl$ \
+  https://livepublication.org/interface-schemas/$1/shapes.ttl [R=302,L,NE]
+
+RewriteRule ^([A-Za-z0-9_-]+)/index\.html$ \
+  https://livepublication.org/interface-schemas/$1/index.html [R=302,L,NE]
+
+# ==============================================================================
+# 5. CATALOG ROOT
+# ==============================================================================
+# Pattern (relative to this dir):
+#   ""  (i.e. /livepublication/interface-schemas/ exactly)
+#
+# That should redirect to the catalog page that lists all modules and contexts.
+
+RewriteRule ^$ \
+  https://livepublication.org/interface-schemas/index.html [R=302,L,NE]
+
+# ==============================================================================
+# 6. FALLBACK
+# ==============================================================================
+# Anything else under this prefix that didn't match above rules goes to the
+# catalog. This handles:
+# - unknown modules (/foo)
+# - requests like /dpc/contexts/latest.jsonld (non-versioned)
+# - typos
+#
+# Example:
+#   /livepublication/interface-schemas/dpc/contexts/latest.jsonld
+# → https://livepublication.org/interface-schemas/index.html
+
+RewriteRule ^.*$ \
+  https://livepublication.org/interface-schemas/index.html [R=302,L,NE]

--- a/livepublication/interface-schemas/README.md
+++ b/livepublication/interface-schemas/README.md
@@ -1,0 +1,78 @@
+# LivePublication Interface Schemas
+
+Persistent identifiers for LivePublication vocabularies and JSON-LD contexts.
+
+## Maintainer
+
+- **Augustus Ellerm**
+- Email: ael854@aucklanduni.ac.nz
+- ORCID: [0000-0001-8260-231X](https://orcid.org/0000-0001-8260-231X)
+- GitHub: [@GusEllerm](https://github.com/GusEllerm)
+
+## Description
+
+This w3id namespace provides persistent identifiers for the LivePublication Interface Schemas, a collection of vocabularies and contexts for describing computational research workflows in a reproducible manner.
+
+**Modules:**
+
+- **DPC** (Distributed Processing Cluster): Hardware runtime environment descriptors
+- **DSC** (Distributed Steps Container): Workflow step definitions and provenance
+- **LP-DSCDPC**: Combined context integrating DPC and DSC
+
+## URLs
+
+### Production
+
+- **Catalog:** https://livepublication.org/interface-schemas/
+- **Repository:** https://github.com/GusEllerm/livepub-interface-schemas
+
+### w3id Persistent Identifiers
+
+- **Base:** https://w3id.org/livepublication/interface-schemas/
+- **Example module (DPC):** https://w3id.org/livepublication/interface-schemas/dpc/
+- **Example context:** https://w3id.org/livepublication/interface-schemas/dpc/contexts/v1.jsonld
+
+## Content Negotiation
+
+Module base URLs support content negotiation:
+
+```bash
+# Default: HTML landing page
+curl https://w3id.org/livepublication/interface-schemas/dpc/
+
+# Turtle: vocabulary
+curl -H "Accept: text/turtle" \
+     https://w3id.org/livepublication/interface-schemas/dpc/
+```
+
+## Redirect Rules
+
+The `.htaccess` file uses **generic patterns** that work for:
+
+- All current modules (dpc, dsc, contexts/lp-dscdpc)
+- All future modules (no w3id updates needed)
+
+Patterns:
+
+- `/{module}/` → HTML landing or Turtle vocabulary (via Accept header)
+- `/{module}/contexts/v{N}.jsonld` → Versioned JSON-LD context (immutable)
+- `/{module}/terms.ttl` → Vocabulary definitions
+- `/{module}/shapes.ttl` → SHACL validation shapes
+- `/contexts/{combined}/v{N}.jsonld` → Combined contexts
+
+## Versioning
+
+**JSON-LD contexts are immutable once published.**
+
+See [PUBLISHING.md](https://github.com/GusEllerm/livepub-interface-schemas/blob/main/PUBLISHING.md) for versioning policy.
+
+## License
+
+Interface schemas are licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+
+## Contact
+
+For issues or questions:
+
+- **GitHub Issues:** https://github.com/GusEllerm/livepub-interface-schemas/issues
+- **Email:** ael854@aucklanduni.ac.nz


### PR DESCRIPTION
## Overview

This PR creates persistent identifiers for the LivePublication Interface Schemas under `/livepublication/interface-schemas/`.

## Maintainer

- **Augustus Ellerm**
- Email: aell854@UoA.auckland.ac.nz
- ORCID: [0000-0001-8260-231X](https://orcid.org/0000-0001-8260-231X)
- GitHub: [@GusEllerm](https://github.com/GusEllerm)


## Modules

The interface schemas provide vocabularies and contexts for describing computational research workflows.

