### PR TITLE
seovoc: fix content negotiation and redirect targets

### DIFF
--- a/seovoc/.htaccess
+++ b/seovoc/.htaccess
@@ -1,49 +1,46 @@
-# Turn off MultiViews
-Options -MultiViews
+# SEOntology w3id configuration
+# Canonical namespace: https://w3id.org/seovoc/
+# Maintainer repository: https://github.com/seontology/seontology
 
-# Directive to ensure *.rdf files served as appropriate content type,
-# if not present in main apache config
-AddType application/rdf+xml .rdf
+Options -MultiViews
+Options +FollowSymLinks
+
+RewriteEngine On
+Header merge Vary "Accept"
+
+# Explicit content-type mappings
 AddType application/rdf+xml .owl
 AddType text/turtle .ttl
-AddType application/n-triples .n3
-AddType application/ld+json .jsonld
-# Rewrite engine setup
-RewriteEngine On
 
-# Rewrite rule to serve HTML content from the vocabulary URI if requested
-# RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
-# RewriteCond %{HTTP_ACCEPT} text/html [OR]
-# RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
-# RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-# RewriteRule ^([^/]+)$ https://example.org/index.html [R=303,L]
-
-# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^([^/]+)$ https://raw.githubusercontent.com/wordlift/wl-ontology/main/seovoc.jsonld [R=303,L]
-
-# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
-RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-# Temporary redirect until we finalize repo and file naming
-RewriteRule ^([^/]+)$ https://raw.githubusercontent.com/wordlift/wl-ontology/main/SEOntology.owl [R=307,L]
-
-# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
-# RewriteCond %{HTTP_ACCEPT} application/n-triples
-# RewriteRule ^([^/]+)$ https://example.org/ontology.nt [R=303,L]
-
-# Rewrite rule to serve TTL content from the vocabulary URI if requested
-RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
-RewriteCond %{HTTP_ACCEPT} text/\* [OR]
-RewriteCond %{HTTP_ACCEPT} \*/turtle
-RewriteRule ^([^/]+)$ https://raw.githubusercontent.com/wordlift/wl-ontology/main/seovoc.ttl [R=303,L]
-
-# 406 Not Acceptable
-# RewriteCond %{HTTP_ACCEPT} .+
-# RewriteRule ^([^/]+)$ https://example.org/406.html [R=406,L]
-
-# Default response
+# Root URI: /seovoc/
 # ---------------------------
-# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
-# Temporary redirect until we finalize repo and file naming
-RewriteRule ^([^/]+)$ https://github.com/wordlift/wl-ontology/blob/main/SEOntology.owl [R=307,L]
+
+# Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC,OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [NC]
+RewriteRule ^$ https://raw.githubusercontent.com/seontology/seontology/main/seovoc.ttl [R=303,L]
+
+# RDF/XML
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC,OR]
+RewriteCond %{HTTP_ACCEPT} application/xml [NC]
+RewriteRule ^$ https://raw.githubusercontent.com/seontology/seontology/main/seovoc.owl [R=303,L]
+
+# Default for humans and unknown media types
+RewriteRule ^$ https://github.com/seontology/seontology [R=303,L]
+
+# Term URIs: /seovoc/<term>
+# e.g. https://w3id.org/seovoc/WebPage
+# ---------------------------
+
+# Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC,OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [NC]
+RewriteRule ^([^/]+)/?$ https://raw.githubusercontent.com/seontology/seontology/main/seovoc.ttl [R=303,L]
+
+# RDF/XML
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC,OR]
+RewriteCond %{HTTP_ACCEPT} application/xml [NC]
+RewriteRule ^([^/]+)/?$ https://raw.githubusercontent.com/seontology/seontology/main/seovoc.owl [R=303,L]
+
+# Default for humans and unknown media types
+RewriteRule ^([^/]+)/?$ https://github.com/seontology/seontology [R=303,L]


### PR DESCRIPTION
## Fix content negotiation for `https://w3id.org/seovoc/`

### Problem
- `/seovoc/` currently returns HTML regardless of `Accept`.
- Term IRIs under `/seovoc/<term>` still redirect to old `wordlift/wl-ontology` targets.
- Existing rules match `^([^/]+)$`, which does not match the root request path in this directory context.

### Changes
- Switched redirect targets to `seontology/seontology` canonical artifacts:
  - Turtle: `https://raw.githubusercontent.com/seontology/seontology/main/seovoc.ttl`
  - RDF/XML: `https://raw.githubusercontent.com/seontology/seontology/main/seovoc.owl`
- Added proper root matching with `^$` for `/seovoc/`.
- Kept term URI support (`/seovoc/<term>`) aligned with ontology serializations.
- Removed broad wildcard behavior that could override more specific media-type handling.
- Added `Vary: Accept` header for cache correctness.
- Standardized to 303 redirects for negotiated responses.

### Verification plan
After merge and deployment, check:

- `curl -I -H 'Accept: text/turtle' https://w3id.org/seovoc/`
- `curl -I -H 'Accept: application/rdf+xml' https://w3id.org/seovoc/`
- `curl -I -H 'Accept: text/html' https://w3id.org/seovoc/`
- `curl -I -H 'Accept: text/turtle' https://w3id.org/seovoc/WebPage`

Expected:
- Turtle => `303` to `.../seovoc.ttl`
- RDF/XML => `303` to `.../seovoc.owl`
- HTML/default => `303` to `https://github.com/seontology/seontology`
