### PR TITLE
Update redirection for CASO and IRRIG

### DIFF
--- a/def/.htaccess
+++ b/def/.htaccess
@@ -7,12 +7,12 @@ RewriteRule ^basicsemantics-owl$ https://w3id.org/nta8035/def [R=302,L]
 # Special rule for IRRIG vocabulary (maintainer: Catherine Roussey @croussey)
 # http://www.w3id.org/def/irrig and http://www.w3id.org/def/irrig#RainIntensityBoundary
 RewriteCond %{REQUEST_URI} ^/def/irrig$
-RewriteRule ^def/irrig$ https://agroportal.eu/ontologies/IRRIG [R=302,L]
+RewriteRule ^irrig$ https://agroportal.eu/ontologies/IRRIG [R=302,L]
 
 # Special rule for CASO vocabulary (maintainer: Catherine Roussey @croussey)
 # http://www.w3id.org/def/caso and http://www.w3id.org/def/caso#Boundary
 RewriteCond %{REQUEST_URI} ^/def/caso$
-RewriteRule ^def/irrig$ https://agroportal.eu/ontologies/CASO [R=302,L]
+RewriteRule ^caso$ https://agroportal.eu/ontologies/CASO [R=302,L]
 
 #Rewrite rules for OnToology's vocabularies
 RewriteRule ^(.*) https://ontoology.linkeddata.es/publish/$1 [R=302,L]

--- a/def/.htaccess
+++ b/def/.htaccess
@@ -4,5 +4,15 @@ RewriteEngine on
 # Special rule for CROW vocabulary (maintainer: Redmer Kronemeijer)
 RewriteRule ^basicsemantics-owl$ https://w3id.org/nta8035/def [R=302,L]
 
+# Special rule for IRRIG vocabulary (maintainer: Catherine Roussey @croussey)
+# http://www.w3id.org/def/irrig and http://www.w3id.org/def/irrig#RainIntensityBoundary
+RewriteCond %{REQUEST_URI} ^/def/irrig$
+RewriteRule ^def/irrig$ https://agroportal.eu/ontologies/IRRIG [R=302,L]
+
+# Special rule for CASO vocabulary (maintainer: Catherine Roussey @croussey)
+# http://www.w3id.org/def/caso and http://www.w3id.org/def/caso#Boundary
+RewriteCond %{REQUEST_URI} ^/def/caso$
+RewriteRule ^def/irrig$ https://agroportal.eu/ontologies/CASO [R=302,L]
+
 #Rewrite rules for OnToology's vocabularies
 RewriteRule ^(.*) https://ontoology.linkeddata.es/publish/$1 [R=302,L]


### PR DESCRIPTION
Switching URIs to AgroPortal as https://irstea.github.io will soon be removed

<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
The current server hosting the source file for def/caso and def/irrig will soon be removed by INRAE.
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [x] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.
 The maintener is mentionned @croussey
