### PR TITLE
Modified path to v1.7.0 for the dseco project.

### DIFF
--- a/dseco/.htaccess
+++ b/dseco/.htaccess
@@ -20,7 +20,7 @@ RewriteRule ^ontology/(.*\.ttl)$ https://raw.githubusercontent.com/Orange-OpenSo
 
 # Redirect ontology/<concept|property> to full **latest ontology Turtle file** for computer access
 # e.g. https://w3id.org/dseco/ontology/FQDN => https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/dseco-1.6.1/dseco.ttl
-RewriteRule ^ontology/?(.*)$ https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/dseco-1.6.1/dseco.ttl [R=302,L]
+RewriteRule ^ontology/?(.*)$ https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/dseco-1.7.0/dseco.ttl [R=302,L]
 
 # Redirect doc/<concept|property> to documentation for user-friendly display of a concept/property
 # See also: https://httpd.apache.org/docs/2.2/rewrite/flags.html#flag_ne


### PR DESCRIPTION
## Brief Description
New rewrite rule for https://w3id.org/dseco/ to reflect its upgrade to v1.7.0

Test : https://w3id.org/dseco/ontology/ should redirect to https://raw.githubusercontent.com/Orange-OpenSource/dseco/main/ontology/dseco-1.7.0/dseco.ttl

Related : https://github.com/Orange-OpenSource/dseco/pull/7