### PR TITLE
Add NS4KGE permanent identifier redirects

### DIFF
--- a/ns4kge/.htaccess
+++ b/ns4kge/.htaccess
@@ -1,0 +1,74 @@
+# NS4KGE permanent identifiers
+#
+# This W3ID namespace provides persistent identifiers for the NS4KGE ontology
+# and knowledge graph.
+#
+# Maintainer:
+# Ilyes Tebourski
+# GitHub username: IlyesTebourski
+# Email: ilyes.tebourski@lisn.fr
+#
+# Identifier examples:
+# https://w3id.org/ns4kge/ontology
+# https://w3id.org/ns4kge/ontology#Article
+# https://w3id.org/ns4kge/ontology#hasConfiguration
+# https://w3id.org/ns4kge/ontology/1.0.0
+# https://w3id.org/ns4kge/kg
+# https://w3id.org/ns4kge/kg/1.0.0
+# https://w3id.org/ns4kge/id/article/eans
+Options -MultiViews
+AddType text/turtle .ttl
+Header set Access-Control-Allow-Origin *
+RewriteEngine On
+# Project landing page
+RewriteRule ^$ https://github.com/IlyesTebourski/ns4kge-ontology [R=303,L]
+# Ontology, latest version, human-readable
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^ontology/?$ https://github.com/IlyesTebourski/ns4kge-ontology [R=303,L]
+# Ontology, latest version, Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\*
+RewriteRule ^ontology/?$ https://raw.githubusercontent.com/IlyesTebourski/ns4kge-ontology/v1.0.0/ontology/NSArticles_ontology.ttl [R=303,L]
+# Ontology, version 1.0.0, human-readable
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^ontology/1\.0\.0/?$ https://github.com/IlyesTebourski/ns4kge-ontology/tree/v1.0.0 [R=303,L]
+# Ontology, version 1.0.0, Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\*
+RewriteRule ^ontology/1\.0\.0/?$ https://raw.githubusercontent.com/IlyesTebourski/ns4kge-ontology/v1.0.0/ontology/NSArticles_ontology.ttl [R=303,L]
+# Knowledge graph dataset, latest version, human-readable
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^kg/?$ https://github.com/IlyesTebourski/ns4kge-kg [R=303,L]
+# Knowledge graph dataset, latest version, Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\*
+RewriteRule ^kg/?$ https://raw.githubusercontent.com/IlyesTebourski/ns4kge-kg/v1.0.0-paper/kg/NSArticles_populated.ttl [R=303,L]
+# Knowledge graph dataset, version 1.0.0, human-readable
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^kg/1\.0\.0/?$ https://github.com/IlyesTebourski/ns4kge-kg/tree/v1.0.0-paper [R=303,L]
+# Knowledge graph dataset, version 1.0.0, Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\*
+RewriteRule ^kg/1\.0\.0/?$ https://raw.githubusercontent.com/IlyesTebourski/ns4kge-kg/v1.0.0-paper/kg/NSArticles_populated.ttl [R=303,L]
+# KG instance identifiers, human-readable
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^id/(.*)$ https://github.com/IlyesTebourski/ns4kge-kg [R=303,L]
+# KG instance identifiers, RDF graph
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\*
+RewriteRule ^id/(.*)$ https://raw.githubusercontent.com/IlyesTebourski/ns4kge-kg/v1.0.0-paper/kg/NSArticles_populated.ttl [R=303,L]

--- a/ns4kge/README.md
+++ b/ns4kge/README.md
@@ -28,3 +28,6 @@ NS4KGE is a Semantic Web resource suite for representing scientific articles abo
 Ilyes Tebourski  
 GitHub: `@IlyesTebourski`  
 Email: ilyes.tebourski@lisn.fr
+
+Pierre-Henri Paris
+[PHParis](https://github.com/PHParis)

--- a/ns4kge/README.md
+++ b/ns4kge/README.md
@@ -1,0 +1,30 @@
+# /ns4kge/
+
+Permanent identifiers for the NS4KGE ontology and knowledge graph.
+NS4KGE is a Semantic Web resource suite for representing scientific articles about knowledge graph embeddings and negative sampling methods.
+
+## Identifier Space
+
+| Identifier | Purpose |
+|---|---|
+| `https://w3id.org/ns4kge/ontology` | Ontology IRI |
+| `https://w3id.org/ns4kge/ontology#Article` | Ontology class example |
+| `https://w3id.org/ns4kge/ontology#hasConfiguration` | Ontology property example |
+| `https://w3id.org/ns4kge/ontology/1.0.0` | Versioned ontology IRI |
+| `https://w3id.org/ns4kge/kg` | Knowledge graph dataset IRI |
+| `https://w3id.org/ns4kge/kg/1.0.0` | Versioned knowledge graph dataset IRI |
+| `https://w3id.org/ns4kge/id/article/eans` | Knowledge graph instance example |
+
+## Target Repositories
+
+| Resource | Repository |
+|---|---|
+| Ontology | `https://github.com/IlyesTebourski/ns4kge-ontology` |
+| Extraction pipeline | `https://github.com/IlyesTebourski/ns4kge-extraction-pipeline` |
+| Knowledge graph | `https://github.com/IlyesTebourski/ns4kge-kg` |
+
+## Maintainer
+
+Ilyes Tebourski  
+GitHub: `@IlyesTebourski`  
+Email: ilyes.tebourski@lisn.fr


### PR DESCRIPTION
This PR adds the `https://w3id.org/ns4kge/` namespace for the NS4KGE resource suite.

The namespace includes redirects for:

- NS4KGE ontology IRI and versioned ontology IRI
- NS4KGE ontology term namespace
- NS4KGE knowledge graph dataset IRI
- NS4KGE knowledge graph instance identifiers

Maintainer:

- Ilyes Tebourski
- GitHub: @IlyesTebourski
- Email: ilyes.tebourski@lisn.fr