### PR TITLE
Add Marvin ontology namespace (aigora-de/marvin)

### DIFF
--- a/marvin/.htaccess
+++ b/marvin/.htaccess
@@ -3,7 +3,7 @@
 #
 # This space is administered by:
 # Dave Dyke
-# 23141680+aigora-de@users.noreply.github.com]
+# 23141680+aigora-de@users.noreply.github.com
 # GitHub: aigora-de
 
 Options +FollowSymLinks

--- a/marvin/.htaccess
+++ b/marvin/.htaccess
@@ -2,9 +2,9 @@
 # https://github.com/aigora-de/marvin
 #
 # This space is administered by:
-# [Dave Dyke]
-# [23141680+aigora-de@users.noreply.github.com]
-# GitHub: [aigora-de]
+# Dave Dyke
+# 23141680+aigora-de@users.noreply.github.com]
+# GitHub: aigora-de
 
 Options +FollowSymLinks
 RewriteEngine on
@@ -15,14 +15,15 @@ RewriteEngine on
 
 # Turtle
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^projections/(.*)$ https://raw.githubusercontent.com/aigora-de/marvin/main/ontologies/marvin-projections.ttl [R=303,L]
+RewriteRule ^projections/(.*)$ https://raw.githubusercontent.com/aigora-de/marvin/main/ontology/marvin-projections.ttl [R=303,L]
 
 # RDF/XML
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^projections/(.*)$ https://raw.githubusercontent.com/aigora-de/marvin/main/ontologies/marvin-projections.rdf [R=303,L]
+#RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+#RewriteRule ^projections/(.*)$ https://raw.githubusercontent.com/aigora-de/marvin/main/ontology/marvin-projections.rdf [R=303,L]
 
 # HTML / browser default → docs
-RewriteRule ^projections/(.*)$ https://aigora-de.github.io/marvin/projections/$1 [R=303,L]
+#RewriteRule ^projections/(.*)$ https://aigora-de.github.io/marvin/projections/$1 [R=303,L]
+RewriteRule ^projections/(.*)$ https://github.com/aigora-de/marvin [R=303,L]
 
 # ------------------------------------------------------------------
 # https://w3id.org/marvin/  (root and everything else)
@@ -30,11 +31,12 @@ RewriteRule ^projections/(.*)$ https://aigora-de.github.io/marvin/projections/$1
 
 # Turtle
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^(.*)$ https://raw.githubusercontent.com/aigora-de/marvin/main/ontologies/marvin.ttl [R=303,L]
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/aigora-de/marvin/main/ontology/marvin.ttl [R=303,L]
 
 # RDF/XML
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^(.*)$ https://raw.githubusercontent.com/aigora-de/marvin/main/ontologies/marvin.rdf [R=303,L]
+#RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+#RewriteRule ^(.*)$ https://raw.githubusercontent.com/aigora-de/marvin/main/ontology/marvin.rdf [R=303,L]
 
 # HTML / browser default → docs
-RewriteRule ^(.*)$ https://aigora-de.github.io/marvin/ [R=303,L]
+#RewriteRule ^(.*)$ https://aigora-de.github.io/marvin/ [R=303,L]
+RewriteRule ^(.*)$ https://github.com/aigora-de/marvin [R=303,L]

--- a/marvin/.htaccess
+++ b/marvin/.htaccess
@@ -1,0 +1,40 @@
+# Marvin — AI-augmented ontology development environment
+# https://github.com/aigora-de/marvin
+#
+# This space is administered by:
+# [Dave Dyke]
+# [23141680+aigora-de@users.noreply.github.com]
+# GitHub: [aigora-de]
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# ------------------------------------------------------------------
+# https://w3id.org/marvin/projections/
+# ------------------------------------------------------------------
+
+# Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^projections/(.*)$ https://raw.githubusercontent.com/aigora-de/marvin/main/ontologies/marvin-projections.ttl [R=303,L]
+
+# RDF/XML
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^projections/(.*)$ https://raw.githubusercontent.com/aigora-de/marvin/main/ontologies/marvin-projections.rdf [R=303,L]
+
+# HTML / browser default → docs
+RewriteRule ^projections/(.*)$ https://aigora-de.github.io/marvin/projections/$1 [R=303,L]
+
+# ------------------------------------------------------------------
+# https://w3id.org/marvin/  (root and everything else)
+# ------------------------------------------------------------------
+
+# Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/aigora-de/marvin/main/ontologies/marvin.ttl [R=303,L]
+
+# RDF/XML
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/aigora-de/marvin/main/ontologies/marvin.rdf [R=303,L]
+
+# HTML / browser default → docs
+RewriteRule ^(.*)$ https://aigora-de.github.io/marvin/ [R=303,L]

--- a/marvin/README.md
+++ b/marvin/README.md
@@ -16,9 +16,9 @@ ontology extensions, with particular focus on 4D extensional ontologies.
 
 This space is administered by:
 
-[Dave Dyke]
-[23141680+aigora-de@users.noreply.github.com]
-GitHub: [aigora-de]
+Dave Dyke
+23141680+aigora-de@users.noreply.github.com
+GitHub: aigora-de
 
 ## Repository
 

--- a/marvin/README.md
+++ b/marvin/README.md
@@ -1,0 +1,25 @@
+# Marvin
+
+Persistent URI namespace for the Marvin AI-augmented ontology development environment.
+
+Marvin provides collaborative, AI-assisted tooling for developing and maintaining
+ontology extensions, with particular focus on 4D extensional ontologies.
+
+## Namespaces registered
+
+| URI | Description |
+|-----|-------------|
+| `https://w3id.org/marvin/` | Core Marvin ontology |
+| `https://w3id.org/marvin/projections/` | Marvin projections ontology |
+
+## Contact
+
+This space is administered by:
+
+[Dave Dyke]
+[23141680+aigora-de@users.noreply.github.com]
+GitHub: [aigora-de]
+
+## Repository
+
+https://github.com/aigora-de/marvin

--- a/marvin/README.md
+++ b/marvin/README.md
@@ -16,8 +16,8 @@ ontology extensions, with particular focus on 4D extensional ontologies.
 
 This space is administered by:
 
-Dave Dyke
-23141680+aigora-de@users.noreply.github.com
+Dave Dyke<br>
+23141680+aigora-de@users.noreply.github.com<br>
 GitHub: aigora-de
 
 ## Repository


### PR DESCRIPTION
## Brief Description
Add a new w3id namespace for Marvin, an AI-augmented ontology development 
environment for 4D extensional ontologies. Registers two namespaces:
- `https://w3id.org/marvin/` — core Marvin ontology
- `https://w3id.org/marvin/projections/` — Marvin projections ontology

Turtle requests redirect to raw GitHub content; HTML requests redirect to 
the project repository. RDF/XML rules are present but commented out pending 
serialisation of those files.

## General Checklist
- [ ] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- Not applicable — this is a new ID directory. -->

## Optional Requests for W3ID Maintainers
<!-- None. -->
