### PR TITLE
cdisc/usdm/v4: switch to slash semantics with content negotiation (v0.3)

### DIFF
--- a/cdisc/usdm/v4/.htaccess
+++ b/cdisc/usdm/v4/.htaccess
@@ -1,13 +1,15 @@
 # /cdisc/usdm/v4/
 #
-# https://w3id.org/cdisc/usdm/v4 redirects to a Turtle (RDF/OWL) rendering
+# https://w3id.org/cdisc/usdm/v4/ redirects to a Turtle (RDF/OWL) rendering
 # of CDISC USDM v4, generated mechanically from the CDISC DDF-RA YAML
-# source. Hash semantics: every minted IRI (e.g. .../v4#Activity) is a
-# fragment of the same Turtle document.
+# source. Slash semantics (since v0.3): each minted IRI dereferences
+# individually — class IRIs to per-class HTML anchors, property IRIs
+# to property anchors on the class page; the canonical Turtle (version-
+# pinned at the v0.3.0 tag) is served for tools requesting RDF.
 #
 # Status: draft, not a normative CDISC artifact. Offered for transfer to
 # CDISC governance; transfer is a single PR against this .htaccess to
-# change the redirect target. See README.md.
+# change the redirect targets. See README.md.
 #
 # ## Contact
 # Kerstin Forsberg
@@ -15,4 +17,33 @@
 # GitHub username: kerfors
 
 RewriteEngine on
-RewriteRule ^$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.2.0/usdm_v4.ttl [R=303,L]
+RewriteBase /cdisc/usdm/v4
+
+# JSON-LD
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(.*)$ https://kerfors.github.io/usdm-rdf/ontology.jsonld [R=303,L]
+
+# RDF/XML
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(.*)$ https://kerfors.github.io/usdm-rdf/ontology.owl [R=303,L]
+
+# N-Triples
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(.*)$ https://kerfors.github.io/usdm-rdf/ontology.nt [R=303,L]
+
+# Turtle — canonical, version-pinned at the v0.3.0 tag
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.3.0/usdm_v4.ttl [R=303,L]
+
+# HTML for browsers — namespace root and per-IRI variants
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://kerfors.github.io/usdm-rdf/ [R=303,L]
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(.+)$ https://kerfors.github.io/usdm-rdf/index.html#$1 [R=303,NE,L]
+
+# Default fallback (no Accept header, programmatic clients): canonical Turtle
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.3.0/usdm_v4.ttl [R=303,L]


### PR DESCRIPTION
Updates the existing `cdisc/usdm/v4/.htaccess` (originally added in #5994 for v0.2) to handle the v0.3 release of `kerfors/usdm-rdf`.

## What changes

v0.2 used hash IRIs (`https://w3id.org/cdisc/usdm/v4#Activity`) and the `.htaccess` was a single rule redirecting the namespace to a static Turtle file. v0.3 (tagged `v0.3.0` on 2026-05-03) switches to slash semantics (`https://w3id.org/cdisc/usdm/v4/Activity`) and adds per-IRI HTML rendering, so the `.htaccess` grows to a content-negotiation shape:

- `text/html` → per-class HTML page with anchored fragment, served from GitHub Pages at `https://kerfors.github.io/usdm-rdf/`
- `text/turtle` → canonical Turtle, version-pinned at the v0.3.0 tag on raw GitHub
- `application/ld+json`, `application/rdf+xml`, `application/n-triples` → corresponding WIDOCO-generated serializations on Pages
- Default fallback (no Accept header) → canonical Turtle

## Why

Per-IRI server-side dereferencing (one of the standard motivations for slash IRIs in linked-data publication). Hash semantics couples every IRI to a single document; slash decouples them, enabling per-class HTML rendering with each IRI resolving to its own page anchor.

## Risk

Low. v0.2 was 4 days old when v0.3 was scoped (no known external consumers, no external citations). The v0.2 Turtle remains accessible as a static file at the v0.2.0 git tag; this PR only changes what `https://w3id.org/cdisc/usdm/v4/...` resolves to going forward. Migration documentation: https://github.com/kerfors/usdm-rdf/blob/main/docs/v0.2-to-v0.3-migration.md

## Verification

- v0.3.0 tag on `kerfors/usdm-rdf`: https://github.com/kerfors/usdm-rdf/releases/tag/v0.3.0
- Live HTML rendering: https://kerfors.github.io/usdm-rdf/
- Canonical Turtle (the redirect target for `text/turtle`): https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.3.0/usdm_v4.ttl
- Reference copy of this `.htaccess` in the source repo: https://github.com/kerfors/usdm-rdf/blob/main/docs/htaccess.txt

## Contact

Kerstin Forsberg — kerstin.l.forsberg@gmail.com — GitHub `@kerfors`. Same maintainer as the v0.2 namespace registration in #5994.