### PR TITLE
Add Vibe Ontology permanent identifier

### DIFF
--- a/vibe-ontology/.htaccess
+++ b/vibe-ontology/.htaccess
@@ -1,0 +1,17 @@
+Options +FollowSymLinks
+RewriteEngine On
+
+# Vibe Ontology namespace:
+# https://w3id.org/vibe-ontology/
+
+# RDF clients: redirect ontology namespace and term IRIs to the Turtle file.
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/x-turtle|application/rdf\+xml|application/ld\+json|application/n-triples|application/n-quads) [NC]
+RewriteRule ^.*$ https://raw.githubusercontent.com/dersuchendee/vibe-ontology/main/ontology/latest/vibeontology.ttl [R=303,L]
+
+# Human-readable documentation for the ontology namespace.
+RewriteRule ^$ https://dersuchendee.github.io/vibe-ontology/ [R=303,L]
+
+# Human-readable documentation for individual ontology terms.
+# Example:
+# https://w3id.org/vibe-ontology/Aesthetic
+RewriteRule ^(.+)$ https://dersuchendee.github.io/vibe-ontology/#$1 [R=303,L,NE]

--- a/vibe-ontology/README.md
+++ b/vibe-ontology/README.md
@@ -1,0 +1,20 @@
+# Vibe Ontology
+
+Permanent identifier namespace for the Vibe Ontology.
+
+## Namespace
+
+https://w3id.org/vibe-ontology/
+
+## Ontology
+
+The Vibe Ontology models aesthetics as emergent, collection-based categories grounded in representative associations.
+
+## Redirects
+
+- HTML documentation: https://dersuchendee.github.io/vibe-ontology/
+- Turtle ontology file: https://raw.githubusercontent.com/dersuchendee/vibe-ontology/main/ontology/latest/vibeontology.ttl
+
+## Maintainer
+
+- GitHub: https://github.com/dersuchendee


### PR DESCRIPTION
This pull request adds a permanent identifier namespace for the Vibe Ontology:

https://w3id.org/vibe-ontology/

The namespace redirects to the ontology documentation and Turtle file hosted in the Vibe Ontology GitHub repository.

Redirect targets:

- HTML documentation: https://dersuchendee.github.io/vibe-ontology/
- Turtle ontology file: https://raw.githubusercontent.com/dersuchendee/vibe-ontology/main/ontology/latest/vibeontology.ttl

Maintainer:

- https://github.com/dersuchendee