### PR TITLE
Add FAIR-O ontology namespace

### DIFF
--- a/fair-o/.htaccess
+++ b/fair-o/.htaccess
@@ -1,0 +1,18 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# FAIR-O persistent identifier
+# Namespace: https://w3id.org/fair-o#
+
+# HTML documentation for browsers
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteRule ^$ https://GabrieleT0.github.io/FAIR-O-An-Ontology-for-FAIR-Assessment-and-Scoring/ [R=303,L]
+
+# Turtle serialization
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^$ https://raw.githubusercontent.com/GabrieleT0/FAIR-O-An-Ontology-for-FAIR-Assessment-and-Scoring/main/FAIR-O.ttl [R=303,L]
+
+# Default fallback: HTML documentation
+RewriteRule ^$ https://GabrieleT0.github.io/FAIR-O-An-Ontology-for-FAIR-Assessment-and-Scoring/ [R=303,L]

--- a/fair-o/README.md
+++ b/fair-o/README.md
@@ -1,0 +1,36 @@
+# FAIR-O
+
+This directory contains the permanent identifier configuration for FAIR-O: an ontology for FAIR assessment and scoring.
+
+## Namespace
+
+```text
+https://w3id.org/fair-o#
+```
+
+## Ontology document
+
+```text
+https://w3id.org/fair-o
+```
+
+## Repository
+
+```text
+https://github.com/GabrieleT0/FAIR-O-An-Ontology-for-FAIR-Assessment-and-Scoring
+```
+
+## Documentation
+
+```text
+https://gabrielet0.github.io/FAIR-O-An-Ontology-for-FAIR-Assessment-and-Scoring/
+```
+
+## Turtle serialization
+
+```text
+https://raw.githubusercontent.com/GabrieleT0/FAIR-Assessment-Ontology/main/FAIR-O.ttl
+```
+
+## Maintener 
+Gabriele Tuozzo

--- a/fair-o/README.md
+++ b/fair-o/README.md
@@ -32,5 +32,5 @@ https://gabrielet0.github.io/FAIR-O-An-Ontology-for-FAIR-Assessment-and-Scoring/
 https://raw.githubusercontent.com/GabrieleT0/FAIR-Assessment-Ontology/main/FAIR-O.ttl
 ```
 
-## Maintener 
+## Maintainer 
 Gabriele Tuozzo - GitHub: [@GabrieleT0](https://github.com/GabrieleT0)

--- a/fair-o/README.md
+++ b/fair-o/README.md
@@ -33,4 +33,4 @@ https://raw.githubusercontent.com/GabrieleT0/FAIR-Assessment-Ontology/main/FAIR-
 ```
 
 ## Maintener 
-Gabriele Tuozzo
+Gabriele Tuozzo - GitHub: [@GabrieleT0](https://github.com/GabrieleT0)


### PR DESCRIPTION
## Brief Description
This PR adds a new persistent identifier directory for FAIR-O, an ontology for FAIR assessment and scoring.
Requested namespace:
```text
https://w3id.org/fair-o#
```

Ontology document IRI:
```text
https://w3id.org/fair-o
```

The directory contains only redirect configuration and basic maintainer/repository information. The ontology content and documentation are hosted externally in the FAIR-O GitHub repository and GitHub Pages.

Redirect targets:

* HTML documentation: https://gabrielet0.github.io/FAIR-O-An-Ontology-for-FAIR-Assessment-and-Scoring/
* Turtle serialization: https://raw.githubusercontent.com/GabrieleT0/FAIR-Assessment-Ontology/main/FAIR-O.ttl

Maintainer:

* Gabriele Tuozzo — @GabrieleT0


General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

New ID Directory Checklist

- [x] Maintainer details are in .htaccess or README.md.
- [x] GitHub username ids are listed in the maintainer details.

Update ID Directory Checklist

- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

Optional Requests for W3ID Maintainers

- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.