### PR TITLE
Add FAIR-MIND Application Profile namespace

### DIFF
--- a/fair-mind/.htaccess
+++ b/fair-mind/.htaccess
@@ -1,0 +1,10 @@
+Options -MultiViews
+Require all granted
+Header set Access-Control-Allow-Origin *
+Header set Cache-Control "max-age=3600"
+
+# Redirect AP namespace to GitHub raw TTL
+RewriteEngine on
+
+RewriteRule ^ap$ https://raw.githubusercontent.com/cik860/fair-mind-ap/main/fair_mind_ap_v3.ttl [R=303,L]
+RewriteRule ^ap/(.*)$ https://raw.githubusercontent.com/cik860/fair-mind-ap/main/fair_mind_ap_v3.ttl [R=303,L]

--- a/fair-mind/README.md
+++ b/fair-mind/README.md
@@ -1,0 +1,8 @@
+# FAIR-MIND Application Profile
+
+Maintainer: Inkyung Choi (@cik860), Sungkyunkwan University
+Contact: cik860@skku.edu
+ORCID: 0000-0001-5048-8516
+
+Namespace: https://w3id.org/fair-mind/ap#
+DOI: https://doi.org/10.5281/zenodo.19856971


### PR DESCRIPTION
This adds a permanent URI namespace for the FAIR-MIND 
Application Profile (AP) for integrating depression clinical 
data with ECG-derived HRV biomarkers.

- 39 variables mapped to 8 established ontologies
- Validated on MIMIC-IV-ECG (~290,000 ECG records)
- SHACL validation: 7 shapes, 0 violations

Contact: cik860@skku.edu
GitHub: cik860
Maintainer: Inkyung Choi, Sungkyunkwan University, South Korea

## General Checklist
<!-- For all ID related PRs. -->
- [X] Changes have been tested.
- [X] The number of commits is minimal. Squash if needed.
- [X] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [X] Maintainer details are in `.htaccess` or `README.md`.
- [X] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
