### PR TITLE
first commit to add readme and htaccess for agri-image ontology

### DIFF
--- a/agri-image/.htaccess
+++ b/agri-image/.htaccess
@@ -1,0 +1,49 @@
+# ======================================
+# .htaccess for https://w3id.org/agri-image/
+# Redirects to:
+#   https://raw.githubusercontent.com/TeamWalabi/agriculture-image-metadata/main/ontology/ontology.ttl
+#
+# Best practice: 303 redirects for Linked Data identifiers
+# ======================================
+
+Options +FollowSymLinks
+RewriteEngine On
+
+# --------------------------------------
+# Base redirect (no file requested)
+# --------------------------------------
+# /agri-image  → Turtle ontology
+RewriteCond %{REQUEST_URI} ^/agri-image/?$
+RewriteRule ^$ https://raw.githubusercontent.com/TeamWalabi/agriculture-image-metadata/main/ontology/ontology.ttl [R=303,L]
+
+# --------------------------------------
+# /agri-image/ontology  → same ontology
+# --------------------------------------
+RewriteCond %{REQUEST_URI} ^/agri-image/ontology/?$
+RewriteRule ^ontology/?$ https://raw.githubusercontent.com/TeamWalabi/agriculture-image-metadata/main/ontology/ontology.ttl [R=303,L]
+
+# --------------------------------------
+# Content negotiation (if Accept header is given)
+# All cases point to TTL because you only provide Turtle.
+# --------------------------------------
+
+# Turtle requested
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/TeamWalabi/agriculture-image-metadata/main/ontology/ontology.ttl [R=303,L]
+
+# JSON-LD requested → we return TTL
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/TeamWalabi/agriculture-image-metadata/main/ontology/ontology.ttl [R=303,L]
+
+# RDF/XML requested → TTL fallback
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/TeamWalabi/agriculture-image-metadata/main/ontology/ontology.ttl [R=303,L]
+
+# HTML requested → TTL fallback
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/TeamWalabi/agriculture-image-metadata/main/ontology/ontology.ttl [R=303,L]
+
+# --------------------------------------
+# Fallback for everything else → TTL
+# --------------------------------------
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/TeamWalabi/agriculture-image-metadata/main/ontology/ontology.ttl [R=303,L]

--- a/agri-image/README.md
+++ b/agri-image/README.md
@@ -1,0 +1,68 @@
+# Agri-Image Ontology — w3id.org Permanent Identifier
+
+This directory contains the configuration for the persistent identifier:
+
+**https://w3id.org/agri-image/**
+
+The purpose of this namespace is to provide **stable, permanent URIs** for the
+**Agri-Image ontology**, its classes, and properties.  
+All resources under this namespace are redirected to the maintained ontology
+hosted on GitHub.
+
+## Project Description
+
+The *Agri-Image Ontology* defines semantic concepts and metadata structures
+for agricultural image datasets, including cameras, platforms, plots,
+crops, datasets, and image-level metadata.  
+The ontology is developed as part of the *Agriculture Image Metadata*
+initiative by Team Walabi.
+
+The ontology is made available in **Turtle (TTL)** format. Additional RDF
+serializations may be added in the future.
+
+## Maintainer(s)
+
+- **Joep Tummers**  
+  Wageningen University & Research  
+  Email: <walabi.wser@wur.nl>  
+  GitHub: [@TeamWalabi](https://github.com/TeamWalabi)
+
+
+## Redirects
+
+This namespace redirects to the ontology resources stored at:
+
+- https://github.com/TeamWalabi/agriculture-image-metadata/tree/main/ontology  
+
+Primary ontology file:
+
+- **ontology.ttl**  
+  https://raw.githubusercontent.com/TeamWalabi/agriculture-image-metadata/main/ontology/ontology.ttl
+
+## Content Negotiation
+
+The `.htaccess` in this folder supports HTTP content negotiation.  
+Because the ontology currently provides only Turtle serialization,
+all media types are redirected to the `.ttl` file.
+
+Examples:
+
+- `curl -L -H "Accept: text/turtle" https://w3id.org/agri-image/ontology`  
+- `curl -L -H "Accept: application/ld+json" https://w3id.org/agri-image/ontology`  
+- `curl -L -H "Accept: application/rdf+xml" https://w3id.org/agri-image/ontology"`
+
+All requests currently return the same Turtle file.
+
+## Documentation
+
+Project documentation, code, and the ontology source can be found at:
+
+https://github.com/TeamWalabi/agriculture-image-metadata
+
+## Persistence Commitment
+
+This namespace is registered through **w3id.org**, a permanent identifier
+service operated by the W3C Permanent Identifier Community Group.  
+The maintainers commit to keeping the target resources available and to
+updating redirects as necessary to maintain long-term persistence.
+


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->

## Brief Description
This PR introduces a new permanent identifier namespace:

**https://w3id.org/agri-image/**

The namespace provides persistent, stable URIs for the **Agri-Image Ontology**, developed by Team Walabi.  
The ontology is publicly hosted at:

https://github.com/TeamWalabi/agriculture-image-metadata

All identifiers redirect (via 303) to the canonical ontology file located in the `ontology/` folder.  
The namespace currently serves a single Turtle serialization (`ontology.ttl`) with content negotiation support.

---

## General Checklist
- [x] Changes have been tested (curl tests with multiple Accept headers).
- [x] The number of commits is minimal.  
- [x] Commits only include redirects and core metadata for the namespace.

---

## New ID Directory Checklist
- [x] Maintainer details are included in the `README.md`.
- [x] GitHub usernames of maintainers are listed in the `README.md`.

---

## Update ID Directory Checklist
*(Not applicable — this PR introduces a new namespace.)*
- [ ] GitHub usernames are listed in changed maintainer details.
- [ ] PR submitter is listed as a maintainer of changed directories, or maintainers have been tagged.

---

## Optional Requests for W3ID Maintainers
- [x] Please squash commits for me. I understand this may require resyncing my fork before future PRs.