### PR TITLE
Add permanent identifiers for OpenSyndrome ontologies, context and schema

### DIFF
--- a/opensyndrome/.htaccess
+++ b/opensyndrome/.htaccess
@@ -1,12 +1,28 @@
 # /opensyndrome/
-# Redirects https://w3id.org/opensyndrome/* to https://opensyndrome.org/schema/*
+# Permanent identifiers for the Open Syndrome Definition.
+#
+# Root:
+#   /opensyndrome/                  → GitHub repository
+#
+# Latest aliases (track the current schema version):
+#   /opensyndrome/ns                → ontology.ttl  (also ns/, ns/<Term>)
+#   /opensyndrome/schema.json       → schema.json
+#   /opensyndrome/context.jsonld    → context.jsonld
+#
+# Versioned aliases (pin to a specific schema version):
+#   /opensyndrome/v<N>/<file>       → schema/v<N>/<file>
 
 Options -MultiViews
 RewriteEngine on
 
-# Redirect root to GitHub repository
+# --- Root ---
 RewriteRule ^$ https://github.com/OpenSyndrome/schema/ [R=302,L]
 
-# Redirect everything else to the schema site
-RewriteRule ^(.+)$ https://opensyndrome.org/schema/$1 [R=302,L]
+# --- Latest aliases ---
+RewriteRule ^ns(/.*)?$        https://opensyndrome.org/ontology.ttl   [R=302,L]
+RewriteRule ^schema\.json$    https://opensyndrome.org/schema.json    [R=302,L]
+RewriteRule ^context\.jsonld$ https://opensyndrome.org/context.jsonld [R=302,L]
+
+# --- Versioned aliases ---
+RewriteRule ^(v[0-9]+/.+)$    https://opensyndrome.org/schema/$1      [R=302,L]
 


### PR DESCRIPTION
## Brief Description

Updates the existing `/opensyndrome/` redirects to expose stable identifiers for all three Open Syndrome Definition artifacts (JSON Schema, JSON-LD context, OWL ontology), separating "latest" aliases from versioned ones:

- `/opensyndrome/ns` (also `ns/`, `ns/<Term>`) → `https://opensyndrome.org/ontology.ttl`(this is the namespace IRI used by the JSON-LD context, so term IRIs now dereference)
- `/opensyndrome/schema.json` → `https://opensyndrome.org/schema.json`
- `/opensyndrome/context.jsonld` → `https://opensyndrome.org/context.jsonld`
- `/opensyndrome/v<N>/<file>` → `https://opensyndrome.org/schema/v<N>/<file>`

The previous catch-all `^(.+)$ → /schema/$1` is replaced by explicit rules so unknown paths fail loudly (404) instead of silently redirecting into 404s on the target site. The existing root → GitHub redirect is preserved.

Verified end-to-end with curl: all listed redirects resolve to HTTP 200 on `opensyndrome.org`; previously-working `/v1/...` paths continue to work.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

<!-- N/A — this updates the existing /opensyndrome/ directory. -->

 ## Update ID Directory Checklist

- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers

- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
