### PR TITLE
Add mdrs-onto persistent URI for Medical Device Regulatory and Surveillance Ontology

### DIFF
--- a/mdrs-onto/.htaccess
+++ b/mdrs-onto/.htaccess
@@ -1,0 +1,13 @@
+Options +FollowSymLinks
+RewriteEngine On
+
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^$ https://danielagarciachavero.github.io/medicalDeviceOntology/index.html [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://danielagarciachavero.github.io/medicalDeviceOntology/MDRS-Onto.owl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^$ https://danielagarciachavero.github.io/medicalDeviceOntology/MDRS-Onto.ttl [R=303,L]
+
+RewriteRule ^$ https://danielagarciachavero.github.io/medicalDeviceOntology/MDRS-Onto.owl [R=303,L]

--- a/mdrs-onto/README:md
+++ b/mdrs-onto/README:md
@@ -1,0 +1,12 @@
+# Medical Device Regulatory and Surveillance Ontology (MDRS-Onto)
+
+Persistent URI for the MDRS-Onto ontology.
+
+- **URI**: https://w3id.org/mdrs-onto
+- **OWL**: https://danielagarciachavero.github.io/medicalDeviceOntology/MDRS-Onto.owl
+- **Authors**: Daniela Garcia Chavero, Johan Marin Chamorro
+- **License**: CC BY 4.0
+- **GitHub**: https://github.com/danielagarciachavero/medicalDeviceOntology
+
+## Contact
+- GitHub: johanmarin01


### PR DESCRIPTION
## Brief Description
Adding persistent URI redirect for the Medical Device Regulatory and Surveillance Ontology (MDRS-Onto), an OWL ontology for post-market surveillance of medical devices under EU MDR/IVDR regulations.

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.