### PR TITLE
Add wiren301-iso27001-skos for ISO/IEC 27001:2022 SKOS taxonomy

### DIFF
--- a/wiren301-iso27001-skos/.htaccess
+++ b/wiren301-iso27001-skos/.htaccess
@@ -1,0 +1,8 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Redirect /repo to GitHub repository
+RewriteRule ^repo/?$ https://github.com/wiren301/iso27001-skos-taxonomy [R=303,L]
+
+# Default: redirect to GitHub Pages interface
+RewriteRule ^.*$ https://wiren301.github.io/iso27001-skos-taxonomy/ [R=303,L]

--- a/wiren301-iso27001-skos/README.md
+++ b/wiren301-iso27001-skos/README.md
@@ -1,0 +1,14 @@
+# wiren301-iso27001-skos
+
+A SKOS taxonomy of ISO/IEC 27001:2022 information security standard.
+
+## URIs
+
+- `https://w3id.org/wiren301-iso27001-skos/` → Interactive visualization
+- `https://w3id.org/wiren301-iso27001-skos/repo` → GitHub repository
+
+## Contact
+
+**Ion Donos**
+- Email: iondonos2002@gmail.com
+- GitHub: [@wiren301](https://github.com/wiren301)


### PR DESCRIPTION
## Summary

Adding a persistent identifier for a SKOS taxonomy of ISO/IEC 27001:2022 information security standard.

- **Identifier**: `wiren301-iso27001-skos`
- **URI**: `https://w3id.org/wiren301-iso27001-skos/` → https://wiren301.github.io/iso27001-skos-taxonomy/

## Contact

- **Name**: Ion Donos
- **Email**: iondonos2002@gmail.com
- **GitHub**: [@wiren301](https://github.com/wiren301)

## Description

This taxonomy formalizes 307 security concepts from ISO/IEC 27000, 27001, and 27002 (2022 editions) into a machine-readable SKOS format, enabling SPARQL queries and programmatic access to the standard's structure.