### PR TITLE
dpv: remove trailing slash before processing

### DIFF
--- a/dpv/.htaccess
+++ b/dpv/.htaccess
@@ -19,6 +19,10 @@ Header set Access-Control-Allow-Origin *
 Options +FollowSymLinks
 RewriteEngine on
 
+# Remove trailing slash if exists
+RewriteCond %{REQUEST_URI} /$
+RewriteRule ^(.*)/$ $1 [L,R=301]
+
 SetEnvIf Request_URI ^.*$ BASE=https://w3c.github.io/dpv
 SetEnvIf Request_URI ^.*$ DEV=https://dev.dpvcg.org
 SetEnvIf Request_URI ^.*$ LATEST=2.2


### PR DESCRIPTION
- see w3c/dpv#398 for issue
- example: https://w3id.org/dpv/examples/ give 404
- fix: https://w3id.org/dpv/examples does not

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.

We want the trailing slashes in our paths to be removed before processing other rules. This seems to work locally, but because of the specific set up of w3id config (with directory as base) I'm unsure as to the correct syntax to use here. I've copied the commit code below for convenience. Thank you in advance.

```
# Remove trailing slash if exists
RewriteCond %{REQUEST_URI} /$
RewriteRule ^(.*)/$ $1 [L,R=301]
```