### PR TITLE
Add /pip/ namespace for Peirce Interprets Peirce KG

### DIFF
--- a/pip/.htaccess
+++ b/pip/.htaccess
@@ -1,0 +1,51 @@
+# Peirce Interprets Peirce (PIP) namespace redirects
+#
+# Maintained by Carlo Teo Pedretti <0000-0002-4115-0078>
+# Bibliotheca Hertziana, Max Planck Institute for Art History
+#
+# Source repository:
+#   https://github.com/Peirce-Team/PublishingPeircePlatform
+#
+# Persistent archive (Zenodo):
+#   https://doi.org/10.5281/zenodo.20056038
+
+Options +FollowSymLinks
+RewriteEngine On
+
+# -----------------------------------------------------------------------------
+# 1. Schema (LMM3 ontology)
+# -----------------------------------------------------------------------------
+# https://w3id.org/pip/lmm3 -> ontology TTL on GitHub (main branch)
+RewriteRule ^lmm3$ https://raw.githubusercontent.com/Peirce-Team/PublishingPeircePlatform/main/ontology/lmm3_v07.ttl [R=302,L]
+RewriteRule ^lmm3/?$ https://raw.githubusercontent.com/Peirce-Team/PublishingPeircePlatform/main/ontology/lmm3_v07.ttl [R=302,L]
+RewriteRule ^lmm3#.*$ https://raw.githubusercontent.com/Peirce-Team/PublishingPeircePlatform/main/ontology/lmm3_v07.ttl [R=302,L]
+
+# -----------------------------------------------------------------------------
+# 2. Named graphs (kg)
+# -----------------------------------------------------------------------------
+# https://w3id.org/pip/kg/<name> -> corresponding TTL file on GitHub
+RewriteRule ^kg/schema$ https://raw.githubusercontent.com/Peirce-Team/PublishingPeircePlatform/main/ontology/lmm3_v07.ttl [R=302,L]
+RewriteRule ^kg/archive$ https://raw.githubusercontent.com/Peirce-Team/PublishingPeircePlatform/main/ontology/archive_houghton.ttl [R=302,L]
+RewriteRule ^kg/semiotic$ https://raw.githubusercontent.com/Peirce-Team/PublishingPeircePlatform/main/ontology/semiotic_pilot.ttl [R=302,L]
+RewriteRule ^kg/commens$ https://raw.githubusercontent.com/Peirce-Team/PublishingPeircePlatform/main/ontology/commens.ttl [R=302,L]
+RewriteRule ^kg/cp-bridge$ https://raw.githubusercontent.com/Peirce-Team/PublishingPeircePlatform/main/ontology/cp_bridge.ttl [R=302,L]
+RewriteRule ^kg/provenance$ https://raw.githubusercontent.com/Peirce-Team/PublishingPeircePlatform/main/ontology/provenance.ttl [R=302,L]
+
+# -----------------------------------------------------------------------------
+# 3. Data namespaces (instance IRIs)
+# -----------------------------------------------------------------------------
+# https://w3id.org/pip/houghton/...     -> archive TTL
+# https://w3id.org/pip/concept/...      -> commens TTL
+# https://w3id.org/pip/commens/...      -> commens TTL
+# https://w3id.org/pip/cp/...           -> cp_bridge TTL
+RewriteRule ^houghton/.*$ https://raw.githubusercontent.com/Peirce-Team/PublishingPeircePlatform/main/ontology/archive_houghton.ttl [R=302,L]
+RewriteRule ^concept/.*$ https://raw.githubusercontent.com/Peirce-Team/PublishingPeircePlatform/main/ontology/commens.ttl [R=302,L]
+RewriteRule ^commens/.*$ https://raw.githubusercontent.com/Peirce-Team/PublishingPeircePlatform/main/ontology/commens.ttl [R=302,L]
+RewriteRule ^cp/.*$ https://raw.githubusercontent.com/Peirce-Team/PublishingPeircePlatform/main/ontology/cp_bridge.ttl [R=302,L]
+
+# -----------------------------------------------------------------------------
+# 4. Default landing
+# -----------------------------------------------------------------------------
+# https://w3id.org/pip -> GitHub repository (human-readable landing page)
+RewriteRule ^$ https://github.com/Peirce-Team/PublishingPeircePlatform [R=302,L]
+RewriteRule ^/?$ https://github.com/Peirce-Team/PublishingPeircePlatform [R=302,L]

--- a/pip/.htaccess
+++ b/pip/.htaccess
@@ -1,6 +1,7 @@
 # Peirce Interprets Peirce (PIP) namespace redirects
 #
-# Maintained by Carlo Teo Pedretti <0000-0002-4115-0078>
+# Maintainer: Carlo Teo Pedretti <0000-0002-4115-0078>
+# Maintainer: friendlynihilist
 # Bibliotheca Hertziana, Max Planck Institute for Art History
 #
 # Source repository:


### PR DESCRIPTION
This PR adds the /pip/ namespace for the Peirce Interprets Peirce Knowledge Graph (PIP-KG), a layered RDF knowledge graph of the Charles S. Peirce manuscripts (MS Am 1632) developed within the project "Peirce Interprets Peirce".

- Resource on Zenodo: https://doi.org/10.5281/zenodo.20056038
- Source repository: https://github.com/Peirce-Team/PublishingPeircePlatform
- Maintainer: Carlo Teo Pedretti (ORCID: 0000-0002-4115-0078)
- License: CC BY 4.0 for data and ontology, MIT for code