### PR TITLE
Add w3id.org/allmac/lope redirect (LOPE module in ALLMaC)

### DIFF
--- a/allmac/lope/.htaccess
+++ b/allmac/lope/.htaccess
@@ -1,0 +1,12 @@
+# w3id.org redirect for ALLMaC / LOPE
+# Maintainer: Sandra Schaftner (@SandraSchaftner)
+# Contact: sandra.schaftner@informatik.tu-chemnitz.de
+
+# Permanent identifier: https://w3id.org/allmac/lope
+# Target: LOPE GitHub repository with code and materials
+#         for "The LOPE Method – Improving Consistent Property Extraction for Scientific Knowledge Graphs Using LLMs".
+
+RewriteEngine On
+
+# Redirect all requests for /allmac/lope to the GitHub repository
+RewriteRule ^allmac/lope/?$ https://github.com/SandraSchaftner/lope [R=301,L]

--- a/allmac/lope/README.md
+++ b/allmac/lope/README.md
@@ -1,0 +1,31 @@
+# ALLMaC / LOPE
+
+This directory contains the configuration for the permanent identifier:
+
+- [**https://w3id.org/allmac/lope**](https://w3id.org/allmac/lope)
+
+It currently redirects to the LOPE GitHub repository:
+
+- [**https://github.com/SandraSchaftner/lope**](https://github.com/SandraSchaftner/lope)
+
+LOPE (*LLM-driven Ontology-based Property Extraction*) is a module within the
+**ALLMaC – Agentic LLM-augmented Construction of Scientific Knowledge Graphs (SKGs)** framework.
+It provides an automated pipeline for ontology-based property extraction and mapping for SKGs, as described
+in the paper *"The LOPE Method – Improving Consistent Property Extraction for
+Scientific Knowledge Graphs Using LLMs" (to be published).
+
+## Maintainer
+
+- **Name:** Sandra Schaftner  
+- **Affiliation:** Technische Universität Chemnitz  
+- **GitHub:** [@SandraSchaftner](https://github.com/SandraSchaftner)  
+- **Email:** sandra.schaftner@informatik.tu-chemnitz.de
+
+## Intended usage
+
+The `https://w3id.org/allmac/lope` identifier is intended to provide a stable,
+persistent URL for:
+
+- the LOPE code and configuration,  
+- evaluation data and result artifacts used in the LOPE experiments, 
+- future updates of the LOPE module as part of the overall ALLMaC pipeline.


### PR DESCRIPTION

## Brief Description
This PR adds a new permanent identifier:

- https://w3id.org/allmac/lope

It redirects to the LOPE GitHub repository:
- https://github.com/SandraSchaftner/lope

LOPE (LLM-driven Ontology-based Property Extraction) is a module within the
ALLMaC framework (Agentic LLM-augmented Construction of Scientific Knowledge Graphs).
The README in allmac/lope includes maintainer and contact information.


## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
