### PR TITLE
New Module and Extension for OCQA

### DIFF
--- a/ocqa/.htaccess
+++ b/ocqa/.htaccess
@@ -46,11 +46,15 @@ RewriteRule ^rule$ https://sebseis.github.io/OCQA/Modules/Rule/ [R=303,NE,L] # D
 # AC Module
 RewriteRule ^ocqa-ac.ttl$          https://sebseis.github.io/OCQA/Modules/AC/OCQA-AC.ttl [R=302,NE,L]
 RewriteRule ^ocqa-ac.html$         https://sebseis.github.io/OCQA/Modules/AC/            [R=302,NE,L]
-RewriteRule ^ocqa-ac$              https://sebseis.github.io/OCQA/Modules/AC/            [R=303,NE,L]
+RewriteRule ^ocqa-ac$              https://sebseis.github.io/OCQA/Modules/AC/            [R=303,NE,L] # Default response: html
 # Risk Module
 RewriteRule ^ocqa-risk.ttl$        https://sebseis.github.io/OCQA/Modules/Risk/OCQA-Risk.ttl [R=302,NE,L]
 RewriteRule ^ocqa-risk.html$       https://sebseis.github.io/OCQA/Modules/Risk/              [R=302,NE,L]
-RewriteRule ^ocqa-risk$            https://sebseis.github.io/OCQA/Modules/Risk/ [R=302,NE,L]
+RewriteRule ^ocqa-risk$            https://sebseis.github.io/OCQA/Modules/Risk/ [R=302,NE,L] # Default response: html
+# Adaptive Module for contextualization
+RewriteRule ^ocqa-adaptive.ttl$        https://sebseis.github.io/OCQA/Modules/Adaptive/OCQA-Adaptive.ttl [R=302,NE,L]
+RewriteRule ^ocqa-adaptive.html$       https://sebseis.github.io/OCQA/Modules/Adaptive/              [R=302,NE,L]
+RewriteRule ^ocqa-adaptive$            https://sebseis.github.io/OCQA/Modules/Adaptive/ [R=302,NE,L] # Default response: html
 
 # Link to Extensions, already described in main document
 # Screed Extension
@@ -61,3 +65,7 @@ RewriteRule ^screed$ https://sebseis.github.io/OCQA/Extensions/Screed/ [R=303,NE
 RewriteRule ^thermalInsulation.ttl$ https://sebseis.github.io/OCQA/Extensions/Insulation/OCQA-ThermalInsulation.ttl [R=302,NE,L]
 RewriteRule ^thermalInsulation.html$ https://sebseis.github.io/OCQA/Extensions/Insulation/ [R=302,NE,L]
 RewriteRule ^thermalInsulation$ https://sebseis.github.io/OCQA/Extensions/Insulation/ [R=303,NE,L] # Default response: html
+# DryWall Extension
+RewriteRule ^drywall.ttl$ https://sebseis.github.io/OCQA/Extensions/DryWall/OCQA-DryWall.ttl [R=302,NE,L]
+RewriteRule ^drywall.html$ https://sebseis.github.io/OCQA/Extensions/DryWall/ [R=302,NE,L]
+RewriteRule ^drywall$ https://sebseis.github.io/OCQA/Extensions/DryWall/ [R=303,NE,L] # Default response: html


### PR DESCRIPTION
Hey,

We added the OCQA-Adaptive module and the OCQA-DryWall extension.

Thanks for the support.


## Brief Description
Two new modules for the OCQA ontology. 

## General Checklist

- [ X] Changes have been tested.
- [X ] The number of commits is minimal. Squash if needed.
- [ X] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ X] GitHub username ids are listed in the changed maintainer details.
- [ X] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

