### PR TITLE
Fix redirect rules for gaia-x4plcaad and ascs-ev/envited-x

### DIFF
--- a/ascs-ev/envited-x/.htaccess
+++ b/ascs-ev/envited-x/.htaccess
@@ -14,38 +14,54 @@ RewriteEngine on
 # =============================================================================
 # ENVITED-X Simulation Asset Ontologies - Static GitHub Pages resolution
 # Pattern: /ascs-ev/envited-x/{ontology}/{version}[/][shapes]
+# Target:  ascs-ev.github.io/ontology-management-base/w3id/ascs-ev/envited-x/...
 # =============================================================================
 
-# Turtle format requests -> static TTL
+# --- Turtle / RDF-XML ---
+
+# Ontology (versioned)
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
 RewriteRule ^([^/]+)/(v[0-9]+|latest)/?$ https://ascs-ev.github.io/ontology-management-base/w3id/ascs-ev/envited-x/$1/$2/ontology.ttl [R=303,L]
 
-# SHACL Shapes requests -> static TTL
+# SHACL shapes (versioned)
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
 RewriteRule ^([^/]+)/(v[0-9]+|latest)/shapes/?$ https://ascs-ev.github.io/ontology-management-base/w3id/ascs-ev/envited-x/$1/$2/shapes.ttl [R=303,L]
 
-# JSON-LD requests -> static TTL (JSON-LD not published yet)
+# --- JSON-LD ---
+
+# JSON-LD context (versioned)
 RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
 RewriteCond %{HTTP_ACCEPT} application/json
-RewriteRule ^([^/]+)/(v[0-9]+|latest)/?$ https://ascs-ev.github.io/ontology-management-base/w3id/ascs-ev/envited-x/$1/$2/ontology.ttl [R=303,L]
+RewriteRule ^([^/]+)/(v[0-9]+|latest)/?$ https://ascs-ev.github.io/ontology-management-base/w3id/ascs-ev/envited-x/$1/$2/context.jsonld [R=303,L]
 
-# JSON-LD shapes requests -> static TTL (JSON-LD not published yet)
+# JSON-LD shapes (versioned) — no JSON-LD shapes published, serve Turtle
 RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
 RewriteCond %{HTTP_ACCEPT} application/json
 RewriteRule ^([^/]+)/(v[0-9]+|latest)/shapes/?$ https://ascs-ev.github.io/ontology-management-base/w3id/ascs-ev/envited-x/$1/$2/shapes.ttl [R=303,L]
 
-# Base IRI (no version) -> latest
+# --- Bare IRI (no version) → latest ---
+
+# Turtle / RDF-XML
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
 RewriteRule ^([^/]+)/?$ https://ascs-ev.github.io/ontology-management-base/w3id/ascs-ev/envited-x/$1/latest/ontology.ttl [R=303,L]
 
-# -----------------------------------------------------------------------------
-# Default: Redirect to documentation (HTML)
-# -----------------------------------------------------------------------------
-RewriteRule ^([^/]+)/(v[0-9]+|latest)/?$ https://ascs-ev.github.io/ontology-management-base/ontologies/#$1 [R=303,L]
-RewriteRule ^([^/]+)/(v[0-9]+|latest)/shapes/?$ https://ascs-ev.github.io/ontology-management-base/ontologies/#$1 [R=303,L]
+# JSON-LD
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^([^/]+)/?$ https://ascs-ev.github.io/ontology-management-base/w3id/ascs-ev/envited-x/$1/latest/context.jsonld [R=303,L]
 
 # -----------------------------------------------------------------------------
-# Root redirect to documentation
+# HTML fallback — redirect browsers to MkDocs documentation pages
+# (No fragment identifiers — Apache encodes '#' to '%23' in redirects)
 # -----------------------------------------------------------------------------
-RewriteRule ^$ https://ascs-ev.github.io/ontology-management-base/ [R=303,L]
+RewriteRule ^([^/]+)/(v[0-9]+|latest)/?$ https://ascs-ev.github.io/ontology-management-base/ontologies/classes/$1/ [R=303,L]
+RewriteRule ^([^/]+)/(v[0-9]+|latest)/shapes/?$ https://ascs-ev.github.io/ontology-management-base/ontologies/classes/$1/ [R=303,L]
+RewriteRule ^([^/]+)/?$ https://ascs-ev.github.io/ontology-management-base/ontologies/classes/$1/ [R=303,L]
+
+# -----------------------------------------------------------------------------
+# Root redirect to documentation catalog
+# -----------------------------------------------------------------------------
+RewriteRule ^$ https://ascs-ev.github.io/ontology-management-base/ontologies/catalog/ [R=303,L]

--- a/gaia-x4plcaad/.htaccess
+++ b/gaia-x4plcaad/.htaccess
@@ -11,5 +11,8 @@ AddType application/ld+json .jsonld
 Options +FollowSymLinks
 RewriteEngine on
 
+# NOTE: Repository migrated from GAIA-X4PLC-AAD to ASCS-eV.
+#       All redirects now point to ascs-ev.github.io.
+
 # Default redirect to project documentation (GitHub Pages)
-RewriteRule ^$ https://gaia-x4plc-aad.github.io/ontology-management-base/ [R=303,L]
+RewriteRule ^$ https://ascs-ev.github.io/ontology-management-base/ [R=303,L]

--- a/gaia-x4plcaad/README.md
+++ b/gaia-x4plcaad/README.md
@@ -1,11 +1,14 @@
 # GAIA-X 4 PLC AAD Research Project
 
+> **Note:** This project has been archived. Active development continues at
+> [ASCS-eV/ontology-management-base](https://github.com/ASCS-eV/ontology-management-base).
+
 GAIA-X 4 Product Lifecycle Across Automated Driving (PLC-AAD) research project ontologies.
 
 ## Homepage
 
-- https://gaia-x4plc-aad.github.io/ontology-management-base/
-- Ontology catalog and documentation: https://gaia-x4plc-aad.github.io/ontology-management-base/ontologies/
+- https://ascs-ev.github.io/ontology-management-base/
+- Ontology catalog and documentation: https://ascs-ev.github.io/ontology-management-base/ontologies/catalog/
 
 ## Subfolders
 
@@ -13,7 +16,8 @@ GAIA-X 4 Product Lifecycle Across Automated Driving (PLC-AAD) research project o
 
 ## GitHub Repository
 
-- https://github.com/GAIA-X4PLC-AAD/ontology-management-base
+- https://github.com/ASCS-eV/ontology-management-base (active)
+- https://github.com/GAIA-X4PLC-AAD/ontology-management-base (archived)
 
 ## Contacts
 

--- a/gaia-x4plcaad/ontologies/.htaccess
+++ b/gaia-x4plcaad/ontologies/.htaccess
@@ -13,35 +13,57 @@ RewriteEngine on
 
 # =============================================================================
 # GAIA-X 4 PLC AAD Ontologies - Static GitHub Pages resolution
+# NOTE: Repository migrated from GAIA-X4PLC-AAD to ASCS-eV.
+#       All redirects now point to ascs-ev.github.io.
 # Pattern: /{ontology}/v{version}[/][shapes]
+# Target:  ascs-ev.github.io/ontology-management-base/w3id/gaia-x4plcaad/ontologies/...
 # =============================================================================
 
-# Turtle / RDF-XML requests -> static TTL
+# --- Turtle / RDF-XML ---
+
+# Ontology (versioned)
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^([^/]+)/(v[0-9]+|latest)/?$ https://gaia-x4plc-aad.github.io/ontology-management-base/w3id/gaia-x4plcaad/ontologies/$1/$2/ontology.ttl [R=303,L]
+RewriteRule ^([^/]+)/(v[0-9]+|latest)/?$ https://ascs-ev.github.io/ontology-management-base/w3id/gaia-x4plcaad/ontologies/$1/$2/ontology.ttl [R=303,L]
 
-# Turtle / RDF-XML shapes requests -> static TTL
+# SHACL shapes (versioned)
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^([^/]+)/(v[0-9]+|latest)/shapes/?$ https://gaia-x4plc-aad.github.io/ontology-management-base/w3id/gaia-x4plcaad/ontologies/$1/$2/shapes.ttl [R=303,L]
+RewriteRule ^([^/]+)/(v[0-9]+|latest)/shapes/?$ https://ascs-ev.github.io/ontology-management-base/w3id/gaia-x4plcaad/ontologies/$1/$2/shapes.ttl [R=303,L]
 
-# JSON-LD requests -> static TTL (JSON-LD not published yet)
+# --- JSON-LD ---
+
+# JSON-LD context (versioned)
 RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
 RewriteCond %{HTTP_ACCEPT} application/json
-RewriteRule ^([^/]+)/(v[0-9]+|latest)/?$ https://gaia-x4plc-aad.github.io/ontology-management-base/w3id/gaia-x4plcaad/ontologies/$1/$2/ontology.ttl [R=303,L]
+RewriteRule ^([^/]+)/(v[0-9]+|latest)/?$ https://ascs-ev.github.io/ontology-management-base/w3id/gaia-x4plcaad/ontologies/$1/$2/context.jsonld [R=303,L]
 
-# JSON-LD shapes requests -> static TTL (JSON-LD not published yet)
+# JSON-LD shapes (versioned) — no JSON-LD shapes published, serve Turtle
 RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
 RewriteCond %{HTTP_ACCEPT} application/json
-RewriteRule ^([^/]+)/(v[0-9]+|latest)/shapes/?$ https://gaia-x4plc-aad.github.io/ontology-management-base/w3id/gaia-x4plcaad/ontologies/$1/$2/shapes.ttl [R=303,L]
+RewriteRule ^([^/]+)/(v[0-9]+|latest)/shapes/?$ https://ascs-ev.github.io/ontology-management-base/w3id/gaia-x4plcaad/ontologies/$1/$2/shapes.ttl [R=303,L]
 
-# Base IRI (no version) -> latest
-RewriteRule ^([^/]+)/?$ https://gaia-x4plc-aad.github.io/ontology-management-base/w3id/gaia-x4plcaad/ontologies/$1/latest/ontology.ttl [R=303,L]
+# --- Bare IRI (no version) → latest ---
 
-# HTML fallback to docs
-RewriteRule ^([^/]+)/(v[0-9]+|latest)/?$ https://gaia-x4plc-aad.github.io/ontology-management-base/ontologies/#$1 [R=303,L]
-RewriteRule ^([^/]+)/(v[0-9]+|latest)/shapes/?$ https://gaia-x4plc-aad.github.io/ontology-management-base/ontologies/#$1 [R=303,L]
+# Turtle / RDF-XML
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^([^/]+)/?$ https://ascs-ev.github.io/ontology-management-base/w3id/gaia-x4plcaad/ontologies/$1/latest/ontology.ttl [R=303,L]
 
-# Root redirect to docs
-RewriteRule ^$ https://gaia-x4plc-aad.github.io/ontology-management-base/ontologies/ [R=303,L]
+# JSON-LD
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^([^/]+)/?$ https://ascs-ev.github.io/ontology-management-base/w3id/gaia-x4plcaad/ontologies/$1/latest/context.jsonld [R=303,L]
+
+# -----------------------------------------------------------------------------
+# HTML fallback — redirect browsers to MkDocs documentation pages
+# (No fragment identifiers — Apache encodes '#' to '%23' in redirects)
+# -----------------------------------------------------------------------------
+RewriteRule ^([^/]+)/(v[0-9]+|latest)/?$ https://ascs-ev.github.io/ontology-management-base/ontologies/classes/$1/ [R=303,L]
+RewriteRule ^([^/]+)/(v[0-9]+|latest)/shapes/?$ https://ascs-ev.github.io/ontology-management-base/ontologies/classes/$1/ [R=303,L]
+RewriteRule ^([^/]+)/?$ https://ascs-ev.github.io/ontology-management-base/ontologies/classes/$1/ [R=303,L]
+
+# -----------------------------------------------------------------------------
+# Root redirect to documentation catalog
+# -----------------------------------------------------------------------------
+RewriteRule ^$ https://ascs-ev.github.io/ontology-management-base/ontologies/catalog/ [R=303,L]

--- a/gaia-x4plcaad/ontologies/README.md
+++ b/gaia-x4plcaad/ontologies/README.md
@@ -1,16 +1,19 @@
 # GAIA-X 4 PLC AAD Research Project Ontologies
 
+> **Note:** This project has been archived. Active development continues at
+> [ASCS-eV/ontology-management-base](https://github.com/ASCS-eV/ontology-management-base).
+
 Ontologies developed as part of the GAIA-X 4 PLC AAD research project.
 
 ## Homepage
 
-- <https://gaia-x4plc-aad.github.io/ontology-management-base/>
+- <https://ascs-ev.github.io/ontology-management-base/>
 
 ## Documentation
 
 Refer to the documentation site for the current ontology catalog, version details, and downloadable artifacts:
 
-- https://gaia-x4plc-aad.github.io/ontology-management-base/ontologies/
+- https://ascs-ev.github.io/ontology-management-base/ontologies/catalog/
 
 ## URL Patterns
 
@@ -20,11 +23,13 @@ Refer to the documentation site for the current ontology catalog, version detail
 
 ## Resolution
 
-W3ID IRIs resolve to static files published on GitHub Pages. Use the documentation site for the full catalog and links to each published file.
+W3ID IRIs resolve to static files published on GitHub Pages at `ascs-ev.github.io`.
+Use the documentation site for the full catalog and links to each published file.
 
 ## GitHub Repository
 
-- <https://github.com/GAIA-X4PLC-AAD/ontology-management-base>
+- <https://github.com/ASCS-eV/ontology-management-base> (active)
+- <https://github.com/GAIA-X4PLC-AAD/ontology-management-base> (archived)
 
 ## Contacts
 


### PR DESCRIPTION
## Summary

- Fix six bugs in `.htaccess` redirect rules for `gaia-x4plcaad/` and `ascs-ev/envited-x/`
- Update `gaia-x4plcaad/` redirect targets from archived `gaia-x4plc-aad.github.io` to active `ascs-ev.github.io`
- Update READMEs with archived notice and new repository URLs

## Context

The [GAIA-X4PLC-AAD/ontology-management-base](https://github.com/GAIA-X4PLC-AAD/ontology-management-base) repository has been archived. Active development continues at [ASCS-eV/ontology-management-base](https://github.com/ASCS-eV/ontology-management-base). The w3id redirect rules need to be updated to point to the new GitHub Pages host.

## Changes

**`gaia-x4plcaad/.htaccess`** — Update root redirect target from `gaia-x4plc-aad.github.io` to `ascs-ev.github.io`.

**`gaia-x4plcaad/ontologies/.htaccess`** — Six fixes:

1. **Dead redirect targets** — All rules pointed to `gaia-x4plc-aad.github.io` (archived, no longer deployed). Changed to `ascs-ev.github.io`.
2. **Fragment encoding** — HTML fallback rules used `#$1` which Apache encodes to `%23$1`, producing 404s. Replaced with path-based redirects to `/ontologies/classes/$1/`.
3. **JSON-LD content type** — JSON-LD `Accept` header requests were redirected to `.ttl` instead of `.jsonld`. Now redirect to `context.jsonld`.
4. **Missing RewriteCond on bare IRI rule** — Unconditional `RewriteRule ^([^/]+)/?$` caught browser requests before HTML fallback. Added `RewriteCond` guards for content-negotiated formats.
5. **Wrong root redirect** — Pointed to `/ontologies/` (doesn't exist). Changed to `/ontologies/catalog/`.
6. **Bare IRI JSON-LD** — Added JSON-LD content negotiation for bare IRI requests (without version).

**`ascs-ev/envited-x/.htaccess`** — Same structural fixes (2, 3, 4, 5, 6) as above. Target host was already correct.

**`gaia-x4plcaad/README.md`** and **`gaia-x4plcaad/ontologies/README.md`** — Added archived notice, updated URLs from `gaia-x4plc-aad.github.io` → `ascs-ev.github.io`, listed both active and archived repository links.

## Verification

After merge, test with `curl`:

```bash
# Turtle (ascs-ev namespace)
curl -sI -H "Accept: text/turtle" https://w3id.org/ascs-ev/envited-x/hdmap/v5
# → 303 to ascs-ev.github.io/.../w3id/ascs-ev/envited-x/hdmap/v5/ontology.ttl

# HTML browser (ascs-ev namespace)
curl -sI -H "Accept: text/html" https://w3id.org/ascs-ev/envited-x/hdmap/v5
# → 303 to ascs-ev.github.io/.../ontologies/classes/hdmap/

# Turtle (gaia-x4plcaad namespace, now served from ascs-ev)
curl -sI -H "Accept: text/turtle" https://w3id.org/gaia-x4plcaad/ontologies/survey/v6
# → 303 to ascs-ev.github.io/.../w3id/gaia-x4plcaad/ontologies/survey/v6/ontology.ttl

# JSON-LD
curl -sI -H "Accept: application/ld+json" https://w3id.org/ascs-ev/envited-x/hdmap/v5
# → 303 to ascs-ev.github.io/.../w3id/ascs-ev/envited-x/hdmap/v5/context.jsonld

# Root redirects
curl -sI https://w3id.org/ascs-ev/envited-x/
# → 303 to ascs-ev.github.io/.../ontologies/catalog/
curl -sI https://w3id.org/gaia-x4plcaad/ontologies/
# → 303 to ascs-ev.github.io/.../ontologies/catalog/
```

## Contacts

- Carlo van Driesten (GitHub: [@jdsika](https://github.com/jdsika))