### PR TITLE
Add persistent namespace for shaolinpat/hft HL7 FHIR Tool ontology

### DIFF
--- a/shaolinpat/hft/.htaccess
+++ b/shaolinpat/hft/.htaccess
@@ -1,0 +1,2 @@
+Options -MultiViews
+Redirect permanent / https://raw.githubusercontent.com/shaolinpat/hl7_fhir_tool/main/rdf/ontology/hl7_fhir_tool_schema.ttl


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
 Add persistent namespace URI for the HL7 FHIR Tool OWL ontology
(https://github.com/shaolinpat/hl7_fhir_tool). The namespace
https://w3id.org/shaolinpat/hft# is used as the ontology IRI in an
OWL 2 ontology extending FHIR RDF for HL7 v2 message parsing.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
