### PR TITLE
Update LDES .htaccess to reflect updated spec publishing strategy

### DIFF
--- a/ldes/.htaccess
+++ b/ldes/.htaccess
@@ -6,6 +6,8 @@ Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,
 Options +FollowSymLinks
 RewriteEngine on
 RewriteRule ^context(.jsonld)?$ https://semiceu.github.io/LinkedDataEventStreams/context.jsonld [R=303,L]
+RewriteRule ^specification$ https://semiceu.github.io/LinkedDataEventStreams/ [R=303,L]
+
 # Rule for things like releases, context, server-primer, specification, vocabulary...
 RewriteRule ^(.+)$ https://semiceu.github.io/LinkedDataEventStreams/$1 [R=303,L]
 

--- a/ldes/.htaccess
+++ b/ldes/.htaccess
@@ -5,15 +5,14 @@ Header set Access-Control-Allow-Origin *
 Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^specification$ https://semiceu.github.io/LinkedDataEventStreams/ [R=303,L]
-RewriteRule ^server-primer$ https://semiceu.github.io/LinkedDataEventStreams/server-primer.html [R=303,L]
-
 RewriteRule ^context(.jsonld)?$ https://semiceu.github.io/LinkedDataEventStreams/context.jsonld [R=303,L]
+# Rule for things like releases, context, server-primer, specification, vocabulary...
+RewriteRule ^(.+)$ https://semiceu.github.io/LinkedDataEventStreams/$1 [R=303,L]
 
 # Rewrite rule to serve HTML content on the vocabulary
 RewriteCond %{HTTP_ACCEPT} text/html
-RewriteRule ^$ https://semiceu.github.io/LinkedDataEventStreams/vocabulary.html [R=303,L]
+RewriteRule ^$ https://semiceu.github.io/LinkedDataEventStreams/vocabulary [R=303,L]
 
 # Rewrite rule to serve TTL content on the vocabulary
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^.*$ https://cdn.jsdelivr.net/gh/semiceu/LinkedDataEventStreams@master/vocabulary.ttl [R=303,L]
+RewriteRule ^.*$ https://semiceu.github.io/LinkedDataEventStreams/vocabulary.ttl [R=303,L]


### PR DESCRIPTION

The LDES spec now has multiple documents and also archives its older releases. Also the vocabulary is now published in the same place as well.

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.