### PR TITLE
Add CCO namespace redirect

### DIFF
--- a/cco/.htaccess
+++ b/cco/.htaccess
@@ -1,0 +1,4 @@
+Options -MultiViews
+RewriteEngine on
+RewriteRule ^$ https://rgu-computing.github.io/CCO/ [R=303,L]
+RewriteRule ^(.*)$ https://rgu-computing.github.io/CCO/$1 [R=303,L]

--- a/cco/.htaccess
+++ b/cco/.htaccess
@@ -1,4 +1,8 @@
 Options -MultiViews
-RewriteEngine on
-RewriteRule ^$ https://rgu-computing.github.io/CCO/ [R=303,L]
-RewriteRule ^(.*)$ https://rgu-computing.github.io/CCO/$1 [R=303,L]
+RewriteEngine On
+# /cco/  -> documentation homepage
+RewriteRule ^$ https://rgu-computing.github.io/CCO/index-en.html [R=303,L]
+# /cco/cco  -> documentation homepage
+RewriteRule ^cco/?$ https://rgu-computing.github.io/CCO/index-en.html [R=303,L]
+# /cco/cco/...  -> map directly under /CCO/...
+RewriteRule ^cco/(.*)$ https://rgu-computing.github.io/CCO/$1 [R=303,L]

--- a/cco/README.md
+++ b/cco/README.md
@@ -1,5 +1,7 @@
 # CCO Namespace
 
 Maintainer: Umair Arshad 
+
 Contact: u.arshad1@rgu.ac.uk
+
 GitHub: https://github.com/RGU-Computing/CCO

--- a/cco/README.md
+++ b/cco/README.md
@@ -1,0 +1,5 @@
+# CCO Namespace
+
+Maintainer: Umair Arshad 
+Contact: u.arshad1@rgu.ac.uk
+GitHub: https://github.com/RGU-Computing/CCO

--- a/cco/README.md
+++ b/cco/README.md
@@ -1,6 +1,6 @@
 # CCO Namespace
 
-Maintainer: Umair Arshad 
+Maintainer: Umair Arshad (@UmairMarry )
 
 Contact: u.arshad1@rgu.ac.uk
 


### PR DESCRIPTION
Adding redirect for Core Compliance Ontology (CCO) 
namespace https://www.w3id.org/cco/cco to 
https://rgu-computing.github.io/CCO/