### PR TITLE
Introduction of the mdr namespace

### DIFF
--- a/mdr/.htaccess
+++ b/mdr/.htaccess
@@ -1,0 +1,49 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .jsonld
+
+RewriteEngine on
+
+# Rewrite rule for latest version.
+RewriteRule ^$ latest [L]
+
+# Rewrite rules for any other version.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(.+)$ https://art.uniroma2.it/mdr/releases/$1/index-en.html [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(.+)$ https://art.uniroma2.it/mdr/releases/$1/mdr.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(.+)$ https://art.uniroma2.it/mdr/releases/$1/mdr.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^(.+)$ https://art.uniroma2.it/mdr/releases/$1/mdr.ttl [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(.+)$ https://art.uniroma2.it/mdr/releases/$1/mdr.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^(.+)$ - [R=406,L]
+
+# Default response
+# ---------------------------
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^(.+)$ https://art.uniroma2.it/mdr/releases/latest/mdr.owl [R=303,L]

--- a/mdr/README.md
+++ b/mdr/README.md
@@ -1,0 +1,13 @@
+# /mdr/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the Metadata Registry (MDR) ontology.
+
+## Contact
+This space is administered by:
+
+**Manuel Fiorelli**  
+*Research Fellow*  
+[Tor Vergata University of Rome](https://web.uniroma2.it/)  
+Roma, Italy  
+<manuel.fiorelli@uniroma2.it>  
+GitHub: [manuelfiorelli](https://github.com/manuelfiorelli)  
+ORCID: [0000-0001-7079-8941](https://orcid.org/0000-0001-7079-8941)


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description

This PR adds an ID directory for the Metadata Registry (MDR) ontology.

Quick tests:

```bash
curl -L https://w3id.org/mdr
```
Shall redirect to an RDF/XML document for the ontology.

The same URL in a web browser should redirect to the ontology HTML documentation.

<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
