### PR TITLE
add spot folder with readme and htaccess files

### DIFF
--- a/spot/.htaccess
+++ b/spot/.htaccess
@@ -1,0 +1,40 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://design-computation.pages.git-ce.rwth-aachen.de/spot/ [R=302,NE,L]
+
+# In case of accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.*
+RewriteRule ^$ https://design-computation.pages.git-ce.rwth-aachen.de/spot/ontology.ttl [R=303,NE,L]
+
+# In case of accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://design-computation.pages.git-ce.rwth-aachen.de/spot/ontology.xml [R=302,NE,L]
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^ontology.ttl$ https://design-computation.pages.git-ce.rwth-aachen.de/spot/ontology.ttl [R=302,NE,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^ontology.html$ https://design-computation.pages.git-ce.rwth-aachen.de/spot/ [R=302,NE,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^ontology.rdf$ https://design-computation.pages.git-ce.rwth-aachen.de/spot/ontology.xml [R=302,NE,L]
+
+# If suffix jsonld, redirect to jsonld version
+RewriteRule ^ontology.jsonld$ https://design-computation.pages.git-ce.rwth-aachen.de/spot/ontology.json [R=302,NE,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^ontology.nt$ https://design-computation.pages.git-ce.rwth-aachen.de/spot/ontology.nt [R=302,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://design-computation.pages.git-ce.rwth-aachen.de/spot/ [R=303,NE,L]

--- a/spot/am/.htaccess
+++ b/spot/am/.htaccess
@@ -1,0 +1,40 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://design-computation.pages.git-ce.rwth-aachen.de/spot/am/ [R=302,NE,L]
+
+# In case of accept header <text/turtle>
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.*
+RewriteRule ^$ https://design-computation.pages.git-ce.rwth-aachen.de/spot/am/ontology.ttl [R=303,NE,L]
+
+# In case of accept header <application/rdf+xml>
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://design-computation.pages.git-ce.rwth-aachen.de/spot/am/ontology.xml [R=302,NE,L]
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^ontology.ttl$ https://design-computation.pages.git-ce.rwth-aachen.de/spot/am/ontology.ttl [R=302,NE,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^ontology.html$ https://design-computation.pages.git-ce.rwth-aachen.de/spot/am/ [R=302,NE,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^ontology.rdf$ https://design-computation.pages.git-ce.rwth-aachen.de/spot/am/ontology.xml [R=302,NE,L]
+
+# If suffix jsonld, redirect to jsonld version
+RewriteRule ^ontology.jsonld$ https://design-computation.pages.git-ce.rwth-aachen.de/spot/am/ontology.json [R=302,NE,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^ontology.nt$ https://design-computation.pages.git-ce.rwth-aachen.de/spot/am/ontology.nt [R=302,NE,L]
+
+# Default response: html
+RewriteRule ^$ https://design-computation.pages.git-ce.rwth-aachen.de/spot/am/ [R=303,NE,L]

--- a/spot/readme.md
+++ b/spot/readme.md
@@ -1,0 +1,21 @@
+
+## Space Type Ontology
+### With Space Type Axis Mapping Extension Ontology
+
+Core Ontology
+
+* **Doc** — https://design-computation.pages.git-ce.rwth-aachen.de/spot/
+* **Turtle** — https://design-computation.pages.git-ce.rwth-aachen.de/spot/ontology.ttl
+
+Exentsion Ontology
+- in "am" subfolder
+
+* **Doc** — https://design-computation.pages.git-ce.rwth-aachen.de/spot/am/
+* **Turtle** — https://design-computation.pages.git-ce.rwth-aachen.de/spot/am/ontology.ttl
+
+
+Contacts
+* Public repository: https://git-ce.rwth-aachen.de/design-computation/spot
+* Anne Göbels <goebels@dc.rwth-aachen.de>, Oliver Schulz <schulz@dc.rwth-aachen.de>
+* GitHub Contact: https://github.com/AnneGoebels
+


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
Add the folder "spot" for hosting the htaccess files for the "SPOT Ontology" and its extension the "SPOT AM Ontology".

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

