### PR TITLE
Add /opencredentials/ permanent URI namespace

### DIFF
--- a/opencredentials/.htaccess
+++ b/opencredentials/.htaccess
@@ -1,0 +1,25 @@
+# OpenCredentials — JSON-LD context and vocabulary
+#
+# Homepage: https://github.com/TinyCloudLabs/opencredentials
+#
+# Maintainers:
+#   - Sam Gbafa (@skgbafa)
+#
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type
+Options +FollowSymLinks
+RewriteEngine on
+
+# Serve JSON-LD context if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^$ https://spec.opencredentials.xyz/contexts/v1 [R=302,L]
+
+# Serve HTML documentation by default
+RewriteRule ^$ https://spec.opencredentials.xyz/ [R=302,L]
+
+# Versioned contexts
+RewriteRule ^v1$ https://spec.opencredentials.xyz/contexts/v1 [R=302,L]
+
+# Catch-all for sub-paths
+RewriteRule ^(.+)$ https://spec.opencredentials.xyz/$1 [R=302,L]

--- a/opencredentials/README.md
+++ b/opencredentials/README.md
@@ -1,0 +1,29 @@
+# /opencredentials/
+
+Permanent URI namespace for the **OpenCredentials** project.
+
+## Purpose
+
+This redirect provides stable, permanent identifiers for:
+
+- **JSON-LD context documents** — used in Verifiable Credentials issued by OpenCredentials
+- **Vocabulary terms** — verification types, evidence types, and credential schemas
+
+## Target
+
+All requests to `https://w3id.org/opencredentials/` are redirected to `https://spec.opencredentials.xyz/`.
+
+## Examples
+
+| URI | Redirects to |
+|-----|-------------|
+| `https://w3id.org/opencredentials/` | `https://spec.opencredentials.xyz/` |
+| `https://w3id.org/opencredentials/v1` | `https://spec.opencredentials.xyz/contexts/v1` |
+
+## Maintainers
+
+- Sam Gbafa ([@skgbafa](https://github.com/skgbafa)), TinyCloud Labs
+
+## Project
+
+- GitHub: [TinyCloudLabs/opencredentials](https://github.com/TinyCloudLabs/opencredentials)


### PR DESCRIPTION
## Summary

Register `w3id.org/opencredentials/` to provide permanent URIs for the [OpenCredentials](https://github.com/TinyCloudLabs/opencredentials) project.

- **Target**: `https://spec.opencredentials.xyz/`
- **Purpose**: JSON-LD context documents and vocabulary terms for verifiable credentials
- **Content negotiation**: Returns JSON-LD context for `application/ld+json` / `application/json` requests, HTML documentation otherwise
- **Versioned contexts**: `w3id.org/opencredentials/v1` redirects to the v1 context document

## Files

- `opencredentials/.htaccess` — Apache redirect rules
- `opencredentials/README.md` — Namespace description and maintainer info

## Maintainer

- Sam Gbafa ([@skgbafa](https://github.com/skgbafa))