### PR TITLE
Register kr-shinhwa namespace for Korean mythology ontology

### DIFF
--- a/kr-shinhwa/.htaccess
+++ b/kr-shinhwa/.htaccess
@@ -1,0 +1,3 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^(.*)$ https://pon00050.github.io/kr-shinhwa/$1 [R=303,L]

--- a/kr-shinhwa/README.md
+++ b/kr-shinhwa/README.md
@@ -1,0 +1,24 @@
+# kr-shinhwa
+
+Permanent identifier namespace for the kr-신화 knowledge graph of Korean
+shamanic mythology (무속신화).
+
+## Namespace
+
+`https://w3id.org/kr-shinhwa/`
+
+All requests redirect (303 See Other) to:
+`https://pon00050.github.io/kr-shinhwa/`
+
+## Description
+
+kr-신화 is a citation-traceable, variant-preserving, bilingual knowledge graph
+of Korean shamanic mythology (무속신화), anchored on 차사본풀이 as prototype.
+Ontology modeled in RDF/Turtle with CIDOC-CRM and PROV-O alignment.
+
+## Contact
+
+- Maintainer: pon00050 (Jisoo Yi)
+- Email: pon00050@gmail.com
+- GitHub: https://github.com/pon00050/kr-shinhwa
+- Project site: https://pon00050.github.io/kr-shinhwa/


### PR DESCRIPTION
## Summary

This PR registers the `kr-shinhwa` namespace for the kr-신화 project — a citation-traceable, variant-preserving, bilingual knowledge graph of Korean shamanic mythology (무속신화).

## Namespace

- **IRI prefix**: `https://w3id.org/kr-shinhwa/`
- **Redirects to**: `https://pon00050.github.io/kr-shinhwa/` (303 See Other)
- **Path-preserving**: yes — `https://w3id.org/kr-shinhwa/{id}` → `https://pon00050.github.io/kr-shinhwa/{id}`

## About the project

kr-신화 is an RDF/OWL ontology anchored on 차사본풀이 (origin of the underworld messengers), a narrative family from 제주도 일반신본풀이. The ontology is entity-primary, variant-preserving (each recorded Witness is a distinct transcript with named performer, recorder, year, and region), and source-attributed (T1–T3 tier discipline). CIDOC-CRM and PROV-O lightweight alignment is planned for v0.

GitHub repository: https://github.com/pon00050/kr-shinhwa
Project site (live): https://pon00050.github.io/kr-shinhwa/

## Redirect

`kr-shinhwa/.htaccess` contains a 303 redirect (W3C "Cool URIs for the Semantic Web" convention for ontology IRIs) with path preservation for future content negotiation.