### PR TITLE
Add /xch-mind/ namespace

### DIFF
--- a/xch-mind/.htaccess
+++ b/xch-mind/.htaccess
@@ -1,0 +1,49 @@
+# /xch-mind/
+#
+# Persistent URI namespace for the xch-MIND ontology and resources.
+# xch-MIND (Multi-agent Interpretive Nexus Discovery)
+#
+# https://w3id.org/xch-mind/ redirects to https://github.com/6MicheleStingo9/xch-MIND
+#
+# ## Contact
+# This space is administered by:
+#
+# Michele Stingo
+# michele.stingo@activadigital.it
+# GitHub username: 6MicheleStingo9
+
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks -MultiViews
+RewriteEngine on
+
+# === ONTOLOGY ===
+
+# Turtle content negotiation
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^ontology/?$ https://raw.githubusercontent.com/6MicheleStingo9/xch-MIND/main/ontology/xch/xch-core.ttl [R=303,L]
+
+# HTML (default) — redirect to GitHub folder
+RewriteRule ^ontology/?$ https://github.com/6MicheleStingo9/xch-MIND/tree/main/ontology/xch [R=303,L]
+
+# Ontology version IRIs (currently all resolve to latest)
+# TODO: implement versioned releases via Git tags or release folders
+RewriteRule ^ontology/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raw.githubusercontent.com/6MicheleStingo9/xch-MIND/main/ontology/xch/xch-core.ttl [R=303,L]
+
+# === SHACL SHAPES ===
+
+# Turtle content negotiation
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^shapes/?$ https://raw.githubusercontent.com/6MicheleStingo9/xch-MIND/main/ontology/xch/xch-shapes.ttl [R=303,L]
+
+# HTML (default) — redirect to GitHub folder
+RewriteRule ^shapes/?$ https://github.com/6MicheleStingo9/xch-MIND/tree/main/ontology/xch [R=303,L]
+
+# === RESOURCES (placeholder) ===
+
+RewriteRule ^resource/(.*)$ https://github.com/6MicheleStingo9/xch-MIND [R=303,L]
+
+# === DATA (placeholder) ===
+
+RewriteRule ^data/(.*)$ https://github.com/6MicheleStingo9/xch-MIND [R=303,L]

--- a/xch-mind/README.md
+++ b/xch-mind/README.md
@@ -1,0 +1,26 @@
+# xch-mind (`/xch-mind/`)
+
+Persistent URI namespace for the **xch-MIND** ontology and resources.
+
+## URIs
+
+| URI                                   | Description               |
+| ------------------------------------- | ------------------------- |
+| `https://w3id.org/xch-mind/ontology/` | xch ontology (OWL/Turtle) |
+| `https://w3id.org/xch-mind/shapes/`   | SHACL validation shapes   |
+| `https://w3id.org/xch-mind/resource/` | Named individuals         |
+| `https://w3id.org/xch-mind/data/`     | Generated data instances  |
+
+## Project
+
+**xch-MIND** (Multi-agent Interpretive Nexus Discovery) — a multi-agent system for interpretive enrichment of Cultural Heritage Linked Data.
+
+- **Source:** <https://github.com/6MicheleStingo9/xch-MIND>
+- **Ontology:** [`ontology/xch/xch-core.ttl`](https://github.com/6MicheleStingo9/xch-MIND/tree/main/ontology/xch)
+- **License:** [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) (ontology), MIT (code)
+
+## Contact
+
+**Michele Stingo** — <michele.stingo@activadigital.it>
+
+GitHub: [@6MicheleStingo9](https://github.com/6MicheleStingo9)


### PR DESCRIPTION
## Brief Description

Registers the `/xch-mind/` persistent URI namespace for the **xch-MIND** (Multi-agent Interpretive Nexus Discovery) project — a multi-agent system for interpretive enrichment of Cultural Heritage Linked Data.

### Namespace URIs

| URI | Description |
|-----|-------------|
| `https://w3id.org/xch-mind/ontology/` | xch ontology (OWL/Turtle) |
| `https://w3id.org/xch-mind/shapes/` | SHACL validation shapes |
| `https://w3id.org/xch-mind/resource/` | Named individuals |
| `https://w3id.org/xch-mind/data/` | Generated data instances |

Source: https://github.com/6MicheleStingo9/xch-MIND

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.