### PR TITLE
Add permanent identifier namespace for FiCR ontology (https://w3id.org/bam/ficr#)

### DIFF
--- a/bam/ficr/.htaccess
+++ b/bam/ficr/.htaccess
@@ -2,6 +2,11 @@
 # Namespace: https://w3id.org/bam/ficr#
 # Base IRI:   https://w3id.org/bam/ficr
 
+# Maintainer:
+# GitHub: RainGo111
+# Name: Rain Cheung
+# Project: FiCR Ontology
+
 Options +FollowSymLinks
 RewriteEngine On
 


### PR DESCRIPTION
## Brief Description
This PR adds a new W3ID namespace:
https://w3id.org/bam/ficr#
for the FiCR (Fire Compliance and Risk Analysis) ontology.

FiCR is an OWL ontology developed to support interoperable representation,
inspection, compliance checking, and fire risk analysis for buildings during
operation and maintenance phases.
The namespace resolves to versioned ontology files hosted on GitHub, with
content negotiation supporting HTML documentation and RDF (Turtle) access.

Maintainer:
Yu Zhang (GitHub: RainGo111)
Primary repository:
https://github.com/RainGo111/FiCR

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal.
- [x] Commits only include redirect rules and basic information.

## New ID Directory Checklist
- [x] Maintainer details are included in `.htaccess`.
- [x] GitHub username (RainGo111) is listed in maintainer details.

## Optional Requests for W3ID Maintainers
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
