### PR TITLE
Add RIPE persistent identifiers

### DIFF
--- a/ripe/.htaccess
+++ b/ripe/.htaccess
@@ -1,0 +1,36 @@
+Options -MultiViews
+
+Header always set Access-Control-Allow-Origin "*"
+Header always set Vary "Accept"
+
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .nt
+AddType application/ld+json .jsonld
+
+RewriteEngine on
+
+# RIPE Observatory
+RewriteRule ^$ https://ripe-observatory.github.io/ [R=303,L]
+
+# RIPE-O ontology document, latest and version 1.0.0
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^ripe-o(/1\.0\.0)?/?$ https://ripe-observatory.github.io/RIPE-O/release/1.0.0/ontology.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^ripe-o(/1\.0\.0)?/?$ https://ripe-observatory.github.io/RIPE-O/release/1.0.0/ontology.owl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples [NC]
+RewriteRule ^ripe-o(/1\.0\.0)?/?$ https://ripe-observatory.github.io/RIPE-O/release/1.0.0/ontology.nt [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC,OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [NC,OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle [NC]
+RewriteRule ^ripe-o(/1\.0\.0)?/?$ https://ripe-observatory.github.io/RIPE-O/release/1.0.0/ontology.ttl [R=303,L]
+
+RewriteRule ^ripe-o(/1\.0\.0)?/?$ https://ripe-observatory.github.io/RIPE-O/release/1.0.0/index-en.html [R=303,L]
+
+# RIPE Knowledge Graph and INSPECT-AI software
+RewriteRule ^ripe-kg/?$ https://ripe-kg.inspectai.app/ [R=303,L]
+RewriteRule ^ripe-kg/(.+)$ https://ripe-kg.inspectai.app/ripe-kg/$1 [R=303,NE,L]
+RewriteRule ^inspect-ai/?$ https://github.com/RIPE-Observatory/INSPECT-AI_open_source [R=303,L]

--- a/ripe/README.md
+++ b/ripe/README.md
@@ -1,0 +1,17 @@
+# RIPE
+
+This W3ID provides persistent identifiers for the Research Integrity Provenance and Evidence (RIPE) Observatory.
+
+## Identifiers
+
+- `https://w3id.org/ripe` redirects to the RIPE Observatory website.
+- `https://w3id.org/ripe/ripe-o` identifies the RIPE ontology document and supports content negotiation for HTML, Turtle, RDF/XML, JSON-LD, and N-Triples.
+- `https://w3id.org/ripe/ripe-o/1.0.0` identifies version 1.0.0 of the RIPE ontology document.
+- `https://w3id.org/ripe/ripe-kg` redirects to the RIPE Knowledge Graph interface.
+- `https://w3id.org/ripe/ripe-kg/...` redirects to RIPE Knowledge Graph resources.
+- `https://w3id.org/ripe/inspect-ai` redirects to the INSPECT-AI open-source repository.
+
+## Maintainers
+
+- Milan Markovic, University of Aberdeen
+- GitHub: [@m-markovic](https://github.com/m-markovic)


### PR DESCRIPTION
## Brief Description
This PR adds the `https://w3id.org/ripe` namespace for the Research Integrity Provenance and Evidence (RIPE) Observatory.

The namespace provides redirects for:

- `https://w3id.org/ripe` to the RIPE Observatory website
- `https://w3id.org/ripe/ripe-o` and `https://w3id.org/ripe/ripe-o/1.0.0` to the RIPE ontology documentation, with content negotiation for HTML, Turtle, RDF/XML, JSON-LD, and N-Triples
- `https://w3id.org/ripe/ripe-kg` and `https://w3id.org/ripe/ripe-kg/...` to the RIPE Knowledge Graph interface and resource resolver
- `https://w3id.org/ripe/inspect-ai` to the INSPECT-AI open-source repository

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Optional Requests for W3ID Maintainers
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.