### PR TITLE
Add /plato/ namespace for Place Attestation Ontology

### DIFF
--- a/plato/.htaccess
+++ b/plato/.htaccess
@@ -1,0 +1,22 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+# --- Ontology content negotiation ---
+
+# Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^$ https://raw.githubusercontent.com/WorldHistoricalGazetteer/place-ontology/main/ontology.ttl [R=303,L]
+
+# --- HTML/XHTML: WIDOCO documentation ---
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteRule ^$ https://worldhistoricalgazetteer.github.io/place-ontology/index-en.html [R=303,L]
+
+# --- JSON Schemas ---
+RewriteRule ^schemas/(.+)$ https://raw.githubusercontent.com/WorldHistoricalGazetteer/place-ontology/main/schemas/$1 [R=303,L]
+
+
+# --- Default: browser gets WIDOCO docs ---
+RewriteRule ^$ https://worldhistoricalgazetteer.github.io/place-ontology/index-en.html [R=303,L]

--- a/plato/README.md
+++ b/plato/README.md
@@ -1,0 +1,23 @@
+# /plato/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for [*PLATO*](https://github.com/WorldHistoricalGazetteer/place-ontology/blob/main/README.md):
+## Place Attestation Ontology
+
+An ontology for describing places and their geographic and historical characteristics, developed by the World Historical Gazetteer project.
+
+| PLATO Vector      | Behaviour |
+|-------------------|-----------|
+| `/schemas/`       | Returns the JSON schema files from the GitHub repository (`schemas/*`). |
+| `*`               | Default access: returns the Turtle representation of the ontology (`ontology.ttl`) for semantic clients accepting RDF formats. Browsers are redirected to WIDOCO documentation (`index-en.html`). |
+
+> **Note:** Content negotiation is used to serve Turtle to semantic clients and HTML to browsers.
+
+## Contact
+
+**[Stephen Gadd](https://www.wikidata.org/wiki/Q7609282)**<br/>
+[Docuracy Ltd](https://docuracy.co.uk)<br/>
+[Rotherhithe, UK](https://www.wikidata.org/wiki/Q2886632)<br/>
+<stephen@docuracy.co.uk>  <br/>
+GitHub: [docuracy](https://github.com/docuracy)<br/>
+ORCID: [0000-0003-3060-0181](https://orcid.org/0000-0003-3060-0181)<br/>
+
+


### PR DESCRIPTION
This PR adds a persistent URI namespace for **PLATO** (Place Attestation Ontology)

### What's included:
- **Content negotiation** via `.htaccess` to serve:
  - Turtle format (`ontology.ttl`) for semantic clients
  - WIDOCO documentation (`index-en.html`) for browsers
- **JSON schemas** served via `/schemas/` path
- **README** with project description and contact information

### Repository
https://github.com/WorldHistoricalGazetteer/place-ontology

<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
