### PR TITLE
Update /ontodisinfo/ with content negotiation and documentation shortcuts

### DIFF
--- a/ontodisinfo/.htaccess
+++ b/ontodisinfo/.htaccess
@@ -1,12 +1,18 @@
 # -----------------------------------------------------------------------------
 # Redirect rules for the /ontodisinfo/ namespace on w3id.org
 #
-# Provides persistent IRIs for OntoDisinfo-Electoral — an OWL-DL modular
+# Provides persistent IRIs for OntoDisinfo-Electoral: an OWL-DL modular
 # ontology for representation of electoral disinformation in social media.
 #
 # Source repository: https://gitlab.com/gustavosouto/ontodisinfo-electoral
-# License: CC-BY-4.0
-# Maintainer: Gustavo Souto Silva de Barros Santos <gssbs@cin.ufpe.br>
+# Documentation:     https://gustavosouto.gitlab.io/ontodisinfo-electoral/
+# License:           CC-BY-4.0
+# Maintainer:        Gustavo Souto Silva de Barros Santos <gssbs@cin.ufpe.br>
+#
+# Content negotiation strategy:
+#   - `Accept: text/html` (browsers)     -> human-readable documentation
+#   - `Accept: text/turtle|rdf+xml|...`  -> raw Turtle for RDF tooling
+#   - `Accept: */*` or no header (curl)  -> raw Turtle (Linked Data default)
 # -----------------------------------------------------------------------------
 
 Options +FollowSymLinks
@@ -17,21 +23,65 @@ AddType application/ld+json .jsonld
 RewriteEngine on
 RewriteBase /ontodisinfo/
 
-# Base repository URL for raw Turtle files (GitLab)
-# Rewrite targets use the `main` branch — update if moving to a different default branch
-# or a different hosting service.
+# =============================================================================
+# 1. Namespace root: https://w3id.org/ontodisinfo/
+# =============================================================================
+# Browsers -> documentation site
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/  [R=302,L]
+# RDF tools -> consolidated Turtle (ontodis-full.ttl imports all modules)
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/(rdf\+xml|x-turtle|ld\+json|n-triples|n-quads))
+RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/infrastructure/ontodis-full.ttl  [R=302,L]
+# Default (no Accept header, curl, etc.) -> Turtle, Linked Data convention
+RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/infrastructure/ontodis-full.ttl  [R=302,L]
 
-# --- Individual modules ---
-RewriteRule ^core/?$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/domain/core/ontodis-core.ttl                [R=302,L]
-RewriteRule ^ml/?$              https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/domain/ml/ontodis-ml.ttl                    [R=302,L]
-RewriteRule ^electoral/?$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/domain/electoral/ontodis-elec.ttl           [R=302,L]
-RewriteRule ^legal/?$           https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/domain/legal/ontodis-legal.ttl              [R=302,L]
-RewriteRule ^inference/?$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/application/ontodis-inference.ttl           [R=302,L]
-RewriteRule ^alignments/?$      https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/adapter/ontodis-alignments.ttl              [R=302,L]
-RewriteRule ^gufo-alignment/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/adapter/ontodis-gufo-alignment.ttl          [R=302,L]
-RewriteRule ^full/?$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/infrastructure/ontodis-full.ttl             [R=302,L]
+# =============================================================================
+# 2. Individual modules with content negotiation
+#    Browsers see the module documentation page; RDF tools see the .ttl.
+# =============================================================================
 
-# --- Versioned IRIs (owl:versionIRI — 1.0.0) ---
+# --- core ---
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^core/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/core/  [R=302,L]
+RewriteRule ^core/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/domain/core/ontodis-core.ttl  [R=302,L]
+
+# --- ml ---
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^ml/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/ml/  [R=302,L]
+RewriteRule ^ml/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/domain/ml/ontodis-ml.ttl  [R=302,L]
+
+# --- electoral ---
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^electoral/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/electoral/  [R=302,L]
+RewriteRule ^electoral/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/domain/electoral/ontodis-elec.ttl  [R=302,L]
+
+# --- legal ---
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^legal/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/legal/  [R=302,L]
+RewriteRule ^legal/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/domain/legal/ontodis-legal.ttl  [R=302,L]
+
+# --- inference ---
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^inference/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/inference/  [R=302,L]
+RewriteRule ^inference/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/application/ontodis-inference.ttl  [R=302,L]
+
+# --- alignments (external) ---
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^alignments/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/reference/alignments/  [R=302,L]
+RewriteRule ^alignments/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/adapter/ontodis-alignments.ttl  [R=302,L]
+
+# --- gufo-alignment (no dedicated doc page; always Turtle) ---
+RewriteRule ^gufo-alignment/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/adapter/ontodis-gufo-alignment.ttl  [R=302,L]
+
+# --- full integrated (entry point for Protege/reasoners) ---
+RewriteRule ^full/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/infrastructure/ontodis-full.ttl  [R=302,L]
+
+# =============================================================================
+# 3. Versioned IRIs (owl:versionIRI)
+#    Always Turtle, pinned to the corresponding Git tag.
+# =============================================================================
+
+# --- 1.0.0 ---
 RewriteRule ^1\.0\.0/core$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.0.0/ontology/domain/core/ontodis-core.ttl          [R=302,L]
 RewriteRule ^1\.0\.0/ml$              https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.0.0/ontology/domain/ml/ontodis-ml.ttl              [R=302,L]
 RewriteRule ^1\.0\.0/electoral$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.0.0/ontology/domain/electoral/ontodis-elec.ttl     [R=302,L]
@@ -41,7 +91,7 @@ RewriteRule ^1\.0\.0/alignments$      https://gitlab.com/gustavosouto/ontodisinf
 RewriteRule ^1\.0\.0/gufo-alignment$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.0.0/ontology/adapter/ontodis-gufo-alignment.ttl    [R=302,L]
 RewriteRule ^1\.0\.0/full$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.0.0/ontology/infrastructure/ontodis-full.ttl       [R=302,L]
 
-# --- Versioned IRIs (owl:versionIRI — 1.1.0) ---
+# --- 1.1.0 ---
 RewriteRule ^1\.1\.0/core$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.1.0/ontology/domain/core/ontodis-core.ttl          [R=302,L]
 RewriteRule ^1\.1\.0/ml$              https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.1.0/ontology/domain/ml/ontodis-ml.ttl              [R=302,L]
 RewriteRule ^1\.1\.0/electoral$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.1.0/ontology/domain/electoral/ontodis-elec.ttl     [R=302,L]
@@ -51,14 +101,20 @@ RewriteRule ^1\.1\.0/alignments$      https://gitlab.com/gustavosouto/ontodisinf
 RewriteRule ^1\.1\.0/gufo-alignment$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.1.0/ontology/adapter/ontodis-gufo-alignment.ttl    [R=302,L]
 RewriteRule ^1\.1\.0/full$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.1.0/ontology/infrastructure/ontodis-full.ttl       [R=302,L]
 
-# --- Latest stable (alias for /full pointing to main) ---
+# =============================================================================
+# 4. Documentation shortcuts (HTML site sections)
+#    Citable URLs for specific parts of the public documentation.
+# =============================================================================
+RewriteRule ^docs/?$             https://gustavosouto.gitlab.io/ontodisinfo-electoral/                    [R=302,L]
+RewriteRule ^about/?$            https://gustavosouto.gitlab.io/ontodisinfo-electoral/about/              [R=302,L]
+RewriteRule ^cite/?$             https://gustavosouto.gitlab.io/ontodisinfo-electoral/about/#como-citar   [R=302,L]
+RewriteRule ^scenarios/?$        https://gustavosouto.gitlab.io/ontodisinfo-electoral/scenarios/          [R=302,L]
+RewriteRule ^pipeline/?$         https://gustavosouto.gitlab.io/ontodisinfo-electoral/pipeline/           [R=302,L]
+RewriteRule ^reproducibility/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/reproducibility/    [R=302,L]
+RewriteRule ^metrics/?$          https://gustavosouto.gitlab.io/ontodisinfo-electoral/metrics/            [R=302,L]
+
+# =============================================================================
+# 5. Convenience redirects
+# =============================================================================
 RewriteRule ^latest/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/infrastructure/ontodis-full.ttl  [R=302,L]
-
-# --- Human-readable documentation (GitLab Pages, generated by pyLODE) ---
-RewriteRule ^docs/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/  [R=302,L]
-
-# --- Source repository (for HTML/browser requests) ---
-RewriteRule ^repo/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral  [R=302,L]
-
-# --- Namespace root: full integrated ontology (default) ---
-RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/main/ontology/infrastructure/ontodis-full.ttl  [R=302,L]
+RewriteRule ^repo/?$    https://gitlab.com/gustavosouto/ontodisinfo-electoral                                                      [R=302,L]


### PR DESCRIPTION
#### Purpose of this update

Two improvements to the existing `/ontodisinfo/` namespace registered in PR #5959:

1. **Content negotiation** at the namespace root and at each module IRI. Browsers
   accessing `https://w3id.org/ontodisinfo/` (or any module) in `Accept: text/html`
   now get the human-readable documentation site hosted on GitLab Pages. RDF
   tooling (`Accept: text/turtle`, `rdf+xml`, `ld+json`, etc.) continues to
   receive the raw Turtle, following the Linked Data convention — the same
   pattern used by FOAF, PROV-O and Schema.org.

2. **Documentation shortcuts**. Stable, citable paths pointing to specific
   sections of the public documentation:

   | Path | Target |
   |------|--------|
   | `/ontodisinfo/docs`            | Documentation home |
   | `/ontodisinfo/about`           | About page (context, methodology, authorship) |
   | `/ontodisinfo/cite`            | Citation block (BibTeX + ABNT) |
   | `/ontodisinfo/scenarios`       | Applied scenarios (five end-to-end cases) |
   | `/ontodisinfo/pipeline`        | Decision flow (abstract pipeline) |
   | `/ontodisinfo/reproducibility` | How to reproduce the ontology locally |
   | `/ontodisinfo/metrics`         | Detailed graph metrics |

   These stabilize URLs used in papers and external references so that the
   citation remains valid even if the hosting platform of the documentation
   site (currently GitLab Pages) ever changes.

#### What is preserved from PR #5959

- All module IRIs (`/core`, `/ml`, `/electoral`, `/legal`, `/inference`,
  `/alignments`, `/gufo-alignment`, `/full`) continue resolving to their
  canonical Turtle sources by default.
- All versioned IRIs (`/1.0.0/*` and `/1.1.0/*`) remain unchanged.
- `/latest` and `/repo` shortcuts preserved.
- License, serialization, OWL profile and maintainer remain the same.

#### Backwards compatibility

Zero breaking changes: every IRI that resolved after PR #5959 continues to
resolve the same way when accessed by RDF tooling (the default behavior).
The only behavioral change is that browsers now land on the documentation
instead of seeing a raw Turtle file — which is a strict improvement for
human consumers.

#### Maintainer

- **Name:** Gustavo Souto Silva de Barros Santos
- **Affiliation:** Center for Informatics (CIn), Federal University of
  Pernambuco (UFPE), Brazil
- **Email:** gssbs@cin.ufpe.br
- **GitLab:** [@gustavosouto](https://gitlab.com/gustavosouto)
- **GitHub:** [@gustavosouto](https://github.com/gustavosouto)

#### Checklist

- [x] `.htaccess` updated in place (no new directories added)
- [x] All existing redirects preserved
- [x] Content negotiation follows the same pattern as other w3id namespaces
      (foaf, prov, schema)
- [x] New shortcut paths tested against live target URLs
- [x] `ontodisinfo/README.md` (maintainer information) remains valid
