### PR TITLE
fix(pedropaulofb): correct Google Scholar redirect

### DIFF
--- a/pedropaulofb/.htaccess
+++ b/pedropaulofb/.htaccess
@@ -6,7 +6,7 @@ Options -MultiViews
 
 # Profile redirects
 RewriteRule ^linkedin/?$ https://www.linkedin.com/in/pedro-paulo-favato-barcelos/ [R=302,L]
-RewriteRule ^scholar/?$ https://scholar.google.com/citations?user=1kf9fgwaaaaj [R=302,L]
+RewriteRule ^scholar/?$ https://scholar.google.com/citations?user=1kF9FGwAAAAJ [R=302,L]
 RewriteRule ^orcid/?$ https://orcid.org/0000-0003-2736-7817 [R=302,L]
 RewriteRule ^github/?$ https://github.com/pedropaulofb/ [R=302,L]
 


### PR DESCRIPTION
Update the Google Scholar user ID with the correct case-sensitive value.

<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
Small fix in the redirection. Problem was caused because I was considering the URL was case-insensitive.
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [X] Changes have been tested.
- [X] The number of commits is minimal. Squash if needed.
- [X] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
