### PR TITLE
Update AQFO .htaccess for redirects to AgroPortal

### DIFF
--- a/aqfo/.htaccess
+++ b/aqfo/.htaccess
@@ -7,7 +7,10 @@
 # GitHub username: marieALaporte
 
 RewriteEngine on
-RewriteRule ^ https://raw.githubusercontent.com/WorldFishCenter/fish-ontology/main/aquaculture_small_scale_fisheries_ontology.owl [R=303,L]
+#RewriteRule ^ https://raw.githubusercontent.com/WorldFishCenter/fish-ontology/main/aquaculture_small_scale_fisheries_ontology.owl [R=303,L]
+# Base redirect to the AgroPortal landing page
+RewriteRule ^$ https://agroportal.lirmm.fr/ontologies/AQFO [R=302,L]
 
-# Rewrite for a term id
-RewriteRule (.+) https://agroportal.lirmm.fr/ontologies/AQFO/?p=classes&conceptid=https://w3id.org/aqfo/$1
+# Redirect specific entities to their AgroPortal page (e.g., classes or terms)
+RewriteCond %{REQUEST_URI} ^.*AQFO.*$
+RewriteRule ^.*/([^/#]+)/?$ https://agroportal.lirmm.fr/ontologies/AQFO/$1 [R=302,L]


### PR DESCRIPTION
This PR will implement/fix the redirection to AgroPortal's twin URI for AQFO. 
Those twin URIs are invisible to the user and support both resolution and content negociation as explained in https://hal.science/hal-05240849

CC: @marieALaporte