### PR TITLE
Add pvcollada namespace redirect

### DIFF
--- a/pvcollada/.htaccess
+++ b/pvcollada/.htaccess
@@ -1,3 +1,8 @@
+# This namespace is maintained by the Universy of Central Florida
+# Current maintainers are:
+# Brent Thompson (https://github.com/TheAlgoDev) – UCF, CWRU, PSEL
+# Contact Info: brent.thompson@ucf.edu
+
 Options +FollowSymLinks
 RewriteEngine on
 

--- a/pvcollada/.htaccess
+++ b/pvcollada/.htaccess
@@ -1,0 +1,12 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Serve Turtle when requested by an RDF client
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/n-triples [OR]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/TheAlgoDev/pvcollada-onto/main/ontology/pvcollada_onto.ttl [R=303,L]
+
+# Default: redirect to GitHub repo (human readable)
+RewriteRule ^(.*)$ https://github.com/TheAlgoDev/pvcollada-onto [R=303,L]

--- a/pvcollada/.htaccess
+++ b/pvcollada/.htaccess
@@ -10,3 +10,5 @@ RewriteRule ^(.*)$ https://raw.githubusercontent.com/TheAlgoDev/pvcollada-onto/m
 
 # Default: redirect to GitHub repo (human readable)
 RewriteRule ^(.*)$ https://github.com/TheAlgoDev/pvcollada-onto [R=303,L]
+
+# Contact Info : Brent Thompson - brent.thompson@ucf.edu


### PR DESCRIPTION
This PR adds a persistent namespace redirect for the PV-Collada OWL 2 ontology.

## Namespace

`https://w3id.org/pvcollada`

## Redirects

- **RDF clients** (Accept: text/turtle / application/rdf+xml / etc.) → raw TTL file on GitHub
- **Browsers** → GitHub repository page

## About the ontology

- Derived from the PV-Collada 2.0 XSD schema for photovoltaic system modeling
- Aligned with [MDS-Onto](https://cwrusdle.bitbucket.io/mds/) (Materials Data Science Ontology)
- Source: https://github.com/TheAlgoDev/pvcollada-onto
- Maintainer: TheAlgoDev (thompsonsolutionscompany@gmail.com)
- License: CC BY-SA 4.0
- Contact Information: brent.thompson@ucf.edu