### PR TITLE
Fix DSMS redirects using RedirectMatch for term-level URIs

### DIFF
--- a/dsms/.htaccess
+++ b/dsms/.htaccess
@@ -12,30 +12,21 @@
 # - <usecase> is optional and ignored for documentation
 # - Namespace is preserved
 # - Term becomes a fragment identifier
-# ## Contact
-# This space is administered by:
 #
-# Kiran Kumaraswamy
-# kiran.kumaraswamy@iwm.fraunhofer.de
-# GitHub username: Kirankumaraswamy
-#
-# Yoav Nahshon
-# yoav.nahshon@iwm.fraunhofer.de
-# GitHub username: yoavnash
+# Contact:
+#   Kiran Kumaraswamy (Kirankumaraswamy)
+#   Yoav Nahshon (yoavnash)
 # ==================================================
 
-RewriteEngine On
+# --------------------------------------------------
+# Case 1: /<namespace>/<usecase>/<term>
+# (must come FIRST – more specific)
+# --------------------------------------------------
+RedirectMatch 302 ^/dsms/([^/]+)/([^/]+)/([^/]+)/?$ \
+https://kiran.materials-data.space/vocabulary/docs/$1#$3
 
 # --------------------------------------------------
-# Case 1: /<namespace>/<term>
+# Case 2: /<namespace>/<term>
 # --------------------------------------------------
-RewriteRule ^([^/]+)/([^/]+)$ \
-https://kiran.materials-data.space/vocabulary/docs/$1#$2 \
-[R=302,L]
-
-# --------------------------------------------------
-# Case 2: /<namespace>/<usecase>/<term>
-# --------------------------------------------------
-RewriteRule ^([^/]+)/([^/]+)/([^/]+)$ \
-https://kiran.materials-data.space/vocabulary/docs/$1#$3 \
-[R=302,L]
+RedirectMatch 302 ^/dsms/([^/]+)/([^/]+)/?$ \
+https://kiran.materials-data.space/vocabulary/docs/$1#$2

--- a/dsms/README.md
+++ b/dsms/README.md
@@ -47,7 +47,7 @@ Notes:
 
 ---
 
-## Maintenance Commitment
+## RDF Usage
 
 The canonical identifiers for RDF **must use w3id.org URIs**, not the
 documentation URLs.
@@ -63,7 +63,7 @@ dsms:Material a owl:Class ;
   rdfs:seeAlso <https://kiran.materials-data.space/vocabulary/docs/steel#Material> .
 ```
 
-## RDF Usage
+## Maintenance Commitment
 
 The DSMS team commits to:
 


### PR DESCRIPTION
This change fixes term-level redirects under https://w3id.org/dsms/.

Previously, requests such as:
https://w3id.org/dsms/aid4greenest/Gleeble1

returned 404 Not Found, because the existing rewrite rules did not match
reliably on w3id.org.

What changed
Replaced RewriteRule-based redirects with RedirectMatch (mod_alias)
Added explicit handling for both supported URI patterns:
/dsms/namespace/term
/dsms/namespace/usecase/term

Ensured the more specific three-segment pattern is matched first

No changes were made to the published URI structure; this fix only affects
the redirect implementation.