### PR TITLE
Add DSMS persistent identifiers

### DIFF
--- a/dsms/.htaccess
+++ b/dsms/.htaccess
@@ -1,0 +1,41 @@
+# ==================================================
+# w3id.org persistent identifiers for DSMS vocabularies
+#
+# Pattern:
+#   https://w3id.org/dsms/<namespace>/<term>
+#   https://w3id.org/dsms/<namespace>/<usecase>/<term>
+#
+# Redirects to:
+#   https://kiran.materials-data.space/vocabulary/docs/<namespace>#<term>
+#
+# Notes:
+# - <usecase> is optional and ignored for documentation
+# - Namespace is preserved
+# - Term becomes a fragment identifier
+# ## Contact
+# This space is administered by:
+#
+# Kiran Kumaraswamy
+# kiran.kumaraswamy@iwm.fraunhofer.de
+# GitHub username: Kirankumaraswamy
+#
+# Yoav Nahshon
+# yoav.nahshon@iwm.fraunhofer.de
+# GitHub username: yoavnash
+# ==================================================
+
+RewriteEngine On
+
+# --------------------------------------------------
+# Case 1: /<namespace>/<term>
+# --------------------------------------------------
+RewriteRule ^([^/]+)/([^/]+)$ \
+https://kiran.materials-data.space/vocabulary/docs/$1#$2 \
+[R=302,L]
+
+# --------------------------------------------------
+# Case 2: /<namespace>/<usecase>/<term>
+# --------------------------------------------------
+RewriteRule ^([^/]+)/([^/]+)/([^/]+)$ \
+https://kiran.materials-data.space/vocabulary/docs/$1#$3 \
+[R=302,L]

--- a/dsms/README.md
+++ b/dsms/README.md
@@ -1,0 +1,87 @@
+# DSMS Persistent Identifiers
+
+This directory defines persistent HTTP identifiers for vocabularies
+published by the **Data Space Management System (DSMS)**.
+
+The identifiers are hosted under `https://w3id.org/dsms/` and are intended
+to be stable, long-term URIs for RDF vocabularies and terms.
+
+---
+
+## URI Pattern
+
+The following URI patterns are supported:
+
+- https://w3id.org/dsms/<namespace>/<term>
+- https://w3id.org/dsms/<namespace>/<usecase>/<term>
+  
+Where:
+
+- `<namespace>` is the vocabulary namespace (e.g. `steel`, `battery`)
+- `<usecase>` is an optional grouping or application context
+- `<term>` is the vocabulary term identifier
+
+Examples:
+
+- https://w3id.org/dsms/steel/Material
+- https://w3id.org/dsms/steel/Gleeble/Strain
+
+## URI Pattern
+
+All DSMS identifiers redirect to human-readable documentation hosted at:
+
+https://kiran.materials-data.space/vocabulary/docs/
+
+The redirection rules are:
+
+| w3id URI | Redirects to |
+|:--------:|:-------------:|
+| `/dsms/steel/Material` | `/vocabulary/docs/steel#Material` |
+| `/dsms/steel/gleeble/Strain` | `/vocabulary/docs/steel#Strain` |
+
+Notes:
+
+- The optional `<usecase>` path segment is ignored for documentation
+- The `<term>` is mapped to a fragment identifier (`#term`)
+- The documentation is publicly accessible over HTTPS
+
+---
+
+## Maintenance Commitment
+
+The canonical identifiers for RDF **must use w3id.org URIs**, not the
+documentation URLs.
+
+Example (Turtle):
+
+```turtle
+@prefix dsms: <https://w3id.org/dsms/steel/> .
+
+dsms:Material a owl:Class ;
+  rdfs:label "Material" ;
+  rdfs:isDefinedBy <https://w3id.org/dsms/steel/> ;
+  rdfs:seeAlso <https://kiran.materials-data.space/vocabulary/docs/steel#Material> .
+```
+
+## RDF Usage
+
+The DSMS team commits to:
+
+- Maintaining the redirection rules under w3id.org/dsms/
+- Keeping documentation URLs stable
+- Preserving the meaning of published identifiers over time
+
+Changes to hosting or documentation infrastructure will be handled
+exclusively via updates to redirection targets, without modifying
+the published w3id.org identifiers.
+
+## Contact
+
+Maintained by the DSMS team.
+
+For questions or issues, please open an issue in the DSMS GitHub organization
+or contact the maintainers directly.
+
+- Yoav Nahshon (Fraunhofer IWM) <yoav.nahshon@iwm.fraunhofer.de>
+- Kiran Kumaraswamy (Fraunhofer IWM) <kiran.kumaraswamy@iwm.fraunhofer.de>
+  


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
This pull request registers the dsms namespace under w3id.org to provide persistent HTTP IRIs for vocabularies published through the Data Space Management platform (DSMS). https://materials-data.space/

DSMS is a product platform where users create vocabulary namespaces and define RDF vocabulary terms within those namespaces via a frontend interface. 
Once created:
- Vocabulary terms are published with stable IRIs under https://w3id.org/dsms/
- Human-readable documentation for each term is hosted within the DSMS platform
- RDF serializations are stored in a public GitHub repository for backup and versioning purposes

## Temporary Documentation Domain
The documentation domain used in this PR (kiran.materials-data.space) is temporary and used for testing purposes.

Once the final production domain is established, the redirection target will be updated via a follow-up pull request without changing any published w3id.org identifiers.

## Maintenance Commitment

The DSMS team commits to:
- Maintaining the dsms namespace under w3id.org
- Ensuring long-term stability of published identifiers
- Updating redirection targets as needed while preserving identifier semantics

## Contact
- Yoav Nahshon (Fraunhofer IWM) <yoav.nahshon@iwm.fraunhofer.de>
- Kiran Kumaraswamy (Fraunhofer IWM) <kiran.kumaraswamy@iwm.fraunhofer.de>