### PR TITLE
Add cybed/ namespace for cybedtools R package

### DIFF
--- a/cybed/.htaccess
+++ b/cybed/.htaccess
@@ -1,0 +1,12 @@
+# cybed
+# Cybersecurity-education vocabulary for the cybedtools R package.
+# Maintainer: Ryan Straight <ryanstraight@arizona.edu>
+# ORCID: 0000-0002-6251-5662
+# Repository: https://github.com/ryanstraight/cybedtools
+# Documentation: https://ryanstraight.github.io/cybedtools/
+
+Options +FollowSymLinks
+RewriteEngine on
+
+RewriteRule ^ontology(.*)$ https://ryanstraight.github.io/cybedtools/articles/namespace-architecture.html [R=302,L]
+RewriteRule ^ https://ryanstraight.github.io/cybedtools/ [R=302,L]

--- a/cybed/README.md
+++ b/cybed/README.md
@@ -1,0 +1,29 @@
+# cybed
+
+Cybersecurity-education vocabulary for the cybedtools R package.
+
+## Namespace URI
+
+`https://w3id.org/cybed/ontology#`
+
+## Resolves to
+
+- `/cybed/` → cybedtools documentation site
+- `/cybed/ontology` → vocabulary documentation
+
+## Maintainer
+
+- Ryan Straight
+- ryanstraight@arizona.edu
+- ORCID: 0000-0002-6251-5662
+- College of Information Science, University of Arizona
+
+## Package
+
+The cybed: vocabulary is the framework-agnostic two-tier base schema used by the cybedtools R package to express eight cybersecurity workforce and learning frameworks (NICE, DCWF, ECSF, SFIA, Cyber.org K-12, CSTA, ACM/IEEE CSEC2017, DigComp 2.2) in a comparable form.
+
+- Repository: https://github.com/ryanstraight/cybedtools
+- Documentation: https://ryanstraight.github.io/cybedtools/
+- DOI: https://doi.org/10.5281/zenodo.20076116
+- License: MIT (package code); framework source text retains upstream licensing
+- First release: v0.1.0, 2026-05-07


### PR DESCRIPTION
This PR adds a `cybed/` namespace redirect for the cybedtools R package.

## Namespace URI

`https://w3id.org/cybed/ontology#`

## Package

| Field | Value |
|---|---|
| Repository | https://github.com/ryanstraight/cybedtools |
| Documentation | https://ryanstraight.github.io/cybedtools/ |
| DOI | https://doi.org/10.5281/zenodo.20076116 |
| First release | v0.1.0, 2026-05-07 |
| License | MIT (package code); framework source text retains upstream licensing |

## Maintainer

- Ryan Straight
- ryanstraight@arizona.edu
- ORCID: 0000-0002-6251-5662
- College of Information Science, University of Arizona

## What the package is

A reproducible R pipeline for ingesting and analyzing eight cybersecurity workforce and learning frameworks (NICE, DCWF, ECSF, SFIA, Cyber.org K-12, CSTA, ACM/IEEE CSEC2017, DigComp 2.2) via JSON-LD and SPARQL. The `cybed:` namespace is the package's framework-agnostic two-tier base vocabulary; per-framework prefixes specialize Tier 1 types (`cybed:Framework`, `cybed:Role`, `cybed:RoleElement`).

## Vocabulary documentation

The closest thing to a formal ontology document at v0.1.0 lives in the package's pkgdown article: <https://ryanstraight.github.io/cybedtools/articles/namespace-architecture.html>

## Redirect behavior

- `https://w3id.org/cybed/` → cybedtools documentation site
- `https://w3id.org/cybed/ontology` (and any sub-path) → namespace-architecture article

302 (temporary) is appropriate while the spec is referenced via the package articles. A follow-up PR will switch to 303 (See Other) once a formal ontology document (Turtle/RDF) is published in a future release.

## Long-term commitment

I commit to maintaining this redirect for the lifetime of the cybedtools package and to opening follow-up PRs if the redirect target needs to change (e.g., when a formal ontology document is published).