### PR TITLE
Add /ontodisinfo/1.4.0/* redirects and pin unversioned redirects to v1.4.0

### DIFF
--- a/ontodisinfo/.htaccess
+++ b/ontodisinfo/.htaccess
@@ -37,9 +37,9 @@ RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/  [R=302,L]
 # RDF tools -> consolidated Turtle pinned to the latest release tag
 RewriteCond %{HTTP_ACCEPT} (text/turtle|application/(rdf\+xml|x-turtle|ld\+json|n-triples|n-quads))
-RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 # Default (no Accept header, curl, etc.) -> Turtle, Linked Data convention
-RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 
 # =============================================================================
 # 2. Individual modules with content negotiation
@@ -49,38 +49,38 @@ RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3
 # --- core ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^core/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/core/  [R=302,L]
-RewriteRule ^core/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/domain/core/ontodis-core.ttl  [R=302,L]
+RewriteRule ^core/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/domain/core/ontodis-core.ttl  [R=302,L]
 
 # --- ml ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^ml/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/ml/  [R=302,L]
-RewriteRule ^ml/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/domain/ml/ontodis-ml.ttl  [R=302,L]
+RewriteRule ^ml/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/domain/ml/ontodis-ml.ttl  [R=302,L]
 
 # --- electoral ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^electoral/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/electoral/  [R=302,L]
-RewriteRule ^electoral/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/domain/electoral/ontodis-elec.ttl  [R=302,L]
+RewriteRule ^electoral/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/domain/electoral/ontodis-elec.ttl  [R=302,L]
 
 # --- legal ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^legal/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/legal/  [R=302,L]
-RewriteRule ^legal/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/domain/legal/ontodis-legal.ttl  [R=302,L]
+RewriteRule ^legal/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/domain/legal/ontodis-legal.ttl  [R=302,L]
 
 # --- inference ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^inference/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/inference/  [R=302,L]
-RewriteRule ^inference/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/application/ontodis-inference.ttl  [R=302,L]
+RewriteRule ^inference/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/application/ontodis-inference.ttl  [R=302,L]
 
 # --- alignments (external) ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^alignments/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/reference/alignments/  [R=302,L]
-RewriteRule ^alignments/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/adapter/ontodis-alignments.ttl  [R=302,L]
+RewriteRule ^alignments/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/adapter/ontodis-alignments.ttl  [R=302,L]
 
 # --- gufo-alignment (no dedicated doc page; always Turtle) ---
-RewriteRule ^gufo-alignment/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/adapter/ontodis-gufo-alignment.ttl  [R=302,L]
+RewriteRule ^gufo-alignment/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/adapter/ontodis-gufo-alignment.ttl  [R=302,L]
 
 # --- full integrated (entry point for Protege/reasoners) ---
-RewriteRule ^full/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^full/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 
 # =============================================================================
 # 3. Versioned IRIs (owl:versionIRI)
@@ -129,6 +129,23 @@ RewriteRule ^1\.3\.0/alignments$      https://gitlab.com/gustavosouto/ontodisinf
 RewriteRule ^1\.3\.0/gufo-alignment$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/adapter/ontodis-gufo-alignment.ttl    [R=302,L]
 RewriteRule ^1\.3\.0/full$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/composition/ontodis-full.ttl          [R=302,L]
 
+# --- 1.4.0 ---
+# Auditoria normativa (tempus regit actum) e bump consequente. Adiciona
+# 5 propriedades de vigência temporal, declara 12 NamedIndividuals de norma
+# vigente em 2022 com cadeia de alterações modelada (incluindo art. 9º-A da
+# Res. 23.610/2019 com vigência fixada 14/12/2021..19/10/2022, revogado pela
+# Res. 23.714/2022 art. 8º), reescreve fundamentos da ADI 7.261/DF e do
+# legal:AbusoPodeComunicacao, e introduz a SHACL :CoerenciaTemporalNormaShape.
+RewriteRule ^1\.4\.0/core$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/domain/core/ontodis-core.ttl          [R=302,L]
+RewriteRule ^1\.4\.0/ml$              https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/domain/ml/ontodis-ml.ttl              [R=302,L]
+RewriteRule ^1\.4\.0/electoral$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/domain/electoral/ontodis-elec.ttl     [R=302,L]
+RewriteRule ^1\.4\.0/legal$           https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/domain/legal/ontodis-legal.ttl        [R=302,L]
+RewriteRule ^1\.4\.0/inference$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/application/ontodis-inference.ttl     [R=302,L]
+RewriteRule ^1\.4\.0/alignments$      https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/adapter/ontodis-alignments.ttl        [R=302,L]
+RewriteRule ^1\.4\.0/gufo-alignment$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/adapter/ontodis-gufo-alignment.ttl    [R=302,L]
+RewriteRule ^1\.4\.0/full$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/composition/ontodis-full.ttl          [R=302,L]
+
+
 # =============================================================================
 # 4. Documentation shortcuts (HTML site sections)
 #    Citable URLs for specific parts of the public documentation.
@@ -144,5 +161,5 @@ RewriteRule ^metrics/?$          https://gustavosouto.gitlab.io/ontodisinfo-elec
 # =============================================================================
 # 5. Convenience redirects
 # =============================================================================
-RewriteRule ^latest/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^latest/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 RewriteRule ^repo/?$    https://gitlab.com/gustavosouto/ontodisinfo-electoral                                                      [R=302,L]


### PR DESCRIPTION
This PR adds a new `/1.4.0/*` block to `ontodisinfo/.htaccess` and repoints the unversioned redirects (`/`, `/full`, `/latest`, and the seven module shortcuts) from the `v1.3.0` tag to the `v1.4.0` tag.

The existing `/1.3.0/*` block remains pinned to `v1.3.0`, preserving the resolution policy established by [#5978](https://github.com/perma-id/w3id.org/pull/5978): every published versioned IRI continues to resolve to the corresponding Git tag forever.

## What's in OntoDisinfo-Electoral v1.4.0

The release consolidates a normative audit applied to the legal module, operationalising the *tempus regit actum* principle at the ontology level. Highlights:

- **Temporal validity layer** in `legal:NormaJuridica`: five new properties (`:dataInicioVigencia`, `:dataFimVigencia`, `:revogadaPor`, `:alteradaPor`, `:fundamentoSuperveniente`).
- **12 NamedIndividuals** of norms in force during the 2022 Brazilian electoral cycle, declared with explicit validity windows and modelled amendment chains. Includes art. 9-A of TSE Resolution 23.610/2019 with validity 2021-12-14..2022-10-19, repealed by art. 8 of TSE Resolution 23.714/2022.
- **`legal:AbusoPodeComunicacao`** grounded in art. 22 of LC 64/1990 (AIJE), as cited by Justice Edson Fachin in ADI 7.261/DF: *"the normative basis for the TSE's regulation of fake news lies in art. 22, I, 'b' and 'c', and III, of Complementary Law 64/90"*.
- **`legal:ADI7261_DF`** rewritten with the actual decisum (constitutionality of TSE Resolution 23.714/2022, judged on 2023-12-19 by the Brazilian Supreme Court).
- **SHACL `:CoerenciaTemporalNormaShape`** detects anachronistic legal foundation automatically (lex post facto and use of repealed norms).

Backwards compatibility is preserved: IRIs `https://w3id.org/ontodisinfo/<module>/1.3.0` continue to resolve to the v1.3.0 source via the existing block.

## Release artefacts

- **Tag**: https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/tags/v1.4.0
- **Changelog**: https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/blob/v1.4.0/CHANGELOG.md
- **Audit document**: https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/blob/v1.4.0/docs/analysis/legal-norms-audit.md
- **Documentation site**: https://gustavosouto.gitlab.io/ontodisinfo-electoral/

## Verification after merge

- `https://w3id.org/ontodisinfo/1.4.0/full` should resolve (302) to `https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/composition/ontodis-full.ttl`.
- `https://w3id.org/ontodisinfo/full` should resolve (302) to the same URL above.
- `https://w3id.org/ontodisinfo/1.3.0/full` should continue resolving to `v1.3.0` (unchanged).

## Related PRs (history)

- #5959 — initial namespace
- #5962 — `/1.1.0/*` + `/docs` + `/latest`
- #5974 — content negotiation + documentation shortcuts
- #5975 — `/1.2.0/*` redirects
- #5978 — `/1.3.0/*` redirects + unversioned-pinning policy