### PR TITLE
Fix OCCO redirect - add trailing slash for GitHub Pages compatibility

### DIFF
--- a/occo/.htaccess
+++ b/occo/.htaccess
@@ -6,5 +6,5 @@ Options +FollowSymLinks
 RewriteEngine on
 
 # Redirect to ontology landing page
-RewriteRule ^$ https://saiframahii.github.io/occo [R=302,L]
+RewriteRule ^$ https://saiframahii.github.io/occo/ [R=302,L]
 RewriteRule ^(.*)$ https://saiframahii.github.io/occo/$1 [R=302,L]


### PR DESCRIPTION
## Brief Description

Fix trailing slash redirect for OCCO (Occupant-Centric Control Ontology). The previous configuration caused a 404 on initial page load because [`[w3id.org/occo](http://w3id.org/occo)`](http://w3id.org/occo) redirected to [`[saiframahii.github.io/occo](http://saiframahii.github.io/occo)`](http://saiframahii.github.io/occo) without a trailing slash, triggering GitHub Pages' own redirect and breaking the chain. This update adds the trailing slash to the first rewrite rule.

## General Checklist

- [x]  Changes have been tested.
- [x]  The number of commits is minimal. Squash if needed.
- [x]  Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [ ]  Maintainer details are in `.htaccess` or [`[README.md](http://readme.md/)`](http://README.md).
- [ ]  GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist

- [x]  GitHub username ids are listed in the changed maintainer details.
- [x]  The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers

- [ ]  Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.