### PR TITLE
Add ffonto namespace to def/

### DIFF
--- a/def/ffonto/.htaccess
+++ b/def/ffonto/.htaccess
@@ -1,6 +1,10 @@
 # -----------------------------------------------------------------------
 # W3ID Redirection for FFOnto
 # -----------------------------------------------------------------------
+
+# Maintainers:
+# - Kosala0514 <https://github.com/kosala0514>
+
 Options +FollowSymLinks
 RewriteEngine On
 


### PR DESCRIPTION
Brief Description
I am registering the ffonto namespace under the def/ directory. This is for the "FFOnto" ontology and its associated documentation and dataset links.

General Checklist
[x] Changes have been tested (redirection logic verified).

[x] The number of commits is minimal.

[x] Commits only include redirects.

New ID Directory Checklist
[x] Maintainer details are in .htaccess.

[x] GitHub username ids are listed in the maintainer details.

Update ID Directory Checklist
(Not applicable as this is a new ID)

Optional Requests for W3ID Maintainers
[x] Please squash commits for me.