### PR TITLE
Update .htaccess to remove 'docs' from URLs

### DIFF
--- a/wedowind/.htaccess
+++ b/wedowind/.htaccess
@@ -10,19 +10,19 @@ RewriteEngine On
 
 # Turtle (highest priority)
 RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
-RewriteRule ^$ https://dkwakye.github.io/wedowind/docs/ontology.ttl [R=303,L]
+RewriteRule ^$ https://dkwakye.github.io/wedowind/ontology.ttl [R=303,L]
 
 # JSON-LD
 RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
-RewriteRule ^$ https://dkwakye.github.io/wedowind/docs/ontology.jsonld [R=303,L]
+RewriteRule ^$ https://dkwakye.github.io/wedowind/ontology.jsonld [R=303,L]
 
 # RDF/XML
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
-RewriteRule ^$ https://dkwakye.github.io/wedowind/docs/ontology.rdf [R=303,L]
+RewriteRule ^$ https://dkwakye.github.io/wedowind/ontology.rdf [R=303,L]
 
 # N-Triples
 RewriteCond %{HTTP_ACCEPT} application/n-triples [NC]
-RewriteRule ^$ https://dkwakye.github.io/wedowind/docs/ontology.nt [R=303,L]
+RewriteRule ^$ https://dkwakye.github.io/wedowind/ontology.nt [R=303,L]
 
 # HTML fallback (LAST rule only)
-RewriteRule ^$ https://dkwakye.github.io/wedowind/docs/ [R=303,L]
+RewriteRule ^$ https://dkwakye.github.io/wedowind/ [R=303,L]


### PR DESCRIPTION
Fix GitHub Pages URL mapping and align w3id redirects with root-level ontology resources

<!-- Fix GitHub Pages URL mapping and align w3id redirects with root-level ontology resources -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [ x] Changes have been tested.
- [ x] The number of commits is minimal. Squash if needed.
- [ x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
