### PR TITLE
Create redirects for the Aksimentiev Lab (UIUC) gitlab and website so…

### DIFF
--- a/AksimentievLab/.htaccess
+++ b/AksimentievLab/.htaccess
@@ -1,0 +1,16 @@
+# Example
+#
+# https://w3id.org/examples/simple/ redirects to https://example.com/
+#
+# ## Contact
+# This space is administered by:
+#
+# Chris Maffeo
+# cmaffeo2@illinois.edu
+# GitHub username: cmaffeo2
+
+RewriteEngine on
+
+# Rewrite rule to serve HTML content
+RewriteRule ^git/(.*) https://gitlab.engr.illinois.edu/tbgl/$1 [R=302,L]
+RewriteRule ^(.*) https://bionano.physics.illinois.edu/$1 [R=302,L]

--- a/AksimentievLab/README.md
+++ b/AksimentievLab/README.md
@@ -1,0 +1,9 @@
+# Aksimentiev Lab - Computational research at the interface between physics, biology and nanotechnology
+
+This namespace is for resources related to the Aksimentiev Lab currently at University of Illinois at Urbana Champaign
+
+https://bionano.physics.illinois.edu
+
+Contacts
+* Chris Maffeo <cmaffeo2@illinois.edu> (Maintainer; GitHub: cmaffeo2)
+* Aleksei Aksimentiev <aksiment@illinois.edu>


### PR DESCRIPTION
Add redirects for public-facing Aksimentiev Lab resources (website and UIUC hosted gitlab)

## Brief Description
We wish to include permanent links in a book chapter (in Art of Molecular Programming) that could be robustly redirected even in the event that the lab moves to another institution. 

## General Checklist
- [x] Changes have been tested. 
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.