### PR TITLE
Register H2KG namespace redirects

### DIFF
--- a/h2kg/.htaccess
+++ b/h2kg/.htaccess
@@ -1,0 +1,50 @@
+Options +FollowSymLinks
+RewriteEngine On
+
+# Project home under /h2kg/
+RewriteRule ^$ https://vimilabs.github.io/AIMWORKS/index.html [R=302,L]
+
+# Core H2KG namespace document
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^hydrogen-ontology$ https://raw.githubusercontent.com/ViMiLabs/AIMWORKS/main/ontology_release/output/ontology/core_schema.ttl [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^hydrogen-ontology$ https://raw.githubusercontent.com/ViMiLabs/AIMWORKS/main/ontology_release/output/ontology/core_schema.jsonld [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteRule ^hydrogen-ontology$ https://vimilabs.github.io/AIMWORKS/hydrogen-ontology.html [R=302,L]
+
+RewriteRule ^hydrogen-ontology$ https://vimilabs.github.io/AIMWORKS/hydrogen-ontology.html [R=302,L]
+
+# PEMFC profile namespace document
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^pemfc/hydrogen-ontology$ https://raw.githubusercontent.com/ViMiLabs/AIMWORKS/main/ontology_release/output/ontology/pemfc_schema.ttl [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^pemfc/hydrogen-ontology$ https://raw.githubusercontent.com/ViMiLabs/AIMWORKS/main/ontology_release/output/ontology/pemfc_schema.jsonld [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteRule ^pemfc/hydrogen-ontology$ https://vimilabs.github.io/AIMWORKS/pemfc/hydrogen-ontology.html [R=302,L]
+
+RewriteRule ^pemfc/hydrogen-ontology$ https://vimilabs.github.io/AIMWORKS/pemfc/hydrogen-ontology.html [R=302,L]
+
+# PEMWE profile namespace document
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^pemwe/hydrogen-ontology$ https://raw.githubusercontent.com/ViMiLabs/AIMWORKS/main/ontology_release/output/ontology/pemwe_schema.ttl [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^pemwe/hydrogen-ontology$ https://raw.githubusercontent.com/ViMiLabs/AIMWORKS/main/ontology_release/output/ontology/pemwe_schema.jsonld [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteRule ^pemwe/hydrogen-ontology$ https://vimilabs.github.io/AIMWORKS/pemwe/hydrogen-ontology.html [R=302,L]
+
+RewriteRule ^pemwe/hydrogen-ontology$ https://vimilabs.github.io/AIMWORKS/pemwe/hydrogen-ontology.html [R=302,L]

--- a/h2kg/README.md
+++ b/h2kg/README.md
@@ -1,0 +1,46 @@
+# H2KG w3id Redirect Configuration
+
+Project: `H2KG Application Ontology for Hydrogen Electrochemical Systems`
+
+This directory is intended for a future pull request to `perma-id/w3id.org` to
+register the `https://w3id.org/h2kg/` namespace.
+
+## Namespace policy
+
+- Active strategy: `preserve_hash_namespace`
+- Main ontology IRI: `https://w3id.org/h2kg/hydrogen-ontology`
+- Main namespace URI: `https://w3id.org/h2kg/hydrogen-ontology#`
+- Existing term IRIs are preserved
+
+## Redirect targets
+
+### Shared H2KG namespace
+
+- Browser / HTML: `https://vimilabs.github.io/AIMWORKS/hydrogen-ontology.html`
+- Turtle: `https://raw.githubusercontent.com/ViMiLabs/AIMWORKS/main/ontology_release/output/ontology/core_schema.ttl`
+- JSON-LD: `https://raw.githubusercontent.com/ViMiLabs/AIMWORKS/main/ontology_release/output/ontology/core_schema.jsonld`
+
+### PEMFC profile namespace
+
+- Browser / HTML: `https://vimilabs.github.io/AIMWORKS/pemfc/hydrogen-ontology.html`
+- Turtle: `https://raw.githubusercontent.com/ViMiLabs/AIMWORKS/main/ontology_release/output/ontology/pemfc_schema.ttl`
+- JSON-LD: `https://raw.githubusercontent.com/ViMiLabs/AIMWORKS/main/ontology_release/output/ontology/pemfc_schema.jsonld`
+
+### PEMWE profile namespace
+
+- Browser / HTML: `https://vimilabs.github.io/AIMWORKS/pemwe/hydrogen-ontology.html`
+- Turtle: `https://raw.githubusercontent.com/ViMiLabs/AIMWORKS/main/ontology_release/output/ontology/pemwe_schema.ttl`
+- JSON-LD: `https://raw.githubusercontent.com/ViMiLabs/AIMWORKS/main/ontology_release/output/ontology/pemwe_schema.jsonld`
+
+## Contact and maintenance
+
+- Repository: `https://github.com/ViMiLabs/AIMWORKS`
+- Docs base: `https://vimilabs.github.io/AIMWORKS/`
+- Maintainers: AIMWORKS / ViMiLabs
+
+## Notes
+
+Hash IRIs such as `https://w3id.org/h2kg/hydrogen-ontology#FixedBedReactor`
+resolve through the namespace document `https://w3id.org/h2kg/hydrogen-ontology`.
+The target HTML page therefore needs exact term-fragment anchors, which the
+current documentation build provides.

--- a/h2kg/README.md
+++ b/h2kg/README.md
@@ -36,7 +36,9 @@ register the `https://w3id.org/h2kg/` namespace.
 
 - Repository: `https://github.com/ViMiLabs/AIMWORKS`
 - Docs base: `https://vimilabs.github.io/AIMWORKS/`
-- Maintainers: AIMWORKS / ViMiLabs
+- Maintainers:
+  - Marjan Kohandani (`@Marjanknd`) - Theory and Computation of Energy Materials (IET-3), Institute of Energy Technologies, Forschungszentrum Juelich GmbH, 52425 Juelich, Germany
+  - Mohammad J. Eslamibidgoli (`@meslamib3`) - Centre for Advanced Simulation and Analytics (CASA), Simulation and Data Science Lab for Energy Materials (SDL-EM), Forschungszentrum Juelich GmbH, 52425 Juelich, Germany
 
 ## Notes
 


### PR DESCRIPTION
This PR registers the H2KG namespace under `https://w3id.org/h2kg/`.

Summary:
- preserve the existing hash namespace `https://w3id.org/h2kg/hydrogen-ontology#`
- route browser requests for `/h2kg/hydrogen-ontology` to the human-readable H2KG namespace reference page
- route RDF-aware requests to the canonical Turtle and JSON-LD ontology artifacts
- expose profile namespace documents for:
  - `/h2kg/pemfc/hydrogen-ontology`
  - `/h2kg/pemwe/hydrogen-ontology`

Notes:
- the namespace policy intentionally preserves existing H2KG term IRIs
- term IRIs such as `https://w3id.org/h2kg/hydrogen-ontology#FixedBedReactor` resolve through the namespace document
- the target HTML reference page provides exact fragment anchors for the H2KG namespace terms
- the corresponding RDF targets are published from the AIMWORKS ontology release pipeline

Maintainer / project:
- Repository: https://github.com/ViMiLabs/AIMWORKS
- Documentation base: https://vimilabs.github.io/AIMWORKS/