### PR TITLE
feat(routing): add fallback redirect for semantic-interoperability paths

### DIFF
--- a/health-ri/.htaccess
+++ b/health-ri/.htaccess
@@ -69,3 +69,9 @@ RedirectMatch 302 ^/health-ri/mapping-vocabulary/(spec|specification)/?$ https:/
 # Matches semantic versions like v1.2.3 and redirects to the corresponding static files
 RedirectMatch 302 ^/health-ri/mapping-vocabulary/v([0-9]+\.[0-9]+\.[0-9]+)(/ttl)?/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/vocabulary/versioned/health-ri-vocabulary-v$1.ttl
 RedirectMatch 302 ^/health-ri/mapping-vocabulary/v([0-9]+\.[0-9]+\.[0-9]+)/(spec|specification)/?$ https://raw.githubusercontent.com/Health-RI/semantic-interoperability/refs/heads/main/vocabulary/versioned/documentations/specification-v$1.html
+
+# --------------------------------------------------------------------------------------------------------------
+# FALLBACK FOR SEMANTIC-INTEROPERABILITY PATHS
+# --------------------------------------------------------------------------------------------------------------
+# Any other /health-ri/semantic-interoperability/XXX → GitHub Pages /XXX
+RedirectMatch 302 ^/health-ri/semantic-interoperability/(.+)$ https://health-ri.github.io/semantic-interoperability/$1


### PR DESCRIPTION
## Brief Description
Adds a fallback redirect rule for all unhandled `/health-ri/semantic-interoperability/*` paths, forwarding them to the corresponding GitHub Pages location (`https://health-ri.github.io/semantic-interoperability/<path>`). This ensures full coverage of the namespace without affecting existing specific redirects.

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## Update ID Directory Checklist
- [x] GitHub username ids are listed in the changed maintainer details.  
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR, or one or more of those maintainers are tagged to approve these changes.
