### PR TITLE
update hvdnet .htaccess to redirect to default SkoHub vocabulary server

### DIFF
--- a/hvdnet/.htaccess
+++ b/hvdnet/.htaccess
@@ -1,3 +1,24 @@
-Options +FollowSymLinks
-RewriteEngine on
-RewriteRule ^([\S]*)$ https://highvaluedata.net/$1 [R=303,L]
+# Turn off MultiViews
+Options -MultiViews
+
+# Set content types
+AddType application/ld+json .jsonld
+AddType application/json .json
+AddType text/html .html
+
+# Rewrite engine setup
+RewriteEngine On
+RewriteBase /hvdnet
+
+# Content negotiation for valid vocabularies
+
+# Serve JSON-LD if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^(.+)$ https://hvdnet.github.io/hvdnet-vocabs/w3id.org/hvdnet/$1.jsonld [R=303,L]
+
+# Serve JSON if requested
+RewriteCond %{HTTP_ACCEPT} application/json [NC]
+RewriteRule ^(.+)$ https://hvdnet.github.io/hvdnet-vocabs/w3id.org/hvdnet/$1.json [R=303,L]
+
+# Default: serve HTML for browsers
+RewriteRule ^(.+)$ https://hvdnet.github.io/hvdnet-vocabs/w3id.org/hvdnet/$1.html [R=303,L]


### PR DESCRIPTION
Deployed a SkoHub server to manage vocabularies. This redirects all request there by default (hosted on github.io)

## General Checklist
<!-- For all ID related PRs. -->
- [ √] Changes have been tested.
- [√] The number of commits is minimal. Squash if needed.
- [ √] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [√ ] GitHub username ids are listed in the changed maintainer details.
- [ √] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

