### PR TITLE
Update decade-x README and .htaccess to separate Aerospace-X from Dec…

### DIFF
--- a/decade-x/.htaccess
+++ b/decade-x/.htaccess
@@ -14,44 +14,5 @@ Options +FollowSymLinks
 
 RewriteEngine on
 
-# Redirect to ODRL Verifiable Credential Profile
-RewriteRule ^ovc/* https://gitlab.com/gaia-x/lab/policy-reasoning/odrl-vc-profile/-/raw/main/ovc-1.ttl [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} application/json
-RewriteRule ^specs/cd24.06/criteria/(.*)$ https://docs.gaia-x.eu/policy-rules-committee/compliance-document/24.06/criterions/?id=$1 [R=303,L,NE]
-
-RewriteCond %{HTTP_ACCEPT} text/html
-RewriteRule ^specs/cd24.06/criteria/(.*)$ https://docs.gaia-x.eu/policy-rules-committee/compliance-document/24.06/criterions/#$1 [R=303,L,NE]
-
-# Redirect to LinkML ontology
-RewriteRule ^/?development/linkml/types.yaml$ https://registry.lab.gaia-x.eu/development/linkml/types.yaml [R=303,L]
-
-RewriteRule ^/?([^/]+)/linkml/types.yaml$ https://registry.lab.gaia-x.eu/main/linkml/$1/types.yaml [R=303,L]
-
-# Redirect to Shacl shapes (updated .ttl endpoint)
-RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^/?development$ https://aerospace-x.pages.fraunhofer.de/ap7/ecosystem/ontology-roadmap/gx-ontology.ttl [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^/?([^/]*)$ https://aerospace-x.pages.fraunhofer.de/ap7/ecosystem/ontology-roadmap/gx-ontology.ttl [R=303,L]
-
-# Redirect to JSON-LD context
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^/?development$ https://registry.lab.gaia-x.eu/development/context/development [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^/?([^/]*)$ https://registry.lab.gaia-x.eu/main/context/$1 [R=303,L]
-
-# Redirect to OWL ontology
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^/?development$ https://registry.lab.gaia-x.eu/development/owl/development [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^/?([^/]*)$ https://registry.lab.gaia-x.eu/main/owl/$1 [R=303,L]
-
-# Default redirection to the Gaia-X Ontology documentation
-#RewriteRule ^/?$ https://docs.gaia-x.eu/ontology/development/ [R=303,L]
-#RewriteRule ^/?(.*)$ https://docs.gaia-x.eu/ontology/$1/ [R=303,L]
-
 # Redirect everything to semantic hub
-RewriteRule ^.*$ https://int.semantic-hub.axdata.space/ [R=301,L]
+RewriteRule ^(.*)$ https://int.semantic-hub.axdata.space/$1 [R=301,L]

--- a/decade-x/README.md
+++ b/decade-x/README.md
@@ -1,8 +1,7 @@
-# Project
+# Decade-X Permanent Identifier
 
-## Description
-
-This project utilizes and references concepts and data from the [Gaia-X Ontology](https://docs.gaia-x.eu/ontology/development/). The Gaia-X Ontology provides a framework for interoperability and standardization of data in the context of Gaia-X.
+This prefix provides persistent and reliable identifiers (w3id) for the semantic resources of the **Decade-X** project.
+It redirects to the decade-x Semantic Hub infrastructure, which hosts the Decade-X ontology, related data models and docs.
 
 ## Reference to the Gaia-X Ontology
 
@@ -11,6 +10,10 @@ All relevant information and definitions are sourced from the Gaia-X Ontology. F
 - [Gaia-X Ontology Documentation](https://docs.gaia-x.eu/ontology/development/)
 
 
-## Contact 
+## Contact
+
+[Gilles-L](https://github.com/Gilles-L-Airbus)
+
+[https://github.com/Vincent-Legrand](https://github.com/Vincent-Legrand)
 
 [hennberg](https://github.com/hennberg)


### PR DESCRIPTION
## Brief Description
Update decade-x README and .htaccess to separate Aerospace-X from Decade-X.
Remove obsolete redirects to Gaia-X.

## General Checklist
<!-- For all ID related PRs. -->
- [X] Changes have been tested.
- [X] The number of commits is minimal. Squash if needed.
- [X] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [X] GitHub username ids are listed in the changed maintainer details.
- [X] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.