### PR TITLE
Changes file ending to .ttl to correctly reflect turtle syntax

### DIFF
--- a/hsu-aut/IEEE1872-2/.htaccess
+++ b/hsu-aut/IEEE1872-2/.htaccess
@@ -1,16 +1,22 @@
 RewriteEngine on
 
-# Redirect ontology version IRI to the given version
+# Redirect ontology version IRI to the given version (until v1.0.0 to .owl)
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
-RewriteRule ^(\d\.\d\.\d)/?$ https://raw.githubusercontent.com/hsu-aut/IndustrialStandard-ODP-IEEE1872-2/v$1/AuR_IEEE1872-2.owl [R=303,NC,L]
+RewriteRule ^(1\.0\.0)/?$ https://raw.githubusercontent.com/hsu-aut/IndustrialStandard-ODP-IEEE1872-2/v$1/AuR_IEEE1872-2.owl [R=303,NC,L]
+
+# Redirect ontology version IRI to the given version (from v1.1.0 to .ttl)
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^(\d\.\d\.\d)/?$ https://raw.githubusercontent.com/hsu-aut/IndustrialStandard-ODP-IEEE1872-2/v$1/AuR_IEEE1872-2.ttl [R=303,NC,L]
 
 # Redirect ontology IRI (without version) to the current main branch version
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
-RewriteRule ^/?$ https://raw.githubusercontent.com/hsu-aut/IndustrialStandard-ODP-IEEE1872-2/main/AuR_IEEE1872-2.owl [R=303,NC,L]
+RewriteRule ^/?$ https://raw.githubusercontent.com/hsu-aut/IndustrialStandard-ODP-IEEE1872-2/main/AuR_IEEE1872-2.ttl [R=303,NC,L]
 
 # Redirect HTML requests to the main repository page
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)


### PR DESCRIPTION
This update adjusts the redirection rules for one ontology to reflect a format change from .owl to .ttl., since the ontology has always been written in Turtle syntax. There are no changes to the ontology content itself — only the file extension was corrected to accurately reflect the format being used. The redirect rules only switch from .owl to .ttl starting at the corresponding new version.