### PR TITLE
Add /philokg/ — PhiloKG knowledge graph namespace

### DIFF
--- a/philokg/.htaccess
+++ b/philokg/.htaccess
@@ -1,0 +1,39 @@
+# w3id.org redirect rules for PhiloKG
+# Namespace: http://w3id.org/philokg/
+#
+# PhiloKG is a knowledge graph of classical philosophical discourse,
+# comprising 2M+ triples extracted from 1,000+ philosophical texts.
+
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Accept
+Options +FollowSymLinks
+RewriteEngine on
+
+# --- Ontology (content negotiation) ---
+
+# Turtle request for ontology namespace
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^$ https://zenodo.org/records/19417427/files/philokg.ttl [R=303,L]
+
+# RDF/XML request for ontology namespace
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://zenodo.org/records/19417427/files/philokg.ttl [R=303,L]
+
+# N-Triples request for ontology namespace
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://zenodo.org/records/19417427/files/philokg.nt [R=303,L]
+
+# Default: HTML landing page (Zenodo deposit)
+RewriteRule ^$ https://doi.org/10.5281/zenodo.19417427 [R=303,L]
+
+# --- Entity URIs ---
+# http://w3id.org/philokg/entity/X → Zenodo (no per-entity resolution yet)
+RewriteRule ^entity/(.+)$ https://doi.org/10.5281/zenodo.19417427 [R=303,L]
+
+# --- Statement URIs ---
+# http://w3id.org/philokg/stmt/X → Zenodo
+RewriteRule ^stmt/(.+)$ https://doi.org/10.5281/zenodo.19417427 [R=303,L]
+
+# --- Catch-all ---
+RewriteRule ^(.+)$ https://doi.org/10.5281/zenodo.19417427 [R=303,L]

--- a/philokg/README.md
+++ b/philokg/README.md
@@ -1,0 +1,29 @@
+# PhiloKG — /philokg/
+
+## Purpose
+
+Persistent URI namespace for the **PhiloKG** knowledge graph and ontology.
+
+PhiloKG is a knowledge graph of classical philosophical discourse, comprising
+2M+ triples extracted from over 1,000 philosophical texts by 142+ authors
+spanning from ancient Greece to the early twentieth century.
+
+## URIs
+
+| Pattern | Description |
+|---------|-------------|
+| `/philokg/` | PhiloKG ontology namespace |
+| `/philokg/entity/{name}` | Entity URIs (philosophers, concepts, works) |
+| `/philokg/stmt/{hash}` | Statement reifier URIs (consensus annotations) |
+
+## Redirects
+
+- **Ontology** (Turtle/RDF): Zenodo deposit file
+- **HTML**: Zenodo landing page (<https://doi.org/10.5281/zenodo.19417427>)
+- **Entities/Statements**: Zenodo landing page (per-entity resolution planned)
+
+## Contact
+
+**Maintainer**: Kay (@kayess00)
+
+**Repository**: <https://doi.org/10.5281/zenodo.19417427>


### PR DESCRIPTION
## Summary

Add persistent URI namespace `/philokg/` for the **PhiloKG** knowledge graph and ontology.

PhiloKG is a knowledge graph of classical philosophical discourse, comprising 2M+ triples extracted from over 1,000 philosophical texts by 142+ authors spanning from ancient Greece to the early twentieth century.

## URI patterns

| Pattern | Description |
|---------|-------------|
| `/philokg/` | PhiloKG ontology namespace |
| `/philokg/entity/{name}` | Entity URIs (philosophers, concepts, works) |
| `/philokg/stmt/{hash}` | Statement reifier URIs (consensus annotations) |

## Redirects

- **Ontology** (Turtle/RDF/N-Triples): Content negotiation → Zenodo deposit files
- **HTML** (default): Zenodo landing page ([DOI: 10.5281/zenodo.19417427](https://doi.org/10.5281/zenodo.19417427))
- **Entity/Statement URIs**: Zenodo landing page (per-entity resolution planned)

## Context

PhiloKG is being submitted to the ISWC 2026 Resources Track. The ontology and data exports use `http://w3id.org/philokg/` as the base namespace. Resources are archived on Zenodo under CC-BY 4.0.

## Maintainer

- **GitHub**: @kayess00