### PR TITLE
Make TTL the default redirect for w3id.org/rfd-connect

### DIFF
--- a/rdf-connect/.htaccess
+++ b/rdf-connect/.htaccess
@@ -34,10 +34,10 @@ RewriteRule ontology https://rdf-connect.github.io/ontology [R=302,L]
 RewriteCond %{REQUEST_URI} specification
 RewriteRule specification https://rdf-connect.github.io/specification [R=302,L]
 
-# Rewrite rule to serve TTL content
-RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^$ https://rdf-connect.github.io/ontology/rdf-connect.ttl [R=302,L]
+# Rewrite rule to serve HTML content
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^$ https://rdf-connect.github.io/ [R=302,L]
 
 # Default response
 # ---------------------------
-RewriteRule ^$ https://rdf-connect.github.io/ [R=302,L]
+RewriteRule ^$ https://rdf-connect.github.io/ontology/rdf-connect.ttl [R=302,L]


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->
Switches the TTL rule and the default rule such that the TTL content is now the default and the redirect to the HTML content only happens with an Accept header of `text/html`.

## General Checklist
<!-- For all ID related PRs. -->
- [ ] Changes have been tested.
- [ ] The number of commits is minimal. Squash if needed.
- [ ] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
