### PR TITLE
fix: changed destination of redirects for oak resources in w3id.org/u…

### DIFF
--- a/uk/curriculum/.htaccess
+++ b/uk/curriculum/.htaccess
@@ -409,16 +409,16 @@ RewriteRule ^oak-data/$ https://raw.githubusercontent.com/oaknational/oak-curric
 # ----------------------------------------------------------------------
 
 # Versioned resources
-RewriteRule ^oak-data/resources/([0-9]+\.[0-9]+\.[0-9]+)$ https://raw.githubusercontent.com/oaknational/oak-curriculum-ontology/main/data/oak-curriculum/versions/resources-$1.ttl [R=303,L]
+RewriteRule ^oak-data/resources/([0-9]+\.[0-9]+\.[0-9]+)$ https://raw.githubusercontent.com/oaknational/oak-curriculum-ontology/main/data/oak-curriculum/resources/versions/resources-$1.ttl [R=303,L]
 
 # Main resources file (latest version)
-RewriteRule ^oak-data/resources\.ttl$ https://raw.githubusercontent.com/oaknational/oak-curriculum-ontology/main/data/oak-curriculum/resources.ttl [R=303,L]
+RewriteRule ^oak-data/resources\.ttl$ https://raw.githubusercontent.com/oaknational/oak-curriculum-ontology/main/data/oak-curriculum/resources/resources.ttl [R=303,L]
 
 # Oak resources namespace (for individual resource terms)
-RewriteRule ^oak-data/resources$ https://raw.githubusercontent.com/oaknational/oak-curriculum-ontology/main/data/oak-curriculum/resources.ttl [R=303,L]
+RewriteRule ^oak-data/resources$ https://raw.githubusercontent.com/oaknational/oak-curriculum-ontology/main/data/oak-curriculum/resources/resources.ttl [R=303,L]
 
 # Oak resources namespace root
-RewriteRule ^oak-data/resources/$ https://raw.githubusercontent.com/oaknational/oak-curriculum-ontology/main/data/oak-curriculum/resources.ttl [R=303,L]
+RewriteRule ^oak-data/resources/$ https://raw.githubusercontent.com/oaknational/oak-curriculum-ontology/main/data/oak-curriculum/resources/resources.ttl [R=303,L]
 
 # ----------------------------------------------------------------------
 # FALLBACK - Repository root and other files


### PR DESCRIPTION
…k/curriculum

<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
