### PR TITLE
Add /ontodisinfo/1.2.0/* redirects for OntoDisinfo-Electoral v1.2.0

### DIFF
--- a/ontodisinfo/.htaccess
+++ b/ontodisinfo/.htaccess
@@ -101,6 +101,16 @@ RewriteRule ^1\.1\.0/alignments$      https://gitlab.com/gustavosouto/ontodisinf
 RewriteRule ^1\.1\.0/gufo-alignment$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.1.0/ontology/adapter/ontodis-gufo-alignment.ttl    [R=302,L]
 RewriteRule ^1\.1\.0/full$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.1.0/ontology/infrastructure/ontodis-full.ttl       [R=302,L]
 
+# --- 1.2.0 ---
+RewriteRule ^1\.2\.0/core$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.2.0/ontology/domain/core/ontodis-core.ttl          [R=302,L]
+RewriteRule ^1\.2\.0/ml$              https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.2.0/ontology/domain/ml/ontodis-ml.ttl              [R=302,L]
+RewriteRule ^1\.2\.0/electoral$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.2.0/ontology/domain/electoral/ontodis-elec.ttl     [R=302,L]
+RewriteRule ^1\.2\.0/legal$           https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.2.0/ontology/domain/legal/ontodis-legal.ttl        [R=302,L]
+RewriteRule ^1\.2\.0/inference$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.2.0/ontology/application/ontodis-inference.ttl     [R=302,L]
+RewriteRule ^1\.2\.0/alignments$      https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.2.0/ontology/adapter/ontodis-alignments.ttl        [R=302,L]
+RewriteRule ^1\.2\.0/gufo-alignment$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.2.0/ontology/adapter/ontodis-gufo-alignment.ttl    [R=302,L]
+RewriteRule ^1\.2\.0/full$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.2.0/ontology/infrastructure/ontodis-full.ttl       [R=302,L]
+
 # =============================================================================
 # 4. Documentation shortcuts (HTML site sections)
 #    Citable URLs for specific parts of the public documentation.


### PR DESCRIPTION
#### Purpose of this update

Adds eight version-pinned redirects under `/ontodisinfo/1.2.0/*`,
following the convention established by the existing `/ontodisinfo/1.0.0/*`
and `/ontodisinfo/1.1.0/*` blocks. Each new redirect targets the raw
Turtle of the corresponding module on Git tag `v1.2.0` of the source
repository.

#### What v1.2.0 adds (relative to v1.1.0)

OntoDisinfo-Electoral v1.2.0 is a strictly **additive** release:

- Full bilingual PT+EN coverage in `rdfs:comment` (230 annotations
  across 5 modules) — v1.1.0 had bilingual `rdfs:label` only.
- Bilingual `sh:message` and `sh:name` across the 4 SHACL shapes
  (39 messages).
- Bilingual headers (PT + EN) in the 10 SPARQL Competency Questions.
- Bilingual `rdfs:label` on the 52 NamedIndividuals of the example
  dataset.
- `dcterms:source` on 7 classes of the `legal` module, pointing to
  the official Brazilian normative source (Lei 9.504/1997, Lei 13.709/2018,
  Constituição Federal de 1988, Resolução TSE nº 23.610/2019, Resolução
  TSE nº 23.732/2024).

No class, property or axiom was removed or modified in an incompatible way.

#### Mapping

| Path | Target |
|------|--------|
| `/ontodisinfo/1.2.0/core` | `raw/v1.2.0/ontology/domain/core/ontodis-core.ttl` |
| `/ontodisinfo/1.2.0/ml` | `raw/v1.2.0/ontology/domain/ml/ontodis-ml.ttl` |
| `/ontodisinfo/1.2.0/electoral` | `raw/v1.2.0/ontology/domain/electoral/ontodis-elec.ttl` |
| `/ontodisinfo/1.2.0/legal` | `raw/v1.2.0/ontology/domain/legal/ontodis-legal.ttl` |
| `/ontodisinfo/1.2.0/inference` | `raw/v1.2.0/ontology/application/ontodis-inference.ttl` |
| `/ontodisinfo/1.2.0/alignments` | `raw/v1.2.0/ontology/adapter/ontodis-alignments.ttl` |
| `/ontodisinfo/1.2.0/gufo-alignment` | `raw/v1.2.0/ontology/adapter/ontodis-gufo-alignment.ttl` |
| `/ontodisinfo/1.2.0/full` | `raw/v1.2.0/ontology/infrastructure/ontodis-full.ttl` |

#### What is preserved

- `/ontodisinfo/{core, ml, electoral, legal, inference, alignments,
  gufo-alignment, full}` (unversioned, current main).
- `/ontodisinfo/1.0.0/*` and `/ontodisinfo/1.1.0/*`.
- `/ontodisinfo/{docs, about, cite, scenarios, pipeline, reproducibility,
  metrics}` (documentation shortcuts from PR #5974).
- `/ontodisinfo/latest` and `/ontodisinfo/repo`.
- Content negotiation behavior from PR #5974.

#### Backwards compatibility

Zero breaking changes: all existing redirects continue to behave exactly
as before. The `v1.2.0` Git tag has been created and pushed to
[`gustavosouto/ontodisinfo-electoral`](https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/tags/v1.2.0),
so the new targets resolve immediately upon merge.

#### Maintainer

- **Name:** Gustavo Souto Silva de Barros Santos
- **Affiliation:** Center for Informatics (CIn), Federal University of
  Pernambuco (UFPE), Brazil
- **Email:** gssbs@cin.ufpe.br
- **GitLab:** [@gustavosouto](https://gitlab.com/gustavosouto)
- **GitHub:** [@gustavosouto](https://github.com/gustavosouto)

#### Checklist

- [x] `.htaccess` updated in place (no new directories added)
- [x] All existing redirects preserved
- [x] New `/1.2.0/*` block follows the same shape and indentation as `/1.0.0/*` and `/1.1.0/*`
- [x] Source Git tag `v1.2.0` exists and resolves
- [x] `ontodisinfo/README.md` (maintainer information) remains valid
