### PR TITLE
MoRe-SFB1475: add redirect for ontology

### DIFF
--- a/MoRe-SFB1475/.htaccess
+++ b/MoRe-SFB1475/.htaccess
@@ -2,6 +2,7 @@ RewriteEngine On
 
 # Redirect to website for the root URI
 RewriteRule	  ^$ https://sfb1475.ruhr-uni-bochum.de/ [R=302,L]
+
 # Redirect to "Conceptual Thesaurus" vocabulary overview
 RewriteRule   ^CT/?$	https://metaphors.skosmos.ub.rub.de/ct/en/ [R=303,L,QSA]
 # Resolve conceptScheme URI
@@ -13,6 +14,14 @@ RewriteRule   ^CT/concepts/(.+)$ https://metaphors.skosmos.ub.rub.de/ct/en/page/
 RewriteRule   ^MITS$	https://metaphors.skosmos.ub.rub.de/mits/ [R=303,L,QSA]
 # Redirect to individual MITS concepts
 RewriteRule   ^MITS/(.+)$	https://metaphors.skosmos.ub.rub.de/mits/en/page/$1 [R=303,L,QSA]
+
+# Redirects for the Metaphor Ontology
+# Serve RDF/XML if requested
+RewriteCond	%{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule	^MetOnt/?$	https://pages.ceres.rub.de/metont.rdf [R=303,L,QSA]
+# By default, serve the HTML documentation
+RewriteRule	^MetOnt/?$	https://pages.ceres.rub.de/metont/ [R=303,L,QSA]
+
 
 # Redirect to utility software repo
 RewriteRule   ^waps-annotation-migrator/?$   https://gitlab.ruhr-uni-bochum.de/sfb-1475-inf/waps-annotation-migrator/  [R=303,L]

--- a/MoRe-SFB1475/README.md
+++ b/MoRe-SFB1475/README.md
@@ -4,14 +4,15 @@ This [W3ID](https://w3id.org) provides a persistent URI namespace for a thesauru
 
 ## Uses
 
-The namespace currently only contains the project website, the conceptual thesaurus itself, and a few auxiliary resources:
+The namespace currently contains the following redirects:
 
-* **`/MoRe-SFB1475/`** redirects to the project website
-* **`/MoRe-SFB1475/CT/`** is the entry point to the thesaurus
-* **`/MoRe-SFB1475/CT/concepts/`** is used for the individual concepts
-* **`/MoRe-SFB1475/MITS`** is the entry point to a small controlled vocabulary, the "Metaphor Identification Tagset"
-* **`/MoRe-SFB1475/waps-annotation-migrator`** utility software
-* **`/MoRe-SFB1475/repo/util/`** (image) resources used inside our textual data 
+* **`/MoRe-SFB1475/`** redirects to the project website.
+* **`/MoRe-SFB1475/CT/`** is the entry point to our conceptual thesaurus.
+* **`/MoRe-SFB1475/CT/concepts/`** is used for the individual concepts of the conceptual thesaurus.
+* **`/MoRe-SFB1475/MITS`** is the entry point to a small controlled vocabulary, the "Metaphor Identification Tagset".
+* **`/MoRe-SFB1475/MetOnt`** refers to our Metaphor Ontology and its documentation.
+* **`/MoRe-SFB1475/waps-annotation-migrator`** refers to a repo of utility software.
+* **`/MoRe-SFB1475/repo/util/`** redirects to (image) resources that are referenced inside our textual data.
 
 ## Contact
 


### PR DESCRIPTION
## Brief Description

Add new redirect for our metaphor ontology and its documentation.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.
