### PR TITLE
Enhance .htaccess for content negotiation and versioning; update readme with canonical IRIs and usage examples

### DIFF
--- a/gcdfo/salmon/.htaccess
+++ b/gcdfo/salmon/.htaccess
@@ -1,21 +1,57 @@
 # # /gcdfo/salmon/
 #
+# GC DFO Salmon Ontology (OWL + SKOS)
 #
-# https://w3id.org/gcdfo/salmon redirects to
-# https://dfo-pacific-science.github.io/dfo-salmon-ontology/
+# Latest ontology IRI (unversioned):
+#   https://w3id.org/gcdfo/salmon
+#
+# Version IRIs:
+#   https://w3id.org/gcdfo/salmon/X.Y.Z
+#
+# Redirect targets (GitHub Pages):
+# - HTML docs (latest): https://dfo-pacific-science.github.io/dfo-salmon-ontology/
+# - Turtle (latest):    https://dfo-pacific-science.github.io/dfo-salmon-ontology/gcdfo.ttl
+# - RDF/XML (latest):   https://dfo-pacific-science.github.io/dfo-salmon-ontology/gcdfo.owl
+# - JSON-LD (latest):   https://dfo-pacific-science.github.io/dfo-salmon-ontology/gcdfo.jsonld
+# - Version snapshot:   https://dfo-pacific-science.github.io/dfo-salmon-ontology/releases/X.Y.Z/
 #
 # ## Contact
-# This space is administered by:  
+# This space is administered by:
 #
-# Data Stewardship Unit, Fishery & Assessment Data Section 
-# Fisheries and Oceans Canada, Pacific Region
+# Data Stewardship Unit, Fishery & Assessment Data Section (FADS)
+# Fisheries and Oceans Canada (DFO), Pacific Region
 #
 # Brett Johnson     GitHub: Br-Johnson
 # Melissa Morrison  GitHub: mkmor
 
-# Rewrite engine setup
+Options +FollowSymLinks
 RewriteEngine On
 
-# Default response
+# Tell caches that responses vary by content negotiation.
+Header merge Vary "Accept"
+
+# Latest (no version path)
 # ---------------------------
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^$ https://dfo-pacific-science.github.io/dfo-salmon-ontology/gcdfo.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^$ https://dfo-pacific-science.github.io/dfo-salmon-ontology/gcdfo.owl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^$ https://dfo-pacific-science.github.io/dfo-salmon-ontology/gcdfo.jsonld [R=303,L]
+
 RewriteRule ^$ https://dfo-pacific-science.github.io/dfo-salmon-ontology/ [R=303,L]
+
+# Version paths (SemVer: X.Y.Z)
+# ---------------------------
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://dfo-pacific-science.github.io/dfo-salmon-ontology/releases/$1/gcdfo.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://dfo-pacific-science.github.io/dfo-salmon-ontology/releases/$1/gcdfo.owl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://dfo-pacific-science.github.io/dfo-salmon-ontology/releases/$1/gcdfo.jsonld [R=303,L]
+
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://dfo-pacific-science.github.io/dfo-salmon-ontology/releases/$1/ [R=303,L]

--- a/gcdfo/salmon/readme.md
+++ b/gcdfo/salmon/readme.md
@@ -1,5 +1,36 @@
-# /gcdfo/
-This [W3ID](https://w3id.org) provides a persistent URI namespace for **GC DFO Salmon** Ontology resources.
+# `/gcdfo/salmon/`
+
+This [W3ID](https://w3id.org) space provides a persistent IRI namespace for the **GC DFO Salmon Ontology**.
+
+## Canonical IRIs
+
+- Ontology IRI (latest): `https://w3id.org/gcdfo/salmon`
+- Term namespace (hash IRIs): `https://w3id.org/gcdfo/salmon#`
+- Version IRIs: `https://w3id.org/gcdfo/salmon/X.Y.Z`
+
+## Redirect targets (current)
+
+The canonical IRIs above redirect (303) to the project’s GitHub Pages site:
+
+- HTML docs (latest): `https://dfo-pacific-science.github.io/dfo-salmon-ontology/`
+- Serializations (latest): `https://dfo-pacific-science.github.io/dfo-salmon-ontology/gcdfo.{ttl,owl,jsonld}`
+- Version snapshots: `https://dfo-pacific-science.github.io/dfo-salmon-ontology/releases/X.Y.Z/`
+
+## Content negotiation
+
+Clients can retrieve a specific representation by setting the HTTP `Accept` header.
+
+Examples:
+
+```bash
+curl -I https://w3id.org/gcdfo/salmon/
+curl -I -H 'Accept: text/turtle' https://w3id.org/gcdfo/salmon/
+curl -I -H 'Accept: application/rdf+xml' https://w3id.org/gcdfo/salmon/
+curl -I -H 'Accept: application/ld+json' https://w3id.org/gcdfo/salmon/
+
+curl -I https://w3id.org/gcdfo/salmon/0.0.999
+curl -I -H 'Accept: application/ld+json' https://w3id.org/gcdfo/salmon/0.0.999
+```
 
 ## Contact
 This space is administered by:  
@@ -7,11 +38,11 @@ This space is administered by:
 **Data Stewardship Unit, Fishery & Assessment Data Section**  
 *Fisheries and Oceans Canada - Pacific Region*  
 
-Brett Johnson, [Br-Johnson](github.com/Br-Johnson)
-Melissa Morrison, [mkmor](github.com/mkmor)
+Brett Johnson, GitHub: [Br-Johnson](https://github.com/Br-Johnson)  
+Melissa Morrison, GitHub: [mkmor](https://github.com/mkmor)
 
 
 For questions and contributions, please submit a ticket or email us at:
 
 GitHub issues: [dfo-salmon-ontology](https://github.com/dfo-pacific-science/dfo-salmon-ontology/issues)
-Email: [FADS Data Stewardship Unit](FADSDataStewardship-GestiondesdonneesSFDA@dfo-mpo.gc.ca)
+Email: [FADS Data Stewardship Unit](mailto:FADSDataStewardship-GestiondesdonneesSFDA@dfo-mpo.gc.ca)


### PR DESCRIPTION
<!-- NOTE: This PR updates the active gcdfo/salmon namespace to add content negotiation and version IRIs. The older GCDFO rules point at raw GitHub paths that no longer match the current repo layout, so this PR avoids those targets and uses the GitHub Pages artifacts instead. -->

## Brief Description
Enable content negotiation at `https://w3id.org/gcdfo/salmon/` and add version‑path redirects for `https://w3id.org/gcdfo/salmon/X.Y.Z`, pointing to the current GitHub Pages artifacts and immutable release snapshots.

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
