### PR TITLE
Add SSCO persistent identifier

### DIFF
--- a/ssco/.htaccess
+++ b/ssco/.htaccess
@@ -1,0 +1,31 @@
+# /ssco/
+# Persistent identifiers for the SSCO ontology.
+#
+# Maintainer:
+# Shihang Zhang
+# GitHub: Shihang-Z
+
+RewriteEngine On
+
+# Content negotiation for RDF serializations
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^$ https://shihang-z.github.io/SSCO/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/owl\+xml
+RewriteRule ^$ https://shihang-z.github.io/SSCO/ontology.owl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://shihang-z.github.io/SSCO/ontology.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://shihang-z.github.io/SSCO/ontology.nt [R=303,L]
+
+# HTML documentation as default representation
+RewriteRule ^$ https://shihang-z.github.io/SSCO/ [R=303,L]
+
+# Explicit file-like aliases
+RewriteRule ^ontology.ttl$ https://shihang-z.github.io/SSCO/ontology.ttl [R=303,L]
+RewriteRule ^ontology.owl$ https://shihang-z.github.io/SSCO/ontology.owl [R=303,L]
+RewriteRule ^ontology.jsonld$ https://shihang-z.github.io/SSCO/ontology.jsonld [R=303,L]
+RewriteRule ^ontology.nt$ https://shihang-z.github.io/SSCO/ontology.nt [R=303,L]

--- a/ssco/README.md
+++ b/ssco/README.md
@@ -1,0 +1,22 @@
+# /ssco/
+
+This namespace provides persistent identifiers for the SSCO ontology.
+
+## Namespace
+
+- `https://w3id.org/ssco/`
+
+## Redirect targets
+
+- HTML documentation: `https://shihang-z.github.io/SSCO/`
+- Turtle: `https://shihang-z.github.io/SSCO/ontology.ttl`
+- RDF/XML or OWL: `https://shihang-z.github.io/SSCO/ontology.owl`
+- JSON-LD: `https://shihang-z.github.io/SSCO/ontology.jsonld`
+- N-Triples: `https://shihang-z.github.io/SSCO/ontology.nt`
+
+## Maintainer
+
+This namespace is maintained by:
+
+- Shihang Zhang
+- GitHub: [Shihang-Z](https://github.com/Shihang-Z)


### PR DESCRIPTION
This pull request adds the `/ssco/` namespace for the SSCO ontology.

The namespace redirects to the public GitHub Pages documentation and RDF serializations of the ontology. The redirect rules include content negotiation for HTML, Turtle, RDF/XML/OWL, JSON-LD, and N-Triples representations.

Maintainer:
Shihang Zhang
GitHub: @Shihang-Z