### PR TITLE
Add SHACL-DS permanent identifier redirect

### DIFF
--- a/shacl-ds/.htaccess
+++ b/shacl-ds/.htaccess
@@ -1,0 +1,11 @@
+# https://w3id.org/shacl-ds redirects to the SHACL-DS vocabulary Turtle file.
+#
+# ## Contact
+# This space is administered by:
+#
+# CHIEM DAO, Davan
+# davan.chiemdao@uliege.be
+# GitHub username: Ikeragnell
+
+RewriteEngine on
+RewriteRule ^ https://raw.githubusercontent.com/Ikeragnell/SHACL-DS/master/docs/shacl-ds.ttl [R=301,L]

--- a/shacl-ds/README.md
+++ b/shacl-ds/README.md
@@ -1,0 +1,13 @@
+# SHACL-DS vocabulary
+
+Permanent identifier for the SHACL-DS vocabulary. SHACL-DS is an extension of [SHACL](https://www.w3.org/TR/shacl/) that enables native validation of RDF Datasets.
+
+Requests are redirected to the GitHub repository of the SHACL-DS project:
+<https://github.com/Ikeragnell/SHACL-DS>
+
+## Maintainers
+
+- **Name:** CHIEM DAO, Davan
+- **Affiliation:** University of Liège
+- **Email:** davan.chiemdao@uliege.be
+- **GitHub:** [@Ikeragnell](https://github.com/Ikeragnell)


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
This PR adds a permanent identifier redirect for the SHACL-DS vocabulary, an extension of SHACL for native validation of RDF Datasets.

- Redirect: https://w3id.org/shacl-ds → SHACL-DS Turtle file on GitHub (https://raw.githubusercontent.com/Ikeragnell/SHACL-DS/master/docs/shacl-ds.ttl)
- Contact: davan.chiemdao@uliege.be / GitHub: @Ikeragnell
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested. (New ID so no changes)
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.