### PR TITLE
Adds redirects for citydata and itsdata

### DIFF
--- a/citydata/.htaccess
+++ b/citydata/.htaccess
@@ -1,3 +1,12 @@
+# https://w3id.org/citydata/ redirects to https://isotc204.org/ontology-cdm-p1/latest/
+#
+# ## Contact
+# This space is administered by:
+# The ISO/IEC 5087 series editors, including:
+# Kenneth Vaughn
+# kvaughn@trevilon.com
+# GitHub username: k-vaughn
+
 RewriteEngine On
 
 # Content negotiation: Set FORMAT env variable based on Accept header

--- a/citydata/README.md
+++ b/citydata/README.md
@@ -1,14 +1,19 @@
-# City Data Model 
+# City Data Model
+
+## Uses
 
 The City Data Model is an effort to standardize definitions of data used within smart and sustainable cities and communities. The content of the models are developed in an open community on GitHub but are ultimately standardized in the ISO/IEC 5087 series. The part numbers contained in the w3id address correspond to the part numbers of the document series.
 
 * Part 1: Foundation level concepts
 * Part 2: City level concepts
 * Part 3: Service level concepts for transport
- 
-For now, the files are maintained at https://github.com/ISO-TC204/ontology-cdm-p# (where # indicates the part number). It is expected that this site will migrate to a new site once the project migrates from ISO/IEC JTC1 WG 11 to the new ISO/IEC JTC4 and a new GitHub account is created.
 
-Contact:
- * ISO/IEC 5087 series editor: [Mark Fox](mailto:msf@eil.utoronto.ca)
- * ISO/IEC 5087-3 editor: [Ken Vaughn](mailto:kvaughn@trevilon.com)
- 
+For now, the files are maintained under the [TC 204 website](https://github.com/ISO-TC204/ontology-cdm-p#) (where # indicates the part number). It is expected that this site will migrate to a new site once the project migrates from ISO/IEC JTC1 WG 11 to the new ISO/IEC JTC4 and a new GitHub account is created.
+
+## Contact
+
+This space is administered by:
+
+The editors and leadership for the ISO/IEC 5087 series, including:
+
+*[Kenneth Vaughn](mailto:kvaughn@trevilon.com)*<br />_Editor for ISO/IEC 5087-3_<br />GitHub: [k-vaughn](https://github.com/k-vaughn)

--- a/itsdata/.htaccess
+++ b/itsdata/.htaccess
@@ -1,3 +1,12 @@
+# https://w3id.org/itsdata/ redirects to https://isotc204.org/ontology-its-xxx/latest/ where xxx is the topic area
+#
+# ## Contact
+# This space is administered by:
+# ISO/TC 204 WG 1 Convenor
+# Kenneth Vaughn
+# kvaughn@trevilon.com
+# GitHub username: k-vaughn
+
 RewriteEngine On
 Options -MultiViews
 

--- a/itsdata/README.md
+++ b/itsdata/README.md
@@ -1,13 +1,13 @@
 # Ontology for Intelligent Transport Systems
 
-The Ontology for Intelligent Transport Systems (ITS) is an effort to standardize definitions of data used within ITS. The content of the models are developed in an open community on GitHub but are ultimately referenced and standardized in various standards developed by ISO TC 204. 
+## Uses
 
-The files are maintained at https://github.com/ISO-TC204/ontology-its-xxxxx (where xxxxx indicates data topic of interest). Current topics include:
+The Ontology for Intelligent Transport Systems (ITS) is an effort to standardize definitions of data used within ITS. The content of the models are developed in an open community on GitHub but are ultimately referenced and standardized in various standards developed by ISO TC 204.
 
-* Location
-* Registration
-* Time
+The files are maintained on the [ISO TC 204 GitHub account](https://github.com/ISO-TC204/) in repositories of the form ontology-its-xxxxx, where xxxxx indicates the data topic of interest.
 
-Contact:
- * ISO/TC 204 WG 1 convenor: [Ken Vaughn](mailto:kvaughn@trevilon.com)
- 
+## Contact
+
+This space is administered by ISO TC 204, including:
+
+*[Kenneth Vaughn](mailto:kvaughn@trevilon.com)*<br />_Convenor of ISO TC 204 WG 1_<br />GitHub: [k-vaughn](https://github.com/k-vaughn)


### PR DESCRIPTION
Adds .htaccess files to configure content negotiation and redirects for city data model (CDM) and intelligent transport systems (ITS) ontology.

- City Data is for ontology files related to the City Data Model (ISO/IEC 5087 series)
- ITS data is for ontology files used within the ITS domain as managed by ISO TC 204.

<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [ ] Changes have been tested.
- [ ] The number of commits is minimal. Squash if needed.
- [ ] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
