### PR TITLE
Add catalysis-data-format namespace

### DIFF
--- a/catalysis-data-format/.htaccess
+++ b/catalysis-data-format/.htaccess
@@ -13,10 +13,10 @@ RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
 RewriteCond %{HTTP_ACCEPT} \*/\*
-RewriteRule ^ontology/catalysis-data-format$ https://CorsinBattaglia.github.io/catalysis-data-format-ontology/catalysis-data-format.ttl [R=303,L]
+RewriteRule ^ontology/catalysis-data-format$ https://catalysis-data-alliance.github.io/catalysis-data-format-ontology/catalysis-data-format.ttl [R=303,L]
 
 # Browsers (HTML) for the ontology IRI
-RewriteRule ^ontology/catalysis-data-format$ https://github.com/CorsinBattaglia/catalysis-data-format [R=303,L]
+RewriteRule ^ontology/catalysis-data-format$ https://github.com/catalysis-data-alliance/catalysis-data-format [R=303,L]
 
 # ── Catch-all for any sub-path ────────────────────────────────────────────
-RewriteRule ^(.*)$ https://github.com/CorsinBattaglia/catalysis-data-format/$1 [R=303,L]
+RewriteRule ^(.*)$ https://github.com/catalysis-data-alliance/catalysis-data-format/$1 [R=303,L]

--- a/catalysis-data-format/.htaccess
+++ b/catalysis-data-format/.htaccess
@@ -1,0 +1,22 @@
+Options -MultiViews
+ErrorDocument 404 /errors/404.html
+
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+
+# Redirect ontology IRI with content negotiation
+RewriteEngine on
+
+# ── Ontology TTL (exact path) ──────────────────────────────────────────────
+# Machines requesting Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\*
+RewriteRule ^ontology/catalysis-data-format$ https://CorsinBattaglia.github.io/catalysis-data-format-ontology/catalysis-data-format.ttl [R=303,L]
+
+# Browsers (HTML) for the ontology IRI
+RewriteRule ^ontology/catalysis-data-format$ https://github.com/CorsinBattaglia/catalysis-data-format [R=303,L]
+
+# ── Catch-all for any sub-path ────────────────────────────────────────────
+RewriteRule ^(.*)$ https://github.com/CorsinBattaglia/catalysis-data-format/$1 [R=303,L]

--- a/catalysis-data-format/README.md
+++ b/catalysis-data-format/README.md
@@ -1,0 +1,17 @@
+# catalysis-data-format
+
+**Catalysis Data Format (CDF)** — a standardised tabular format for electrochemical catalysis (electrolysis) time-series data.
+
+| Field | Value |
+|-------|-------|
+| Namespace | `https://w3id.org/catalysis-data-format/` |
+| Maintainer | CorsinBattaglia |
+| GitHub | https://github.com/CorsinBattaglia/catalysis-data-format |
+| Contact | 104415854+CorsinBattaglia@users.noreply.github.com |
+
+## Namespace structure
+
+| Path | Resolves to |
+|------|-------------|
+| `/ontology/catalysis-data-format` | Ontology TTL (machines) / GitHub repo (browsers) |
+| `/catalysis-data-format/*` | GitHub repo (catch-all) |

--- a/catalysis-data-format/README.md
+++ b/catalysis-data-format/README.md
@@ -6,7 +6,7 @@
 |-------|-------|
 | Namespace | `https://w3id.org/catalysis-data-format/` |
 | Maintainer | CorsinBattaglia |
-| GitHub | https://github.com/CorsinBattaglia/catalysis-data-format |
+| GitHub | https://github.com/catalysis-data-alliance/catalysis-data-format |
 | Contact | 104415854+CorsinBattaglia@users.noreply.github.com |
 
 ## Namespace structure


### PR DESCRIPTION
Registers the `https://w3id.org/catalysis-data-format/` persistent namespace for the **Catalysis Data Format (CDF)** - a standardised tabular format for electrochemical catalysis (electrolysis) time-series data.`n`nThe `.htaccess` provides content-negotiated redirects for the ontology IRI (`/ontology/catalysis-data-format`) to a Turtle file for machines and the GitHub repository for browsers, plus a catch-all for sub-paths.`n`nMaintainer: CorsinBattaglia - https://github.com/catalysis-data-alliance/catalysis-data-format