### PR TITLE
hyperloop-dpp: GS1 Digital Link – Segment + Batch redirects

### DIFF
--- a/hyperloop-dpp/.htaccess
+++ b/hyperloop-dpp/.htaccess
@@ -1,12 +1,21 @@
 Options -MultiViews
 RewriteEngine on
 
-# JSON-LD content negotiation: SN-xxx -> passports/SN-xxx.jsonld
+# ── Segment SGTIN: /01/[GTIN]/21/[SN] ────────────────────────────────────────
+# Content negotiation: JSON-LD for machines
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^(SN-[0-9]+)$ https://DPPIP.github.io/DPP-EUROTUBE/passports/$1.jsonld [R=303,L]
+RewriteRule ^01/([0-9]{14})/21/([0-9]+)$ https://DPPIP.github.io/DPP-EUROTUBE/passports/$2.jsonld [R=303,L]
 
-# HTML: SN-xxx -> passports/SN-xxx.html
-RewriteRule ^(SN-[0-9]+)$ https://DPPIP.github.io/DPP-EUROTUBE/passports/$1.html [R=303,L]
+# HTML viewer for humans
+RewriteRule ^01/([0-9]{14})/21/([0-9]+)$ https://DPPIP.github.io/DPP-EUROTUBE/passports/viewer.html?sn=$2 [R=303,L,QSA]
 
-# Fallback: redirect to main page
+# ── Batch LGTIN: /01/[GTIN]/10/[LOT] ─────────────────────────────────────────
+# Content negotiation: JSON-LD for machines
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^01/([0-9]{14})/10/([0-9]+)$ https://DPPIP.github.io/DPP-EUROTUBE/batch/$2.jsonld [R=303,L]
+
+# HTML batch viewer for humans
+RewriteRule ^01/([0-9]{14})/10/([0-9]+)$ https://DPPIP.github.io/DPP-EUROTUBE/batch/index.html?batch=$2 [R=303,L,QSA]
+
+# ── Fallback ──────────────────────────────────────────────────────────────────
 RewriteRule ^$ https://DPPIP.github.io/DPP-EUROTUBE/ [R=303,L]


### PR DESCRIPTION
Replaces the old SN-xxx pattern with full GS1 Digital Link URIs:

  Segment (SGTIN): /01/[GTIN-14]/21/[serial]
    → JSON-LD: passports/{serial}.jsonld  (Accept: application/ld+json)
    → HTML:    passports/viewer.html?sn={serial}

  Batch (LGTIN): /01/[GTIN-14]/10/[lot]
    → JSON-LD: batch/{lot}.jsonld         (Accept: application/ld+json)
    → HTML:    batch/index.html?batch={lot}

Implements ISO/IEC 18975 (GS1 Digital Link) for Hyperloop DPP. Compliant with EU ESPR / prEN 18222/18223 Digital Product Passport.

