### PR TITLE
Add /sstim namespace for the Sensory Stimulation ontology

### DIFF
--- a/sstim/.htaccess
+++ b/sstim/.htaccess
@@ -1,0 +1,54 @@
+# SSTIM — Sensory Stimulation Ontology
+# Persistent identifier base: https://w3id.org/sstim
+# Target:                     https://labiosyncare.github.io/ontology/
+# Maintainer:                 Renato Fabbri <renato.fabbri@gmail.com>
+# Source repository:          https://github.com/laBioSynCare/laBioSynCare.github.io
+
+Options +FollowSymLinks
+Options -MultiViews
+
+# Ensure RDF MIME types (belt-and-suspenders; GitHub Pages handles .ttl already)
+AddType text/turtle           .ttl
+AddType application/rdf+xml   .rdf .owl
+AddType application/ld+json   .jsonld
+AddType application/n-triples .nt
+
+Header set Access-Control-Allow-Origin *
+
+RewriteEngine On
+
+# -------------------------------------------------------------------------
+# /sstim/vocab — SKOS vocabulary (frequency bands, groups, sub-bands, …)
+# -------------------------------------------------------------------------
+RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
+RewriteRule ^vocab$ https://labiosyncare.github.io/ [R=303,L]
+
+RewriteRule ^vocab$ https://labiosyncare.github.io/ontology/sstim-vocab.ttl [R=303,L]
+
+# -------------------------------------------------------------------------
+# /sstim/shapes — SHACL validation shapes
+# -------------------------------------------------------------------------
+RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
+RewriteRule ^shapes$ https://labiosyncare.github.io/ [R=303,L]
+
+RewriteRule ^shapes$ https://labiosyncare.github.io/ontology/sstim-shapes.ttl [R=303,L]
+
+# -------------------------------------------------------------------------
+# /sstim/alignments — external ontology alignments (BFO, OBI, Wikidata, …)
+# -------------------------------------------------------------------------
+RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
+RewriteRule ^alignments$ https://labiosyncare.github.io/ [R=303,L]
+
+RewriteRule ^alignments$ https://labiosyncare.github.io/ontology/sstim-alignments.ttl [R=303,L]
+
+# -------------------------------------------------------------------------
+# /sstim — core ontology (OWL classes and properties). Fragment IRIs such
+# as /sstim#Preset resolve here; the fragment is handled client-side.
+# -------------------------------------------------------------------------
+# Browser → human-readable landing page (WIDOCO docs will replace this
+# target in Phase 1 once they are generated).
+RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
+RewriteRule ^$ https://labiosyncare.github.io/ [R=303,L]
+
+# Turtle or unspecified → core ontology file
+RewriteRule ^$ https://labiosyncare.github.io/ontology/sstim-core.ttl [R=303,L]

--- a/sstim/README.md
+++ b/sstim/README.md
@@ -46,10 +46,16 @@ individual terms.
 ## Project
 
 - **Source repository:** <https://github.com/laBioSynCare/laBioSynCare.github.io>
-- **Ontology license:** CC BY 4.0 (planned; being finalized in Phase 1)
+  (open-source — ontology and documentation under CC BY 4.0; application
+  code under a permissive OSI-approved license, both being finalized in Phase 1)
+- **Scope:** BSC Lab is the open scientific infrastructure for sensory
+  stimulation: ontology, evidence framework, and a planned multi-engine
+  audiovisual stimulation application (Web Audio, AudioWorklets, PixiJS).
+  The SSTIM ontology is designed to be reusable beyond BSC Lab by any
+  project in this domain.
 - **Related commercial project:** BioSynCare (React Native app, separate
-  repository) consumes BSC Lab's preset catalog exported as JSON; the
-  ontology itself is reusable beyond BSC Lab.
+  closed-source repository) will consume BSC Lab's exported preset catalog
+  as JSON; it does not use or import the ontology namespace directly.
 
 ## Contact
 

--- a/sstim/README.md
+++ b/sstim/README.md
@@ -8,7 +8,7 @@ project.
 - **Base PID:** <https://w3id.org/sstim>
 - **Target (GitHub Pages):** <https://labiosyncare.github.io/ontology/>
 - **Maintainer:** Renato Fabbri — GitHub [@ttm](https://github.com/ttm) —
-  `renato.fabbri@gmail.com` —
+  `renato@junto.space` —
   ORCID [0000-0002-9699-629X](https://orcid.org/0000-0002-9699-629X)
 
 SSTIM is an OWL ontology with a companion SKOS vocabulary and SHACL

--- a/sstim/README.md
+++ b/sstim/README.md
@@ -7,7 +7,8 @@ project.
 
 - **Base PID:** <https://w3id.org/sstim>
 - **Target (GitHub Pages):** <https://labiosyncare.github.io/ontology/>
-- **Maintainer:** Renato Fabbri — `renato.fabbri@gmail.com` —
+- **Maintainer:** Renato Fabbri — GitHub [@ttm](https://github.com/ttm) —
+  `renato.fabbri@gmail.com` —
   ORCID [0000-0002-9699-629X](https://orcid.org/0000-0002-9699-629X)
 
 SSTIM is an OWL ontology with a companion SKOS vocabulary and SHACL

--- a/sstim/README.md
+++ b/sstim/README.md
@@ -1,0 +1,58 @@
+# sstim — Sensory Stimulation Ontology
+
+Persistent identifier (PID) home for the **SSTIM** (Sensory Stimulation)
+ontology, developed and maintained as part of the open-source
+[**BSC Lab**](https://github.com/laBioSynCare/laBioSynCare.github.io)
+project.
+
+- **Base PID:** <https://w3id.org/sstim>
+- **Target (GitHub Pages):** <https://labiosyncare.github.io/ontology/>
+- **Maintainer:** Renato Fabbri — `renato.fabbri@gmail.com`
+
+SSTIM is an OWL ontology with a companion SKOS vocabulary and SHACL
+validation shapes, describing stimulation protocols (auditory,
+visual, haptic), their parameters (frequency bands, voice types,
+breathing models), evidence chains, and session instances. It is
+designed to be reusable by any sensory-stimulation research or
+application project — not specific to BSC Lab or BioSynCare.
+
+## Resolvable resources
+
+| PID                                   | Content                                           | Format |
+|---------------------------------------|---------------------------------------------------|--------|
+| `https://w3id.org/sstim`              | Core ontology — OWL classes and properties        | Turtle |
+| `https://w3id.org/sstim/vocab`        | SKOS vocabulary — frequency bands, groups, tiers  | Turtle |
+| `https://w3id.org/sstim/shapes`       | SHACL validation shapes                           | Turtle |
+| `https://w3id.org/sstim/alignments`   | External alignments (BFO, OBI, IAO, Wikidata, …)  | Turtle |
+
+Fragment IRIs such as `https://w3id.org/sstim#Preset` or
+`https://w3id.org/sstim/vocab#alpha` resolve to the same base
+document; the fragment is resolved client-side by the RDF tool.
+
+## Content negotiation
+
+The `.htaccess` dispatches on the `Accept` header:
+
+| `Accept` header                      | Response                                           |
+|--------------------------------------|----------------------------------------------------|
+| `text/turtle` (and unspecified)      | The corresponding `.ttl` file                      |
+| `text/html`, `application/xhtml+xml` | BSC Lab landing page (<https://labiosyncare.github.io/>) |
+
+**Planned (Phase 1):** HTML requests will redirect to WIDOCO-generated
+ontology documentation, which will allow anchor navigation to
+individual terms.
+
+## Project
+
+- **Source repository:** <https://github.com/laBioSynCare/laBioSynCare.github.io>
+- **Ontology license:** CC BY 4.0 (planned; being finalized in Phase 1)
+- **Related commercial project:** BioSynCare (React Native app, separate
+  repository) consumes BSC Lab's preset catalog exported as JSON; the
+  ontology itself is reusable beyond BSC Lab.
+
+## Contact
+
+- PID redirection issues → open an issue at
+  <https://github.com/laBioSynCare/laBioSynCare.github.io/issues>
+- Upstream `w3id.org` configuration issues →
+  <https://github.com/perma-id/w3id.org/issues>

--- a/sstim/README.md
+++ b/sstim/README.md
@@ -7,7 +7,8 @@ project.
 
 - **Base PID:** <https://w3id.org/sstim>
 - **Target (GitHub Pages):** <https://labiosyncare.github.io/ontology/>
-- **Maintainer:** Renato Fabbri — `renato.fabbri@gmail.com`
+- **Maintainer:** Renato Fabbri — `renato.fabbri@gmail.com` —
+  ORCID [0000-0002-9699-629X](https://orcid.org/0000-0002-9699-629X)
 
 SSTIM is an OWL ontology with a companion SKOS vocabulary and SHACL
 validation shapes, describing stimulation protocols (auditory,


### PR DESCRIPTION
## Summary

Adds a new persistent identifier `https://w3id.org/sstim` for the **SSTIM** (Sensory Stimulation) ontology, maintained as part of the open-source [BSC Lab](https://github.com/laBioSynCare/laBioSynCare.github.io) project.

SSTIM is an OWL + SKOS + SHACL artifact describing sensory-stimulation protocols (auditory, visual, haptic), their parameters (frequency bands, voice types, breathing models), evidence chains, and session instances. It is designed to be reusable beyond its originating project — e.g. by other audio-entrainment or neurofeedback research platforms.

## Resolvable paths

| PID | Target | Content |
|---|---|---|
| `https://w3id.org/sstim` | `https://labiosyncare.github.io/ontology/sstim-core.ttl` | OWL classes + properties |
| `https://w3id.org/sstim/vocab` | `.../sstim-vocab.ttl` | SKOS vocabulary (multilingual) |
| `https://w3id.org/sstim/shapes` | `.../sstim-shapes.ttl` | SHACL shapes |
| `https://w3id.org/sstim/alignments` | `.../sstim-alignments.ttl` | External alignments (BFO, OBI, IAO, Wikidata) |

## Content negotiation

- `Accept: text/turtle` (and unspecified) corresponding .ttl file
- `Accept: text/html` human-readable landing page on GitHub Pages

HTML will be redirected to WIDOCO-generated ontology documentation once that is deployed (Phase 1 of BSC Lab).

## Verification

All target files are already live on GitHub Pages and return `200 text/turtle`:

```
curl -sI https://labiosyncare.github.io/ontology/sstim-core.ttl | head -3
HTTP/2 200
content-type: text/turtle; charset=utf-8
```

## Project

- **Source repository:** https://github.com/laBioSynCare/laBioSynCare.github.io (open-source — ontology and documentation under CC BY 4.0; application code under a permissive OSI-approved license, both being finalized in Phase 1)
- **Scope:** BSC Lab is the open scientific infrastructure for sensory stimulation: ontology, evidence framework, and a planned multi-engine audiovisual stimulation application (Web Audio, AudioWorklets, PixiJS). The SSTIM ontology is designed to be reusable beyond BSC Lab by any project in this domain.
- **Related commercial project:** BioSynCare (React Native app, separate closed-source repository) will consume BSC Lab exported preset catalog as JSON; it does not use or import the ontology namespace directly.

## Maintainer

Renato Fabbri — GitHub @ttm (https://github.com/ttm) — renato@junto.space — ORCID [0000-0002-9699-629X](https://orcid.org/0000-0002-9699-629X). Source repo: https://github.com/laBioSynCare/laBioSynCare.github.io
