### PR TITLE
add liccium ontology

### DIFF
--- a/liccium/.htaccess
+++ b/liccium/.htaccess
@@ -1,4 +1,4 @@
-# Liccium Schema & Context Redirects
+# Liccium Schema, Context & Ontology Redirects
 # https://w3id.org/liccium
 #
 # Repository: https://github.com/liccium/w3id.docs
@@ -13,6 +13,7 @@ Options -MultiViews
 
 # MIME type declarations
 AddType application/json .json
+AddType text/turtle .ttl
 
 # Rewrite engine setup
 RewriteEngine On
@@ -27,6 +28,11 @@ RewriteRule ^schema/(.+)\.json$ https://raw.githubusercontent.com/liccium/w3id.d
 # Context files
 # ------------------------------
 RewriteRule ^context/(.+)\.json$ https://raw.githubusercontent.com/liccium/w3id.docs/main/context/$1.json [R=303,L]
+
+# ------------------------------
+# Ontology files
+# ------------------------------
+RewriteRule ^ont/(.+)\.ttl$ https://raw.githubusercontent.com/liccium/w3id.docs/main/ont/$1.ttl [R=303,L]
 
 # ------------------------------
 # Default response (redirect to GitHub repo)

--- a/liccium/README.md
+++ b/liccium/README.md
@@ -1,20 +1,22 @@
-# Liccium Schema & Context
+# Liccium Schema, Context & Ontology
 
-Versioned JSON Schema and JSON-LD context definitions for Liccium metadata declarations.
+Versioned JSON Schema, JSON-LD context, and OWL ontology definitions for Liccium metadata declarations.
 
 ## Contents
 
 - **`schema/`** — JSON Schema files for validating declaration metadata
 - **`context/`** — JSON-LD context files for semantic interoperability
+- **`ont/`** — OWL ontology files for semantic definitions
 
 ## Usage
 
 Reference these files via w3id.org persistent URLs:
 
-| Format          | URL                                          |
-| --------------- | -------------------------------------------- |
-| **JSON Schema** | https://w3id.org/Liccium/schema/0.1.0.json |
-| **JSON-LD**     | https://w3id.org/Liccium/context/0.1.0.json |
+| Format           | URL                                          |
+| ---------------- | -------------------------------------------- |
+| **JSON Schema**  | https://w3id.org/liccium/schema/0.1.0.json   |
+| **JSON-LD**      | https://w3id.org/liccium/context/0.1.0.json  |
+| **OWL Ontology** | https://w3id.org/liccium/ont/0.1.0.ttl |
 
 **Repository:** https://github.com/Liccium/w3id.docs
 


### PR DESCRIPTION
Brief Description
This PR creates a new permanent identifier namespace for Liccium at https://w3id.org/liccium/.

Liccium provides versioned JSON Schema and JSON-LD context and ontology files definitions for metadata declarations. The redirects point to:

https://w3id.org/liccium/schema/*.json → JSON Schema files
https://w3id.org/liccium/context/*.json → JSON-LD context files
https://w3id.org/liccium/ont/*.ttl → Ontology ttl files
Source repository: https://github.com/liccium/w3id.docs

General Checklist
 Changes have been tested.

 The number of commits is minimal. Squash if needed.

 Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

New ID Directory Checklist
 Maintainer details are in .htaccess or README.md.

 GitHub username ids are listed in the maintainer details.

Update ID Directory Checklist
 GitHub username ids are listed in the changed maintainer details.

 The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

Optional Requests for W3ID Maintainers
 Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
Maintainers:

Yury Kharytanovich (@yurykharytanovich) — [yury.kharytanovich.liccium@gmail.com](mailto:yury.kharytanovich.liccium@gmail.com)
Sebastian Posth (@sposth) — [Info@liccium.com](mailto:Info@liccium.com)