### PR TITLE
HPCC Ontology

### DIFF
--- a/hpcc/.htaccess
+++ b/hpcc/.htaccess
@@ -1,0 +1,31 @@
+# https://w3id.org/hpcc/ redirects via HTTP 303 using content negotiation:
+# - HTML requests are redirected to:
+#   https://paitools.github.io/HPCCOntology/documentation/index-en.html
+# - RDF/OWL requests are redirected to:
+#   https://paitools.github.io/HPCCOntology/HPCC.owl
+
+# ## Contact
+# This space is administered by:
+#
+# Pavle Ivanovic
+# ivanovip@hsu-hh.de
+# GitHub username: paitools
+
+RewriteEngine On
+
+# --- Human-facing documentation (HTML) ---
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteRule ^$ https://paitools.github.io/HPCCOntology/documentation/index-en.html [R=303,L]
+
+# --- Machine-facing ontology (RDF/OWL) ---
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/n-triples [OR]
+RewriteCond %{HTTP_ACCEPT} application/owl\+xml
+RewriteRule ^$ https://paitools.github.io/HPCCOntology/HPCC.owl [R=303,L]
+
+# --- Fallback (if no/unknown Accept header) ---
+RewriteRule ^$ https://paitools.github.io/HPCCOntology/HPCC.owl [R=303,L]
+

--- a/hpcc/.htaccess
+++ b/hpcc/.htaccess
@@ -1,6 +1,6 @@
 # https://w3id.org/hpcc/ redirects via HTTP 303 using content negotiation:
 # - HTML requests are redirected to:
-#   https://paitools.github.io/HPCCOntology/documentation/index-en.html
+#   https://paitools.github.io/HPCCOntology/docs/index-en.html
 # - RDF/OWL requests are redirected to:
 #   https://paitools.github.io/HPCCOntology/HPCC.owl
 
@@ -16,7 +16,7 @@ RewriteEngine On
 # --- Human-facing documentation (HTML) ---
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
-RewriteRule ^$ https://paitools.github.io/HPCCOntology/documentation/index-en.html [R=303,L]
+RewriteRule ^$ https://paitools.github.io/HPCCOntology/docs/index-en.html [R=303,L]
 
 # --- Machine-facing ontology (RDF/OWL) ---
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]

--- a/hpcc/README.md
+++ b/hpcc/README.md
@@ -1,0 +1,19 @@
+# HPCC Ontology
+
+This identifier is for the HPCC Ontology, an OWL ontology for modeling
+HPC thermal management telemetry.
+
+The ontology extends the W3C SSN/SOSA standards to capture HPC cooling concepts,
+including heat pumps, heat exchangers, pumps, coolers, and re-coolers. 
+Designed for the datacenter thermal management domain, the ontology supports anomaly detection,
+real-time condition monitoring, and advanced system analytics.
+
+The ontology is developed as part of the HPCCool, a framework for ontology-based
+data access (OBDA), HPC cooling‑system management, and real-time analytics.
+
+
+Pavle Ivanovic
+Email: ivanovip@hsu-hh.de  
+GitHub: https://github.com/paitools
+
+


### PR DESCRIPTION
# HPCC Ontology

This identifier is for the HPCC Ontology, an OWL ontology for modeling
HPC thermal management telemetry.

The ontology extends the W3C SSN/SOSA standards to capture HPC cooling concepts,
including heat pumps, heat exchangers, pumps, coolers, and re-coolers. 
Designed for the datacenter thermal management domain, the ontology supports anomaly detection,
real-time condition monitoring, and advanced system analytics.

The ontology is developed as part of the HPCCool, a framework for ontology-based
data access (OBDA), HPC cooling‑system management, and real-time analytics.


Pavle Ivanovic
Email: ivanovip@hsu-hh.de  
GitHub: https://github.com/paitools


