### PR TITLE
Add Simplest Data w3id namespace

### DIFF
--- a/simplestdata/.htaccess
+++ b/simplestdata/.htaccess
@@ -1,0 +1,18 @@
+# Simplest Data permanent identifier namespace
+#
+# W3ID namespace:
+# https://w3id.org/simplestdata/
+#
+# Canonical identifier host:
+# https://id.simplestdata.com/
+#
+# Maintainer:
+# Gregory Kulp
+# greg@simplestdata.com
+
+Options -MultiViews
+
+RewriteEngine on
+
+RewriteRule ^$ https://id.simplestdata.com/ [R=302,L]
+RewriteRule ^(.*)$ https://id.simplestdata.com/$1 [R=302,L]

--- a/simplestdata/README.md
+++ b/simplestdata/README.md
@@ -1,0 +1,26 @@
+# Simplest Data Permanent Identifier Namespace
+
+This directory defines the W3ID permanent identifier namespace for Simplest Data.
+
+## Namespace
+
+<https://w3id.org/simplestdata/>
+
+## Canonical identifier host
+
+<https://id.simplestdata.com/>
+
+All paths under `https://w3id.org/simplestdata/` redirect to the corresponding path under `https://id.simplestdata.com/`.
+
+For example:
+
+`https://w3id.org/simplestdata/example`
+
+redirects to:
+
+`https://id.simplestdata.com/example`
+
+## Maintainer
+
+Gregory Kulp  
+Email: <greg@simplestdata.com>


### PR DESCRIPTION
This PR adds a W3ID permanent identifier namespace for Simplest Data:

- W3ID namespace: https://w3id.org/simplestdata/
- Canonical identifier host: https://id.simplestdata.com/
- Redirect type: 302

All paths under `/simplestdata/` redirect to the corresponding path under `https://id.simplestdata.com/`.

Maintainer:

Gregory Kulp  
greg@simplestdata.com