### PR TITLE
Add AMD ontology permanent identifier

### DIFF
--- a/amd-ontology/.htaccess
+++ b/amd-ontology/.htaccess
@@ -1,0 +1,5 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Serve OWL ontology for /ont or root
+RewriteRule ^(ont)?$ https://raw.githubusercontent.com/CalinaBorzan/AMD-ontology/main/ontology/AMD_final_clean.owl [R=303,L]

--- a/amd-ontology/README.md
+++ b/amd-ontology/README.md
@@ -4,10 +4,10 @@
 OWL 2 DL ontology for Age-Related Macular Degeneration (AMD) covering clinical entities, treatments, biomarkers, risk factors, and diagnostic methods, engineered from clinical trial abstracts using agentic AI and DL-Learner.
 
 ## Contact
-Calina Annemary Borzan
-borzan.fl.calina@student.utcluj.ro
-Technical University of Cluj-Napoca
-GitHub: CalinaBorzan
+- Calina Annemary Borzan
+- borzan.fl.calina@student.utcluj.ro
+- Technical University of Cluj-Napoca
+- GitHub: CalinaBorzan
 
 ## Repository
 https://github.com/CalinaBorzan/AMD-ontology

--- a/amd-ontology/README.md
+++ b/amd-ontology/README.md
@@ -1,0 +1,13 @@
+# AMD Ontology
+
+## Purpose
+OWL 2 DL ontology for Age-Related Macular Degeneration (AMD) covering clinical entities, treatments, biomarkers, risk factors, and diagnostic methods, engineered from clinical trial abstracts using agentic AI and DL-Learner.
+
+## Contact
+Calina Annemary Borzan
+borzan.fl.calina@student.utcluj.ro
+Technical University of Cluj-Napoca
+GitHub: CalinaBorzan
+
+## Repository
+https://github.com/CalinaBorzan/AMD-ontology


### PR DESCRIPTION
Title: Add AMD ontology permanent identifier

Brief Description:
Adds a permanent identifier for the AMD (Age-Related Macular Degeneration)  ontology at https://w3id.org/amd-ontology, redirecting to the OWL file hosted on GitHub.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
