### PR TITLE
Update redirect to new vocab location.

### DIFF
--- a/vvc/.htaccess
+++ b/vvc/.htaccess
@@ -2,8 +2,6 @@
 #
 # homepage:
 # - https://stateofca.github.io/vehicle-credentials-vocabulary/
-# source:
-# - https://stateofca.github.io/vehicle-credentials-vocabulary/
 # maintainers:
 # - @davidlehn
 # - @dlongley
@@ -11,5 +9,5 @@
 # - @wes-smith
 
 RewriteEngine on
-RewriteRule ^$ https://stateofca.github.io/vehicle-credentials-vocabulary/[R=302,L]
+RewriteRule ^$ https://stateofca.github.io/vehicle-credentials-vocabulary/ [R=302,L]
 RewriteRule ^v(.*)$ https://stateofca.github.io/vehicle-credentials-vocabulary/contexts/vvc-v$1.jsonld [R=302,L]


### PR DESCRIPTION
## Brief Description
This PR updates the `vvc` namespace redirects to point to the new location for the Verifiable Vehicle Credentials vocabulary and associated JSON-LD data.

