### PR TITLE
Add /hebrew-manuscripts/ for Hebrew Manuscripts Ontology

### DIFF
--- a/hebrew-manuscripts/.htaccess
+++ b/hebrew-manuscripts/.htaccess
@@ -1,0 +1,39 @@
+# Hebrew Manuscripts Ontology (HMO)
+# Maintained by the Mapping Hebrew Manuscripts (MHM) project,
+# Bar-Ilan University.
+#
+# Maintainer:
+#   Alexander Goldberg
+#   GitHub: @alexandergolbergwix
+#   ORCID:  0009-0004-5967-9377
+#   Email:  shvedbook@gmail.com
+#
+# Repository:     https://github.com/alexandergolbergwix/pipeline
+# Zenodo deposit: https://doi.org/10.5281/zenodo.19560383
+
+Options +FollowSymLinks
+AddType application/rdf+xml .rdf .owl
+AddType text/turtle .ttl
+AddType application/ld+json .jsonld
+
+RewriteEngine on
+
+# Content negotiation:
+#   text/turtle      -> hebrew-manuscripts.ttl
+#   application/rdf+xml or */* -> hebrew-manuscripts.owl
+#   text/html (browsers) -> the GitHub directory page
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^$ https://github.com/alexandergolbergwix/pipeline/raw/main/ontology/hebrew-manuscripts.ttl [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://github.com/alexandergolbergwix/pipeline/raw/main/ontology/hebrew-manuscripts.owl [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^$ https://github.com/alexandergolbergwix/pipeline/tree/main/ontology [R=302,L]
+
+# Default (no specific Accept header): serve the OWL/RDF-XML document
+RewriteRule ^$ https://github.com/alexandergolbergwix/pipeline/raw/main/ontology/hebrew-manuscripts.owl [R=302,L]
+
+# Fragment / sub-path requests (e.g. /hebrew-manuscripts/F4_Manifestation_Singleton)
+# also resolve to the canonical OWL document (the term IRIs live inside it).
+RewriteRule ^(.+)$ https://github.com/alexandergolbergwix/pipeline/raw/main/ontology/hebrew-manuscripts.owl [R=302,L]

--- a/hebrew-manuscripts/README.md
+++ b/hebrew-manuscripts/README.md
@@ -1,0 +1,34 @@
+# Hebrew Manuscripts Ontology (HMO)
+
+## Namespace
+
+- Base namespace: `https://w3id.org/hebrew-manuscripts/`
+- Maintainer: Alexander Goldberg
+- Project repository: https://github.com/alexandergolbergwix/pipeline
+- Zenodo deposit: https://doi.org/10.5281/zenodo.19560383
+
+## Project Description
+
+The **Hebrew Manuscripts Ontology (HMO)** is an OWL ontology for representing Hebrew manuscripts as Linked Open Data. Developed by the Mapping Hebrew Manuscripts (MHM) project at Bar-Ilan University, HMO integrates a cataloging-bibliographic layer (LRMoo Work / Expression / Manifestation Singleton), a philological layer (TextTradition, TransmissionWitness), and an epistemological layer (Attribution, EpistemologicalStatus), aligned with CIDOC CRM and LRMoo.
+
+The ontology supports structural granularity through Bibliographic Unit / Codicological Unit / Paleographical Unit (BU-CU-PU) and adopts event-centric modelling for production, transfer, and ownership.
+
+## Content negotiation
+
+| Accept header | Response |
+|---|---|
+| `text/turtle` | Turtle serialisation |
+| `application/rdf+xml` | OWL/RDF-XML serialisation |
+| `text/html` | GitHub repository page |
+
+## License
+
+The ontology is released under [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+
+## Contact
+
+- **Name:** Alexander Goldberg
+- **GitHub:** [@alexandergolbergwix](https://github.com/alexandergolbergwix)
+- **ORCID:** [0009-0004-5967-9377](https://orcid.org/0009-0004-5967-9377)
+- **Email:** shvedbook@gmail.com
+- **Affiliation:** Bar-Ilan University, Ramat-Gan, Israel


### PR DESCRIPTION
## Brief Description
Adds a new permanent identifier `https://w3id.org/hebrew-manuscripts/` for the **Hebrew Manuscripts Ontology (HMO)**, an OWL ontology developed by the Mapping Hebrew Manuscripts (MHM) project at Bar-Ilan University.

The redirect uses HTTP content negotiation:
- `text/turtle` → `hebrew-manuscripts.ttl` on GitHub
- `application/rdf+xml` (and default) → `hebrew-manuscripts.owl` on GitHub
- `text/html` → the GitHub directory page for human browsers

## Maintainer
- **Name:** Alexander Goldberg
- **GitHub:** @alexandergolbergwix
- **ORCID:** 0009-0004-5967-9377
- **Email:** shvedbook@gmail.com
- **Affiliation:** Department of Information Science and Applied Artificial Intelligence, Bar-Ilan University, Israel

## Linked artefacts
- Source repository: https://github.com/alexandergolbergwix/pipeline
- Ontology TTL: https://github.com/alexandergolbergwix/pipeline/raw/main/ontology/hebrew-manuscripts.ttl
- Ontology OWL/RDF-XML: https://github.com/alexandergolbergwix/pipeline/raw/main/ontology/hebrew-manuscripts.owl
- Zenodo deposit (frozen v1.0): https://doi.org/10.5281/zenodo.19560383

## License
The ontology is released under the Creative Commons Attribution 4.0 International license (CC-BY 4.0).

The companion paper has been submitted to the Semantic Web Journal.

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`. (in `.htaccess` header)
- [x] GitHub username ids are listed in the maintainer details.

## Optional Requests for W3ID Maintainers
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.