### PR TITLE
battery-data-alliance: fix -inferred rule ordering, add JSON-LD and vendor schema redirects

### DIFF
--- a/battery-data-alliance/.htaccess
+++ b/battery-data-alliance/.htaccess
@@ -1,6 +1,6 @@
 # This namespace is maintained by the Battery Data Alliance, https://lfenergy.org/projects/battery-data-alliance/
 # Current maintainers are:
-# Gabe Hege (https://github.com/pghege) – NVIDIA, AmpLabs  
+# Gabe Hege (https://github.com/pghege) – NVIDIA, AmpLabs
 # Simon Clark (https://github.com/jsimonclark) – SINTEF
 # If testing on https://htaccess.madewithlove.com/ , remove w3id.org such that https://w3id.org/battery-data-alliance/ becomes https://battery-data-alliance/
 
@@ -11,66 +11,84 @@ RewriteEngine On
 # Non-Versioned Redirects
 # ==============================================
 
-# [R1] /ontology/{name} → HTML if browser
+# [R1] /ontology/{name}-inferred (alternate form) — MUST precede catch-all R2/R3/R4
+RewriteRule ^ontology/([^/]+)-inferred/?$ https://battery-data-alliance.github.io/$1-ontology/$1-inferred.ttl [R=303,NE,L]
+
+# [R2] /ontology/{name} → HTML if browser
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
 RewriteRule ^ontology/([^/]+)/?$ https://battery-data-alliance.github.io/$1-ontology/$1.html [R=303,NE,L]
 
-# [R2] /ontology/{name} → TTL fallback
+# [R3] /ontology/{name} → JSON-LD context if agent requests it
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^ontology/([^/]+)/?$ https://battery-data-alliance.github.io/$1-ontology/context/context.json [R=303,NE,L]
+
+# [R4] /ontology/{name} → TTL fallback for all other agents
 RewriteRule ^ontology/([^/]+)/?$ https://battery-data-alliance.github.io/$1-ontology/$1.ttl [R=303,NE,L]
 
-# [R3] /ontology/{name}/inferred
+# [R5] /ontology/{name}/inferred
 RewriteRule ^ontology/([^/]+)/inferred/?$ https://battery-data-alliance.github.io/$1-ontology/$1-inferred.ttl [R=303,NE,L]
 
-# [R4] /ontology/{name}-inferred (alternate form)
-RewriteRule ^ontology/([^/]+)-inferred/?$ https://battery-data-alliance.github.io/$1-ontology/$1-inferred.ttl [R=303,NE,L]
-
-# [R5] /ontology/{name}/latest
+# [R6] /ontology/{name}/latest
 RewriteRule ^ontology/([^/]+)/latest/?$ https://raw.githubusercontent.com/battery-data-alliance/$1-ontology/main/$1.ttl [R=303,NE,L]
 
-# [R6] /ontology/{name}/source
+# [R7] /ontology/{name}/source
 RewriteRule ^ontology/([^/]+)/source/?$ https://raw.githubusercontent.com/battery-data-alliance/$1-ontology/main/$1.ttl [R=303,NE,L]
 
-# [R7] /ontology/{name}/context
+# [R8] /ontology/{name}/context
 RewriteRule ^ontology/([^/]+)/context/?$ https://battery-data-alliance.github.io/$1-ontology/context/context.json [R=303,NE,L]
 
-# [R8] /ontology/{name}/schema
+# [R9] /ontology/{name}/schema/vendors/{vendor}
+RewriteRule ^ontology/([^/]+)/schema/vendors/([^/]+)/?$ https://battery-data-alliance.github.io/$1-ontology/schema/vendors/$2.json [R=303,NE,L]
+
+# [R10] /ontology/{name}/schema
 RewriteRule ^ontology/([^/]+)/schema/?$ https://battery-data-alliance.github.io/$1-ontology/schema/schema.json [R=303,NE,L]
 
 # ==============================================
 # Versioned Redirects
 # ==============================================
 
-# [R9] /ontology/{name}/{version} → HTML if browser
+# [R11] /ontology/{name}/{version}/{name}-inferred — MUST precede catch-all R12/R13/R14
+RewriteRule ^ontology/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/\1-inferred/?$ https://battery-data-alliance.github.io/$1-ontology/versions/$2/$1-inferred.ttl [R=303,NE,L]
+
+# [R12] /ontology/{name}/{version} → HTML if browser
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
 RewriteRule ^ontology/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://battery-data-alliance.github.io/$1-ontology/versions/$2/$1.html [R=303,NE,L]
 
-# [R10] /ontology/{name}/{version} → TTL fallback
+# [R13] /ontology/{name}/{version} → JSON-LD context if agent requests it
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^ontology/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://battery-data-alliance.github.io/$1-ontology/versions/$2/context/context.json [R=303,NE,L]
+
+# [R14] /ontology/{name}/{version} → TTL fallback for all other agents
 RewriteRule ^ontology/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://battery-data-alliance.github.io/$1-ontology/versions/$2/$1.ttl [R=303,NE,L]
 
-# [R11] /ontology/{name}/{version}/{name} (alternate path) → HTML if browser
+# [R15] /ontology/{name}/{version}/{name} (versionIRI path) → HTML if browser
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
 RewriteRule ^ontology/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/\1/?$ https://battery-data-alliance.github.io/$1-ontology/versions/$2/$1.html [R=303,NE,L]
 
-# [R12] /ontology/{name}/{version}/{name} → TTL fallback
+# [R16] /ontology/{name}/{version}/{name} → JSON-LD context if agent requests it
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^ontology/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/\1/?$ https://battery-data-alliance.github.io/$1-ontology/versions/$2/context/context.json [R=303,NE,L]
+
+# [R17] /ontology/{name}/{version}/{name} → TTL fallback
 RewriteRule ^ontology/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/\1/?$ https://battery-data-alliance.github.io/$1-ontology/versions/$2/$1.ttl [R=303,NE,L]
 
-# [R13] /ontology/{name}/{version}/inferred
+# [R18] /ontology/{name}/{version}/inferred
 RewriteRule ^ontology/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/inferred/?$ https://battery-data-alliance.github.io/$1-ontology/versions/$2/$1-inferred.ttl [R=303,NE,L]
 
-# [R14] /ontology/{name}/{version}/{name}-inferred (alternate path)
-RewriteRule ^ontology/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/\1-inferred/?$ https://battery-data-alliance.github.io/$1-ontology/versions/$2/$1-inferred.ttl [R=303,NE,L]
-
-# [R15] /ontology/{name}/{version}/latest
+# [R19] /ontology/{name}/{version}/latest
 RewriteRule ^ontology/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/latest/?$ https://raw.githubusercontent.com/battery-data-alliance/$1-ontology/$2/$1.ttl [R=303,NE,L]
 
-# [R16] /ontology/{name}/{version}/source
+# [R20] /ontology/{name}/{version}/source
 RewriteRule ^ontology/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/source/?$ https://raw.githubusercontent.com/battery-data-alliance/$1-ontology/$2/$1.ttl [R=303,NE,L]
 
-# [R17] /ontology/{name}/{version}/context
+# [R21] /ontology/{name}/{version}/context
 RewriteRule ^ontology/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/context/?$ https://battery-data-alliance.github.io/$1-ontology/versions/$2/context/context.json [R=303,NE,L]
 
-# [R18] /ontology/{name}/{version}/schema
+# [R22] /ontology/{name}/{version}/schema/vendors/{vendor}
+RewriteRule ^ontology/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/schema/vendors/([^/]+)/?$ https://battery-data-alliance.github.io/$1-ontology/versions/$2/schema/vendors/$3.json [R=303,NE,L]
+
+# [R23] /ontology/{name}/{version}/schema
 RewriteRule ^ontology/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/schema/?$ https://battery-data-alliance.github.io/$1-ontology/versions/$2/schema/schema.json [R=303,NE,L]

--- a/battery-data-alliance/README.md
+++ b/battery-data-alliance/README.md
@@ -19,11 +19,11 @@ This PURL namespace provides stable, long-term IRIs for:
 - Asserted ontology files
 - Inferred variants
 - JSON-LD context documents
-- CSVW table schemas
+- CSVW table schemas and vendor-specific column mappings
 - Human-readable documentation
 - Versioned variants and GitHub source references
 
-It ensures compliance with FAIR and linked data principles, enabling machine-readable and human-readable resolution of resources.
+It ensures compliance with FAIR and linked data principles, enabling machine-readable and human-readable resolution of resources. Content negotiation is supported: browsers receive HTML documentation, JSON-LD agents receive the context document, and all other agents receive Turtle by default.
 
 ---
 
@@ -33,31 +33,40 @@ The `.htaccess` file uses redirect rules to support both **non-versioned** and *
 
 ### Non-Versioned Redirects
 
-| Rule | IRI Pattern                          | Description                                |
-|------|--------------------------------------|--------------------------------------------|
-| R1   | `/ontology/{name}`                  | HTML view if browser Accepts HTML          |
-| R2   | `/ontology/{name}`                  | TTL fallback                               |
-| R3   | `/ontology/{name}/inferred`         | Inferred TTL                               |
-| R4   | `/ontology/{name}-inferred`         | Alternate path to inferred TTL             |
-| R5   | `/ontology/{name}/latest`           | Raw TTL from main branch                   |
-| R6   | `/ontology/{name}/source`           | Source file on GitHub                      |
-| R7   | `/ontology/{name}/context`          | JSON-LD context                            |
-| R8   | `/ontology/{name}/schema`           | CSVW schema                                |
+| Rule | IRI Pattern | Accept header | Destination |
+|------|-------------|---------------|-------------|
+| R1 | `/ontology/{name}-inferred` | any | Inferred TTL (alternate path) |
+| R2 | `/ontology/{name}` | `text/html` | HTML documentation |
+| R3 | `/ontology/{name}` | `application/ld+json` | JSON-LD context |
+| R4 | `/ontology/{name}` | any | TTL fallback |
+| R5 | `/ontology/{name}/inferred` | any | Inferred TTL |
+| R6 | `/ontology/{name}/latest` | any | Raw TTL from main branch |
+| R7 | `/ontology/{name}/source` | any | Source file on GitHub |
+| R8 | `/ontology/{name}/context` | any | JSON-LD context |
+| R9 | `/ontology/{name}/schema/vendors/{vendor}` | any | Vendor CSVW column mapping |
+| R10 | `/ontology/{name}/schema` | any | Canonical CSVW schema |
+
+> **Note:** R1 must precede R2–R4 to prevent the catch-all from swallowing the `-inferred` alternate form.
 
 ### Versioned Redirects (`MAJOR.MINOR.PATCH`)
 
-| Rule | IRI Pattern                                           | Description                                |
-|------|--------------------------------------------------------|--------------------------------------------|
-| R9   | `/ontology/{name}/{version}`                         | HTML view if browser Accepts HTML          |
-| R10  | `/ontology/{name}/{version}`                         | TTL fallback                               |
-| R11  | `/ontology/{name}/{version}/{name}`                  | Alternate path for HTML                    |
-| R12  | `/ontology/{name}/{version}/{name}`                  | Alternate path for TTL                     |
-| R13  | `/ontology/{name}/{version}/inferred`                | Inferred TTL                               |
-| R14  | `/ontology/{name}/{version}/{name}-inferred`         | Alternate path to inferred TTL             |
-| R15  | `/ontology/{name}/{version}/latest`                  | Raw TTL from tagged release branch         |
-| R16  | `/ontology/{name}/{version}/source`                  | Source file on GitHub at tagged version    |
-| R17  | `/ontology/{name}/{version}/context`                 | JSON-LD context for specific version       |
-| R18  | `/ontology/{name}/{version}/schema`                  | CSVW schema for specific version           |
+| Rule | IRI Pattern | Accept header | Destination |
+|------|-------------|---------------|-------------|
+| R11 | `/ontology/{name}/{version}/{name}-inferred` | any | Inferred TTL (alternate path) |
+| R12 | `/ontology/{name}/{version}` | `text/html` | HTML documentation |
+| R13 | `/ontology/{name}/{version}` | `application/ld+json` | JSON-LD context |
+| R14 | `/ontology/{name}/{version}` | any | TTL fallback |
+| R15 | `/ontology/{name}/{version}/{name}` | `text/html` | HTML documentation |
+| R16 | `/ontology/{name}/{version}/{name}` | `application/ld+json` | JSON-LD context |
+| R17 | `/ontology/{name}/{version}/{name}` | any | TTL fallback |
+| R18 | `/ontology/{name}/{version}/inferred` | any | Inferred TTL |
+| R19 | `/ontology/{name}/{version}/latest` | any | Raw TTL from tagged release |
+| R20 | `/ontology/{name}/{version}/source` | any | Source file at tagged version |
+| R21 | `/ontology/{name}/{version}/context` | any | JSON-LD context |
+| R22 | `/ontology/{name}/{version}/schema/vendors/{vendor}` | any | Vendor CSVW column mapping |
+| R23 | `/ontology/{name}/{version}/schema` | any | Canonical CSVW schema |
+
+> **Note:** R11 must precede R12–R14 for the same reason as R1 above. R15–R17 handle the `owl:versionIRI` path form `/{version}/{name}`.
 
 ---
 
@@ -73,16 +82,22 @@ Each ontology is published in its own GitHub repository. This redirect scheme as
 ├── context/
 │   └── context.json
 ├── schema/
-│   └── schema.json
+│   ├── schema.json
+│   └── vendors/
+│       ├── arbin-csv.json
+│       ├── biologic-mpt.json
+│       └── ...
 └── versions/
-    └── 0.1.0/
+    └── 1.0.0/
         ├── {resource}.ttl
         ├── {resource}.html
         ├── {resource}-inferred.ttl
         ├── context/
         │   └── context.json
         └── schema/
-            └── schema.json
+            ├── schema.json
+            └── vendors/
+                └── ...
 ```
 
 Replace `{resource}` with your ontology name in kebab-case (e.g., `battery-data-format`).


### PR DESCRIPTION
## Brief Description

Updates the `battery-data-alliance` redirect rules with three changes:

1. **Bug fix** — the `{name}-inferred` alternate-path rules (non-versioned R1, versioned R11) were unreachable because the catch-all `^ontology/([^/]+)/?$` matched first. Both rules have been moved above the catch-all block.
2. **Content negotiation** — added `application/ld+json` rules (R3, R13, R16) so agents requesting JSON-LD receive the context document rather than falling through to Turtle.
3. **Vendor schema IRIs** — added rules (R9, R22) to resolve vendor-specific CSVW column mapping IRIs of the form `/ontology/{name}/schema/vendors/{vendor}` to the corresponding `.json` file on GitHub Pages.

README updated to reflect the new rule table and repository structure.

All 23 rules verified against 28 test cases using a local mod_rewrite simulator before submission.

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## Update ID Directory Checklist
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
