### PR TITLE
Add /mhm/ prefix for Mapping Hebrew Manuscripts (MHM) project

### DIFF
--- a/mhm/.htaccess
+++ b/mhm/.htaccess
@@ -1,0 +1,38 @@
+# w3id.org/mhm — Mapping Hebrew Manuscripts (MHM) project permalinks
+#
+# This is the permalink layer for the MHM project at Bar-Ilan University.
+# All URIs minted by the pipeline (Wikidata P2888 exact-match, HMO ontology,
+# scholarly citation URIs) resolve through this prefix so the canonical
+# identifiers stay valid even if the underlying hosting changes.
+#
+# Project:    https://github.com/alexandergolbergwix/pipeline
+# Hosting:    https://mhm-hmo.wikibase.cloud
+# Maintainer: Alexander Goldberg <alexandergo@wix.com>
+# Institution: Bar-Ilan University
+# Date:       2026-05-17
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# ── Manuscript permalinks ───────────────────────────────────────────
+# The path segment is the NLI System Number (control number) of the
+# manuscript record, e.g.:
+#   https://w3id.org/mhm/manuscript/990000827290205171
+# → https://mhm-hmo.wikibase.cloud/wiki/MS_990000827290205171
+RewriteRule ^manuscript/(.+)$ https://mhm-hmo.wikibase.cloud/wiki/MS_$1 [R=302,L]
+
+# ── Person permalinks ────────────────────────────────────────────────
+# The path segment is the local HMO Wikibase ID (assigned by the project
+# Wikibase Cloud instance on upload).
+RewriteRule ^person/(.+)$ https://mhm-hmo.wikibase.cloud/wiki/Person_$1 [R=302,L]
+
+# ── Work permalinks ──────────────────────────────────────────────────
+RewriteRule ^work/(.+)$ https://mhm-hmo.wikibase.cloud/wiki/Work_$1 [R=302,L]
+
+# ── Ontology TTL ─────────────────────────────────────────────────────
+# Resolve to the canonical HMO ontology Turtle source on GitHub.
+RewriteRule ^ontology$ https://raw.githubusercontent.com/alexandergolbergwix/pipeline/main/ontology/hebrew-manuscripts.ttl [R=302,L]
+RewriteRule ^ontology/(.+)$ https://raw.githubusercontent.com/alexandergolbergwix/pipeline/main/ontology/$1 [R=302,L]
+
+# ── Project landing ──────────────────────────────────────────────────
+RewriteRule ^/?$ https://mhm-hmo.wikibase.cloud/ [R=302,L]

--- a/mhm/.htaccess
+++ b/mhm/.htaccess
@@ -7,7 +7,7 @@
 #
 # Project:    https://github.com/alexandergolbergwix/pipeline
 # Hosting:    https://mhm-hmo.wikibase.cloud
-# Maintainer: Alexander Goldberg <alexandergo@wix.com>
+# Maintainer: Alexander Goldberg <shvedbook@gmail.com>
 # Institution: Bar-Ilan University
 # Date:       2026-05-17
 

--- a/mhm/README.md
+++ b/mhm/README.md
@@ -1,0 +1,36 @@
+# /mhm/ — Mapping Hebrew Manuscripts (MHM)
+
+This [W3ID](https://w3id.org) namespace provides persistent URIs for the
+**Mapping Hebrew Manuscripts (MHM)** project — a doctoral research project at
+Bar-Ilan University that converts Hebrew manuscript catalog records (MARC)
+into a CIDOC-CRM / LRMoo aligned ontology (HMO) and publishes the result to
+both Wikidata and a project-owned Wikibase Cloud instance.
+
+The MHM pipeline emits `https://w3id.org/mhm/manuscript/<nli-control-number>`
+as the value of Wikidata property `P2888` (exact match) on every manuscript
+item it projects to Wikidata, bridging the public Wikidata projection to the
+project's canonical HMO graph.
+
+## Resolved URIs
+
+| URI pattern                                      | Target                                                                 |
+|--------------------------------------------------|------------------------------------------------------------------------|
+| `w3id.org/mhm/`                                  | https://mhm-hmo.wikibase.cloud/                                        |
+| `w3id.org/mhm/manuscript/<nli-control-number>`   | https://mhm-hmo.wikibase.cloud/wiki/MS_<nli-control-number>            |
+| `w3id.org/mhm/person/<id>`                       | https://mhm-hmo.wikibase.cloud/wiki/Person_<id>                        |
+| `w3id.org/mhm/work/<id>`                         | https://mhm-hmo.wikibase.cloud/wiki/Work_<id>                          |
+| `w3id.org/mhm/ontology`                          | https://raw.githubusercontent.com/alexandergolbergwix/pipeline/main/ontology/hebrew-manuscripts.ttl |
+
+## Related resources
+
+- Project repository: <https://github.com/alexandergolbergwix/pipeline>
+- HMO ontology (Turtle): <https://github.com/alexandergolbergwix/pipeline/blob/main/ontology/hebrew-manuscripts.ttl>
+- Wikibase Cloud instance: <https://mhm-hmo.wikibase.cloud>
+- Institution: Bar-Ilan University
+
+## Maintainers
+
+- Alexander Goldberg
+    - [@alexandergolbergwix](https://github.com/alexandergolbergwix)
+    - <alexandergo@wix.com>
+    - Bar-Ilan University


### PR DESCRIPTION
This PR registers a new permalink prefix `/mhm/` for the Mapping Hebrew Manuscripts (MHM) project, a doctoral research project at Bar-Ilan University that converts Hebrew manuscript catalog records (MARC) into a CIDOC-CRM / LRMoo aligned ontology (HMO) and publishes the result to both Wikidata and a project-owned Wikibase Cloud instance.

**Maintainer**: Alexander Goldberg <alexandergo@wix.com>
**Institution**: Bar-Ilan University
**Project repository**: https://github.com/alexandergolbergwix/pipeline
**Wikibase Cloud instance**: https://mhm-hmo.wikibase.cloud
**Ontology**: https://github.com/alexandergolbergwix/pipeline/blob/main/ontology/hebrew-manuscripts.ttl

## What the prefix resolves to

| URL pattern | Target |
|---|---|
| `w3id.org/mhm/` | https://mhm-hmo.wikibase.cloud/ (project landing) |
| `w3id.org/mhm/manuscript/<nli-control-number>` | https://mhm-hmo.wikibase.cloud/wiki/MS_<cn> |
| `w3id.org/mhm/person/<id>` | https://mhm-hmo.wikibase.cloud/wiki/Person_<id> |
| `w3id.org/mhm/work/<id>` | https://mhm-hmo.wikibase.cloud/wiki/Work_<id> |
| `w3id.org/mhm/ontology` | https://raw.githubusercontent.com/alexandergolbergwix/pipeline/main/ontology/hebrew-manuscripts.ttl |

All redirects are temporary (302) so corrections during initial rollout remain cheap; they can be reviewed and promoted to 303 (See Other) once content negotiation is added on the ontology IRI.

## Usage

The pipeline emits `w3id.org/mhm/manuscript/<cn>` as the value of [Wikidata P2888 (exact match)](https://www.wikidata.org/wiki/Property:P2888) on every manuscript item it projects to Wikidata, bridging the public Wikidata projection to the project's canonical HMO graph.

Expected initial use: ~1,939 entities from the test corpus, scaling to the full ~70,000 Hebrew manuscript records in the National Library of Israel catalog over the course of the dissertation.

Thanks for maintaining this service!