### PR TITLE
Modify redirect rule for semantic hub documentation with catch all

### DIFF
--- a/aerospace-x/.htaccess
+++ b/aerospace-x/.htaccess
@@ -53,6 +53,6 @@ RewriteRule ^/?([^/]*)$ https://aerospace-x.pages.fraunhofer.de/ap7/ecosystem/on
 #RewriteRule ^/?$ https://docs.gaia-x.eu/ontology/development/ [R=303,L]
 #RewriteRule ^/?(.*)$ https://docs.gaia-x.eu/ontology/$1/ [R=303,L]
 
-# Redirect to semantic hub documentation
-RewriteRule ^/?$ https://int.semantic-hub.axdata.space/ [R=303,L]
+# Redirect to semantic hub documentation catch all the rest
+RewriteRule ^(.*)$ https://int.semantic-hub.axdata.space/$1 [R=303,L]
 


### PR DESCRIPTION
Updated the .htaccess file to redirect all requests to the semantic hub documentation.

<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
Missing catch all redirect

## General Checklist
<!-- For all ID related PRs. -->
- [ x] Changes have been tested.
- [ x] The number of commits is minimal. Squash if needed.
- [ x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ x] Maintainer details are in `.htaccess` or `README.md`.
- [x ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ x] GitHub username ids are listed in the changed maintainer details.
- [x ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

