### PR TITLE
Fix greedy mod_rewrite pattern causing malformed ontology redirects

### DIFF
--- a/fossr/ontology/.htaccess
+++ b/fossr/ontology/.htaccess
@@ -8,7 +8,7 @@ SetEnvIf Accept ^.*text/html.* SYNTAX=html
 SetEnvIf Request_URI ^.*$ ROOT_URL=https://raw.githubusercontent.com/fossr-project/ontology/refs/heads/main
 
 RewriteCond %{ENV:SYNTAX} ^(rdf|ttl|jsonld)$
-RewriteRule ^(.+)/?$ %{ENV:ROOT_URL}/$1/$1.%{ENV:SYNTAX} [R=302,L]
+RewriteRule ^([^/]+)/?$ %{ENV:ROOT_URL}/$1/$1.%{ENV:SYNTAX} [R=302,L]
 
 RewriteCond %{ENV:SYNTAX} ^html$
-RewriteRule ^(.+)/?$ http://semantics.istc.cnr.it/lode/extract?url=https://w3id.org/fossr/ontology/$1 [R=302,L]
+RewriteRule ^([^/]+)/?$ http://semantics.istc.cnr.it/lode/extract?url=https://w3id.org/fossr/ontology/$1 [R=302,L]


### PR DESCRIPTION
Fix greedy mod_rewrite pattern affecting content negotiation under
fossr/ontology

Replaced the RewriteRule pattern `^(.+)/?$` with `^([^/]+)/?$` to
prevent the trailing slash from being captured in `$1`.

This change affects the behaviour of content negotiation and URL
rewriting under the `fossr/ontology` path, fixing malformed redirects
such as:

`.../bdi//bdi/.ttl`

which occurred when resolving ontology resources requested with a
trailing slash.