### PR TITLE
Improve OSO W3ID redirects using generic regex version rules

### DIFF
--- a/earthsemantics/OSO/.htaccess
+++ b/earthsemantics/OSO/.htaccess
@@ -1,38 +1,108 @@
 Options +FollowSymLinks
 RewriteEngine On
 
-# Version IRIs -> archived Turtle files in the OSO repository
-RewriteRule ^1\.0\.0/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/versions/1.0.0/OSO.ttl [R=302,L]
-RewriteRule ^1\.0\.1/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/versions/1.0.1/OSO.ttl [R=302,L]
-RewriteRule ^1\.0\.2/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/versions/1.0.2/OSO.ttl [R=302,L]
-RewriteRule ^1\.0\.3/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/versions/1.0.3/OSO.ttl [R=302,L]
-RewriteRule ^1\.0\.4/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/versions/1.0.4/OSO.ttl [R=302,L]
+# ====================================================================
+# Versioned ontology IRIs
+# ====================================================================
+#
+# Examples:
+# /1.0.5
+# /1.0.5.ttl
+# /1.0.5.owl
+# /1.0.5.jsonld
+# /1.0.5.nt
+# /1.0.5.n3
+# /1.0.5.trig
+# /1.0.5.rdfjson
+#
+# ====================================================================
 
-# SPARQL endpoint
-RewriteRule ^sparql/?$ https://virtuoso.ifremer.fr/oso/sparql/ [R=302,L]
+# Default version access -> Turtle
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/versions/$1/OSO.ttl [R=303,L]
 
-# SPARQL UI
-RewriteRule ^ui/?$ https://virtuoso.ifremer.fr/oso/ [R=302,L]
+# Explicit versioned serializations
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)\.ttl/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/versions/$1/OSO.ttl [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)\.owl/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/versions/$1/OSO.owl [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)\.rdf/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/versions/$1/OSO.owl [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)\.jsonld/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/versions/$1/OSO.jsonld [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)\.nt/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/versions/$1/OSO.nt [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)\.n3/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/versions/$1/OSO.n3 [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)\.trig/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/versions/$1/OSO.trig [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)\.rdfjson/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/versions/$1/OSO.rdfjson [R=303,L]
 
-# Main ontology IRI: HTML if requested
+# ====================================================================
+# SPARQL endpoint and UI
+# ====================================================================
+
+RewriteRule ^sparql/?$ https://virtuoso.ifremer.fr/oso/sparql [R=303,L]
+RewriteRule ^ui/?$ https://virtuoso.ifremer.fr/oso/ [R=303,L]
+
+# ====================================================================
+# Main ontology IRI content negotiation
+# https://w3id.org/earthsemantics/OSO
+# ====================================================================
+
+# HTML documentation
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
-RewriteRule ^$ https://emso-eric.github.io/oso-ontology/ [R=302,L]
+RewriteRule ^$ https://emso-eric.github.io/oso-ontology/ [R=303,L]
 
-# Main ontology IRI: RDF/Turtle-oriented fallback
+# Turtle
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
-RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
-RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.ttl [R=303,L]
+
+# RDF/XML
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.owl [R=303,L]
+
+# Generic XML fallback
+RewriteCond %{HTTP_ACCEPT} application/xml
+RewriteRule ^$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.owl [R=303,L]
+
+# JSON-LD
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.jsonld [R=303,L]
+
+# RDF/JSON
+RewriteCond %{HTTP_ACCEPT} application/rdf\+json
+RewriteRule ^$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.rdfjson [R=303,L]
+
+# N-Triples
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.nt [R=303,L]
+
+# N3
+RewriteCond %{HTTP_ACCEPT} text/n3
+RewriteRule ^$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.n3 [R=303,L]
+
+# TriG
+RewriteCond %{HTTP_ACCEPT} application/trig
+RewriteRule ^$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.trig [R=303,L]
+
+# Plain text fallback -> Turtle
 RewriteCond %{HTTP_ACCEPT} text/plain
-RewriteRule ^$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.ttl [R=302,L]
+RewriteRule ^$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.ttl [R=303,L]
 
-# Default fallback: documentation
-RewriteRule ^$ https://emso-eric.github.io/oso-ontology/ [R=302,L]
+# Default fallback -> documentation
+RewriteRule ^$ https://emso-eric.github.io/oso-ontology/ [R=303,L]
 
-# Explicit Turtle serialization
-RewriteRule ^ttl/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.ttl [R=302,L]
+# ====================================================================
+# Explicit serialization URLs
+# ====================================================================
 
+RewriteRule ^ttl/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.ttl [R=303,L]
+RewriteRule ^owl/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.owl [R=303,L]
+RewriteRule ^rdf/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.owl [R=303,L]
+RewriteRule ^jsonld/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.jsonld [R=303,L]
+RewriteRule ^rdfjson/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.rdfjson [R=303,L]
+RewriteRule ^nt/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.nt [R=303,L]
+RewriteRule ^n3/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.n3 [R=303,L]
+RewriteRule ^trig/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.trig [R=303,L]
+
+# ====================================================================
 # Metadata artifacts
-RewriteRule ^void/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/void.ttl [R=302,L]
-RewriteRule ^dcat/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/dcat.ttl [R=302,L]
+# ====================================================================
+
+RewriteRule ^void/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/void.ttl [R=303,L]
+RewriteRule ^dcat/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/dcat.ttl [R=303,L]

--- a/earthsemantics/OSO/README.md
+++ b/earthsemantics/OSO/README.md
@@ -31,11 +31,11 @@ Supported serializations
 - TriG
 
 Examples
-https://w3id.org/earthsemantics/OSO
-https://w3id.org/earthsemantics/OSO/1.0.5
-https://w3id.org/earthsemantics/OSO.jsonld
-https://w3id.org/earthsemantics/OSO.nt
-https://w3id.org/earthsemantics/OSO/sparql
+[https://w3id.org/earthsemantics/OSO](https://w3id.org/earthsemantics/OSO)
+[https://w3id.org/earthsemantics/OSO/1.0.5](https://w3id.org/earthsemantics/OSO/1.0.5)
+[https://w3id.org/earthsemantics/OSO.jsonld](https://w3id.org/earthsemantics/OSO.jsonld)
+[https://w3id.org/earthsemantics/OSO.nt](https://w3id.org/earthsemantics/OSO.nt)
+[https://w3id.org/earthsemantics/OSO/sparql](https://virtuoso.ifremer.fr/oso/sparql)
 
 Target project
 https://github.com/emso-eric/oso-ontology

--- a/earthsemantics/OSO/README.md
+++ b/earthsemantics/OSO/README.md
@@ -1,20 +1,23 @@
-OSO namespace at w3id.org
+# OSO namespace at w3id.org
 
 This subpath provides persistent identifiers and content negotiation
 for the Observatories of the Seas Ontology (OSO) and related metadata artifacts.
 
-Maintainer
-Steven Piel / @spiel-ifremer
+## Maintainer
+
+Steven Piel / @spiel-ifremer  
 https://github.com/spiel-ifremer
 
-Scope
-/earthsemantics/OSO
-/earthsemantics/OSO/void
-/earthsemantics/OSO/dcat
-/earthsemantics/OSO/sparql
-/earthsemantics/OSO/ui
+## Scope
 
-Features
+- `/earthsemantics/OSO`
+- `/earthsemantics/OSO/void`
+- `/earthsemantics/OSO/dcat`
+- `/earthsemantics/OSO/sparql`
+- `/earthsemantics/OSO/ui`
+
+## Features
+
 - Persistent ontology IRIs
 - Generic version resolution
 - RDF content negotiation
@@ -22,7 +25,8 @@ Features
 - SPARQL endpoint access
 - Metadata artifact resolution (VoID / DCAT)
 
-Supported serializations
+## Supported serializations
+
 - Turtle
 - RDF/XML
 - JSON-LD
@@ -30,15 +34,18 @@ Supported serializations
 - N3
 - TriG
 
-Examples
-[https://w3id.org/earthsemantics/OSO](https://w3id.org/earthsemantics/OSO)
-[https://w3id.org/earthsemantics/OSO/1.0.5](https://w3id.org/earthsemantics/OSO/1.0.5)
-[https://w3id.org/earthsemantics/OSO.jsonld](https://w3id.org/earthsemantics/OSO.jsonld)
-[https://w3id.org/earthsemantics/OSO.nt](https://w3id.org/earthsemantics/OSO.nt)
-[https://w3id.org/earthsemantics/OSO/sparql](https://virtuoso.ifremer.fr/oso/sparql)
+## Examples
 
-Target project
+- https://w3id.org/earthsemantics/OSO
+- https://w3id.org/earthsemantics/OSO/1.0.5
+- https://w3id.org/earthsemantics/OSO.jsonld
+- https://w3id.org/earthsemantics/OSO.nt
+- https://virtuoso.ifremer.fr/oso/sparql
+
+## Target project
+
 https://github.com/emso-eric/oso-ontology
 
-Notes
+## Notes
+
 This subpath is maintained independently and does not modify other earthsemantics namespaces.

--- a/earthsemantics/OSO/README.md
+++ b/earthsemantics/OSO/README.md
@@ -1,18 +1,44 @@
-# OSO namespace at w3id.org
+OSO namespace at w3id.org
 
-This subpath provides persistent identifiers for the OSO ontology and its related metadata descriptions.
+This subpath provides persistent identifiers and content negotiation
+for the Observatories of the Seas Ontology (OSO) and related metadata artifacts.
 
-## Maintainer
-Steven / @spiel-ifremer  
+Maintainer
+Steven Piel / @spiel-ifremer
 https://github.com/spiel-ifremer
 
-## Scope
-- /earthsemantics/OSO
-- /earthsemantics/OSO/void
-- /earthsemantics/OSO/dcat
+Scope
+/earthsemantics/OSO
+/earthsemantics/OSO/void
+/earthsemantics/OSO/dcat
+/earthsemantics/OSO/sparql
+/earthsemantics/OSO/ui
 
-## Target project
+Features
+- Persistent ontology IRIs
+- Generic version resolution
+- RDF content negotiation
+- Multiple RDF serializations
+- SPARQL endpoint access
+- Metadata artifact resolution (VoID / DCAT)
+
+Supported serializations
+- Turtle
+- RDF/XML
+- JSON-LD
+- N-Triples
+- N3
+- TriG
+
+Examples
+https://w3id.org/earthsemantics/OSO
+https://w3id.org/earthsemantics/OSO/1.0.5
+https://w3id.org/earthsemantics/OSO.jsonld
+https://w3id.org/earthsemantics/OSO.nt
+https://w3id.org/earthsemantics/OSO/sparql
+
+Target project
 https://github.com/emso-eric/oso-ontology
 
-## Notes
+Notes
 This subpath is maintained independently and does not modify other earthsemantics namespaces.


### PR DESCRIPTION
## Brief Description

This PR updates the W3ID configuration for the Observatories of the Seas Ontology (OSO).

Following the suggestion from @dgarijo in:
https://github.com/perma-id/w3id.org/pull/6046#issuecomment-4419000322

the version handling has been improved by replacing manually-added version redirects with a generic regular expression rule capable of resolving future ontology versions automatically.

### Changes included

- Added support for OSO version 1.0.5
- Replaced manual version-specific redirects with generic regex-based rules
- Simplified long-term maintenance of ontology version IRIs
- Improved consistency of persistent ontology access

### Examples

- https://w3id.org/earthsemantics/OSO/1.0.5
- future versions are now resolved automatically through regex rules

### Related resources

- Ontology repository:
  https://github.com/emso-eric/oso-ontology

- Persistent ontology IRI:
  https://w3id.org/earthsemantics/OSO

### Checklist

- [x] Changes tested
- [x] Redirects validated
- [x] Minimal update