### PR TITLE
Add redirects for CMECS root summary page

### DIFF
--- a/CMECS/.htaccess
+++ b/CMECS/.htaccess
@@ -8,7 +8,8 @@
 
 RewriteEngine on
 
-#redirect terms to https://ecoportal.lifewatch.eu/ontologies
-#test using https://w3id.org/CMECS/CMECS_00000389 (Geologic Substrate)
+# 1. Redirect the root (/CMECS/ or /CMECS) to the summary page
+RewriteRule ^$ https://ecoportal.lifewatch.eu/ontologies/CMECS?p=summary [R=301,L]
 
+# 2. Redirect individual terms (e.g., /CMECS/CMECS_00000389)
 RewriteRule ^([^/#]+)/?$ http://ecoportal.lifewatch.eu/ontologies/CMECS/$1 [R=301,L]


### PR DESCRIPTION
A redirect rule was added so that the root URL https://w3id.org/CMECS/ would redirect to the Summary page instead of an index page.

These rules were tested using https://htaccess.madewithlove.com/ to generate EcoPortal URLs from w3id URLs then tested successfully in an incognito browser.

<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [ ] Changes have been tested.
- [ ] The number of commits is minimal. Squash if needed.
- [ ] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
