### PR TITLE
Add /spectra namespace for SPECTRA ontology

### DIFF
--- a/spectra/.htaccess
+++ b/spectra/.htaccess
@@ -18,15 +18,16 @@
 Options +FollowSymLinks
 RewriteEngine on
 Header set Access-Control-Allow-Origin *
+Header set Vary "Accept"
 
-# Content negotiation for ontology IRI
-RewriteCond %{HTTP_ACCEPT} text/turtle
+# Content negotiation for ontology IRI (case-insensitive Accept matching)
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
 RewriteRule ^$ https://github.com/spectra-ontology/spec-trace/releases/latest/download/spectra.ttl [R=303,L]
 
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
 RewriteRule ^$ https://github.com/spectra-ontology/spec-trace/releases/latest/download/spectra.ttl [R=303,L]
 
-RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteCond %{HTTP_ACCEPT} application/n-triples [NC]
 RewriteRule ^$ https://github.com/spectra-ontology/spec-trace/releases/latest/download/spectra.ttl [R=303,L]
 
 # Default (HTML / browser): PyLODE documentation on GitHub Pages

--- a/spectra/.htaccess
+++ b/spectra/.htaccess
@@ -22,16 +22,16 @@ Header set Vary "Accept"
 
 # Content negotiation for ontology IRI (case-insensitive Accept matching)
 RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
-RewriteRule ^$ https://github.com/spectra-ontology/spec-trace/releases/latest/download/spectra.ttl [R=303,L]
+RewriteRule ^$ https://spectra-ontology.github.io/spec-trace/spectra.ttl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
-RewriteRule ^$ https://github.com/spectra-ontology/spec-trace/releases/latest/download/spectra.ttl [R=303,L]
+RewriteRule ^$ https://spectra-ontology.github.io/spec-trace/spectra.ttl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/n-triples [NC]
-RewriteRule ^$ https://github.com/spectra-ontology/spec-trace/releases/latest/download/spectra.ttl [R=303,L]
+RewriteRule ^$ https://spectra-ontology.github.io/spec-trace/spectra.ttl [R=303,L]
 
 # Default (HTML / browser): PyLODE documentation on GitHub Pages
 RewriteRule ^$ https://spectra-ontology.github.io/spec-trace/ [R=303,L]
 
 # Sub-paths (term IRIs): same TTL (single-file ontology)
-RewriteRule ^(.*)$ https://github.com/spectra-ontology/spec-trace/releases/latest/download/spectra.ttl [R=303,L]
+RewriteRule ^(.*)$ https://spectra-ontology.github.io/spec-trace/spectra.ttl [R=303,L]

--- a/spectra/.htaccess
+++ b/spectra/.htaccess
@@ -6,9 +6,10 @@
 # Hosting:          https://github.com/spectra-ontology/spec-trace (v1.0.0)
 # Companion paper:  ISWC 2026 Resources Track (under review)
 #
-# Maintainers (GitHub usernames):
-#   @shychoi10 — Sihyeon Choi (corresponding) <shyun12.choi@samsung.com>
-#              — Junho Lee                    <junho515.lee@samsung.com>
+# Maintainer (GitHub username):
+#   @shychoi10 — Sihyeon Choi <shyun12.choi@samsung.com>
+# Co-author / contact:
+#              — Junho Lee   <junho515.lee@samsung.com>
 #
 # Content negotiation:
 #   Accept: text/turtle | application/rdf+xml | application/n-triples → ontology TTL

--- a/spectra/.htaccess
+++ b/spectra/.htaccess
@@ -1,0 +1,26 @@
+# /spectra/.htaccess — to be placed at github.com/perma-id/w3id.org : spectra/.htaccess
+#
+# Redirects https://w3id.org/spectra and https://w3id.org/spectra# to the
+# latest GitHub release of the SPECTRA ontology, with content negotiation:
+#  - Accept: text/turtle      → ontology TTL
+#  - Accept: text/html (default) → PyLODE documentation on GitHub Pages
+#  - sub-paths (term IRIs) → ontology TTL (single-file ontology)
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# Redirect bare ontology IRI based on Accept header
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^$ https://github.com/spectra-ontology/spec-trace/releases/latest/download/spectra.ttl [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://github.com/spectra-ontology/spec-trace/releases/latest/download/spectra.ttl [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://github.com/spectra-ontology/spec-trace/releases/latest/download/spectra.ttl [R=302,L]
+
+# Default (HTML / browser): GitHub Pages PyLODE documentation
+RewriteRule ^$ https://spectra-ontology.github.io/spec-trace/ [R=302,L]
+
+# Any sub-path (e.g., w3id.org/spectra/Tdoc): same TTL (the ontology is single-file)
+RewriteRule ^(.*)$ https://github.com/spectra-ontology/spec-trace/releases/latest/download/spectra.ttl [R=302,L]

--- a/spectra/.htaccess
+++ b/spectra/.htaccess
@@ -1,26 +1,36 @@
-# /spectra/.htaccess — to be placed at github.com/perma-id/w3id.org : spectra/.htaccess
+# /spectra/.htaccess — perma-id/w3id.org persistent identifier directory for SPECTRA
 #
-# Redirects https://w3id.org/spectra and https://w3id.org/spectra# to the
-# latest GitHub release of the SPECTRA ontology, with content negotiation:
-#  - Accept: text/turtle      → ontology TTL
-#  - Accept: text/html (default) → PyLODE documentation on GitHub Pages
-#  - sub-paths (term IRIs) → ontology TTL (single-file ontology)
+# Namespace:        https://w3id.org/spectra
+# Resource:         SPECTRA — A Traceability Ontology for the 3GPP RAN Standardization Process
+# License:          CC-BY 4.0
+# Hosting:          https://github.com/spectra-ontology/spec-trace (v1.0.0)
+# Companion paper:  ISWC 2026 Resources Track (under review)
+#
+# Maintainers (GitHub usernames):
+#   @shychoi10 — Sihyeon Choi (corresponding) <shyun12.choi@samsung.com>
+#              — Junho Lee                    <junho515.lee@samsung.com>
+#
+# Content negotiation:
+#   Accept: text/turtle | application/rdf+xml | application/n-triples → ontology TTL
+#   Accept: text/html (default)                                       → PyLODE HTML on GitHub Pages
+#   sub-paths (term IRIs like /spectra#Tdoc)                          → ontology TTL (single-file)
 
 Options +FollowSymLinks
 RewriteEngine on
+Header set Access-Control-Allow-Origin *
 
-# Redirect bare ontology IRI based on Accept header
+# Content negotiation for ontology IRI
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^$ https://github.com/spectra-ontology/spec-trace/releases/latest/download/spectra.ttl [R=302,L]
+RewriteRule ^$ https://github.com/spectra-ontology/spec-trace/releases/latest/download/spectra.ttl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^$ https://github.com/spectra-ontology/spec-trace/releases/latest/download/spectra.ttl [R=302,L]
+RewriteRule ^$ https://github.com/spectra-ontology/spec-trace/releases/latest/download/spectra.ttl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^$ https://github.com/spectra-ontology/spec-trace/releases/latest/download/spectra.ttl [R=302,L]
+RewriteRule ^$ https://github.com/spectra-ontology/spec-trace/releases/latest/download/spectra.ttl [R=303,L]
 
-# Default (HTML / browser): GitHub Pages PyLODE documentation
-RewriteRule ^$ https://spectra-ontology.github.io/spec-trace/ [R=302,L]
+# Default (HTML / browser): PyLODE documentation on GitHub Pages
+RewriteRule ^$ https://spectra-ontology.github.io/spec-trace/ [R=303,L]
 
-# Any sub-path (e.g., w3id.org/spectra/Tdoc): same TTL (the ontology is single-file)
-RewriteRule ^(.*)$ https://github.com/spectra-ontology/spec-trace/releases/latest/download/spectra.ttl [R=302,L]
+# Sub-paths (term IRIs): same TTL (single-file ontology)
+RewriteRule ^(.*)$ https://github.com/spectra-ontology/spec-trace/releases/latest/download/spectra.ttl [R=303,L]


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. -->
## Brief Description

This PR adds a new persistent identifier directory `/spectra` for **SPECTRA — A Traceability Ontology for the 3GPP RAN Standardization Process** (companion to an ISWC 2026 Resources Track submission, currently under review). The directory contains only redirect configuration with content negotiation: `text/turtle` (and equivalent RDF serialisation Accept headers) → ontology TTL on GitHub releases; HTML/browser → PyLODE documentation on GitHub Pages.

Requested namespace:

```text
https://w3id.org/spectra#
```

Ontology document IRI:

```text
https://w3id.org/spectra
```

Redirect targets (all verified HTTP 200 prior to this PR):

- HTML / browser → [https://spectra-ontology.github.io/spec-trace/](https://spectra-ontology.github.io/spec-trace/)
- `text/turtle`, `application/rdf+xml`, `application/n-triples` → [https://spectra-ontology.github.io/spec-trace/spectra.ttl](https://spectra-ontology.github.io/spec-trace/spectra.ttl) (served as `text/turtle; charset=utf-8` for RDF tool auto-detection)
- Sub-paths (term IRIs like `/spectra#Tdoc`) → same TTL (single-file ontology)

The ontology content and documentation are hosted externally in the GitHub repository [spectra-ontology/spec-trace](https://github.com/spectra-ontology/spec-trace) (v1.0.0 published, [release page](https://github.com/spectra-ontology/spec-trace/releases/tag/v1.0.0)); the per-WG body-text knowledge graphs are deposited on Zenodo (DOI [10.5281/zenodo.20034872](https://doi.org/10.5281/zenodo.20034872)).

## General Checklist

- [x] Changes have been tested. (TTL latest-download: HTTP 200; GitHub Pages root: HTTP 200; both verified.)
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Resource details

- **Type**: OWL 2 ontology (Turtle), 26 classes, 53 object properties, 81 data properties
- **License**: CC-BY 4.0 (SPECTRA-authored components); per-WG body-text literals on Zenodo retain explicit 3GPP attribution
- **Maintainer**: [@shychoi10](https://github.com/shychoi10) — Sihyeon Choi — shyun12.choi@samsung.com
- **Co-author / contact**: Junho Lee — junho515.lee@samsung.com
- **Affiliation**: System LSI Business, Device Solutions Division, Samsung Electronics, South Korea
- **Files in this PR**: `spectra/.htaccess`

## Optional Requests for W3ID Maintainers

- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
