### PR TITLE
Refactor .htaccess ontology redirection rules

### DIFF
--- a/aerospace-x/.htaccess
+++ b/aerospace-x/.htaccess
@@ -21,28 +21,20 @@ RewriteEngine on
 RewriteRule ^ovc(/.*)?$ https://gitlab.com/gaia-x/lab/policy-reasoning/odrl-vc-profile/-/raw/main/ovc-1.ttl [R=303,L]
 
 # ============================================
-# 2. Ontology - Direct file access
+# 3. Ontology - Content Negotiation (Gaia-X pattern)
+#    Same URI, different representation based on Accept header
 # ============================================
 
-RewriteRule ^ontology/ontology\.ttl$ https://a-x.pages.fraunhofer.de/ontology/ontology.owl.ttl [R=303,L]
-RewriteRule ^ontology/shapes\.ttl$ https://a-x.pages.fraunhofer.de/ontology/ontology.shacl.ttl [R=303,L]
+# Redirect to SHACL shapes (text/turtle → shapes)
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^ontology(/development|/[0-9.]+)?/?$ https://a-x.pages.fraunhofer.de/ontology/ontology.shacl.ttl [R=303,L]
 
-# ============================================
-# 3. Ontology - Content Negotiation
-#    Matches: ontology/ontology, ontology/, ontology/{version}
-# ============================================
+# Redirect to OWL ontology (application/rdf+xml → OWL)
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^ontology(/development|/[0-9.]+)?/?$ https://a-x.pages.fraunhofer.de/ontology/ontology.owl.ttl [R=303,L]
 
-# SHACL shapes (separate URI)
-RewriteRule ^ontology/shapes(/development|/[0-9.]+)?/?$ https://a-x.pages.fraunhofer.de/ontology/ontology.shacl.ttl [R=303,L]
-
-# OWL ontology (any RDF Accept)
-RewriteCond %{HTTP_ACCEPT} text/turtle [NC,OR]
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC,OR]
-RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
-RewriteRule ^ontology(/ontology|/development|/[0-9.]+)?/?$ https://a-x.pages.fraunhofer.de/ontology/ontology.owl.ttl [R=303,L]
-
-# OWL ontology (default/browser)
-RewriteRule ^ontology(/ontology|/development|/[0-9.]+)?/?$ https://a-x.pages.fraunhofer.de/ontology/ontology.owl.ttl [R=303,L]
+# Default: redirect to HTML documentation
+RewriteRule ^ontology(/development|/[0-9.]+)?/?$ https://a-x.pages.fraunhofer.de/ontology/ [R=303,L]
 
 # ============================================
 # 4. Data Product Models - Content Negotiation


### PR DESCRIPTION
Updated ontology redirection rules for content negotiation and removed obsolete rules.

<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [ x] Changes have been tested.
- [ x] The number of commits is minimal. Squash if needed.
- [ x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ x] Maintainer details are in `.htaccess` or `README.md`.
- [ x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [x ] GitHub username ids are listed in the changed maintainer details.
- [x ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
