### PR TITLE
chore: update w3id redirects for TOSL Risk ontology

### DIFF
--- a/tosl/.htaccess
+++ b/tosl/.htaccess
@@ -1,2 +1,5 @@
 RewriteEngine On
+
+RewriteRule ^$ https://isa-group.github.io/tosl/ [R=302,L]
+RewriteRule ^risk(/.*)?$ https://isa-group.github.io/tosl-risk/ [R=302,L]
 RewriteRule ^(.*)$ https://isa-group.github.io/tosl/ [R=302,L]

--- a/tosl/README.md
+++ b/tosl/README.md
@@ -1,6 +1,7 @@
 # Traceability
 
 - https://github.com/isa-group/tosl
+- https://isa-group.github.io/tosl-risk/
 
 ## Maintainers
 


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
Changes:
- keep https://w3id.org/tosl/ redirecting to the main TOSL ontology
- add https://w3id.org/tosl/risk redirecting to the TOSL Risk ontology
- ensure all paths under /tosl/risk redirect to the risk ontology

Testing:
- tested locally with Apache
- confirmed that /tosl/risk redirects to https://isa-group.github.io/tosl-risk/
- confirmed that /tosl/ redirects to https://isa-group.github.io/tosl/

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
