### PR TITLE
Add ASTRA namespace redirect (astra/)

### DIFF
--- a/astra/.htaccess
+++ b/astra/.htaccess
@@ -1,0 +1,39 @@
+# ASTRA — Agentic Schema for Transparent Research Analysis
+#
+# https://w3id.org/astra/ is the namespace IRI for the ASTRA specification,
+# a declarative format for scientific analyses defined in LinkML.
+#
+# The spec site is versioned with mike: each release is deployed to its own
+# subdirectory (e.g. /0.0.8/) on https://astra-spec.org, with /latest/
+# tracking the most recent release. Bare requests resolve to the latest
+# version; a version segment may be inserted to pin to a specific release.
+#
+# Project:   https://github.com/LightconeResearch/astra-spec
+# Spec site: https://astra-spec.org
+#
+# ## Contact
+# This space is administered by:
+#
+# Francois Lanusse
+# GitHub username: eiffl
+
+RewriteEngine on
+
+# Version-pinned requests: /astra/X.Y.Z/... or /astra/latest/...
+# Pass straight through to the matching versioned path on the spec site.
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+|latest)(/.*)?$ https://astra-spec.org/$1$2 [R=302,L]
+
+# Schema artifacts (LinkML source, JSON Schema, JSON-LD context, etc.) — latest
+RewriteRule ^schema/(.*)$ https://astra-spec.org/latest/schema/$1 [R=302,L]
+
+# Per-element doc pages — latest
+RewriteRule ^elements/(.*)$ https://astra-spec.org/latest/elements/$1 [R=302,L]
+
+# Documentation sections — latest
+RewriteRule ^(about|cli|community|getting-started|specification|assets)(/.*)?$ https://astra-spec.org/latest/$1$2 [R=302,L]
+
+# Term URIs (e.g. /astra/Input, /astra/recipe) -> per-element doc pages on latest
+RewriteRule ^([A-Za-z][A-Za-z0-9_-]*)/?$ https://astra-spec.org/latest/elements/$1/ [R=302,L]
+
+# Namespace root and anything else -> spec homepage (mike redirects / to /latest/)
+RewriteRule ^ https://astra-spec.org/ [R=302,L]

--- a/astra/README.md
+++ b/astra/README.md
@@ -1,0 +1,32 @@
+# /astra/
+
+Namespace IRI for the **ASTRA** specification — *Agentic Schema for Transparent Research Analysis* — a declarative format for scientific analyses defined in [LinkML](https://linkml.io).
+
+- Specification site: [astra-spec.org](https://astra-spec.org)
+- Source repository: [LightconeResearch/astra-spec](https://github.com/LightconeResearch/astra-spec)
+- Schema license: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)
+
+## Versioning
+
+The spec site is versioned with [mike](https://github.com/jimporter/mike): each release is deployed to its own subdirectory of `astra-spec.org` (e.g. `/0.0.8/`), with `/latest/` tracking the most recent release. The redirects default to `latest`; a version segment may be inserted to pin to a specific release.
+
+## Redirection policy
+
+| Request | Redirects to |
+|---|---|
+| `https://w3id.org/astra/` | `https://astra-spec.org/` |
+| `https://w3id.org/astra/X.Y.Z/...` | `https://astra-spec.org/X.Y.Z/...` (version pin) |
+| `https://w3id.org/astra/latest/...` | `https://astra-spec.org/latest/...` |
+| `https://w3id.org/astra/schema/<file>` | `https://astra-spec.org/latest/schema/<file>` |
+| `https://w3id.org/astra/elements/<term>/` | `https://astra-spec.org/latest/elements/<term>/` |
+| `https://w3id.org/astra/<Term>` | `https://astra-spec.org/latest/elements/<Term>/` |
+| `https://w3id.org/astra/<section>` (`about`, `cli`, `community`, `getting-started`, `specification`, `assets`) | `https://astra-spec.org/latest/<section>` |
+
+All redirects use HTTP 302.
+
+## Contact
+
+This space is administered by:
+
+**Francois Lanusse**
+GitHub: [eiffl](https://github.com/eiffl)


### PR DESCRIPTION
Adds /astra/ as the namespace IRI for ASTRA — Agentic Schema for Transparent Research Analysis, a declarative LinkML format for scientific analyses.

Redirects resolve to the versioned mike-hosted spec site at astra-spec.org. Bare requests default to /latest/; a /X.Y.Z/ or /latest/ segment may be inserted to pin to a specific release.

Project: https://github.com/LightconeResearch/astra-spec
Contact: Francois Lanusse (GitHub: eiffl)

<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.
