### PR TITLE
Add lcabim namespace redirects

### DIFF
--- a/lcabim/.htaccess
+++ b/lcabim/.htaccess
@@ -1,0 +1,15 @@
+RewriteEngine On
+
+# Root
+RewriteRule ^$ https://g3rezz.github.io/lcabim-ontology/ [R=302,L]
+
+# Module document IRIs
+RewriteRule ^din276/?$        https://g3rezz.github.io/lcabim-ontology/din276/index-en.html [R=302,L]
+RewriteRule ^bki/?$           https://g3rezz.github.io/lcabim-ontology/bki/index-en.html [R=302,L]
+RewriteRule ^obd/?$           https://g3rezz.github.io/lcabim-ontology/obd/index-en.html [R=302,L]
+RewriteRule ^concreteclass/?$ https://g3rezz.github.io/lcabim-ontology/concreteclass/index-en.html [R=302,L]
+RewriteRule ^ilcd/?$          https://g3rezz.github.io/lcabim-ontology/ilcd/index-en.html [R=302,L]
+RewriteRule ^lcabimcore/?$    https://g3rezz.github.io/lcabim-ontology/lcabimcore/index-en.html [R=302,L]
+
+# Everything else
+RewriteRule ^(.*)$ https://g3rezz.github.io/lcabim-ontology/$1 [R=302,L]

--- a/lcabim/README.md
+++ b/lcabim/README.md
@@ -1,0 +1,23 @@
+# w3id.org/lcabim
+
+This folder defines persistent redirects for the **LCABIM Ontology** namespaces used in the _LCA–BIM Workflow_ project.
+
+## Namespace
+
+- Base namespace: `https://w3id.org/lcabim/`
+
+## Redirect target (current hosting)
+
+The ontology documentation and RDF serializations are currently hosted via GitHub Pages:
+
+- `https://g3rezz.github.io/lcabim-ontology/`
+
+The w3id.org namespace provides persistent IRIs that redirect to the current hosting location.
+
+## Maintainer
+
+- GitHub: `g3rezz`
+
+## Notes
+
+- Redirect rules are defined in `.htaccess`.


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
This PR adds the new `lcabim` namespace under `https://w3id.org/lcabim/` and configures redirects to the current hosting location on GitHub Pages:
`https://g3rezz.github.io/lcabim-ontology/`.

Redirects cover the namespace root and the ontology modules (ilcd, din276, obd, bki, concreteclass, lcabimcore).

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
