### PR TITLE
Added rewrites for ontology and taxonomy based on content type

### DIFF
--- a/zinl/.htaccess
+++ b/zinl/.htaccess
@@ -1,3 +1,29 @@
+# Directive to ensure *.ttl files served as appropriate content type,
+# if not present in main apache config
+AddType text/turtle .ttl
+
 RewriteEngine on
-RewriteRule ^fdp/?(.*)$ https://fdp-zin.dci.thehyve.nl/$1 [R=307,L]
-RewriteRule ^package-statements/(.*)$ https://graph-zin.dci.thehyve.nl/repositories/$1/statements [R=307,L]
+RewriteRule ^fdp/?(.*)$ https://fdp-zin.dci.thehyve.nl/$1 [R=307,NE,L]
+RewriteRule ^package-statements/(.*)$ https://graph-zin.dci.thehyve.nl/repositories/$1/statements [R=307,NE,L]
+
+
+# Rewrite rules for fpr-o Ontology
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} (Mozilla|Chrome|Safari|Edge|Opera|Trident) [NC]
+RewriteRule ^fpr-o$ https://thehyve.github.io/fair-package-registry/ontology.html [R=307,NE,L]
+
+# Default response: turtle
+RewriteRule ^fpr-o$ https://raw.githubusercontent.com/thehyve/fair-package-registry/refs/heads/main/fpr-o.ttl [R=307,NE,L]
+
+
+# Rewrite rules for fpr-tax Taxonomy
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} (Mozilla|Chrome|Safari|Edge|Opera|Trident) [NC]
+RewriteRule ^fpr-tax$ https://thehyve.github.io/fair-package-registry/taxonomy-complete.html [R=307,NE,L]
+
+# Default response: turtle
+RewriteRule ^fpr-tax$ https://raw.githubusercontent.com/thehyve/fair-package-registry/refs/heads/main/fpr-tax.ttl [R=307,NE,L]


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description

Added rewrite rules for ZIN FAIR Package Registry ontology and taxonomy, based on content type/user agent.

## General Checklist
<!-- For all ID related PRs. -->
- [ ] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
