### PR TITLE
Add ontometal ontology namespace

### DIFF
--- a/ontometal/.htaccess
+++ b/ontometal/.htaccess
@@ -1,0 +1,5 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+RewriteRule ^$ https://oceanberlinghieri.github.io/ontometal/ [R=303,L]
+RewriteRule ^(.*)$ https://oceanberlinghieri.github.io/ontometal/$1 [R=303,L]

--- a/ontometal/README.md
+++ b/ontometal/README.md
@@ -1,0 +1,16 @@
+# Ontometal
+
+OntoMetal models bands, artists, albums, songs and genres in the Heavy Metal domain, an ontology for modeling and publishing Heavy Metal data as Linked Data.
+
+## Namespace
+
+https://w3id.org/ontometal/
+
+## Homepage
+
+https://oceanberlinghieri.github.io/ontometal/
+
+## Maintainers
+
+- Ocean Berlinghieri: https://github.com/OceanBerlinghieri
+- Contact: berlinghieri10@gmail.com


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->
OntoMetal is an ontology for modeling Heavy Metal domain knowledge, including bands, artists, albums, songs, and genres, published as Linked Data.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.
