### PR TITLE
Add T3 HR Context.

### DIFF
--- a/hr/.htaccess
+++ b/hr/.htaccess
@@ -1,0 +1,14 @@
+# HR and SelfIssuedCredentials Contexts
+#
+# homepage:
+#   - https://github.com/t3-innovation-network/hr-context
+# maintainers:
+#   - Dmitri Zagidulin (@dmitrizagidulin)
+#   - Phillip Long (@longpd)
+#
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ https://t3-innovation-network.github.io/hr-context/ [R=302,L]
+RewriteRule ^v(.+)$ https://t3-innovation-network.github.io/hr-context/contexts/v$1.jsonld [R=302,L]

--- a/hr/README.md
+++ b/hr/README.md
@@ -1,0 +1,8 @@
+# HR and SelfIssuedCredentials Contexts/Vocabulary
+
+- https://github.com/t3-innovation-network/hr-context
+
+## Maintainers
+
+- Dmitri Zagidulin (@dmitrizagidulin)
+- Phillip Long (@longpd)


### PR DESCRIPTION
## Brief Description
Create a new identifier for T3 Chamber of Commerce and HROpen related contexts. This will be used for HR JSON-LD `@context`s for use with Skill related Verifiable Credentials.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.
