### PR TITLE
Add Verisav vocabularies (DPP, RMA, WTY) persistent URIs

### DIFF
--- a/verisav/dpp/.htaccess
+++ b/verisav/dpp/.htaccess
@@ -1,0 +1,45 @@
+# W3ID Redirections pour Verisav DPP Vocabulary
+# Digital Product Passport (DPP) Vocabulary
+
+# Redirection du namespace principal vers la documentation HTML
+RewriteEngine On
+RewriteBase /verisav/dpp/
+
+# Redirection du namespace avec fragment (#) vers la page de documentation
+RewriteRule ^#$ https://ns.verisav.fr/dpp/ [R=303,L]
+
+# Redirection du namespace sans slash vers la page de documentation
+RewriteRule ^$ https://ns.verisav.fr/dpp/ [R=303,L]
+
+# Redirection du fichier Turtle (.ttl)
+RewriteRule ^dpp\.ttl$ https://ns.verisav.fr/dpp/dpp.ttl [R=303,L]
+RewriteRule ^\.ttl$ https://ns.verisav.fr/dpp/dpp.ttl [R=303,L]
+
+# Redirection du fichier JSON-LD (.jsonld)
+RewriteRule ^dpp\.jsonld$ https://ns.verisav.fr/dpp/dpp.jsonld [R=303,L]
+RewriteRule ^\.jsonld$ https://ns.verisav.fr/dpp/dpp.jsonld [R=303,L]
+
+# Redirection du fichier RDF/XML (.xml)
+RewriteRule ^dpp\.xml$ https://ns.verisav.fr/dpp/dpp.xml [R=303,L]
+RewriteRule ^\.xml$ https://ns.verisav.fr/dpp/dpp.xml [R=303,L]
+
+# Redirection du fichier RDF/XML (.owl) vers le fichier XML
+RewriteRule ^dpp\.owl$ https://ns.verisav.fr/dpp/dpp.xml [R=303,L]
+RewriteRule ^\.owl$ https://ns.verisav.fr/dpp/dpp.xml [R=303,L]
+
+# Content Negotiation : Redirection basée sur l'Accept header
+<IfModule mod_rewrite.c>
+  RewriteCond %{HTTP_ACCEPT} text/turtle [NC,OR]
+  RewriteCond %{HTTP_ACCEPT} application/n-triples [NC]
+  RewriteRule ^$ https://ns.verisav.fr/dpp/dpp.ttl [R=303,L]
+  
+  RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+  RewriteRule ^$ https://ns.verisav.fr/dpp/dpp.jsonld [R=303,L]
+  
+  RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC,OR]
+  RewriteCond %{HTTP_ACCEPT} application/xml [NC]
+  RewriteRule ^$ https://ns.verisav.fr/dpp/dpp.xml [R=303,L]
+</IfModule>
+
+# Par défaut, rediriger vers la documentation HTML
+RewriteRule ^(.*)$ https://ns.verisav.fr/dpp/$1 [R=303,L]

--- a/verisav/dpp/README.md
+++ b/verisav/dpp/README.md
@@ -1,0 +1,66 @@
+# Verisav DPP Vocabulary - W3ID Persistent URI
+
+## Persistent URI
+
+This directory provides persistent URIs for the **Verisav Digital Product Passport (DPP) Vocabulary**.
+
+### Namespace URI
+
+```
+https://w3id.org/verisav/dpp#
+```
+
+### Vocabulary URI
+
+```
+https://w3id.org/verisav/dpp
+```
+
+## Redirects
+
+All requests are redirected to the actual vocabulary location:
+
+- **Namespace:** `https://w3id.org/verisav/dpp#` → `https://ns.verisav.fr/dpp#`
+- **Documentation:** `https://w3id.org/verisav/dpp/` → `https://ns.verisav.fr/dpp/`
+- **Turtle (.ttl):** `https://w3id.org/verisav/dpp/dpp.ttl` → `https://ns.verisav.fr/dpp/dpp.ttl`
+- **JSON-LD (.jsonld):** `https://w3id.org/verisav/dpp/dpp.jsonld` → `https://ns.verisav.fr/dpp/dpp.jsonld`
+- **RDF/XML (.xml):** `https://w3id.org/verisav/dpp/dpp.xml` → `https://ns.verisav.fr/dpp/dpp.xml`
+
+## Content Negotiation
+
+The vocabulary supports content negotiation via HTTP Accept headers:
+
+- `Accept: text/turtle` → Returns Turtle format
+- `Accept: application/ld+json` → Returns JSON-LD format
+- `Accept: application/rdf+xml` → Returns RDF/XML format
+- `Accept: text/html` → Returns HTML documentation (default)
+
+## Vocabulary Description
+
+**Verisav Digital Product Passport (DPP) Vocabulary** is an RDF/OWL vocabulary for representing Digital Product Passports (DPP) in compliance with European regulations effective in 2027 (ESPR EU 2024/1781).
+
+The vocabulary defines classes and properties for:
+- Product lifecycle management
+- Warranties and guarantees
+- Repairs and maintenance
+- Regulatory compliance
+- GS1 Digital Link standards alignment (GTIN, GLN, Application Identifiers)
+- Product traceability (model, batch, serial granularity)
+
+## Links
+
+- **Official namespace:** https://ns.verisav.fr/dpp#
+- **LOV entry:** https://lov.linkeddata.es/dataset/lov/vocabs/dpp
+- **Documentation:** https://ns.verisav.fr/dpp/
+- **GitHub:** https://github.com/kevinbouti/verisav.fr/tree/main/apps/web/public/vocabularies/dpp
+
+## Contact
+
+- **Creator:** Kévin Boutillier (ORCID: [0009-0001-0356-4421](https://orcid.org/0009-0001-0356-4421))
+- **Organization:** Verisav
+- **Email:** contact@verisav.fr
+- **Website:** https://www.verisav.fr
+
+## License
+
+This vocabulary is published under a Creative Commons license. Please refer to the official vocabulary documentation for license details.

--- a/verisav/rma/.htaccess
+++ b/verisav/rma/.htaccess
@@ -1,0 +1,33 @@
+# W3ID Redirections pour Verisav RMA Vocabulary
+# Return Merchandise Authorization (RMA) Vocabulary
+
+# Redirection du namespace principal vers la documentation HTML
+RewriteEngine On
+RewriteBase /verisav/rma/
+
+# Redirection du namespace avec fragment (#) vers la page de documentation
+RewriteRule ^#$ https://ns.verisav.fr/rma/ [R=303,L]
+
+# Redirection du namespace sans slash vers la page de documentation
+RewriteRule ^$ https://ns.verisav.fr/rma/ [R=303,L]
+
+# Redirection du fichier Turtle (.ttl)
+RewriteRule ^rma\.ttl$ https://ns.verisav.fr/rma/rma.ttl [R=303,L]
+RewriteRule ^\.ttl$ https://ns.verisav.fr/rma/rma.ttl [R=303,L]
+
+# Redirection du fichier JSON-LD (.jsonld)
+RewriteRule ^rma\.jsonld$ https://ns.verisav.fr/rma/rma.jsonld [R=303,L]
+RewriteRule ^\.jsonld$ https://ns.verisav.fr/rma/rma.jsonld [R=303,L]
+
+# Content Negotiation : Redirection basée sur l'Accept header
+<IfModule mod_rewrite.c>
+  RewriteCond %{HTTP_ACCEPT} text/turtle [NC,OR]
+  RewriteCond %{HTTP_ACCEPT} application/n-triples [NC]
+  RewriteRule ^$ https://ns.verisav.fr/rma/rma.ttl [R=303,L]
+  
+  RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+  RewriteRule ^$ https://ns.verisav.fr/rma/rma.jsonld [R=303,L]
+</IfModule>
+
+# Par défaut, rediriger vers la documentation HTML
+RewriteRule ^(.*)$ https://ns.verisav.fr/rma/$1 [R=303,L]

--- a/verisav/rma/README.md
+++ b/verisav/rma/README.md
@@ -1,0 +1,64 @@
+# Verisav RMA Vocabulary - W3ID Persistent URI
+
+## Persistent URI
+
+This directory provides persistent URIs for the **Verisav Return Merchandise Authorization (RMA) Vocabulary**.
+
+### Namespace URI
+
+```
+https://w3id.org/verisav/rma#
+```
+
+### Vocabulary URI
+
+```
+https://w3id.org/verisav/rma
+```
+
+## Redirects
+
+All requests are redirected to the actual vocabulary location:
+
+- **Namespace:** `https://w3id.org/verisav/rma#` → `https://ns.verisav.fr/rma#`
+- **Documentation:** `https://w3id.org/verisav/rma/` → `https://ns.verisav.fr/rma/`
+- **Turtle (.ttl):** `https://w3id.org/verisav/rma/rma.ttl` → `https://ns.verisav.fr/rma/rma.ttl`
+- **JSON-LD (.jsonld):** `https://w3id.org/verisav/rma/rma.jsonld` → `https://ns.verisav.fr/rma/rma.jsonld`
+
+## Content Negotiation
+
+The vocabulary supports content negotiation via HTTP Accept headers:
+
+- `Accept: text/turtle` → Returns Turtle format
+- `Accept: application/ld+json` → Returns JSON-LD format
+- `Accept: text/html` → Returns HTML documentation (default)
+
+## Vocabulary Description
+
+**Verisav Return Merchandise Authorization (RMA) Vocabulary** is an RDF/OWL vocabulary for representing return merchandise authorization processes, return requests, refunds, and exchanges in e-commerce and retail contexts.
+
+The vocabulary defines classes and properties for:
+- Return requests and authorization
+- Refund processes
+- Exchange procedures
+- Return shipping and logistics
+- Return status tracking
+- Return disputes and resolutions
+
+## Links
+
+- **Official namespace:** https://ns.verisav.fr/rma#
+- **LOV entry:** https://lov.linkeddata.es/dataset/lov/vocabs/rma
+- **Documentation:** https://ns.verisav.fr/rma/
+- **GitHub:** https://github.com/kevinbouti/verisav.fr/tree/main/apps/web/public/vocabularies/rma
+
+## Contact
+
+- **Creator:** Kévin Boutillier (ORCID: [0009-0001-0356-4421](https://orcid.org/0009-0001-0356-4421))
+- **Organization:** Verisav
+- **Email:** contact@verisav.fr
+- **Website:** https://www.verisav.fr
+
+## License
+
+This vocabulary is published under a Creative Commons license. Please refer to the official vocabulary documentation for license details.

--- a/verisav/wty/.htaccess
+++ b/verisav/wty/.htaccess
@@ -1,0 +1,33 @@
+# W3ID Redirections pour Verisav WTY Vocabulary
+# Warranty (WTY) Vocabulary
+
+# Redirection du namespace principal vers la documentation HTML
+RewriteEngine On
+RewriteBase /verisav/wty/
+
+# Redirection du namespace avec fragment (#) vers la page de documentation
+RewriteRule ^#$ https://ns.verisav.fr/wty/ [R=303,L]
+
+# Redirection du namespace sans slash vers la page de documentation
+RewriteRule ^$ https://ns.verisav.fr/wty/ [R=303,L]
+
+# Redirection du fichier Turtle (.ttl)
+RewriteRule ^wty\.ttl$ https://ns.verisav.fr/wty/wty.ttl [R=303,L]
+RewriteRule ^\.ttl$ https://ns.verisav.fr/wty/wty.ttl [R=303,L]
+
+# Redirection du fichier JSON-LD (.jsonld)
+RewriteRule ^wty\.jsonld$ https://ns.verisav.fr/wty/wty.jsonld [R=303,L]
+RewriteRule ^\.jsonld$ https://ns.verisav.fr/wty/wty.jsonld [R=303,L]
+
+# Content Negotiation : Redirection basée sur l'Accept header
+<IfModule mod_rewrite.c>
+  RewriteCond %{HTTP_ACCEPT} text/turtle [NC,OR]
+  RewriteCond %{HTTP_ACCEPT} application/n-triples [NC]
+  RewriteRule ^$ https://ns.verisav.fr/wty/wty.ttl [R=303,L]
+  
+  RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+  RewriteRule ^$ https://ns.verisav.fr/wty/wty.jsonld [R=303,L]
+</IfModule>
+
+# Par défaut, rediriger vers la documentation HTML
+RewriteRule ^(.*)$ https://ns.verisav.fr/wty/$1 [R=303,L]

--- a/verisav/wty/README.md
+++ b/verisav/wty/README.md
@@ -1,0 +1,64 @@
+# Verisav WTY Vocabulary - W3ID Persistent URI
+
+## Persistent URI
+
+This directory provides persistent URIs for the **Verisav Warranty (WTY) Vocabulary**.
+
+### Namespace URI
+
+```
+https://w3id.org/verisav/wty#
+```
+
+### Vocabulary URI
+
+```
+https://w3id.org/verisav/wty
+```
+
+## Redirects
+
+All requests are redirected to the actual vocabulary location:
+
+- **Namespace:** `https://w3id.org/verisav/wty#` → `https://ns.verisav.fr/wty#`
+- **Documentation:** `https://w3id.org/verisav/wty/` → `https://ns.verisav.fr/wty/`
+- **Turtle (.ttl):** `https://w3id.org/verisav/wty/wty.ttl` → `https://ns.verisav.fr/wty/wty.ttl`
+- **JSON-LD (.jsonld):** `https://w3id.org/verisav/wty/wty.jsonld` → `https://ns.verisav.fr/wty/wty.jsonld`
+
+## Content Negotiation
+
+The vocabulary supports content negotiation via HTTP Accept headers:
+
+- `Accept: text/turtle` → Returns Turtle format
+- `Accept: application/ld+json` → Returns JSON-LD format
+- `Accept: text/html` → Returns HTML documentation (default)
+
+## Vocabulary Description
+
+**Verisav Warranty (WTY) Vocabulary** is an RDF/OWL vocabulary for representing warranties, guarantees, and warranty-related information for products and services.
+
+The vocabulary defines classes and properties for:
+- Warranty types and coverage
+- Warranty periods and expiration
+- Warranty claims and processes
+- Warranty conditions and limitations
+- Warranty extensions and maintenance contracts
+- Warranty status tracking
+
+## Links
+
+- **Official namespace:** https://ns.verisav.fr/wty#
+- **LOV entry:** https://lov.linkeddata.es/dataset/lov/vocabs/wty
+- **Documentation:** https://ns.verisav.fr/wty/
+- **GitHub:** https://github.com/kevinbouti/verisav.fr/tree/main/apps/web/public/vocabularies/wty
+
+## Contact
+
+- **Creator:** Kévin Boutillier (ORCID: [0009-0001-0356-4421](https://orcid.org/0009-0001-0356-4421))
+- **Organization:** Verisav
+- **Email:** contact@verisav.fr
+- **Website:** https://www.verisav.fr
+
+## License
+
+This vocabulary is published under a Creative Commons license. Please refer to the official vocabulary documentation for license details.


### PR DESCRIPTION
This PR adds persistent URI redirects for three Verisav vocabularies:
- DPP (Digital Product Passport): https://w3id.org/verisav/dpp
- RMA (Return Merchandise Authorization): https://w3id.org/verisav/rma
- WTY (Warranty): https://w3id.org/verisav/wty

All redirects point to the official vocabulary location on ns.verisav.fr. The vocabularies are registered on LOV (Linked Open Vocabularies) and follow RDF/OWL standards.

<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [ ] Changes have been tested.
- [ ] The number of commits is minimal. Squash if needed.
- [ ] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
