### PR TITLE
Add Chris Day and Perdl w3id redirect configs

### DIFF
--- a/people/chrisday/.htaccess
+++ b/people/chrisday/.htaccess
@@ -1,0 +1,8 @@
+Options +FollowSymLinks
+RewriteEngine on
+# Rewrite rules for Chris Day's orcid profile
+RewriteRule ^orcid$ https://orcid.org/0000-0001-5095-7052 [R=303,L]
+# Rewrite rules for Chris Day's GitHub profile
+RewriteRule ^github$ https://github.com/chris-day [R=303,L]
+# Rewrite rules for Chris Day's LinkedIn profile
+RewriteRule ^$ https://www.linkedin.com/in/chrisdayabinitio/ [R=303,L]

--- a/people/chrisday/README.md
+++ b/people/chrisday/README.md
@@ -1,0 +1,27 @@
+# Chris Day
+
+This [w3id](https://w3id.org/people/chrisday/) provides a persistent URI namespace to store redirects and content negotiation of resources created by Chris Day (https://github.com/chris-day/) (https://www.linkedin.com/in/chrisdayabinitio/)
+
+# Uses
+
+# Rewrite rules for Chris Day's orcid profile
+RewriteRule ^orcid$ https://orcid.org/0000-0001-5095-7052 [R=303,L]
+# Rewrite rules for Chris Day's GitHub profile
+RewriteRule ^github$ https://github.com/chris-day [R=303,L]
+# Rewrite rules for Chris Day's LinkedIn profile
+RewriteRule ^$ https://www.linkedin.com/in/chrisdayabinitio/ [R=303,L]
+
+# Useful Links for Chris Day
+
+| w3id                        | Description                                    | HTML                                                             |
+|-----------------------------|------------------------------------------------|------------------------------------------------------------------|
+| /                           | LinkedIn Profile                               | https://www.linkedin.com/in/chrisdayabinitio/                    |
+| /orcid                      | ORCID                                          | https://orcid.org/0000-0001-5095-7052                            |
+| **GitHub**                  |                                                |                                                                  |
+| /github                     | GitHub Landing Page                            | https://github.com/chris-day                                     |
+| /github/uml2semantics-python| uml2semantics-python                           | https://github.com/chris-day/uml2semantics-python                |
+| /github/ISO-20022           | ISO 20022 Semantic Models                      | https://github.com/chris-day/ISO-20022                           |
+
+
+# Contact:
+- Chris Day [:email:](mailto:chris.day@perdl.com) [:octocat:](https://github.com/chris-day)

--- a/perdl/.htaccess
+++ b/perdl/.htaccess
@@ -1,0 +1,7 @@
+# Perdl Limited and Perdl LLC
+Options +FollowSymLinks
+RewriteEngine on
+# Rewrite rules for Perdl GitHub
+RewriteRule ^github$ https://github.com/chris-day/ [R=303,L]
+# Rewrite rules for Perdl
+RewriteRule ^$ https://www.perdl.com/ [R=303,L]

--- a/perdl/README.md
+++ b/perdl/README.md
@@ -1,0 +1,25 @@
+# Perdl Limited and Perdl LLC
+
+This [w3id](https://w3id.org/perdl/) provides a persistent URI namespace to store redirects and content negotiation of resources created by Perdl Limited and Perdl LLC.
+
+# Uses
+
+# Rewrite rules for Perdl GitHub
+RewriteRule ^github$ https://github.com/chris-day/ [R=303,L]
+# Rewrite rules for Perdl
+RewriteRule ^$ https://www.perdl.com/ [R=303,L]
+
+# Useful Links for Perdl
+
+
+| w3id                        | Description                                    | HTML                                                             |
+|-----------------------------|------------------------------------------------|------------------------------------------------------------------|
+| /                           | Perdl Homepage                                 | https://www.perdl.com/                    |
+| **GitHub**                  |                                                |                                                                  |
+| /github                     | GitHub Landing Page                            | https://github.com/chris-day                                     |
+| /github/uml2semantics-python| uml2semantics-python                           | https://github.com/chris-day/uml2semantics-python                |
+| /github/ISO-20022           | ISO 20022 Semantic Models                      | https://github.com/chris-day/ISO-20022                           |
+
+
+# Contact:
+- Chris Day [:email:](mailto:chris.day@perdl.com) [:octocat:](https://github.com/chris-day)


### PR DESCRIPTION
Introduces .htaccess and README.md files for Chris Day and Perdl namespaces, providing persistent URI redirects to LinkedIn, ORCID, GitHub, and company homepage. These additions facilitate easier access and content negotiation for related resources.

<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [ ] Changes have been tested.
- [ ] The number of commits is minimal. Squash if needed.
- [ ] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
