### PR TITLE
health-ri: add safe content negotiation and stable redirects for ontology, mappings, vocabulary

### DIFF
--- a/health-ri/.htaccess
+++ b/health-ri/.htaccess
@@ -80,10 +80,6 @@ RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC,OR]
 RewriteCond %{HTTP_ACCEPT} \*/\* [NC]
 RewriteRule ^ontology/?$ https://w3id.org/health-ri/ontology/ttl [R=303,L]
 
-# If an Accept header exists but none matched, return 406 (as in w3id example)
-RewriteCond %{HTTP_ACCEPT} .+
-RewriteRule ^ontology/?$ - [R=406,L]
-
 # Default
 RewriteRule ^ontology/?$ https://w3id.org/health-ri/ontology/ttl [R=303,L]
 
@@ -120,10 +116,6 @@ RewriteCond %{HTTP_ACCEPT} application/n-triples [NC,OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC,OR]
 RewriteCond %{HTTP_ACCEPT} \*/\* [NC]
 RewriteRule ^ontology/v([0-9]+\.[0-9]+\.[0-9]+)/?$ https://w3id.org/health-ri/ontology/v$1/ttl [R=303,L]
-
-# 406 if Accept exists but none matched
-RewriteCond %{HTTP_ACCEPT} .+
-RewriteRule ^ontology/v([0-9]+\.[0-9]+\.[0-9]+)/?$ - [R=406,L]
 
 # Default
 RewriteRule ^ontology/v([0-9]+\.[0-9]+\.[0-9]+)/?$ https://w3id.org/health-ri/ontology/v$1/ttl [R=303,L]
@@ -162,10 +154,6 @@ RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC,OR]
 RewriteCond %{HTTP_ACCEPT} \*/\* [NC]
 RewriteRule ^semantic-interoperability/mappings/?$ https://w3id.org/health-ri/semantic-interoperability/mappings/ttl [R=303,L]
 
-# 406 if Accept exists but none matched
-RewriteCond %{HTTP_ACCEPT} .+
-RewriteRule ^semantic-interoperability/mappings/?$ - [R=406,L]
-
 # Default
 RewriteRule ^semantic-interoperability/mappings/?$ https://w3id.org/health-ri/semantic-interoperability/mappings/ttl [R=303,L]
 
@@ -196,10 +184,6 @@ RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC,OR]
 RewriteCond %{HTTP_ACCEPT} \*/\* [NC]
 RewriteRule ^mapping-vocabulary/?$ https://w3id.org/health-ri/mapping-vocabulary/ttl [R=303,L]
 
-# 406 if Accept exists but none matched
-RewriteCond %{HTTP_ACCEPT} .+
-RewriteRule ^mapping-vocabulary/?$ - [R=406,L]
-
 # Default
 RewriteRule ^mapping-vocabulary/?$ https://w3id.org/health-ri/mapping-vocabulary/ttl [R=303,L]
 
@@ -209,6 +193,7 @@ RewriteRule ^mapping-vocabulary/(spec|specification)/?$ https://health-ri.github
 
 # --- Versioned vocabulary (vX.Y.Z) ---
 # Negotiation
+
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml) [NC]
 RewriteCond %{HTTP_ACCEPT} text/html [NC,OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [NC,OR]
@@ -223,9 +208,6 @@ RewriteCond %{HTTP_ACCEPT} application/n-triples [NC,OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC,OR]
 RewriteCond %{HTTP_ACCEPT} \*/\* [NC]
 RewriteRule ^mapping-vocabulary/v([0-9]+\.[0-9]+\.[0-9]+)/?$ https://w3id.org/health-ri/mapping-vocabulary/v$1/ttl [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} .+
-RewriteRule ^mapping-vocabulary/v([0-9]+\.[0-9]+\.[0-9]+)/?$ - [R=406,L]
 
 RewriteRule ^mapping-vocabulary/v([0-9]+\.[0-9]+\.[0-9]+)/?$ https://w3id.org/health-ri/mapping-vocabulary/v$1/ttl [R=303,L]
 


### PR DESCRIPTION
## Brief Description
This PR updates the `https://w3id.org/health-ri/` namespace redirects (`health-ri/.htaccess`) to consolidate redirects using `mod_rewrite`, add cache-safety, and implement 303 content negotiation for the Health-RI ontology and related artifacts.

Key changes:
- Enable `RewriteEngine` and add cache-safety header `Vary: Accept` for this namespace.
- Implement **303 content negotiation** for:
  - `/ontology` and `/ontology/vX.Y.Z` (ttl/json + HTML doc/spec targets)
  - `/semantic-interoperability/mappings` (ttl/tsv)
  - `/mapping-vocabulary` and `/mapping-vocabulary/vX.Y.Z` (ttl/spec)
  - Default behavior for unmatched/unknown `Accept` is to redirect to the canonical default representation.
- Update ontology HTML endpoints:
  - `/ontology/doc` and `/ontology/spec` now redirect to GitHub Pages under `/deliverables/...` (rendered pages).
- Add simple redirects for:
  - `/semantic-interoperability/hrio-mapping-assistant`
  - `/health-ri-semantic-interoperability-guide`
- Keep existing redirects for metadata releases, project homepages, documents PID pattern, and `/semantic-interoperability/*` fallback.

Testing:
- Local Apache (Docker) test suite:
  - `python test_w3id_htaccess_extensive_v2.py --base http://localhost:8080/health-ri --follow none`
- Result: **Total 46 — PASS 46 — WARN 0 — FAIL 0** (outputs `test_results.csv`, `test_results.md`).

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
N/A (this PR updates an existing ID directory under `health-ri/`).

## Update ID Directory Checklist
Maintainers (update as needed):
- Pedro Paulo Favato Barcelos — GitHub: @pedropaulofb

- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
