### PR TITLE
w3id/kgfixed: Add content negotiation and ROR organization redirects

### DIFF
--- a/kgfixed/.htaccess
+++ b/kgfixed/.htaccess
@@ -1,17 +1,53 @@
 RewriteEngine On
-Options +FollowSymLinks
 
 AddType text/turtle .ttl
 AddType application/ld+json .jsonld
 AddType application/json .json
 
+# ldes rules
+RewriteCond %{HTTP_ACCEPT} text/turtle
+# Redirect LDES endpoint to latest version in Turtle format
+RewriteRule ^ror\.org/(?i:ldes)/?$ https://kgfixed.github.io/ror.org/LDES/latest.ttl [R=303,L]
+
+# latest rules
+RewriteCond %{HTTP_ACCEPT} text/turtle
+# Redirect latest version requests for individual organizations to their Turtle representation
+RewriteRule "^ror\.org/latest/([^/]+)$" https://kgfixed.github.io/ror.org/$1.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/json
+# Redirect latest version requests for individual organizations to their json representation
+RewriteRule "^ror\.org/latest/([^/]+)$" https://kgfixed.github.io/ror.org/$1.json [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+# Redirect latest version requests for individual organizations to their jsonld representation
+RewriteRule "^ror\.org/latest/([^/]+)$" https://kgfixed.github.io/ror.org/$1.jsonld [R=303,L]
+
+# Default rule: redirect latest version requests for individual organizations to their Turtle representation
+RewriteRule "^ror\.org/latest/([^/]+)$" https://kgfixed.github.io/ror.org/$1.ttl [R=303,L]
+
 # Add rules for text/turtle files
-#RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle
+# Redirect versioned organization requests to their specific Turtle representations
+RewriteRule "^ror\.org/([^/]+)/([^/]+)$" https://kgfixed.github.io/ror.org/$1/$2.ttl [R=303,L]
+# Redirect ROR base endpoint to the main GitHub Pages index
+RewriteRule "^ror\.org/$" https://kgfixed.github.io/ror.org/ [R=303,L]
 
-# Redirect to GitHub Pages
+# Add rules for text/jsonld files
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+# Redirect versioned organization requests to their specific jsonld representations
+RewriteRule "^ror\.org/([^/]+)/([^/]+)$" https://kgfixed.github.io/ror.org/$1/$2.jsonld [R=303,L]
+# Redirect ROR base endpoint to the main GitHub Pages index
+RewriteRule "^ror\.org/$" https://kgfixed.github.io/ror.org/ [R=303,L]
+
+# Add rules for text/json files
+RewriteCond %{HTTP_ACCEPT} application/json
+# Redirect versioned organization requests to their specific json representations
+RewriteRule "^ror\.org/([^/]+)/([^/]+)$" https://kgfixed.github.io/ror.org/$1/$2.json [R=303,L]
+# Redirect ROR base endpoint to the main GitHub Pages index
+RewriteRule "^ror\.org/$" https://kgfixed.github.io/ror.org/ [R=303,L]
+
+# By default, ttl file
+RewriteRule "^ror\.org/([^/]+)/([^/]+)$" https://kgfixed.github.io/ror.org/$1/$2.ttl [R=302,L]
+
+# Catch-all rule: redirect any unmatched paths to their equivalent on GitHub Pages
 RewriteRule "^(.*)$" "https://kgfixed.github.io/$1" [R=302,L]
-
-
-
-
-


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
- Add LDES endpoint redirection to latest Turtle version
- Implement content negotiation for Turtle, JSON-LD and JSON formats
- Add individual organization redirects with version support
- Include catch-all fallback rule to GitHub Pages
- Tested with local Apache configuration
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [ x ] Changes have been tested.
- [ x ] The number of commits is minimal. Squash if needed.
- [ x ] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ x ] Maintainer details are in `.htaccess` or `README.md`.
- [ x ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ x ] GitHub username ids are listed in the changed maintainer details.
- [ x ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.

Contact: antoinprovain@gmail.com - @cedricdcc  [VLIZ]
Maintainer: kgfixed