### PR TITLE
Add /ontodisinfo/ namespace for OntoDisinfo-Electoral ontology

### DIFF
--- a/ontodisinfo/.htaccess
+++ b/ontodisinfo/.htaccess
@@ -1,0 +1,48 @@
+# -----------------------------------------------------------------------------
+# Redirect rules for the /ontodisinfo/ namespace on w3id.org
+#
+# Provides persistent IRIs for OntoDisinfo-Electoral — an OWL-DL modular
+# ontology for representation of electoral disinformation in social media.
+#
+# Source repository: https://gitlab.com/gustavosouto/ontodisinfo-electoral
+# License: CC-BY-4.0
+# Maintainer: Gustavo Souto Silva de Barros Santos <gssbs@cin.ufpe.br>
+# -----------------------------------------------------------------------------
+
+Options +FollowSymLinks
+AddType application/rdf+xml .rdf
+AddType text/turtle .ttl
+AddType application/ld+json .jsonld
+
+RewriteEngine on
+RewriteBase /ontodisinfo/
+
+# Base repository URL for raw Turtle files (GitLab)
+# Rewrite targets use the `main` branch — update if moving to a different default branch
+# or a different hosting service.
+
+# --- Individual modules ---
+RewriteRule ^core/?$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/domain/core/ontodis-core.ttl                [R=302,L]
+RewriteRule ^ml/?$              https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/domain/ml/ontodis-ml.ttl                    [R=302,L]
+RewriteRule ^electoral/?$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/domain/electoral/ontodis-elec.ttl           [R=302,L]
+RewriteRule ^legal/?$           https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/domain/legal/ontodis-legal.ttl              [R=302,L]
+RewriteRule ^inference/?$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/application/ontodis-inference.ttl           [R=302,L]
+RewriteRule ^alignments/?$      https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/adapter/ontodis-alignments.ttl              [R=302,L]
+RewriteRule ^gufo-alignment/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/adapter/ontodis-gufo-alignment.ttl          [R=302,L]
+RewriteRule ^full/?$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/infrastructure/ontodis-full.ttl             [R=302,L]
+
+# --- Versioned IRIs (owl:versionIRI — 1.0.0) ---
+RewriteRule ^1\.0\.0/core$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.0.0/ontology/domain/core/ontodis-core.ttl          [R=302,L]
+RewriteRule ^1\.0\.0/ml$              https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.0.0/ontology/domain/ml/ontodis-ml.ttl              [R=302,L]
+RewriteRule ^1\.0\.0/electoral$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.0.0/ontology/domain/electoral/ontodis-elec.ttl     [R=302,L]
+RewriteRule ^1\.0\.0/legal$           https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.0.0/ontology/domain/legal/ontodis-legal.ttl        [R=302,L]
+RewriteRule ^1\.0\.0/inference$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.0.0/ontology/application/ontodis-inference.ttl     [R=302,L]
+RewriteRule ^1\.0\.0/alignments$      https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.0.0/ontology/adapter/ontodis-alignments.ttl        [R=302,L]
+RewriteRule ^1\.0\.0/gufo-alignment$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.0.0/ontology/adapter/ontodis-gufo-alignment.ttl    [R=302,L]
+RewriteRule ^1\.0\.0/full$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.0.0/ontology/infrastructure/ontodis-full.ttl       [R=302,L]
+
+# --- Source repository (for HTML/browser requests) ---
+RewriteRule ^repo/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral  [R=302,L]
+
+# --- Namespace root: full integrated ontology (default) ---
+RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/infrastructure/ontodis-full.ttl  [R=302,L]

--- a/ontodisinfo/README.md
+++ b/ontodisinfo/README.md
@@ -1,0 +1,48 @@
+# /ontodisinfo/
+
+Permanent URL for the **OntoDisinfo-Electoral** ontology — an OWL-DL modular
+ontology for representation of electoral disinformation in social media,
+developed at the Center for Informatics (CIn) of the Federal University of
+Pernambuco (UFPE), Brazil.
+
+## Redirect map
+
+| W3ID URL | Redirects to |
+|----------|--------------|
+| `https://w3id.org/ontodisinfo/` | Integrated ontology (`ontodis-full.ttl`) |
+| `https://w3id.org/ontodisinfo/core` | Core module (social media ecosystem) |
+| `https://w3id.org/ontodisinfo/ml` | Machine Learning pipeline module |
+| `https://w3id.org/ontodisinfo/electoral` | Brazilian political-electoral context module |
+| `https://w3id.org/ontodisinfo/legal` | Normative framework module |
+| `https://w3id.org/ontodisinfo/inference` | Defined classes with OWL-DL axioms |
+| `https://w3id.org/ontodisinfo/alignments` | Alignments with SIOC, schema.org, Dublin Core, PROV-O, FOAF, LKIF-Core, SKOS |
+| `https://w3id.org/ontodisinfo/gufo-alignment` | Top-level alignment with UFO / gUFO |
+| `https://w3id.org/ontodisinfo/full` | Integrated ontology |
+| `https://w3id.org/ontodisinfo/1.0.0/*` | Versioned IRIs (git tag `v1.0.0`) |
+
+All redirects are HTTP 302 and target raw Turtle files on
+https://gitlab.com/gustavosouto/ontodisinfo-electoral.
+
+- **License:** Creative Commons Attribution 4.0 International (CC BY 4.0)
+- **Serialization:** Turtle (`.ttl`)
+- **Profile:** OWL 2 DL
+
+## Maintainer
+
+- **Name:** Gustavo Souto Silva de Barros Santos
+- **Affiliation:** MSc student, Center for Informatics (CIn), Federal University
+  of Pernambuco (UFPE), Brazil
+- **Email:** gssbs@cin.ufpe.br
+- **GitHub:** [@gustavosouto](https://github.com/gustavosouto)
+- **GitLab:** [@gustavosouto](https://gitlab.com/gustavosouto)
+
+## Source repository
+
+https://gitlab.com/gustavosouto/ontodisinfo-electoral
+
+## Persistence commitment
+
+The maintainer commits to keeping these redirects functional for at least 5
+years. If the source repository relocates (e.g., migration to GitHub or
+institutional hosting), a follow-up PR will be submitted to update the
+redirect targets.


### PR DESCRIPTION
### What is the purpose of this namespace?

The `ontodisinfo` namespace hosts the persistent IRIs for **OntoDisinfo-Electoral**, an OWL-DL modular ontology for representation of electoral disinformation in social media, developed at the Center for Informatics (CIn) of the Federal University of Pernambuco (UFPE), Brazil, in the context of an MSc dissertation on neuro-symbolic approaches to decision support for the Brazilian Electoral Justice.

The ontology formalizes four bounded contexts (social media core, ML pipeline, electoral context, legal/normative framework) with automatic inference axioms and alignments to consolidated Semantic Web vocabularies.

### Who is requesting this namespace?

- **Name:** Gustavo Souto Silva de Barros Santos
- **Affiliation:** MSc student, Center for Informatics (CIn), Federal University of Pernambuco (UFPE), Brazil
- **Email:** gssbs@cin.ufpe.br
- **GitLab:** [@gustavosouto](https://gitlab.com/gustavosouto)

### Which ontology/vocabulary will be served?

**OntoDisinfo-Electoral** v1.0.0 — Modular OWL-DL ontology composed of:

| Path | Module |
|------|--------|
| `/ontodisinfo/core` | Social media ecosystem (Postagem, Agente, Plataforma, Evento) |
| `/ontodisinfo/ml` | Machine Learning pipeline (Modelo, Resultado, ExplicacaoXAI, Caracteristica) |
| `/ontodisinfo/electoral` | Brazilian political-electoral context (Eleicao, Candidato, Partido, Jurisdicao) |
| `/ontodisinfo/legal` | Normative framework (NormaJuridica, IlicitoEleitoral, DecisaoJudicial, Sancao) |
| `/ontodisinfo/inference` | Defined classes with OWL-DL axioms (PostagemDeAltoRisco, FonteSuspeita, etc.) |
| `/ontodisinfo/alignments` | Alignments with SIOC, schema.org, Dublin Core, PROV-O, FOAF, LKIF-Core, SKOS |
| `/ontodisinfo/gufo-alignment` | Top-level alignment with UFO / gUFO |
| `/ontodisinfo/full` | Integrated ontology (imports all modules) |
| `/ontodisinfo/` (default) | Redirects to `/ontodisinfo/full` |
| `/ontodisinfo/1.0.0/*` | Versioned IRIs (pinned to git tag `v1.0.0`) |

- **License:** Creative Commons Attribution 4.0 International (CC BY 4.0)
- **Serialization:** Turtle (`.ttl`)
- **Profile:** OWL 2 DL
- **Source repository:** https://gitlab.com/gustavosouto/ontodisinfo-electoral

### Namespace design

The `.htaccess` redirects each module to its canonical Turtle file hosted on GitLab (raw content of the `main` branch for living IRIs; tag `v1.0.0` for versioned IRIs). The default namespace root redirects to the integrated ontology (`ontodis-full.ttl`).

### Persistence commitment

I commit to maintaining these redirects for at least 5 years. If the source repository relocates (e.g., migration to GitHub or institutional hosting), I will submit a follow-up PR to update the redirect targets in this `.htaccess`.

### Checklist

- [x] Single directory added (`/ontodisinfo/`)
- [x] `.htaccess` file included
- [x] All redirects tested locally against the source files
- [x] Namespace does not conflict with existing w3id.org entries
- [x] Maintainer contact information provided
