### PR TITLE
Add provenance namespace for CIDOC-CRM provenance database

### DIFF
--- a/provenance/.htaccess
+++ b/provenance/.htaccess
@@ -1,0 +1,26 @@
+# Provenance Database — Persistent URIs
+# Maintainer: David Witassek <david@witassek.ch>
+# GitHub: https://github.com/dwitassek
+# Description: Persistent identifiers for a CIDOC-CRM based
+#              provenance database (artworks, artists, provenance
+#              features, modification processes)
+
+Options -MultiViews
+RewriteEngine on
+
+# ── Machine requests (JSON / JSON-LD) → REST API ──────────────────────────
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^(werk|kuenstler|provenienzmerkmal|modifikationsprozess)/(.+)$  https://graphapi.witassek.ch/entities/$1/$2 [R=303,L]
+
+# ── Human requests → TYPO3 Frontend ──────────────────────────────────────
+RewriteRule ^werk/(.+)$                  https://t3provenance.witassek.ch/ [R=303,L]
+RewriteRule ^kuenstler/(.+)$             https://t3provenance.witassek.ch/ [R=303,L]
+RewriteRule ^provenienzmerkmal/(.+)$     https://t3provenance.witassek.ch/ [R=303,L]
+RewriteRule ^modifikationsprozess/(.+)$  https://t3provenance.witassek.ch/ [R=303,L]
+
+# ── Ontologie ─────────────────────────────────────────────────────────────
+RewriteRule ^ontology$  https://t3provenance.witassek.ch/ [R=303,L]
+
+# ── Fallback ──────────────────────────────────────────────────────────────
+RewriteRule ^$  https://t3provenance.witassek.ch/ [R=303,L]

--- a/provenance/README.md
+++ b/provenance/README.md
@@ -1,0 +1,29 @@
+# w3id.org/provenance
+
+Persistent URIs for a CIDOC-CRM based provenance database
+documenting artworks and their physical provenance features.
+
+## Namespace
+
+`https://w3id.org/provenance/`
+
+## URI Patterns
+
+| Pattern | Entity |
+|---|---|
+| `https://w3id.org/provenance/werk/{id}` | E22 Human-Made Object (artwork) |
+| `https://w3id.org/provenance/kuenstler/{id}` | E39 Actor (artist) |
+| `https://w3id.org/provenance/provenienzmerkmal/{id}` | E25 Human-Made Feature |
+| `https://w3id.org/provenance/modifikationsprozess/{id}` | E11 Modification |
+| `https://w3id.org/provenance/ontology` | Custom ontology properties |
+
+## Content Negotiation
+
+- `Accept: application/ld+json` or `application/json` → REST API (machine-readable)
+- Default → HTML frontend (human-readable)
+
+## Maintainer
+
+- **Name:** David Witassek
+- **Email:** david@witassek.ch
+- **GitHub:** [dwitassek](https://github.com/dwitassek)


### PR DESCRIPTION
Persistent URIs for a CIDOC-CRM based provenance database 
documenting artworks and their physical provenance features 
(artists, provenance characteristics, modification processes).

Maintainer: david@witassek.ch
GitHub: dwitassek