### PR TITLE
Updated emmo/.htaccess to clearly separate the IRIs of ontologies and entities

### DIFF
--- a/emmo/.htaccess
+++ b/emmo/.htaccess
@@ -36,8 +36,9 @@ RewriteRule ^raw/(.*)$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/$
 ##########################################################################
 
 # Rule 7: https://w3id.org/emmo/{VERSION}/hume
+# Note: for now we have only
 RewriteCond %{HTTP_ACCEPT} text/html
-RewriteRule ^([0-9][^/]*)/hume/?$ https://emmo-repo.github.io/versions/$1/emmo.html [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/hume/?$ https://emmo-repo.github.io/versions/$1/hume.html [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/hume/?$ https://emmo-repo.github.io/versions/$1/hume.ttl [R=303,NE,L]
 
 # Rule 9: https://w3id.org/emmo/{VERSION}/hume/{PATH}
@@ -45,7 +46,7 @@ RewriteRule ^([0-9][^/]*)/hume/(.*)/?$ https://emmo-repo.github.io/versions/$1/h
 
 # Rule 10: https://w3id.org/emmo/hume
 RewriteCond %{HTTP_ACCEPT} text/html
-RewriteRule ^hume/?$ https://emmo-repo.github.io/emmo.html [R=303,NE,L]
+RewriteRule ^hume/?$ https://emmo-repo.github.io/hume.html [R=303,NE,L]
 RewriteRule ^hume/?$ https://emmo-repo.github.io/hume.ttl [R=303,NE,L]
 
 # Rule 12: https://w3id.org/emmo/hume/{PATH}
@@ -216,13 +217,14 @@ RewriteRule ^application/(application-)?([^/]+)/([^0-9].*[^/])/?$ https://raw.gi
 ##########################################################################
 
 # Rule 7a: https://w3id.org/emmo/{VERSION}
-# Redirect to version directory on GitHub pages
+# Specific version of EMMO namespace on GitHub pages (html/ttl)
 # If the request appears coming from a browser, redirect to html documentation otherwise to squashed turtle file for given version.
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^([0-9][^/]*)/?$ https://emmo-repo.github.io/versions/$1/emmo.html [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/?$ https://emmo-repo.github.io/versions/$1/emmo.ttl [R=303,NE,L]
 #
 # Rule 7b: https://w3id.org/emmo/{VERSION}/turtle
+# Specific version of EMMO namespace on GitHub Pages (always turtle)
 RewriteRule ^([0-9][^/]*)/turtle/?$ https://emmo-repo.github.io/versions/$1/emmo.ttl [R=303,NE,L]
 #
 # Rule 7c: https://w3id.org/emmo/{VERSION}/full
@@ -231,6 +233,7 @@ RewriteRule ^([0-9][^/]*)/turtle/?$ https://emmo-repo.github.io/versions/$1/emmo
 #          https://w3id.org/emmo/{VERSION}/inferred
 #          https://w3id.org/emmo/{VERSION}/full/inferred
 #          https://w3id.org/emmo/{VERSION}/hume/inferred
+# Specific version of squashed or inferred ontologies on GitHub Pages
 RewriteRule ^([0-9][^/]*)/full/?$ https://emmo-repo.github.io/versions/$1/full.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/hume/?$ https://emmo-repo.github.io/versions/$1/hume.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/emmo-for-humans/?$ https://emmo-repo.github.io/versions/$1/hume.ttl [R=303,NE,L]
@@ -239,6 +242,7 @@ RewriteRule ^([0-9][^/]*)/full/inferred/?$ https://emmo-repo.github.io/versions/
 RewriteRule ^([0-9][^/]*)/hume/inferred/?$ https://emmo-repo.github.io/versions/$1/hume-inferred.ttl [R=303,NE,L]
 #
 # Rule 7d: https://w3id.org/emmo/{VERSION}/hume/hume
+# Specific version of generated HUME ontology on GitHub Pages
 RewriteRule ^([0-9][^/]*)/hume/hume/?$ https://emmo-repo.github.io/versions/$1/hume/hume.ttl [R=303,NE,L]
 
 # Rule 8: https://w3id.org/emmo/{VERSION}/emmo
@@ -252,7 +256,7 @@ RewriteRule ^([0-9][^/]*)/hume/hume/?$ https://emmo-repo.github.io/versions/$1/h
 #         https://w3id.org/emmo/{VERSION}/reference
 #         https://w3id.org/emmo/{VERSION}/disciplines
 #         https://w3id.org/emmo/{VERSION}/disciplines/units
-# Redirect to specified version branch
+# Specific version of ontologies/subontologies. Redirect to version branch in main repo
 RewriteRule ^([0-9][^/]*)/emmo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/emmo.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/source/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/emmo.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/full/full/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/full.ttl [R=303,NE,L]
@@ -265,21 +269,20 @@ RewriteRule ^([0-9][^/]*)/reference/?$ https://raw.githubusercontent.com/emmo-re
 RewriteRule ^([0-9][^/]*)/disciplines/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/disciplines/disciplines.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/disciplines/units/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/disciplines/units/units.ttl [R=303,NE,L]
 
-
 # Rule 9: https://w3id.org/emmo/{VERSION}/{PATH}/{MODULE}
 # Redirect to specified version branch
 # Turtle file for given version and module of EMMO
 RewriteRule ^([0-9][^/]*)/([^0-9].*[^/])/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/$2.ttl [R=303,NE,L]
 
-
 # Rule 10a: https://w3id.org/emmo
-# Redirect to GitHub Pages
+# EMMO namespace on GitHub Pages (html/ttl)
 # If the request appears coming from a browser, redirect to html documentation otherwise to squashed turtle file.
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^/?$ https://emmo-repo.github.io/emmo.html [R=303,NE,L]
 RewriteRule ^/?$ https://emmo-repo.github.io/emmo.ttl [R=303,NE,L]
 #
 # Rule 10b: https://w3id.org/emmo/turtle
+# EMMO namespace on GitHub Pages (always turtle)
 RewriteRule ^turtle/?$ https://emmo-repo.github.io/emmo.ttl [R=303,NE,L]
 #
 # Rule 10c: https://w3id.org/emmo/full
@@ -288,6 +291,7 @@ RewriteRule ^turtle/?$ https://emmo-repo.github.io/emmo.ttl [R=303,NE,L]
 #           https://w3id.org/emmo/inferred
 #           https://w3id.org/emmo/full/inferred
 #           https://w3id.org/emmo/hume/inferred
+# Squashed or inferred ontologies on GitHub Pages
 RewriteRule ^full/?$ https://emmo-repo.github.io/full.ttl [R=303,NE,L]
 RewriteRule ^hume/?$ https://emmo-repo.github.io/hume.ttl [R=303,NE,L]
 RewriteRule ^emmo-for-humans/?$ https://emmo-repo.github.io/hume.ttl [R=303,NE,L]
@@ -296,6 +300,7 @@ RewriteRule ^full/inferred/?$ https://emmo-repo.github.io/full-inferred.ttl [R=3
 RewriteRule ^hume/inferred/?$ https://emmo-repo.github.io/hume-inferred.ttl [R=303,NE,L]
 #
 # Rule 10d: https://w3id.org/emmo/hume/hume
+# Generated HUME ontology on GitHub Pages
 RewriteRule ^hume/hume/?$ https://emmo-repo.github.io/hume/hume.ttl [R=303,NE,L]
 
 # Rule 11: https://w3id.org/emmo/emmo

--- a/emmo/.htaccess
+++ b/emmo/.htaccess
@@ -32,28 +32,6 @@ RewriteRule ^raw/(.*)$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/$
 
 
 ##########################################################################
-##  Redirections for HUME
-##########################################################################
-
-# Rule 7: https://w3id.org/emmo/{VERSION}/hume
-RewriteCond %{HTTP_ACCEPT} text/html
-RewriteRule ^([0-9][^/]*)/hume/?$ https://emmo-repo.github.io/versions/$1/hume.html [R=303,NE,L]
-RewriteRule ^([0-9][^/]*)/hume/?$ https://emmo-repo.github.io/versions/$1/hume.ttl [R=303,NE,L]
-
-# Rule 9: https://w3id.org/emmo/{VERSION}/hume/{PATH}
-RewriteRule ^([0-9][^/]*)/hume/(.*)/?$ https://emmo-repo.github.io/versions/$1/hume/$2.ttl [R=303,NE,L]
-
-# Rule 10: https://w3id.org/emmo/hume
-RewriteCond %{HTTP_ACCEPT} text/html
-RewriteRule ^hume/?$ https://emmo-repo.github.io/hume.html [R=303,NE,L]
-RewriteRule ^hume/?$ https://emmo-repo.github.io/hume.ttl [R=303,NE,L]
-
-# Rule 12: https://w3id.org/emmo/hume/{PATH}
-RewriteRule ^hume/([^0-9].*)/?$ https://emmo-repo.github.io/hume/$1.ttl [R=303,NE,L]
-
-
-
-##########################################################################
 ##  Redirections for ELITE
 ##########################################################################
 
@@ -216,33 +194,49 @@ RewriteRule ^application/(application-)?([^/]+)/([^0-9].*[^/])/?$ https://raw.gi
 ##########################################################################
 
 # Rule 7a: https://w3id.org/emmo/{VERSION}
+#          https://w3id.org/emmo/{VERSION}/hume
 # Specific version of EMMO namespace on GitHub pages (html/ttl)
 # If the request appears coming from a browser, redirect to html documentation otherwise to squashed turtle file for given version.
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^([0-9][^/]*)/?$ https://emmo-repo.github.io/versions/$1/emmo.html [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/?$ https://emmo-repo.github.io/versions/$1/emmo.ttl [R=303,NE,L]
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^([0-9][^/]*)/hume/?$ https://emmo-repo.github.io/versions/$1/hume.html [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/hume/?$ https://emmo-repo.github.io/versions/$1/hume.ttl [R=303,NE,L]
 #
 # Rule 7b: https://w3id.org/emmo/{VERSION}/turtle
+#          https://w3id.org/emmo/{VERSION}/hume/turtle
 # Specific version of EMMO namespace on GitHub Pages (always turtle)
 RewriteRule ^([0-9][^/]*)/turtle/?$ https://emmo-repo.github.io/versions/$1/emmo.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/hume/turtle/?$ https://emmo-repo.github.io/versions/$1/hume.ttl [R=303,NE,L]
 #
 # Rule 7c: https://w3id.org/emmo/{VERSION}/full (deprecated)
-#          https://w3id.org/emmo/{VERSION}/hume
 #          https://w3id.org/emmo/{VERSION}/emmo-for-humans (deprecated)
 #          https://w3id.org/emmo/{VERSION}/inferred
 #          https://w3id.org/emmo/{VERSION}/full/inferred (deprecated)
 #          https://w3id.org/emmo/{VERSION}/hume/inferred
 # Specific version of squashed or inferred ontologies on GitHub Pages
 RewriteRule ^([0-9][^/]*)/full/?$ https://emmo-repo.github.io/versions/$1/full.ttl [R=303,NE,L]
-RewriteRule ^([0-9][^/]*)/hume/?$ https://emmo-repo.github.io/versions/$1/hume.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/emmo-for-humans/?$ https://emmo-repo.github.io/versions/$1/hume.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/inferred/?$ https://emmo-repo.github.io/versions/$1/emmo-inferred.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/full/inferred/?$ https://emmo-repo.github.io/versions/$1/full-inferred.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/hume/inferred/?$ https://emmo-repo.github.io/versions/$1/hume-inferred.ttl [R=303,NE,L]
 #
 # Rule 7d: https://w3id.org/emmo/{VERSION}/hume/hume
+#          https://w3id.org/emmo/{VERSION}/hume/foundation
+#          https://w3id.org/emmo/{VERSION}/hume/perspectives
+#          https://w3id.org/emmo/{VERSION}/hume/reference
+#          https://w3id.org/emmo/{VERSION}/hume/disciplines
+#          https://w3id.org/emmo/{VERSION}/hume/disciplines/units
+#          https://w3id.org/emmo/{VERSION}/hume/{PATH}/{MODULE}
 # Specific version of generated HUME ontology on GitHub Pages
 RewriteRule ^([0-9][^/]*)/hume/hume/?$ https://emmo-repo.github.io/versions/$1/hume/hume.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/hume/foundation/?$ https://emmo-repo.github.io/versions/$1/hume/foundation/foundation.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/hume/perspectives/?$ https://emmo-repo.github.io/versions/$1/hume/perspectives/perspectives.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/hume/reference/?$ https://emmo-repo.github.io/versions/$1/hume/reference/reference.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/hume/disciplines/?$ https://emmo-repo.github.io/versions/$1/hume/disciplines/disciplines.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/hume/disciplines/units/?$ https://emmo-repo.github.io/versions/$1/hume/disciplines/units/units.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/hume/(.*[^/])/?$ https://emmo-repo.github.io/versions/$1/hume/$2.ttl [R=303,NE,L]
 
 # Rule 8: https://w3id.org/emmo/{VERSION}/emmo
 #         https://w3id.org/emmo/{VERSION}/source (deprecated)
@@ -252,7 +246,7 @@ RewriteRule ^([0-9][^/]*)/hume/hume/?$ https://emmo-repo.github.io/versions/$1/h
 #         https://w3id.org/emmo/{VERSION}/foundation
 #         https://w3id.org/emmo/{VERSION}/mereocausality (deprecated)
 #         https://w3id.org/emmo/{VERSION}/perspectives
-#         https://w3id.org/emmo/{VERSION}/multiperspective
+#         https://w3id.org/emmo/{VERSION}/multiperspective (deprecated)
 #         https://w3id.org/emmo/{VERSION}/reference
 #         https://w3id.org/emmo/{VERSION}/disciplines
 #         https://w3id.org/emmo/{VERSION}/disciplines/units
@@ -262,7 +256,7 @@ RewriteRule ^([0-9][^/]*)/source/?$ https://raw.githubusercontent.com/emmo-repo/
 RewriteRule ^([0-9][^/]*)/emax/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/emax.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/tlo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/tlo.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/mlo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/mlo.ttl [R=303,NE,L]
-RewriteRule ^([0-9][^/]*)/foundation/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/foundation/mereocausality.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/foundation/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/foundation/foundation.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/mereocausality/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/mereocausality/mereocausality.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/perspectives/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/perspectives/perspectives.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/multiperspective/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/multiperspective/multiperspective.ttl [R=303,NE,L]
@@ -273,36 +267,52 @@ RewriteRule ^([0-9][^/]*)/disciplines/units/?$ https://raw.githubusercontent.com
 # Rule 9: https://w3id.org/emmo/{VERSION}/{PATH}/{MODULE}
 # Redirect to specified version branch
 # Turtle file for given version and module of EMMO
-RewriteRule ^([0-9][^/]*)/([^0-9].*[^/])/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/$2.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/(.*[^/])/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/$2.ttl [R=303,NE,L]
 
 # Rule 10a: https://w3id.org/emmo
+#           https://w3id.org/emmo/hume
 # EMMO namespace on GitHub Pages (html/ttl)
 # If the request appears coming from a browser, redirect to html documentation otherwise to squashed turtle file.
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^/?$ https://emmo-repo.github.io/emmo.html [R=303,NE,L]
 RewriteRule ^/?$ https://emmo-repo.github.io/emmo.ttl [R=303,NE,L]
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^hume/?$ https://emmo-repo.github.io/hume.html [R=303,NE,L]
+RewriteRule ^hume/?$ https://emmo-repo.github.io/hume.ttl [R=303,NE,L]
 #
 # Rule 10b: https://w3id.org/emmo/turtle
+#           https://w3id.org/emmo/hume/turtle
 # EMMO namespace on GitHub Pages (always turtle)
 RewriteRule ^turtle/?$ https://emmo-repo.github.io/emmo.ttl [R=303,NE,L]
+RewriteRule ^hume/turtle/?$ https://emmo-repo.github.io/hume.ttl [R=303,NE,L]
 #
 # Rule 10c: https://w3id.org/emmo/full (deprecated)
-#           https://w3id.org/emmo/hume
 #           https://w3id.org/emmo/emmo-for-humans (deprecated)
 #           https://w3id.org/emmo/inferred
 #           https://w3id.org/emmo/full/inferred (deprecated)
 #           https://w3id.org/emmo/hume/inferred
 # Squashed or inferred ontologies on GitHub Pages
 RewriteRule ^full/?$ https://emmo-repo.github.io/full.ttl [R=303,NE,L]
-RewriteRule ^hume/?$ https://emmo-repo.github.io/hume.ttl [R=303,NE,L]
 RewriteRule ^emmo-for-humans/?$ https://emmo-repo.github.io/hume.ttl [R=303,NE,L]
 RewriteRule ^inferred/?$ https://emmo-repo.github.io/emmo-inferred.ttl [R=303,NE,L]
 RewriteRule ^full/inferred/?$ https://emmo-repo.github.io/full-inferred.ttl [R=303,NE,L]
 RewriteRule ^hume/inferred/?$ https://emmo-repo.github.io/hume-inferred.ttl [R=303,NE,L]
 #
 # Rule 10d: https://w3id.org/emmo/hume/hume
+#           https://w3id.org/emmo/hume/foundation
+#           https://w3id.org/emmo/hume/perspectives
+#           https://w3id.org/emmo/hume/reference
+#           https://w3id.org/emmo/hume/disciplines
+#           https://w3id.org/emmo/hume/disciplines/units
+#           https://w3id.org/emmo/hume/{PATH}/{MODULE}
 # Generated HUME ontology on GitHub Pages
 RewriteRule ^hume/hume/?$ https://emmo-repo.github.io/hume/hume.ttl [R=303,NE,L]
+RewriteRule ^hume/foundation/?$ https://emmo-repo.github.io/hume/foundation/foundation.ttl [R=303,NE,L]
+RewriteRule ^hume/perspectives/?$ https://emmo-repo.github.io/hume/perspectives/perspectives.ttl [R=303,NE,L]
+RewriteRule ^hume/reference/?$ https://emmo-repo.github.io/hume/reference/reference.ttl [R=303,NE,L]
+RewriteRule ^hume/disciplines/?$ https://emmo-repo.github.io/hume/disciplines/disciplines.ttl [R=303,NE,L]
+RewriteRule ^hume/disciplines/units/?$ https://emmo-repo.github.io/hume/disciplines/units/units.ttl [R=303,NE,L]
+RewriteRule ^hume/(.*[^/])/?$ https://emmo-repo.github.io/hume/$1.ttl [R=303,NE,L]
 
 # Rule 11: https://w3id.org/emmo/emmo
 #          https://w3id.org/emmo/source (deprecated)
@@ -313,7 +323,7 @@ RewriteRule ^hume/hume/?$ https://emmo-repo.github.io/hume/hume.ttl [R=303,NE,L]
 #          https://w3id.org/emmo/foundation
 #          https://w3id.org/emmo/mereocausality (deprecated)
 #          https://w3id.org/emmo/perspectives
-#          https://w3id.org/emmo/multiperspective
+#          https://w3id.org/emmo/multiperspective (deprecated)
 #          https://w3id.org/emmo/reference
 #          https://w3id.org/emmo/disciplines
 #          https://w3id.org/emmo/disciplines/units
@@ -324,7 +334,7 @@ RewriteRule ^latest/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/e
 RewriteRule ^emax/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/emax.ttl [R=303,NE,L]
 RewriteRule ^tlo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/tlo.ttl [R=303,NE,L]
 RewriteRule ^mlo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/mlo.ttl [R=303,NE,L]
-RewriteRule ^foundation/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/foundation/mereocausality.ttl [R=303,NE,L]
+RewriteRule ^foundation/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/foundation/foundation.ttl [R=303,NE,L]
 RewriteRule ^mereocausality/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/mereocausality/mereocausality.ttl [R=303,NE,L]
 RewriteRule ^perspectives/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/perspectives/perspectives.ttl [R=303,NE,L]
 RewriteRule ^multiperspective/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/multiperspective/multiperspective.ttl [R=303,NE,L]
@@ -332,7 +342,8 @@ RewriteRule ^reference/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/maste
 RewriteRule ^disciplines/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/disciplines/disciplines.ttl [R=303,NE,L]
 RewriteRule ^disciplines/units/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/disciplines/units/units.ttl [R=303,NE,L]
 
+
 # Rule 12: https://w3id.org/emmo/{PATH}/{MODULE}
 # Redirect to specified version branch
 # Turtle file for given module of EMMO
-RewriteRule ^([^0-9].*[^/])/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/$1.ttl [R=303,NE,L]
+RewriteRule ^(.*[^/])/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/$1.ttl [R=303,NE,L]

--- a/emmo/.htaccess
+++ b/emmo/.htaccess
@@ -36,7 +36,6 @@ RewriteRule ^raw/(.*)$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/$
 ##########################################################################
 
 # Rule 7: https://w3id.org/emmo/{VERSION}/hume
-# Note: for now we have only
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^([0-9][^/]*)/hume/?$ https://emmo-repo.github.io/versions/$1/hume.html [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/hume/?$ https://emmo-repo.github.io/versions/$1/hume.ttl [R=303,NE,L]

--- a/emmo/.htaccess
+++ b/emmo/.htaccess
@@ -312,7 +312,7 @@ RewriteRule ^hume/perspectives/?$ https://emmo-repo.github.io/hume/perspectives/
 RewriteRule ^hume/reference/?$ https://emmo-repo.github.io/hume/reference/reference.ttl [R=303,NE,L]
 RewriteRule ^hume/disciplines/?$ https://emmo-repo.github.io/hume/disciplines/disciplines.ttl [R=303,NE,L]
 RewriteRule ^hume/disciplines/units/?$ https://emmo-repo.github.io/hume/disciplines/units/units.ttl [R=303,NE,L]
-RewriteRule ^hume/(.*[^/])/?$ https://emmo-repo.github.io/hume/$1.ttl [R=303,NE,L]
+RewriteRule ^hume/([^0-9].*[^/])/?$ https://emmo-repo.github.io/hume/$1.ttl [R=303,NE,L]
 
 # Rule 11: https://w3id.org/emmo/emmo
 #          https://w3id.org/emmo/source (deprecated)
@@ -346,4 +346,4 @@ RewriteRule ^disciplines/units/?$ https://raw.githubusercontent.com/emmo-repo/EM
 # Rule 12: https://w3id.org/emmo/{PATH}/{MODULE}
 # Redirect to specified version branch
 # Turtle file for given module of EMMO
-RewriteRule ^(.*[^/])/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/$1.ttl [R=303,NE,L]
+RewriteRule ^([^0-9].*[^/])/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/$1.ttl [R=303,NE,L]

--- a/emmo/.htaccess
+++ b/emmo/.htaccess
@@ -37,7 +37,7 @@ RewriteRule ^raw/(.*)$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/$
 
 # Rule 7: https://w3id.org/emmo/{VERSION}/hume
 RewriteCond %{HTTP_ACCEPT} text/html
-RewriteRule ^([0-9][^/]*)/hume/?$ https://emmo-repo.github.io/versions/$1/hume.html [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/hume/?$ https://emmo-repo.github.io/versions/$1/emmo.html [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/hume/?$ https://emmo-repo.github.io/versions/$1/hume.ttl [R=303,NE,L]
 
 # Rule 9: https://w3id.org/emmo/{VERSION}/hume/{PATH}
@@ -45,7 +45,7 @@ RewriteRule ^([0-9][^/]*)/hume/(.*)/?$ https://emmo-repo.github.io/versions/$1/h
 
 # Rule 10: https://w3id.org/emmo/hume
 RewriteCond %{HTTP_ACCEPT} text/html
-RewriteRule ^hume/?$ https://emmo-repo.github.io/hume.html [R=303,NE,L]
+RewriteRule ^hume/?$ https://emmo-repo.github.io/emmo.html [R=303,NE,L]
 RewriteRule ^hume/?$ https://emmo-repo.github.io/hume.ttl [R=303,NE,L]
 
 # Rule 12: https://w3id.org/emmo/hume/{PATH}
@@ -216,47 +216,48 @@ RewriteRule ^application/(application-)?([^/]+)/([^0-9].*[^/])/?$ https://raw.gi
 ##########################################################################
 
 # Rule 7a: https://w3id.org/emmo/{VERSION}
-# Alias:   https://w3id.org/emmo/{VERSION}/
-# Redirect to specified version branch
+# Redirect to version directory on GitHub pages
 # If the request appears coming from a browser, redirect to html documentation otherwise to squashed turtle file for given version.
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^([0-9][^/]*)/?$ https://emmo-repo.github.io/versions/$1/emmo.html [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/?$ https://emmo-repo.github.io/versions/$1/emmo.ttl [R=303,NE,L]
 #
-# Rule 7b: https://w3id.org/emmo/{VERSION}/emmo-full
-#          https://w3id.org/emmo/{VERSION}/emmo-for-humans
-# Redirect to GitHub Pages
-RewriteRule ^([0-9][^/]*)/emmo-([^/]*)/?$ https://emmo-repo.github.io/versions/$1/emmo-$2.ttl [R=303,NE,L]
-#
-# Rule 7c: https://w3id.org/emmo/{VERSION}/inferred
-#          https://w3id.org/emmo/{VERSION}/emmo-full/inferred
-#          https://w3id.org/emmo/{VERSION}/emmo-for-humans/inferred
-# Redirect to GitHub Pages
-RewriteRule ^([0-9][^/]*)/inferred/?$ https://emmo-repo.github.io/versions/$1/emmo-inferred.ttl [R=303,NE,L]
-RewriteRule ^([0-9][^/]*)/emmo-([^/]*)/inferred/?$ https://emmo-repo.github.io/versions/$1/emmo-$2-inferred.ttl [R=303,NE,L]
-#
-# Rule 7d: https://w3id.org/emmo/{VERSION}/turtle
-# Redirect to GitHub Pages
+# Rule 7b: https://w3id.org/emmo/{VERSION}/turtle
 RewriteRule ^([0-9][^/]*)/turtle/?$ https://emmo-repo.github.io/versions/$1/emmo.ttl [R=303,NE,L]
-
-
-# Rule 8a: https://w3id.org/emmo/{VERSION}/source
-# Redirect to specified version branch
-# emmo.ttl file in the root of branch for the given version
-RewriteRule ^([0-9][^/]*)/$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/emmo.ttl [R=303,NE,L]
-RewriteRule ^([0-9][^/]*)/source/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/emmo.ttl [R=303,NE,L]
 #
-# Rule 8b: https://w3id.org/emmo/{VERSION}/tlo
-# Rule 8c: https://w3id.org/emmo/{VERSION}/mlo
-# Rule 8d: https://w3id.org/emmo/{VERSION}/mereocausality
-# Rule 8e: https://w3id.org/emmo/{VERSION}/perspectives
-# Rule 8f: https://w3id.org/emmo/{VERSION}/multiperspective
-# Rule 8g: https://w3id.org/emmo/{VERSION}/reference
-# Rule 8h: https://w3id.org/emmo/{VERSION}/disciplines
-# Rule 8i: https://w3id.org/emmo/{VERSION}/disciplines/units
+# Rule 7c: https://w3id.org/emmo/{VERSION}/full
+#          https://w3id.org/emmo/{VERSION}/hume
+#          https://w3id.org/emmo/{VERSION}/emmo-for-humans (deprecated)
+#          https://w3id.org/emmo/{VERSION}/inferred
+#          https://w3id.org/emmo/{VERSION}/full/inferred
+#          https://w3id.org/emmo/{VERSION}/hume/inferred
+RewriteRule ^([0-9][^/]*)/full/?$ https://emmo-repo.github.io/versions/$1/full.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/hume/?$ https://emmo-repo.github.io/versions/$1/hume.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/emmo-for-humans/?$ https://emmo-repo.github.io/versions/$1/hume.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/inferred/?$ https://emmo-repo.github.io/versions/$1/emmo-inferred.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/full/inferred/?$ https://emmo-repo.github.io/versions/$1/full-inferred.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/hume/inferred/?$ https://emmo-repo.github.io/versions/$1/hume-inferred.ttl [R=303,NE,L]
+#
+# Rule 7d: https://w3id.org/emmo/{VERSION}/hume/hume
+RewriteRule ^([0-9][^/]*)/hume/hume/?$ https://emmo-repo.github.io/versions/$1/hume/hume.ttl [R=303,NE,L]
+
+# Rule 8: https://w3id.org/emmo/{VERSION}/emmo
+#         https://w3id.org/emmo/{VERSION}/source (deprecated)
+#         https://w3id.org/emmo/{VERSION}/full/full
+#         https://w3id.org/emmo/{VERSION}/tlo
+#         https://w3id.org/emmo/{VERSION}/mlo
+#         https://w3id.org/emmo/{VERSION}/mereocausality
+#         https://w3id.org/emmo/{VERSION}/perspectives
+#         https://w3id.org/emmo/{VERSION}/multiperspective
+#         https://w3id.org/emmo/{VERSION}/reference
+#         https://w3id.org/emmo/{VERSION}/disciplines
+#         https://w3id.org/emmo/{VERSION}/disciplines/units
 # Redirect to specified version branch
-RewriteRule ^([0-9][^/]*)/tlo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/emmo-tlo.ttl [R=303,NE,L]
-RewriteRule ^([0-9][^/]*)/mlo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/emmo-mlo.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/emmo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/emmo.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/source/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/emmo.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/full/full/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/full.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/tlo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/tlo.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/mlo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/mlo.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/mereocausality/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/mereocausality/mereocausality.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/perspectives/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/perspectives/perspectives.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/multiperspective/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/multiperspective/multiperspective.ttl [R=303,NE,L]
@@ -272,57 +273,56 @@ RewriteRule ^([0-9][^/]*)/([^0-9].*[^/])/?$ https://raw.githubusercontent.com/em
 
 
 # Rule 10a: https://w3id.org/emmo
-# Alias:   https://w3id.org/emmo/
 # Redirect to GitHub Pages
 # If the request appears coming from a browser, redirect to html documentation otherwise to squashed turtle file.
 RewriteCond %{HTTP_ACCEPT} text/html
-RewriteRule ^$ https://emmo-repo.github.io/emmo.html [R=303,NE,L]
-RewriteRule ^$ https://emmo-repo.github.io/emmo.ttl [R=303,NE,L]
+RewriteRule ^/?$ https://emmo-repo.github.io/emmo.html [R=303,NE,L]
+RewriteRule ^/?$ https://emmo-repo.github.io/emmo.ttl [R=303,NE,L]
 #
-# Rule 10b: https://w3id.org/emmo/emmo-full
-#           https://w3id.org/emmo/emmo-for-humans
-# Redirect to GitHub Pages
-RewriteRule ^emmo-([^/]*)/?$ https://emmo-repo.github.io/emmo-$1.ttl [R=303,NE,L]
-#
-# Rule 10c: https://w3id.org/emmo/inferred
-#           https://w3id.org/emmo/emmo-full/inferred
-#           https://w3id.org/emmo/emmo-for-humans/inferred
-# Redirect to GitHub Pages
-# Inferred ontology (only turtle) on GitHub Pages
-RewriteRule ^inferred/?$ https://emmo-repo.github.io/emmo-inferred.ttl [R=303,NE,L]
-RewriteRule ^emmo-([^/]*)/inferred/?$ https://emmo-repo.github.io/emmo-$1-inferred.ttl [R=303,NE,L]
-#
-# Rule 10d: https://w3id.org/emmo/turtle
-# Redirect to GitHub Pages
-# Squashed ontology on GitHub Pages
+# Rule 10b: https://w3id.org/emmo/turtle
 RewriteRule ^turtle/?$ https://emmo-repo.github.io/emmo.ttl [R=303,NE,L]
-
-
-# Rule 11a: https://w3id.org/emmo/source
-# Alias:   https://w3id.org/emmo/latest
-# Redirect to master branch
-RewriteRule ^/$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/emmo.ttl [R=303,NE,L]
-RewriteRule ^latest/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/emmo.ttl [R=303,NE,L]
-RewriteRule ^source/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/emmo.ttl [R=303,NE,L]
 #
-# Rule 11b: https://w3id.org/emmo/tlo
-# Rule 11c: https://w3id.org/emmo/mlo
-# Rule 11d: https://w3id.org/emmo/mereocausality
-# Rule 11e: https://w3id.org/emmo/perspectives
-# Rule 11f: https://w3id.org/emmo/multiperspective
-# Rule 11g: https://w3id.org/emmo/reference
-# Rule 11h: https://w3id.org/emmo/disciplines
-# Rule 11i: https://w3id.org/emmo/disciplines/units
-# Redirect to master branch
-RewriteRule ^tlo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/emmo-tlo.ttl [R=303,NE,L]
-RewriteRule ^mlo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/emmo-mlo.ttl [R=303,NE,L]
+# Rule 10c: https://w3id.org/emmo/full
+#           https://w3id.org/emmo/hume
+#           https://w3id.org/emmo/emmo-for-humans (deprecated)
+#           https://w3id.org/emmo/inferred
+#           https://w3id.org/emmo/full/inferred
+#           https://w3id.org/emmo/hume/inferred
+RewriteRule ^full/?$ https://emmo-repo.github.io/full.ttl [R=303,NE,L]
+RewriteRule ^hume/?$ https://emmo-repo.github.io/hume.ttl [R=303,NE,L]
+RewriteRule ^emmo-for-humans/?$ https://emmo-repo.github.io/hume.ttl [R=303,NE,L]
+RewriteRule ^inferred/?$ https://emmo-repo.github.io/emmo-inferred.ttl [R=303,NE,L]
+RewriteRule ^full/inferred/?$ https://emmo-repo.github.io/full-inferred.ttl [R=303,NE,L]
+RewriteRule ^hume/inferred/?$ https://emmo-repo.github.io/hume-inferred.ttl [R=303,NE,L]
+#
+# Rule 10d: https://w3id.org/emmo/hume/hume
+RewriteRule ^hume/hume/?$ https://emmo-repo.github.io/hume/hume.ttl [R=303,NE,L]
+
+# Rule 11: https://w3id.org/emmo/emmo
+#          https://w3id.org/emmo/source (deprecated)
+#          https://w3id.org/emmo/latest (deprecated)
+#          https://w3id.org/emmo/full/full
+#          https://w3id.org/emmo/tlo
+#          https://w3id.org/emmo/mlo
+#          https://w3id.org/emmo/mereocausality
+#          https://w3id.org/emmo/perspectives
+#          https://w3id.org/emmo/multiperspective
+#          https://w3id.org/emmo/reference
+#          https://w3id.org/emmo/disciplines
+#          https://w3id.org/emmo/disciplines/units
+# Redirect to specified version branch
+RewriteRule ^emmo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/emmo.ttl [R=303,NE,L]
+RewriteRule ^source/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/emmo.ttl [R=303,NE,L]
+RewriteRule ^latest/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/emmo.ttl [R=303,NE,L]
+RewriteRule ^full/full/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/full.ttl [R=303,NE,L]
+RewriteRule ^tlo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/tlo.ttl [R=303,NE,L]
+RewriteRule ^mlo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/mlo.ttl [R=303,NE,L]
 RewriteRule ^mereocausality/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/mereocausality/mereocausality.ttl [R=303,NE,L]
 RewriteRule ^perspectives/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/perspectives/perspectives.ttl [R=303,NE,L]
 RewriteRule ^multiperspective/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/multiperspective/multiperspective.ttl [R=303,NE,L]
 RewriteRule ^reference/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/reference/reference.ttl [R=303,NE,L]
 RewriteRule ^disciplines/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/disciplines/disciplines.ttl [R=303,NE,L]
 RewriteRule ^disciplines/units/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/disciplines/units/units.ttl [R=303,NE,L]
-
 
 # Rule 12: https://w3id.org/emmo/{PATH}/{MODULE}
 # Redirect to specified version branch

--- a/emmo/.htaccess
+++ b/emmo/.htaccess
@@ -225,11 +225,11 @@ RewriteRule ^([0-9][^/]*)/?$ https://emmo-repo.github.io/versions/$1/emmo.ttl [R
 # Rule 7b: https://w3id.org/emmo/{VERSION}/turtle
 RewriteRule ^([0-9][^/]*)/turtle/?$ https://emmo-repo.github.io/versions/$1/emmo.ttl [R=303,NE,L]
 #
-# Rule 7c: https://w3id.org/emmo/{VERSION}/full
+# Rule 7c: https://w3id.org/emmo/{VERSION}/full (deprecated)
 #          https://w3id.org/emmo/{VERSION}/hume
 #          https://w3id.org/emmo/{VERSION}/emmo-for-humans (deprecated)
 #          https://w3id.org/emmo/{VERSION}/inferred
-#          https://w3id.org/emmo/{VERSION}/full/inferred
+#          https://w3id.org/emmo/{VERSION}/full/inferred (deprecated)
 #          https://w3id.org/emmo/{VERSION}/hume/inferred
 RewriteRule ^([0-9][^/]*)/full/?$ https://emmo-repo.github.io/versions/$1/full.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/hume/?$ https://emmo-repo.github.io/versions/$1/hume.ttl [R=303,NE,L]
@@ -243,10 +243,11 @@ RewriteRule ^([0-9][^/]*)/hume/hume/?$ https://emmo-repo.github.io/versions/$1/h
 
 # Rule 8: https://w3id.org/emmo/{VERSION}/emmo
 #         https://w3id.org/emmo/{VERSION}/source (deprecated)
-#         https://w3id.org/emmo/{VERSION}/full/full
+#         https://w3id.org/emmo/{VERSION}/emax
 #         https://w3id.org/emmo/{VERSION}/tlo
 #         https://w3id.org/emmo/{VERSION}/mlo
-#         https://w3id.org/emmo/{VERSION}/mereocausality
+#         https://w3id.org/emmo/{VERSION}/foundation
+#         https://w3id.org/emmo/{VERSION}/mereocausality (deprecated)
 #         https://w3id.org/emmo/{VERSION}/perspectives
 #         https://w3id.org/emmo/{VERSION}/multiperspective
 #         https://w3id.org/emmo/{VERSION}/reference
@@ -255,9 +256,10 @@ RewriteRule ^([0-9][^/]*)/hume/hume/?$ https://emmo-repo.github.io/versions/$1/h
 # Redirect to specified version branch
 RewriteRule ^([0-9][^/]*)/emmo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/emmo.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/source/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/emmo.ttl [R=303,NE,L]
-RewriteRule ^([0-9][^/]*)/full/full/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/full.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/emax/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/emax.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/tlo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/tlo.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/mlo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/mlo.ttl [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/foundation/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/foundation/mereocausality.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/mereocausality/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/mereocausality/mereocausality.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/perspectives/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/perspectives/perspectives.ttl [R=303,NE,L]
 RewriteRule ^([0-9][^/]*)/multiperspective/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/$1/multiperspective/multiperspective.ttl [R=303,NE,L]
@@ -282,11 +284,11 @@ RewriteRule ^/?$ https://emmo-repo.github.io/emmo.ttl [R=303,NE,L]
 # Rule 10b: https://w3id.org/emmo/turtle
 RewriteRule ^turtle/?$ https://emmo-repo.github.io/emmo.ttl [R=303,NE,L]
 #
-# Rule 10c: https://w3id.org/emmo/full
+# Rule 10c: https://w3id.org/emmo/full (deprecated)
 #           https://w3id.org/emmo/hume
 #           https://w3id.org/emmo/emmo-for-humans (deprecated)
 #           https://w3id.org/emmo/inferred
-#           https://w3id.org/emmo/full/inferred
+#           https://w3id.org/emmo/full/inferred (deprecated)
 #           https://w3id.org/emmo/hume/inferred
 RewriteRule ^full/?$ https://emmo-repo.github.io/full.ttl [R=303,NE,L]
 RewriteRule ^hume/?$ https://emmo-repo.github.io/hume.ttl [R=303,NE,L]
@@ -301,10 +303,11 @@ RewriteRule ^hume/hume/?$ https://emmo-repo.github.io/hume/hume.ttl [R=303,NE,L]
 # Rule 11: https://w3id.org/emmo/emmo
 #          https://w3id.org/emmo/source (deprecated)
 #          https://w3id.org/emmo/latest (deprecated)
-#          https://w3id.org/emmo/full/full
+#          https://w3id.org/emmo/emax
 #          https://w3id.org/emmo/tlo
 #          https://w3id.org/emmo/mlo
-#          https://w3id.org/emmo/mereocausality
+#          https://w3id.org/emmo/foundation
+#          https://w3id.org/emmo/mereocausality (deprecated)
 #          https://w3id.org/emmo/perspectives
 #          https://w3id.org/emmo/multiperspective
 #          https://w3id.org/emmo/reference
@@ -314,9 +317,10 @@ RewriteRule ^hume/hume/?$ https://emmo-repo.github.io/hume/hume.ttl [R=303,NE,L]
 RewriteRule ^emmo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/emmo.ttl [R=303,NE,L]
 RewriteRule ^source/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/emmo.ttl [R=303,NE,L]
 RewriteRule ^latest/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/emmo.ttl [R=303,NE,L]
-RewriteRule ^full/full/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/full.ttl [R=303,NE,L]
+RewriteRule ^emax/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/emax.ttl [R=303,NE,L]
 RewriteRule ^tlo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/tlo.ttl [R=303,NE,L]
 RewriteRule ^mlo/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/mlo.ttl [R=303,NE,L]
+RewriteRule ^foundation/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/foundation/mereocausality.ttl [R=303,NE,L]
 RewriteRule ^mereocausality/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/mereocausality/mereocausality.ttl [R=303,NE,L]
 RewriteRule ^perspectives/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/perspectives/perspectives.ttl [R=303,NE,L]
 RewriteRule ^multiperspective/?$ https://raw.githubusercontent.com/emmo-repo/EMMO/master/multiperspective/multiperspective.ttl [R=303,NE,L]


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
Made the redirection rules consistent with the updated [EMMO structure](https://github.com/emmo-repo/EMMO/tree/emmo-structure?tab=readme-ov-file#emmo-structure) that clearly separate the namespace of ontology and entity (classes/properties/individuals) IRIs. This separation is a result of EMMO using a single namespace for all entities. 

Detailed changes
* Handling HUME similar to other ontologies as described in [EMMO structure](https://github.com/emmo-repo/EMMO/tree/emmo-structure?tab=readme-ov-file#emmo-structure). Removed the special-case section for HUME.
* Renamed EMMO full to EMAX (keeping full for backward compatibility)
* Renamed mereocausality level to fundamental level (keeping mereocausality for backward compatibility)
* Deprecated multiperspective level (but keeping it for backward compatibility)
* Updated redirections for MLO and TLO 
* Made all redirections independent of a trailing slash.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested (with https://htaccess.madewithlove.com/).
- [x] Changes have been carefully reviewed by submitter.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
