### PR TITLE
Add /asgardehs/ — AsgardEHS Ontology

### DIFF
--- a/asgardehs/.htaccess
+++ b/asgardehs/.htaccess
@@ -1,0 +1,41 @@
+# /asgardehs/
+#
+# AsgardEHS Ontology
+# An OWL/Turtle ontology for environmental health & safety regulatory routing
+# across federal frameworks (OSHA, EPA, DOT, NRC, MSHA, NFPA, ANSI).
+#
+# https://w3id.org/asgardehs/ehs           → current ontology (TTL or HTML via content negotiation)
+# https://w3id.org/asgardehs/ehs/X.Y.Z     → versioned snapshot (e.g. /3.3.0)
+#
+# ## Contact
+# This space is administered by:
+#
+# Adam J. Bick
+# asgardehs@proton.me
+# GitHub username: pharomwinters
+# GitHub organization: asgardehs
+
+Options -MultiViews
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+AddType application/ld+json .jsonld
+
+RewriteEngine On
+RewriteBase /asgardehs/
+
+# Current ontology — Turtle for machines (reasoners, curl, Protégé)
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^ehs$ https://asgardehs.github.io/ehs-ontology/ehs.ttl [R=302,L]
+
+# Current ontology — HTML for humans in browsers
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla
+RewriteRule ^ehs$ https://asgardehs.github.io/ehs-ontology/ [R=302,L]
+
+# Default — serve TTL when nothing specific was asked for
+RewriteRule ^ehs$ https://asgardehs.github.io/ehs-ontology/ehs.ttl [R=302,L]
+
+# Versioned snapshots — for owl:versionIRI resolution
+# Matches /asgardehs/ehs/3.3.0 → snapshots/ehs-3.3.0.ttl
+RewriteRule ^ehs/([0-9]+\.[0-9]+\.[0-9]+)$ https://asgardehs.github.io/ehs-ontology/snapshots/ehs-$1.ttl [R=302,L]

--- a/asgardehs/README.md
+++ b/asgardehs/README.md
@@ -1,0 +1,29 @@
+# /asgardehs/ - AsgardEHS Ontology
+
+This [W3ID](https://w3id.org) space provides persistent identifiers for the **AsgardEHS Ontology** — an OWL/Turtle ontology for environmental health & safety regulatory routing across federal frameworks (OSHA, EPA, DOT, NRC, MSHA, NFPA, ANSI).
+
+The ontology models the three-axis routing problem (`HazardType` × `ActionContext` × `ContextualCondition`) and surfaces which regulatory frameworks fire for any given workplace situation.
+
+## URIs
+
+| URI | Redirects to | Description |
+|-----|--------------|-------------|
+| https://w3id.org/asgardehs/ehs | https://asgardehs.github.io/ehs-ontology/ehs.ttl | Current ontology (Turtle, default) |
+| https://w3id.org/asgardehs/ehs | https://asgardehs.github.io/ehs-ontology/ | HTML landing page (browser content negotiation) |
+| https://w3id.org/asgardehs/ehs/3.3.0 | https://asgardehs.github.io/ehs-ontology/snapshots/ehs-3.3.0.ttl | v3.3.0 snapshot |
+| https://w3id.org/asgardehs/ehs/3.2.0 | https://asgardehs.github.io/ehs-ontology/snapshots/ehs-3.2.0.ttl | v3.2.0 snapshot |
+
+## Contact
+
+This space is administered by:
+
+**Adam J. Bick**
+- Email: asgardehs@proton.me
+- GitHub: [@pharomwinters](https://github.com/pharomwinters)
+- Organization: [asgardehs](https://github.com/asgardehs)
+
+## Project Links
+
+- Source repository: [github.com/asgardehs/ehs-ontology](https://github.com/asgardehs/ehs-ontology)
+- Hosted ontology: [asgardehs.github.io/ehs-ontology/](https://asgardehs.github.io/ehs-ontology/)
+- License: [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)


### PR DESCRIPTION
## Brief Description

Adds `/asgardehs/` — a permanent identifier space for the **AsgardEHS Ontology**, an OWL/Turtle ontology for environmental health & safety regulatory routing across federal frameworks (OSHA, EPA, DOT, NRC, MSHA, NFPA, ANSI).

The ontology IRI is `https://w3id.org/asgardehs/ehs`, with `https://w3id.org/asgardehs/ehs/X.Y.Z` resolving to versioned snapshots for `owl:versionIRI` resolution.

Redirect targets are hosted on GitHub Pages and have been verified live before submission.

## General Checklist

- [x] Changes have been tested. (All redirect targets return HTTP 200 with `Content-Type: text/turtle` for `.ttl` files and `text/html` for the landing page.)
- [x] The number of commits is minimal. (Single commit.)
- [x] Commits only include redirects and basic information.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` and `README.md`.
- [x] GitHub username `@pharomwinters` is listed in the maintainer details.

## Verification

| URI | Target | Status |
|-----|--------|--------|
| `https://w3id.org/asgardehs/ehs` (Accept: text/turtle) | https://asgardehs.github.io/ehs-ontology/ehs.ttl | live, 200 |
| `https://w3id.org/asgardehs/ehs` (Accept: text/html) | https://asgardehs.github.io/ehs-ontology/ | live, 200 |
| `https://w3id.org/asgardehs/ehs/3.3.0` | https://asgardehs.github.io/ehs-ontology/snapshots/ehs-3.3.0.ttl | live, 200 |
| `https://w3id.org/asgardehs/ehs/3.2.0` | https://asgardehs.github.io/ehs-ontology/snapshots/ehs-3.2.0.ttl | live, 200 |

Source repository: https://github.com/asgardehs/ehs-ontology