### PR TITLE
Fix redirect rules for kanseki and momijiyama (support alphanumeric IDs)

### DIFF
--- a/kanseki/.htaccess
+++ b/kanseki/.htaccess
@@ -4,4 +4,4 @@ RewriteEngine On
 RewriteRule ^$ https://db2.sido.keio.ac.jp/kanseki/ [R=302,L]
 
 # 書誌詳細ページ
-RewriteRule ^bib/([0-9]+)$ https://db2.sido.keio.ac.jp/kanseki/bib_detail?bibid=$1 [R=302,L]
+RewriteRule ^bib/([A-Za-z0-9]+)$ https://db2.sido.keio.ac.jp/kanseki/bib_detail?bibid=$1 [R=302,L]

--- a/momijiyama/.htaccess
+++ b/momijiyama/.htaccess
@@ -4,4 +4,4 @@ RewriteEngine On
 RewriteRule ^$ https://db2.sido.keio.ac.jp/momijiyama/ [R=302,L]
 
 # 書誌詳細ページ
-RewriteRule ^bib/([0-9]+)$ https://db2.sido.keio.ac.jp/momijiyama/bib_detail?bibid=$1 [R=302,L]
+RewriteRule ^bib/([A-Za-z0-9]+)$ https://db2.sido.keio.ac.jp/momijiyama/bib_detail?bibid=$1 [R=302,L]


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
- Update .htaccess rules to allow alphanumeric bib IDs (e.g., w32414, k12345)
- Fix redirect patterns for /kanseki/bib/{id} and /momijiyama/bib/{id}

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
