### PR TITLE
Add qatypes: permanent identifier for QA Question Types ontology

### DIFF
--- a/qatypes/.htaccess
+++ b/qatypes/.htaccess
@@ -1,0 +1,33 @@
+Options +FollowSymLinks
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+
+RewriteEngine on
+
+# Rewrite rules for QA Types vocabulary
+
+# HTML browsers
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*|\*/\*)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://github.com/UniVR-DH/nl2sparql-benchmark/blob/main/graphs/qa-types.ttl [R=303,NE,L]
+
+# RDF/XML
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteRule ^$ https://raw.githubusercontent.com/UniVR-DH/nl2sparql-benchmark/refs/heads/main/graphs/qa-types.owl [R=303,NE,L]
+
+# Turtle
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.*
+RewriteRule ^$ https://raw.githubusercontent.com/UniVR-DH/nl2sparql-benchmark/refs/heads/main/graphs/qa-types.ttl [R=303,NE,L]
+
+# Default: Turtle
+RewriteRule ^$ https://raw.githubusercontent.com/UniVR-DH/nl2sparql-benchmark/refs/heads/main/graphs/qa-types.ttl [R=303,NE,L]

--- a/qatypes/README.md
+++ b/qatypes/README.md
@@ -1,0 +1,18 @@
+Repository created to store the redirections of the the QA Question Types ontology 
+===================
+
+
+/qatypes: 
+
+HTML: https://github.com/UniVR-DH/nl2sparql-benchmark/
+
+TTL: https://github.com/UniVR-DH/nl2sparql-benchmark/blob/main/graphs/qa-types.ttl
+
+```
+@prefix qat: <https://w3id.org/qatypes#> .
+```
+
+
+Contacts
+
+* Indeewari Balasooriya <Indeewari.Balasooriya@univr.it> (@Indeewarib)


### PR DESCRIPTION
## Brief Description

This PR adds the `qatypes` directory to provide a permanent identifier for the **QA Question Types ontology** developed by the  Verona Intelligent Analytics Systems Lab @ UniVR.

`https://w3id.org/qatypes` redirects to the ontology hosted at https://github.com/UniVR-DH/nl2sparql-benchmark with content negotiation:
- **HTML** (browser) → https://github.com/UniVR-DH/nl2sparql-benchmark/blob/main/graphs/qa-types.ttl
- **text/turtle** → https://raw.githubusercontent.com/UniVR-DH/nl2sparql-benchmark/refs/heads/main/graphs/qa-types.ttl
- **application/rdf+xml** → https://raw.githubusercontent.com/UniVR-DH/nl2sparql-benchmark/refs/heads/main/graphs/qa-types.owl
- **default** → Turtle file

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. 
- [x] Commits only include redirects and basic information. 

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
N/A — this is a new directory.