### PR TITLE
Update .htaccess

### DIFF
--- a/climoo/.htaccess
+++ b/climoo/.htaccess
@@ -20,7 +20,7 @@ RedirectMatch 302 ^/climoo/releases/?$  https://github.com/ClimOO/ClimOO-Ontolog
 
 ## Redirect to RDF content when accessing the root namespace
 RedirectMatch 302 ^/climoo/?$ https://raw.githubusercontent.com/ClimOO/ClimOO-Ontology/refs/heads/main/climoo.ttl
-RedirectMatch 302 ^/climoo/(climoo[^/]*)$ https://raw.githubusercontent.com/ClimOO/ClimOO-Ontology/refs/heads/main//$1.ttl
+RedirectMatch 302 ^/climoo/(climoo[^/]*)$ https://raw.githubusercontent.com/ClimOO/ClimOO-Ontology/refs/heads/main/$1.ttl
 
 ## Redirect documentation requests explicitly
 RedirectMatch 302 ^/climoo/docs/?$ https://github.com/ClimOO/ClimOO-Ontology/docs/index.html


### PR DESCRIPTION
Fixing a typo in the .htaccess that prevented the redirection of modules' class IRIs.