### PR TITLE
Initial commit for Pegazus ontology

### DIFF
--- a/PeGazUs/.htaccess
+++ b/PeGazUs/.htaccess
@@ -57,8 +57,8 @@ RewriteRule ^$ https://charlybernard.github.io/pegazus-paris/ontology.ttl [R=303
 
 
 RewriteCond %{HTTP_ACCEPT} .+
-RewriteRule ^$ 406.html [R=406,L]
+RewriteRule ^$ https://charlybernard.github.io/pegazus-paris/406.html [R=406,L]
 # Default response
 # ---------------------------
 # Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
-RewriteRule ^$ ontology.xml [R=303,L]
+RewriteRule ^$ https://charlybernard.github.io/pegazus-paris/ontology.xml [R=303,L]

--- a/PeGazUs/.htaccess
+++ b/PeGazUs/.htaccess
@@ -1,0 +1,64 @@
+# Turn off MultiViews
+Options -MultiViews
+Options +FollowSymLinks
+
+#Define default language
+DefaultLanguage en
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .json
+# Rewrite engine setup
+RewriteEngine On
+#Change the path to the folder here
+#RewriteBase /test_new 
+
+# Rewrite rules for data
+# Every URI that conatins /id/ is redirected to the triplestore
+RewriteRule ^id/(.*)$ https://data.geohistoricaldata.org/id/$1 [L,R=303]
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP:Accept-Language} ^fr$ [NC]
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://charlybernard.github.io/pegazus-paris/index-fr.html [R=303,L]
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://charlybernard.github.io/pegazus-paris/ [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://charlybernard.github.io/pegazus-paris/ontology.json [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://charlybernard.github.io/pegazus-paris/ontology.xml [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://charlybernard.github.io/pegazus-paris/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle 
+RewriteRule ^$ https://charlybernard.github.io/pegazus-paris/ontology.ttl [R=303,L]
+
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^$ 406.html [R=406,L]
+# Default response
+# ---------------------------
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^$ ontology.xml [R=303,L]

--- a/PeGazUs/.htaccess
+++ b/PeGazUs/.htaccess
@@ -12,6 +12,9 @@ AddType application/rdf+xml .owl
 AddType text/turtle .ttl
 AddType application/n-triples .n3
 AddType application/ld+json .json
+
+# maintainer: @charlybernard @nfabadie @HueyNemud @julienperret
+
 # Rewrite engine setup
 RewriteEngine On
 #Change the path to the folder here

--- a/PeGazUs/.htaccess
+++ b/PeGazUs/.htaccess
@@ -19,7 +19,7 @@ RewriteEngine On
 
 # Rewrite rules for data
 # Every URI that contains /id/ is redirected to the triplestore
-RewriteRule ^id/(.*)$ https://data.geohistoricaldata.org/id/PeGazUs/$1 [L,R=303]
+RewriteRule ^id/(.*)$ https://data.geohistoricaldata.org/PeGazUs/id/$1 [L,R=303]
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP:Accept-Language} ^fr$ [NC]

--- a/PeGazUs/.htaccess
+++ b/PeGazUs/.htaccess
@@ -18,8 +18,8 @@ RewriteEngine On
 #RewriteBase /test_new 
 
 # Rewrite rules for data
-# Every URI that conatins /id/ is redirected to the triplestore
-RewriteRule ^id/(.*)$ https://data.geohistoricaldata.org/id/$1 [L,R=303]
+# Every URI that contains /id/ is redirected to the triplestore
+RewriteRule ^id/(.*)$ https://data.geohistoricaldata.org/id/PeGazUs/$1 [L,R=303]
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP:Accept-Language} ^fr$ [NC]

--- a/PeGazUs/README.md
+++ b/PeGazUs/README.md
@@ -1,13 +1,24 @@
 # PeGazUs: PErpetual GAZeteer of approach-address UtteranceS
 
-Homepage:
+PeGazUs is an ontology to model the evolution of geographical entities and addresses
+
+## Homepage:
 * https://w3id.org/PeGazUs
 
-Contacts:
-- **Charly Bernard** — ORCID: https://orcid.org/0009-0003-8170-3671  
-- **Nathalie Abadie** — ORCID: https://orcid.org/0000-0001-8741-2398  
-- **Bertrand Duménieu** — ORCID: https://orcid.org/0000-0002-2517-2058  
-- **Julien Perret** — ORCID: https://orcid.org/0000-0002-0685-0730  
+## Maintainers
 
-## Description
-PeGazUs is an ontology to model the evolution of geographical entities and addresses
+- **Charly Bernard**  
+  - ORCID: https://orcid.org/0009-0003-8170-3671  
+  - GitHub: @charlybernard
+
+- **Nathalie Abadie**  
+  - ORCID: https://orcid.org/0000-0001-8741-2398  
+  - GitHub: @nfabadie
+
+- **Bertrand Duménieu**  
+  - ORCID: https://orcid.org/0000-0002-2517-2058  
+  - GitHub: @HueyNemud
+
+- **Julien Perret**  
+  - ORCID: https://orcid.org/0000-0002-0685-0730  
+  - GitHub: @julienperret

--- a/PeGazUs/README.md
+++ b/PeGazUs/README.md
@@ -1,0 +1,13 @@
+# PeGazUs: PErpetual GAZeteer of approach-address UtteranceS
+
+Homepage:
+* https://w3id.org/PeGazUs
+
+Contacts:
+- **Charly Bernard** — ORCID: https://orcid.org/0009-0003-8170-3671  
+- **Nathalie Abadie** — ORCID: https://orcid.org/0000-0001-8741-2398  
+- **Bertrand Duménieu** — ORCID: https://orcid.org/0000-0002-2517-2058  
+- **Julien Perret** — ORCID: https://orcid.org/0000-0002-0685-0730  
+
+## Description
+PeGazUs is an ontology to model the evolution of geographical entities and addresses


### PR DESCRIPTION
This PR adds a new persistent identifier for the PeGazUs ontology:
https://w3id.org/PeGazUs

It includes:
- .htaccess redirection
- README with ontology metadata and contacts