### PR TITLE
Add redirect for NORMA-O ontology (https://w3id.org/def/norma-o)

### DIFF
--- a/def/norma-o/.htaccess
+++ b/def/norma-o/.htaccess
@@ -1,0 +1,63 @@
+Options -MultiViews
+Require all granted
+
+AddType application/rdf+xml .rdf .owl
+AddType text/turtle .ttl
+AddType application/n-triples .nt
+AddType application/ld+json .jsonld
+
+RewriteEngine on
+
+# -----------------------------------------------------------------------
+# Base IRI: https://w3id.org/def/norma-o
+# -----------------------------------------------------------------------
+
+# HTML — redirect to Widoco documentation
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://raw.githubusercontent.com/sheyls/norma-semantic-toolkit/main/OnToology/ontology/norma-ontology-v1.rdf/documentation/index-en.html [R=303,L]
+
+# JSON-LD
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://raw.githubusercontent.com/sheyls/norma-semantic-toolkit/main/OnToology/ontology/norma-ontology-v1.rdf/documentation/ontology.jsonld [R=303,L]
+
+# Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^$ https://raw.githubusercontent.com/sheyls/norma-semantic-toolkit/main/norma-ontology/norma-ontology-v1.ttl [R=303,L]
+
+# N-Triples
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://raw.githubusercontent.com/sheyls/norma-semantic-toolkit/main/OnToology/ontology/norma-ontology-v1.rdf/documentation/ontology.nt [R=303,L]
+
+# RDF/XML — also catches */*, which is what most RDF tools send
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\*
+RewriteRule ^$ https://raw.githubusercontent.com/sheyls/norma-semantic-toolkit/main/norma-ontology/norma-ontology-v1.rdf [R=303,L]
+
+# Default (no Accept header or unrecognised): serve RDF/XML
+RewriteRule ^$ https://raw.githubusercontent.com/sheyls/norma-semantic-toolkit/main/norma-ontology/norma-ontology-v1.rdf [R=303,L]
+
+# -----------------------------------------------------------------------
+# Version IRI: https://w3id.org/def/norma-o/1.0
+# -----------------------------------------------------------------------
+
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^1\.0$ https://raw.githubusercontent.com/sheyls/norma-semantic-toolkit/main/OnToology/ontology/norma-ontology-v1.rdf/documentation/index-en.html [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^1\.0$ https://raw.githubusercontent.com/sheyls/norma-semantic-toolkit/main/OnToology/ontology/norma-ontology-v1.rdf/documentation/ontology.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^1\.0$ https://raw.githubusercontent.com/sheyls/norma-semantic-toolkit/main/norma-ontology/norma-ontology-v1.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^1\.0$ https://raw.githubusercontent.com/sheyls/norma-semantic-toolkit/main/OnToology/ontology/norma-ontology-v1.rdf/documentation/ontology.nt [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\*
+RewriteRule ^1\.0$ https://raw.githubusercontent.com/sheyls/norma-semantic-toolkit/main/norma-ontology/norma-ontology-v1.rdf [R=303,L]
+
+RewriteRule ^1\.0$ https://raw.githubusercontent.com/sheyls/norma-semantic-toolkit/main/norma-ontology/norma-ontology-v1.rdf [R=303,L]

--- a/def/norma-o/README.md
+++ b/def/norma-o/README.md
@@ -1,0 +1,17 @@
+# NORMA-O
+
+This namespace provides persistent identifiers for NORMA-O, the NORMA Ontology for Legal Norm Annotations.
+
+Ontology URI:
+
+https://w3id.org/def/norma-o
+
+Maintainer:
+
+- Name: Sheyla Leyva-Sánchez
+- GitHub: https://github.com/sheyls
+- Email: sheyla.leyva.sanchez@upm.es
+
+Repository:
+
+https://github.com/sheyls/norma-semantic-toolkit


### PR DESCRIPTION
## Brief Description

This PR adds a new W3ID redirect for NORMA-O, the NORMA Ontology for Legal Norm Annotations.

The persistent URI is:

https://w3id.org/def/norma-o

The redirect points to the ontology documentation and serializations hosted in the NORMA semantic toolkit repository. This enables a stable URI for ontology consumers, validators, and content negotiation.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist

- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers

- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.