### PR TITLE
remove ao uri path form uri schema

### DIFF
--- a/pmd/hto/.htaccess
+++ b/pmd/hto/.htaccess
@@ -8,10 +8,10 @@ RewriteEngine On
 ##       deploy in the materialdigital github community only 'ontology_publication_template' needs to be changed to your repo
 ##
 
-SetEnvIf Request_URI ^/pmd/ao/hto$ ONT_BASE=https://materialdigital.github.io/heat-treatment-application-ontology 
-SetEnvIf Request_URI ^/pmd/ao/hto/(.*)$ ONT_ANCHOR=$1 ONT_BASE=https://materialdigital.github.io/heat-treatment-application-ontology 
-SetEnvIf Request_URI ^/pmd/ao/hto/(\d+\.\d+\.\d+)$ ONT_VERSION=/$1 ONT_BASE=https://materialdigital.github.io/heat-treatment-application-ontology 
-SetEnvIf Request_URI ^/pmd/ao/hto/(\d+\.\d+\.\d+)/(.*)$ ONT_VERSION=/$1 ONT_ANCHOR=$2 ONT_BASE=https://materialdigital.github.io/heat-treatment-application-ontology 
+SetEnvIf Request_URI ^/pmd/hto$ ONT_BASE=https://materialdigital.github.io/heat-treatment-application-ontology 
+SetEnvIf Request_URI ^/pmd/hto/(.*)$ ONT_ANCHOR=$1 ONT_BASE=https://materialdigital.github.io/heat-treatment-application-ontology 
+SetEnvIf Request_URI ^/pmd/hto/(\d+\.\d+\.\d+)$ ONT_VERSION=/$1 ONT_BASE=https://materialdigital.github.io/heat-treatment-application-ontology 
+SetEnvIf Request_URI ^/pmd/hto/(\d+\.\d+\.\d+)/(.*)$ ONT_VERSION=/$1 ONT_ANCHOR=$2 ONT_BASE=https://materialdigital.github.io/heat-treatment-application-ontology 
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)

--- a/pmd/log/.htaccess
+++ b/pmd/log/.htaccess
@@ -8,10 +8,10 @@ RewriteEngine On
 ##       deploy in the materialdigital github community only 'ontology_publication_template' needs to be changed to your repo
 ##
 
-SetEnvIf Request_URI ^/pmd/ao/log$ ONT_BASE=https://materialdigital.github.io/logistics-application-ontology 
-SetEnvIf Request_URI ^/pmd/ao/log/(.*)$ ONT_ANCHOR=$1 ONT_BASE=https://materialdigital.github.io/logistics-application-ontology 
-SetEnvIf Request_URI ^/pmd/ao/log/(\d+\.\d+\.\d+)$ ONT_VERSION=/$1 ONT_BASE=https://materialdigital.github.io/logistics-application-ontology 
-SetEnvIf Request_URI ^/pmd/ao/log/(\d+\.\d+\.\d+)/(.*)$ ONT_VERSION=/$1 ONT_ANCHOR=$2 ONT_BASE=https://materialdigital.github.io/logistics-application-ontology 
+SetEnvIf Request_URI ^/pmd/log$ ONT_BASE=https://materialdigital.github.io/logistics-application-ontology 
+SetEnvIf Request_URI ^/pmd/log/(.*)$ ONT_ANCHOR=$1 ONT_BASE=https://materialdigital.github.io/logistics-application-ontology 
+SetEnvIf Request_URI ^/pmd/log/(\d+\.\d+\.\d+)$ ONT_VERSION=/$1 ONT_BASE=https://materialdigital.github.io/logistics-application-ontology 
+SetEnvIf Request_URI ^/pmd/log/(\d+\.\d+\.\d+)/(.*)$ ONT_VERSION=/$1 ONT_ANCHOR=$2 ONT_BASE=https://materialdigital.github.io/logistics-application-ontology 
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)

--- a/pmd/tto/.htaccess
+++ b/pmd/tto/.htaccess
@@ -7,7 +7,7 @@ RewriteEngine On
 ##     ONT_BASE points to the address that delivers your ontology documentation and files, if you
 ##       deploy in the materialdigital github community only 'ontology_publication_template' needs to be changed to your repo
 ##
-SetEnvIf Request_URI ^/pmd/ao/tto/(.*)$ ONT_BASE=https://materialdigital.github.io/tensile-test-ontology ONT_ANCHOR=$1
+SetEnvIf Request_URI ^/pmd/tto/(.*)$ ONT_BASE=https://materialdigital.github.io/tensile-test-ontology ONT_ANCHOR=$1
 #SetEnvIf Request_URI ^/pmd/ao/tto/(\d+\.\d+\.\d+)/(.*)$ ONT_VERSION=v$1 ONT_ANCHOR=$2
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested


### PR DESCRIPTION
## Brief Description
we had to change the uri schema for 3 of the redirects. removed /ao from /pmd/ao/... part
## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [] Maintainer details are in `.htaccess` or `README.md`.
- [] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
