### PR TITLE
feat: add redirections for Eclipse Data Plane Signaling project

### DIFF
--- a/dspace-sig/.htaccess
+++ b/dspace-sig/.htaccess
@@ -1,0 +1,18 @@
+#
+# Eclipse Data Plane Signaling project Forwarding Rules
+# tested with https://htaccess.madewithlove.com/
+#
+
+Options -MultiViews
+
+AddType application/ld+json .jsonld
+# Rewrite engine setup
+RewriteEngine On
+#Change the path to the folder here
+RewriteBase /
+
+## Redirect JSON Schemas for 1.0
+RewriteRule ^v1.0/([\w.-]+schema.json) https://eclipse-dataplane-signaling.github.io/dataplane-signaling/schemas/$1 [R=302,L]
+
+# Rewrite rule to default to the signaling spec page
+RewriteRule ^(.*)$ https://eclipse-dataplane-signaling.github.io/dataplane-signaling [R=303,L]

--- a/dspace-sig/README.md
+++ b/dspace-sig/README.md
@@ -1,0 +1,13 @@
+# dspace-sig - Eclipse Data Plane Signaling project
+
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the [DataPlane Signaling Protocol](https://github.com/eclipse-dataplane-signaling/dataplane-signaling).
+
+Data Plane Signaling is an interoperable protocol and API used by connector control plane and data plane services to execute a data transfer.
+
+## Contact
+
+- Enrico Risa <enrico.risa@gmail.com> (https://github.com/wolf4ood)
+- James Marino <jim.marino@gmail.com> (https://github.com/jimmarino)
+- Paul Latzelsperger <Paul.latzelsperger@beardyinc.com> (https://github.com/paullatzelsperger)
+- Arno Weiß <arno.weiss@sap.com> (https://github.com/arnoweiss)
+- Andrea Bertagnolli <andrea.bertagnolli@gmail.com> (https://github.com/ndr-brt)


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description

This PR adds redirections for the [Eclipse Data Plane Signaling project](https://projects.eclipse.org/projects/technology.dataplane-signaling) 

It contains two redirects:

- The redirection for the JSON-Schema.  
- The fallback one to the signaling website.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
