### PR TITLE
New change for AFY with redirects to AgroPortal

### DIFF
--- a/afy/.htaccess
+++ b/afy/.htaccess
@@ -1,74 +1,12 @@
-# Turn off MultiViews 
-Options -MultiViews
+# ## Contact
+# This space is administered by: @rapha34
 
-# Directive to ensure *.rdf files served as appropriate content type,
-# if not present in main apache config
-AddType application/rdf+xml .rdf
-AddType application/rdf+xml .owl
-AddType text/turtle .ttl
-AddType application/n-triples .n3
-AddType application/ld+json .json
 
 RewriteEngine on
 
-# Rewrite rule for latest version.
-RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
-RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://agroforesterie.github.io/afy/index-en.html [R=303,L]
+# Base redirect to the AgroPortal landing page
+RewriteRule ^$ https://agroportal.lirmm.fr/ontologies/AFY [R=302,L]
 
-# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^$ https://agroforesterie.github.io/afy/ontology.json [R=303,L]
-
-# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
-RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^$ https://agroforesterie.github.io/afy/ontology.xml [R=303,L]
-
-# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
-RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^$ https://agroforesterie.github.io/afy/ontology.nt [R=303,L]
-
-# Rewrite rule to serve TTL content from the vocabulary URI if requested
-RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
-RewriteCond %{HTTP_ACCEPT} text/\* [OR]
-RewriteCond %{HTTP_ACCEPT} \*/turtle 
-RewriteRule ^$ https://agroforesterie.github.io/afy/ontology.ttl [R=303,L]
-
-
-# Rewrite rules for any other version.
-RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
-RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(.+)$ https://agroforesterie.github.io/afy/$1/index-en.html [R=303,L]
-
-# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^(.+)$ https://agroforesterie.github.io/afy/$1/ontology.json [R=303,L]
-
-# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
-RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^(.+)$ https://agroforesterie.github.io/afy/$1/ontology.xml [R=303,L]
-
-# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
-RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^(.+)$ https://agroforesterie.github.io/afy/$1/ontology.nt [R=303,L]
-
-# Rewrite rule to serve TTL content from the vocabulary URI if requested
-RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
-RewriteCond %{HTTP_ACCEPT} text/\* [OR]
-RewriteCond %{HTTP_ACCEPT} \*/turtle 
-RewriteRule ^(.+)$ https://agroforesterie.github.io/afy/$1/ontology.ttl [R=303,L]
-
-
-
-RewriteCond %{HTTP_ACCEPT} .+
-RewriteRule ^(.*)$ https://agroforesterie.github.io/afy/406.html [R=406,L]
-# Default response
-# ---------------------------
-# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
-RewriteRule ^$ https://agroforesterie.github.io/afy/ontology.xml [R=303,L]
+# Redirect specific entities to their AgroPortal page (e.g., classes or terms)
+RewriteCond %{REQUEST_URI} ^.*afy.*$
+RewriteRule ^([^/]+)/?$ https://agroportal.lirmm.fr/ontologies/AFY/$1 [R=302,L]


### PR DESCRIPTION
This PR will implement/fix the redirection to AgroPortal's twin URI for AFY.
Those twin URIs are invisible to the user and support both resolution and content negociation as explained in https://hal.science/hal-05240849

To be approved by @rapha34 or @LPTOntology