### PR TITLE
fix(htaccess): update rewrite path for semantic interoperability guide

### DIFF
--- a/health-ri/.htaccess
+++ b/health-ri/.htaccess
@@ -49,8 +49,8 @@ RewriteRule ^$ https://www.health-ri.nl/ [R=302,L]
 # from: w3id.org/health-ri/semantic-interoperability/hrio-mapping-assistant
 RewriteRule ^semantic-interoperability/hrio-mapping-assistant/?$ https://chatgpt.com/g/g-6990a7e348c4819190ef2de88503ff5e-hrio-mapping-assistant [R=302,L]
 
-# from: w3id.org/health-ri/health-ri-semantic-interoperability-guide
-RewriteRule ^health-ri-semantic-interoperability-guide/?$ https://chatgpt.com/g/g-6992c8eb8780819185f0922ac33d79ce-health-ri-semantic-interoperability-guide [R=302,L]
+# from: w3id.org/health-ri/semantic-interoperability/health-ri-semantic-interoperability-guide
+RewriteRule ^semantic-interoperability/health-ri-semantic-interoperability-guide/?$ https://chatgpt.com/g/g-6992c8eb8780819185f0922ac33d79ce-health-ri-semantic-interoperability-guide [R=302,L]
 
 # --------------------------------------------------------------------------------------------------------------
 # ONTOLOGY (HRIO) — CONTENT NEGOTIATION + REPRESENTATION URIs


### PR DESCRIPTION
Move the semantic interoperability guide redirect under /semantic-interoperability/ to match the w3id source path.

## Brief Description
This PR updates the `.htaccess` rewrite rule for the Health-RI Semantic Interoperability Guide so the redirect lives under `/semantic-interoperability/health-ri-semantic-interoperability-guide`, aligning the served path with the corresponding `w3id.org/health-ri/semantic-interoperability/health-ri-semantic-interoperability-guide` source path.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
