### PR TITLE
Update /ontodisinfo/ adding /1.5.0/* redirects

### DIFF
--- a/ontodisinfo/.htaccess
+++ b/ontodisinfo/.htaccess
@@ -37,9 +37,9 @@ RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/  [R=302,L]
 # RDF tools -> consolidated Turtle pinned to the latest release tag
 RewriteCond %{HTTP_ACCEPT} (text/turtle|application/(rdf\+xml|x-turtle|ld\+json|n-triples|n-quads))
-RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 # Default (no Accept header, curl, etc.) -> Turtle, Linked Data convention
-RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 
 # =============================================================================
 # 2. Individual modules with content negotiation
@@ -49,38 +49,38 @@ RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3
 # --- core ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^core/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/core/  [R=302,L]
-RewriteRule ^core/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/domain/core/ontodis-core.ttl  [R=302,L]
+RewriteRule ^core/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/domain/core/ontodis-core.ttl  [R=302,L]
 
 # --- ml ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^ml/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/ml/  [R=302,L]
-RewriteRule ^ml/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/domain/ml/ontodis-ml.ttl  [R=302,L]
+RewriteRule ^ml/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/domain/ml/ontodis-ml.ttl  [R=302,L]
 
 # --- electoral ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^electoral/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/electoral/  [R=302,L]
-RewriteRule ^electoral/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/domain/electoral/ontodis-elec.ttl  [R=302,L]
+RewriteRule ^electoral/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/domain/electoral/ontodis-elec.ttl  [R=302,L]
 
 # --- legal ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^legal/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/legal/  [R=302,L]
-RewriteRule ^legal/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/domain/legal/ontodis-legal.ttl  [R=302,L]
+RewriteRule ^legal/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/domain/legal/ontodis-legal.ttl  [R=302,L]
 
 # --- inference ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^inference/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/inference/  [R=302,L]
-RewriteRule ^inference/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/application/ontodis-inference.ttl  [R=302,L]
+RewriteRule ^inference/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/application/ontodis-inference.ttl  [R=302,L]
 
 # --- alignments (external) ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^alignments/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/reference/alignments/  [R=302,L]
-RewriteRule ^alignments/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/adapter/ontodis-alignments.ttl  [R=302,L]
+RewriteRule ^alignments/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/adapter/ontodis-alignments.ttl  [R=302,L]
 
 # --- gufo-alignment (no dedicated doc page; always Turtle) ---
-RewriteRule ^gufo-alignment/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/adapter/ontodis-gufo-alignment.ttl  [R=302,L]
+RewriteRule ^gufo-alignment/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/adapter/ontodis-gufo-alignment.ttl  [R=302,L]
 
 # --- full integrated (entry point for Protege/reasoners) ---
-RewriteRule ^full/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^full/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 
 # =============================================================================
 # 3. Versioned IRIs (owl:versionIRI)
@@ -129,6 +129,23 @@ RewriteRule ^1\.3\.0/alignments$      https://gitlab.com/gustavosouto/ontodisinf
 RewriteRule ^1\.3\.0/gufo-alignment$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/adapter/ontodis-gufo-alignment.ttl    [R=302,L]
 RewriteRule ^1\.3\.0/full$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/composition/ontodis-full.ttl          [R=302,L]
 
+# --- 1.4.0 ---
+# Auditoria normativa (tempus regit actum) e bump consequente. Adiciona
+# 5 propriedades de vigência temporal, declara 12 NamedIndividuals de norma
+# vigente em 2022 com cadeia de alterações modelada (incluindo art. 9º-A da
+# Res. 23.610/2019 com vigência fixada 14/12/2021..19/10/2022, revogado pela
+# Res. 23.714/2022 art. 8º), reescreve fundamentos da ADI 7.261/DF e do
+# legal:AbusoPodeComunicacao, e introduz a SHACL :CoerenciaTemporalNormaShape.
+RewriteRule ^1\.4\.0/core$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/domain/core/ontodis-core.ttl          [R=302,L]
+RewriteRule ^1\.4\.0/ml$              https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/domain/ml/ontodis-ml.ttl              [R=302,L]
+RewriteRule ^1\.4\.0/electoral$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/domain/electoral/ontodis-elec.ttl     [R=302,L]
+RewriteRule ^1\.4\.0/legal$           https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/domain/legal/ontodis-legal.ttl        [R=302,L]
+RewriteRule ^1\.4\.0/inference$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/application/ontodis-inference.ttl     [R=302,L]
+RewriteRule ^1\.4\.0/alignments$      https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/adapter/ontodis-alignments.ttl        [R=302,L]
+RewriteRule ^1\.4\.0/gufo-alignment$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/adapter/ontodis-gufo-alignment.ttl    [R=302,L]
+RewriteRule ^1\.4\.0/full$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/composition/ontodis-full.ttl          [R=302,L]
+
+
 # =============================================================================
 # 4. Documentation shortcuts (HTML site sections)
 #    Citable URLs for specific parts of the public documentation.
@@ -144,5 +161,5 @@ RewriteRule ^metrics/?$          https://gustavosouto.gitlab.io/ontodisinfo-elec
 # =============================================================================
 # 5. Convenience redirects
 # =============================================================================
-RewriteRule ^latest/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.3.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^latest/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 RewriteRule ^repo/?$    https://gitlab.com/gustavosouto/ontodisinfo-electoral                                                      [R=302,L]

--- a/ontodisinfo/.htaccess
+++ b/ontodisinfo/.htaccess
@@ -37,9 +37,9 @@ RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/  [R=302,L]
 # RDF tools -> consolidated Turtle pinned to the latest release tag
 RewriteCond %{HTTP_ACCEPT} (text/turtle|application/(rdf\+xml|x-turtle|ld\+json|n-triples|n-quads))
-RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.5.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 # Default (no Accept header, curl, etc.) -> Turtle, Linked Data convention
-RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.5.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 
 # =============================================================================
 # 2. Individual modules with content negotiation
@@ -49,38 +49,38 @@ RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4
 # --- core ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^core/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/core/  [R=302,L]
-RewriteRule ^core/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/domain/core/ontodis-core.ttl  [R=302,L]
+RewriteRule ^core/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.5.0/ontology/domain/core/ontodis-core.ttl  [R=302,L]
 
 # --- ml ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^ml/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/ml/  [R=302,L]
-RewriteRule ^ml/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/domain/ml/ontodis-ml.ttl  [R=302,L]
+RewriteRule ^ml/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.5.0/ontology/domain/ml/ontodis-ml.ttl  [R=302,L]
 
 # --- electoral ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^electoral/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/electoral/  [R=302,L]
-RewriteRule ^electoral/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/domain/electoral/ontodis-elec.ttl  [R=302,L]
+RewriteRule ^electoral/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.5.0/ontology/domain/electoral/ontodis-elec.ttl  [R=302,L]
 
 # --- legal ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^legal/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/legal/  [R=302,L]
-RewriteRule ^legal/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/domain/legal/ontodis-legal.ttl  [R=302,L]
+RewriteRule ^legal/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.5.0/ontology/domain/legal/ontodis-legal.ttl  [R=302,L]
 
 # --- inference ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^inference/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/inference/  [R=302,L]
-RewriteRule ^inference/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/application/ontodis-inference.ttl  [R=302,L]
+RewriteRule ^inference/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.5.0/ontology/application/ontodis-inference.ttl  [R=302,L]
 
 # --- alignments (external) ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^alignments/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/reference/alignments/  [R=302,L]
-RewriteRule ^alignments/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/adapter/ontodis-alignments.ttl  [R=302,L]
+RewriteRule ^alignments/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.5.0/ontology/adapter/ontodis-alignments.ttl  [R=302,L]
 
 # --- gufo-alignment (no dedicated doc page; always Turtle) ---
-RewriteRule ^gufo-alignment/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/adapter/ontodis-gufo-alignment.ttl  [R=302,L]
+RewriteRule ^gufo-alignment/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.5.0/ontology/adapter/ontodis-gufo-alignment.ttl  [R=302,L]
 
 # --- full integrated (entry point for Protege/reasoners) ---
-RewriteRule ^full/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^full/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.5.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 
 # =============================================================================
 # 3. Versioned IRIs (owl:versionIRI)
@@ -145,6 +145,25 @@ RewriteRule ^1\.4\.0/alignments$      https://gitlab.com/gustavosouto/ontodisinf
 RewriteRule ^1\.4\.0/gufo-alignment$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/adapter/ontodis-gufo-alignment.ttl    [R=302,L]
 RewriteRule ^1\.4\.0/full$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/composition/ontodis-full.ttl          [R=302,L]
 
+# --- 1.5.0 ---
+# Refatoração de mídia anexada: introduz core:Anexo (Kind UFO) com SubKinds
+# disjuntos core:Imagem, core:Video, core:Audio (alinhados a schema:MediaObject
+# e respectivos schema:ImageObject/VideoObject/AudioObject), propriedades
+# técnicas de identidade (hashArquivo, formatoArquivo, contentUrl) e
+# marcadores de manipulação para análise pericial (foiManipulado,
+# tipoManipulacao com Deepfake/EdicaoEnganosa/RecorteDistorcido/AudioSintetico,
+# fonteOriginal). Conexão Core <-> Legal via legal:temAnexoPericiado.
+# Depreciação ordenada de core:TipoConteudo (substituído por core:Anexo).
+RewriteRule ^1\.5\.0/core$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.5.0/ontology/domain/core/ontodis-core.ttl          [R=302,L]
+RewriteRule ^1\.5\.0/ml$              https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.5.0/ontology/domain/ml/ontodis-ml.ttl              [R=302,L]
+RewriteRule ^1\.5\.0/electoral$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.5.0/ontology/domain/electoral/ontodis-elec.ttl     [R=302,L]
+RewriteRule ^1\.5\.0/legal$           https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.5.0/ontology/domain/legal/ontodis-legal.ttl        [R=302,L]
+RewriteRule ^1\.5\.0/inference$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.5.0/ontology/application/ontodis-inference.ttl     [R=302,L]
+RewriteRule ^1\.5\.0/alignments$      https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.5.0/ontology/adapter/ontodis-alignments.ttl        [R=302,L]
+RewriteRule ^1\.5\.0/gufo-alignment$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.5.0/ontology/adapter/ontodis-gufo-alignment.ttl    [R=302,L]
+RewriteRule ^1\.5\.0/full$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.5.0/ontology/composition/ontodis-full.ttl          [R=302,L]
+
+
 
 # =============================================================================
 # 4. Documentation shortcuts (HTML site sections)
@@ -161,5 +180,5 @@ RewriteRule ^metrics/?$          https://gustavosouto.gitlab.io/ontodisinfo-elec
 # =============================================================================
 # 5. Convenience redirects
 # =============================================================================
-RewriteRule ^latest/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.4.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^latest/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.5.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 RewriteRule ^repo/?$    https://gitlab.com/gustavosouto/ontodisinfo-electoral                                                      [R=302,L]


### PR DESCRIPTION
## Summary

Updates `/ontodisinfo/.htaccess` for the new release `v1.5.0`:

- adds the full `/ontodisinfo/1.5.0/*` block (8 redirects to the GitLab `v1.5.0` tag, one per ontology module + the consolidated `full`);
- repoints the non-versioned redirects (`/`, `/full`, `/latest` and the 7 module shortcuts) from the previous `v1.4.0` tag to `v1.5.0`;
- preserves the `/1.3.0/*` and `/1.4.0/*` blocks pinned to their respective tags, ensuring that IRIs already cited in published artefacts (`https://w3id.org/ontodisinfo/1.3.0/*`, `https://w3id.org/ontodisinfo/1.4.0/*`) keep resolving exactly to the snapshots they were minted against.

The file is otherwise unchanged: same content negotiation rules, same documentation shortcuts, same `examples/` conventions used by previous accepted PRs (#5959, #5962, #5974, #5975, #5978).

## Release notes

`v1.5.0` is a substantive ontological refactor of media attachment modeling. It addresses a structured suggestion from the project advisor (Prof. Fred Freitas, CIn-UFPE) to promote `Imagem`, `Video`, and `Audio` from `NamedIndividuals` of a `Category` to rigid `SubKinds` of a new `Kind` `:Anexo`, with proper criterion of identity (SHA-256 hash + MIME format + canonical content URL).

Highlights:

- new Kind `core:Anexo` with 3 disjoint SubKinds (`core:Imagem`, `core:Video`, `core:Audio`);
- 7 technical properties (hash, format, contentUrl, size, duration, resolution, codec);
- deepfake-relevant manipulation markers (`core:foiManipulado`, `core:tipoManipulacao` ranging over `core:TipoManipulacao` with `Deepfake`, `EdicaoEnganosa`, `RecorteDistorcido`, `AudioSintetico`, plus `core:fonteOriginal`);
- structural Core ↔ Legal integration via `legal:temAnexoPericiado` (closing the chain Postagem → Anexo (technical) → Ocorrência de Ilícito (legal) → Norma vigente (temporal, from v1.4.0));
- alignments to `schema:MediaObject`/`ImageObject`/`VideoObject`/`AudioObject` and `prov:Entity`;
- 2 new Competency Questions (CQ11 manipulated attachments, CQ12 viral attachments via shared hash);
- SHACL `AnexoShape` (mandatory identity) and `AnexoManipulacaoConsistenteShape` (sh:sparql cross-property check);
- 4 new pytest scenarios (34 tests total, all passing);
- backward compatibility preserved: `https://w3id.org/ontodisinfo/<module>/1.4.0` IRIs remain valid via the `v1.4.0` Git tag.

## Validation performed before opening this PR

- ✅ Parsing OWL OK on all 10 modules
- ✅ SHACL conformant on the example dataset (`AnexoShape`, `AnexoManipulacaoConsistenteShape`, plus `CoerenciaTemporalNormaShape` carried over from v1.4.0)
- ✅ All 12 Competency Questions execute against the consolidated graph
- ✅ 34/34 pytest tests passing
- ✅ OOPS! returns 0 critical pitfalls (3 important + 2 minor, same baseline as v1.4.0)

## Test plan

- [x] `apachectl configtest` would pass — only `RewriteRule` and `RewriteCond` directives consistent with the existing block style
- [x] curl checks against the resolved tag URLs return HTTP 200 OK on the GitLab raw side once the tag is published (already pushed: `https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/tags/v1.5.0`)
- [x] historical `/1.3.0/*` and `/1.4.0/*` blocks remain intact in the diff

## Maintainer

Same as previous PRs: [@gustavosouto](https://github.com/gustavosouto), Centro de Informática (CIn) — UFPE.

## Note on dependency with #6009

This PR is stacked on top of [#6009](https://github.com/perma-id/w3id.org/pull/6009) (which introduces the `/1.4.0/*` block). It can be reviewed in either order; if #6009 merges first, this PR will rebase cleanly. If this PR is taken first, #6009's content is fully contained here and #6009 may be closed in favor of merging this one alone — happy to reorganize in whichever direction is more convenient.
