### PR TITLE
Health-RI Semantic Interoperability Initiative: reduces duplication and adds SHACL redirection

### DIFF
--- a/health-ri/.htaccess
+++ b/health-ri/.htaccess
@@ -38,16 +38,14 @@ RedirectMatch 302 ^/health-ri/?$ https://www.health-ri.nl/
 
 ## Latest ontology files (ttl, vpp, json, documentation.html, specification.html)
 RedirectMatch 302 ^/health-ri/ontology(/ttl)?/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/health-ri-ontology.ttl
-RedirectMatch 302 ^/health-ri/ontology/vpp/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/health-ri-ontology.vpp
-RedirectMatch 302 ^/health-ri/ontology/json/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/health-ri-ontology.json
+RedirectMatch 302 ^/health-ri/ontology/(vpp|json|shacl)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/latest/health-ri-ontology.$1
 RedirectMatch 302 ^/health-ri/ontology/(doc|documentation)/?$ https://health-ri.github.io/semantic-interoperability/ontology/documentation/
 RedirectMatch 302 ^/health-ri/ontology/(spec|specification)/?$ https://health-ri.github.io/semantic-interoperability/ontology/specification-ontology.html
 
 ## Versioned ontology files (ttl, vpp, json, documentation.md, specification.html)
 # Matches semantic versions like v1.2.3 and redirects to the corresponding static files
 RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)(/ttl)?/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/health-ri-ontology-v$1.ttl
-RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/vpp/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/health-ri-ontology-v$1.vpp
-RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/json/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/health-ri-ontology-v$1.json
+RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/(vpp|json|shacl)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/health-ri-ontology-v$1.$2
 RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/(doc|documentation)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/documentations/documentation-v$1.md
 RedirectMatch 302 ^/health-ri/ontology/v([0-9]+\.[0-9]+\.[0-9]+)/(spec|specification)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/ontologies/versioned/documentations/specification-v$1.html
 


### PR DESCRIPTION
## Brief Description
Use capture groups to handle vpp/json/shacl endpoints for latest and versioned routes with single rules each; keep TTL and doc/spec routes as before. Reduces duplication and adds SHACL support.

- Latest: /health-ri/ontology/(vpp|json|shacl) → .../ontologies/latest/health-ri-ontology.$1
- Versioned: /health-ri/ontology/vX.Y.Z/(vpp|json|shacl) → .../ontologies/versioned/health-ri-ontology-v$1.$2

No content changes; 302 redirects only.

## General Checklist
<!-- For all ID related PRs. -->
- [X] Changes have been tested.
- [X] The number of commits is minimal. Squash if needed.
- [X] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

