### PR TITLE
Update GEkO ontology to support versioning (v1 and v2) - redirect

### DIFF
--- a/geko/.htaccess
+++ b/geko/.htaccess
@@ -1,4 +1,20 @@
 Options +FollowSymLinks
 RewriteEngine On
-RewriteRule ^$ https://mariafrancesca6.github.io/geko/ [R=302,L]
-RewriteRule (.*) https://mariafrancesca6.github.io/geko/$1 [R=302,L]
+
+# 1. VERSION-SPECIFIC REDIRECTS
+# These allow users to access specific versions directly via w3id.org/geko/v1 or /v2
+
+# Version 1.0
+RewriteRule ^v1$ https://mariafrancesca6.github.io/geko/v1/ [R=302,L]
+RewriteRule ^v1/(.*)$ https://mariafrancesca6.github.io/geko/v1/$1 [R=302,L]
+
+# Version 2.0 (The New Version)
+RewriteRule ^v2$ https://mariafrancesca6.github.io/geko/v2/ [R=302,L]
+RewriteRule ^v2/(.*)$ https://mariafrancesca6.github.io/geko/v2/$1 [R=302,L]
+
+# 2. DEFAULT REDIRECT (LATEST)
+# If someone visits w3id.org/geko/ without a version number, 
+# they are automatically sent to the v2 folder.
+
+RewriteRule ^$ https://mariafrancesca6.github.io/geko/v2/ [R=302,L]
+RewriteRule ^(.*)$ https://mariafrancesca6.github.io/geko/v2/$1 [R=302,L]


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
This PR updates the GEKO ontology to support versioning. The documentation on GitHub Pages has been reorganized into /v1/ and /v2/ subfolders. This update ensures that w3id.org/geko points to the latest version (v2) while maintaining persistent access to version 1 via w3id.org/geko/v1.
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [X] Changes have been tested.
- [X] The number of commits is minimal. Squash if needed.
- [X] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [X] GitHub username ids are listed in the changed maintainer details.
- [X] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [X] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
