### PR TITLE
make ont folder to redirect to 0.1.0 version if version is not specified

### DIFF
--- a/liccium/.htaccess
+++ b/liccium/.htaccess
@@ -32,6 +32,9 @@ RewriteRule ^context/(.+)\.json$ https://raw.githubusercontent.com/liccium/w3id.
 # ------------------------------
 # Ontology files
 # ------------------------------
+# Default: ont/ or ont → 0.1.0.ttl
+RewriteRule ^ont/?$ https://raw.githubusercontent.com/liccium/w3id.docs/main/ont/0.1.0.ttl [R=303,L]
+# Specific file: ont/<version>.ttl
 RewriteRule ^ont/(.+)\.ttl$ https://raw.githubusercontent.com/liccium/w3id.docs/main/ont/$1.ttl [R=303,L]
 
 # ------------------------------


### PR DESCRIPTION
Brief Description

This PR registers a persistent identifier namespace for Liccium at https://w3id.org/liccium/ont.

Redirects:
https://w3id.org/liccium/ont and https://w3id.org/liccium/ont/ → default ontology 0.1.0.ttl
https://w3id.org/liccium/ont/.ttl → corresponding ontology Turtle files
Source repository: https://github.com/liccium/w3id.docs

General Checklist
Changes have been tested.

The number of commits is minimal. Squash if needed.
Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

New ID Directory Checklist
Maintainer details are in .htaccess

GitHub username ids are listed in the maintainer details.

Update ID Directory Checklist
GitHub username ids are listed in the changed maintainer details.

The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

Maintainers:

Yury Kharytanovich (@yurykharytanovich) — [yury.kharytanovich.liccium@gmail.com](mailto:yury.kharytanovich.liccium@gmail.com)
Sebastian Posth (@sposth) — [Info@liccium.com](mailto:Info@liccium.com)