### PR TITLE
Add namespace for desmos ontology

### DIFF
--- a/desmos/.htaccess
+++ b/desmos/.htaccess
@@ -1,10 +1,11 @@
 RewriteEngine On
 
+RewriteRule ^desmos.owl$ https://raw.githubusercontent.com/enricabruno/desmos/main/desmos.owl [R=303,L]
+RewriteRule ^oplepiana.ttl$ https://raw.githubusercontent.com/enricabruno/desmos/main/oplepiana.ttl [R=303,L]
+
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} application/owl\+xml
-RewriteRule ^$ https://zenodo.org/records/18515555/files/desmos.owl?download=1 [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^$ https://zenodo.org/records/18515555/files/oplepiana.ttl?download=1 [R=303,L]
+RewriteRule ^$ https://raw.githubusercontent.com/enricabruno/desmos/main/desmos.owl [R=303,L]
 
 RewriteRule ^$ https://zenodo.org/records/18515555 [R=303,L]
+

--- a/desmos/.htaccess
+++ b/desmos/.htaccess
@@ -7,5 +7,5 @@ RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} application/owl\+xml
 RewriteRule ^$ https://raw.githubusercontent.com/enricabruno/desmos/main/desmos.owl [R=303,L]
 
-RewriteRule ^$ https://zenodo.org/records/18515555 [R=303,L]
+RewriteRule ^(.*)$ https://zenodo.org/records/19605572 [R=303,L]
 

--- a/desmos/.htaccess
+++ b/desmos/.htaccess
@@ -1,0 +1,10 @@
+RewriteEngine On
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/owl\+xml
+RewriteRule ^$ https://zenodo.org/records/18515555/files/desmos.owl?download=1 [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^$ https://zenodo.org/records/18515555/files/oplepiana.ttl?download=1 [R=303,L]
+
+RewriteRule ^$ https://zenodo.org/records/18515555 [R=303,L]

--- a/desmos/README.md
+++ b/desmos/README.md
@@ -1,0 +1,7 @@
+# DeSMòS Namespace
+
+## Maintainers
+* Enrica Bruno ([@enricabruno](https://github.com/enricabruno))
+
+## Contact
+For any issues regarding this namespace, please contact the maintainer via GitHub or at: enricabruno19@gmail.com


### PR DESCRIPTION
I am requesting the registration of the 'desmos' namespace for a PhD project in Digital Humanities. The DeSMOS ontology (v1.1.0) models literary constraints as generative devices.

The redirection is configured as follows:
Direct requests for .owl and .ttl files point to the GitHub raw URLs for immediate access.
Software agents (requesting application/rdf+xml or application/owl+xml) are redirected to the GitHub raw OWL file.
The root URI (https://w3id.org/desmos/) redirects to Zenodo record 18515555 for scholarly citation, metadata, and access to the complete research dataset.