### PR TITLE
Add reactome-ontology namespace with initial redirect

### DIFF
--- a/reactome-ontology/.htaccess
+++ b/reactome-ontology/.htaccess
@@ -1,0 +1,9 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Base namespace
+RewriteRule ^$ https://cair2015.github.io/reactome-ontology/ [R=302,L]
+
+# Optional convenience redirects
+RewriteRule ^index\.html$ https://cair2015.github.io/reactome-ontology/ [R=302,L]
+RewriteRule ^README\.md$ https://github.com/cair2015/reactome-ontology [R=302,L]

--- a/reactome-ontology/README.md
+++ b/reactome-ontology/README.md
@@ -1,0 +1,17 @@
+# Reactome Ontology
+
+## Namespace
+
+- Base namespace: `https://w3id.org/reactome-ontology`
+- Maintainer: Robin Cai
+- Project repository: https://github.com/cair2015/reactome-ontology
+- Documentation site: https://cair2015.github.io/reactome-ontology/
+
+## Project Description
+
+`reactome-ontology` is an ontology-first LinkML project for representing key parts of the Reactome data model as a cleaner ontology-oriented schema.
+
+## Contact
+
+- Robin Cai
+- GitHub: https://github.com/cair2015


### PR DESCRIPTION
## Brief description

This PR requests the `reactome-ontology` namespace for the Reactome Ontology project.

## Included in this PR

- `reactome-ontology/README.md`
- `reactome-ontology/.htaccess`

## Maintainer

- Robin Cai
- GitHub: @cair2015
- Email: robincai92130@gmail.com

## Notes

This namespace currently includes an initial redirect target and will be extended later as the project develops.