### PR TITLE
Add /aic redirect for Agents in Construction (AiC) Ontology

### DIFF
--- a/aic/.htaccess
+++ b/aic/.htaccess
@@ -1,0 +1,12 @@
+RewriteEngine On
+
+# Root redirect to GitHub Pages site
+RewriteRule ^$ https://digiconstructlab-tu-delft.github.io/AiC-Ontology/ [R=302,L]
+
+# Ontology serializations
+RewriteRule ^ontology.ttl$ https://digiconstructlab-tu-delft.github.io/AiC-Ontology/ontology.ttl [R=302,L]
+RewriteRule ^ontology.owl$ https://digiconstructlab-tu-delft.github.io/AiC-Ontology/ontology.owl [R=302,L]
+RewriteRule ^ontology.jsonld$ https://digiconstructlab-tu-delft.github.io/AiC-Ontology/ontology.jsonld [R=302,L]
+
+# Redirect resource folder (e.g., images, CSS, JS)
+RewriteRule ^resources/(.*)$ https://digiconstructlab-tu-delft.github.io/AiC-Ontology/resources/$1 [R=302,L]

--- a/aic/readme.md
+++ b/aic/readme.md
@@ -1,0 +1,38 @@
+# AiC Ontology
+
+This W3ID provides a persistent URI namespace for the **Agents in Construction (AiC) Ontology** developed under the [DigiConstructLab at TU Delft](https://github.com/DigiConstructLab-TU-Delft).
+
+The primary URI for the ontology is:
+
+https://w3id.org/aic
+
+## Redirects
+
+| Path                   | Redirect Target                                                          |
+|------------------------|--------------------------------------------------------------------------|
+| `/aic`                 | Main ontology documentation (GitHub Pages site)                          |
+| `/aic/ontology.ttl`    | Turtle serialization of the ontology                                     |
+| `/aic/ontology.owl`    | RDF/XML serialization of the ontology                                    |
+| `/aic/ontology.jsonld` | JSON-LD serialization of the ontology                                    |
+| `/aic/resources/*`     | Images and assets for visualizing the ontology                           |
+
+## Ontology Repository
+
+The ontology is maintained publicly at:  
+https://github.com/digiconstructlab-tu-delft/aic-ontology
+
+## Maintainers
+
+**Name**: Irfan Čustović
+**Affiliation**: PhD Candidate, TU Delft  
+**Contact**: message.irfan@proton.me 
+**GitHub**: [@irfangh](https://github.com/irfangh)
+
+**Name**: Ranjith Kuttantharappel Soman  
+**Affiliation**: Assistant Professor, TU Delft  
+**Contact**: ranjithsomantudelft@gmail.com  
+**GitHub**: [@ranjithksoman](https://github.com/ranjithksoman)
+
+## License
+
+This ontology and its associated documentation are licensed under the [Creative Commons Attribution 4.0 International License (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
## Brief Description
Request for registering a new persistent identifier for the *Agents in Construction (AiC)* Ontology (https://w3id.org/aic).

The target GitHub Pages site is: https://digiconstructlab-tu-delft.github.io/AiC-Ontology/ 

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
