### PR TITLE
Add permanent identifier namespace for RTSKG

### DIFF
--- a/rtskg/.htaccess
+++ b/rtskg/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine on
+RewriteRule ^$ https://github.com/seucoin/RTSKG [R=303,L]

--- a/rtskg/README.md
+++ b/rtskg/README.md
@@ -1,0 +1,9 @@
+RTSKG: Building a Rail Transit Station Knowledge Graph Dataset
+=======
+
+## Homepage:
+* https://w3id.org/rtskg
+
+## Contacts:
+* Shutong Zhu <shutong_zhu@seu.edu.cn>
+GitHub: [Zstwizard](https://github.com/Zstwizard)


### PR DESCRIPTION
## Brief Description
This PR adds a new W3ID namespace for RTSKG, a Rail Transit Station Knowledge Graph dataset.

The namespace is:

- https://w3id.org/rtskg/

The root namespace currently redirects to the project repository:

- https://github.com/seucoin/RTSKG

The full dataset will be released via the project repository by May 8, 2026, 23:59 Anywhere on Earth. Additional redirects for ontology, resources and documentation may be added in future.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
