### PR TITLE
dpv: remove trailing slash (attempt 2)

### DIFF
--- a/dpv/.htaccess
+++ b/dpv/.htaccess
@@ -24,7 +24,7 @@ SetEnvIf Request_URI ^.*$ DEV=https://dev.dpvcg.org
 SetEnvIf Request_URI ^.*$ LATEST=2.2
 
 # Remove trailing slash if exists
-RewriteRule ^(.*)/$ /$1 [R=302,L]
+RewriteRule ^(.*)/$ /dpv/$1 [R=302,L]
 
 ##### VOCAB: DPV #####
 


### PR DESCRIPTION
The previous PR #5442 did not work. It redirected w3id.org/dpv/examples/ to https://w3id.org/var/www/w3id.org/dpv/examples instead of w3id.org/dpv/examples The fix (hopefully) is to simply rewrite without the trailing slash in this form:
```
# Remove trailing slash if exists
RewriteRule ^(.*)/$ /$1 [R=302,L]
```