### PR TITLE
iadopt: fix content negotiaton in browsers

### DIFF
--- a/iadopt/.htaccess
+++ b/iadopt/.htaccess
@@ -15,8 +15,7 @@ RewriteEngine on
 # Rewrite rule to serve HTML
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
-RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
 RewriteRule ^$ https://i-adopt.github.io/ontology/index.html [R=303,L]
 
 # Rewrite rule to serve JSON-LD

--- a/iadopt/ont/.htaccess
+++ b/iadopt/ont/.htaccess
@@ -17,16 +17,14 @@ RewriteEngine on
 # Rewrite rule to serve HTML with local name
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
-RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
 RewriteCond %{REQUEST_URI} /ont/(\d+)\.(\d+)\.(\d+)/(.+)$
 RewriteRule ^ https://i-adopt.github.io/ontology/archive/%1.%2.%3/index.html#/%4 [NE,R=303,L]
 
 # Rewrite rule to serve HTML without local name
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
-RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
 RewriteCond %{REQUEST_URI} /ont/(\d+)\.(\d+)\.(\d+)
 RewriteRule ^ https://i-adopt.github.io/ontology/archive/%1.%2.%3/index.html [R=303,L]
 
@@ -58,15 +56,13 @@ RewriteRule ^ https://i-adopt.github.io/ontology/archive/%1.%2.%3/ontology.ttl [
 # Rewrite rule to serve HTML with local name
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
-RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
 RewriteRule ^(.+)$ https://i-adopt.github.io/ontology/index.html#/$1 [NE,R=303,L]
 
 # Rewrite rule to serve HTML without local name
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
-RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
 RewriteRule ^(.*)$ https://i-adopt.github.io/ontology/index.html [R=303,L]
 
 # Rewrite rule to serve JSON-LD


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description

this commit fixes the content negotiation for browsers in the iadopt namespace.
previously, the `user-agent` was pretty much overwriting any content type requested via `accept`.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [x] GitHub username ids are listed in the changed maintainer details.
- [ x The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
