### PR TITLE
Add Marvin ontology namespace (aigora-de/marvin)

### DIFF
--- a/marvin/.htaccess
+++ b/marvin/.htaccess
@@ -1,0 +1,40 @@
+# Marvin — AI-augmented ontology development environment
+# https://github.com/aigora-de/marvin-ns
+#
+# This space is administered by:
+# Dave Dyke
+# 23141680+aigora-de@users.noreply.github.com
+# GitHub: aigora-de
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# ------------------------------------------------------------------
+# https://w3id.org/marvin/projections/
+# ------------------------------------------------------------------
+
+# Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^projections/(.*)$ https://raw.githubusercontent.com/aigora-de/marvin-ns/main/ontology/marvin-projections.ttl [R=303,L]
+
+# RDF/XML
+#RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+#RewriteRule ^projections/(.*)$ https://raw.githubusercontent.com/aigora-de/marvin-ns/main/ontology/marvin-projections.rdf [R=303,L]
+
+# HTML / browser default
+RewriteRule ^projections/(.*)$ https://github.com/aigora-de/marvin-ns [R=303,L]
+
+# ------------------------------------------------------------------
+# https://w3id.org/marvin/  (root and everything else)
+# ------------------------------------------------------------------
+
+# Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/aigora-de/marvin-ns/main/ontology/marvin-schema.ttl [R=303,L]
+
+# RDF/XML
+#RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+#RewriteRule ^(.*)$ https://raw.githubusercontent.com/aigora-de/marvin-ns/main/ontology/marvin-schema.rdf [R=303,L]
+
+# HTML / browser default
+RewriteRule ^(.*)$ https://github.com/aigora-de/marvin-ns [R=303,L]

--- a/marvin/README.md
+++ b/marvin/README.md
@@ -1,0 +1,28 @@
+# Marvin
+
+Persistent URI namespace for the Marvin AI-augmented ontology development environment.
+
+Marvin provides collaborative, AI-assisted tooling for developing and maintaining
+ontology extensions, with particular focus on 4D extensional ontologies.
+
+## Namespaces registered
+
+| URI | Description |
+|-----|-------------|
+| `https://w3id.org/marvin/` | Core Marvin ontology |
+| `https://w3id.org/marvin/projections/` | Marvin projections ontology |
+
+Turtle requests (`Accept: text/turtle`) redirect to the raw ontology files;
+all other requests redirect to the repository.
+
+## Contact
+
+This space is administered by:
+
+Dave Dyke<br>
+23141680+aigora-de@users.noreply.github.com<br>
+GitHub: aigora-de
+
+## Repository
+
+https://github.com/aigora-de/marvin-ns


### PR DESCRIPTION
## Brief Description
Add a new w3id namespace for Marvin, an AI-augmented ontology development
environment for 4D extensional ontologies. Registers two namespaces:
- `https://w3id.org/marvin/` — core Marvin ontology
- `https://w3id.org/marvin/projections/` — Marvin projections ontology

Turtle requests (`Accept: text/turtle`) redirect to raw GitHub content; all
other requests redirect to the repository. RDF/XML rules are present but
commented out pending serialisation of those files.

This supersedes #5934, which was closed for inactivity. The reviewer on that
PR correctly observed that the redirect targets returned 404 — they pointed
at a repository that was not publicly readable. The ontology artefacts are
now published in the public repository `aigora-de/marvin-ns`, and every
redirect target has been verified to resolve anonymously:

| Target | Anonymous HTTP |
|---|---|
| `raw.githubusercontent.com/aigora-de/marvin-ns/main/ontology/marvin-schema.ttl` | 200 |
| `raw.githubusercontent.com/aigora-de/marvin-ns/main/ontology/marvin-projections.ttl` | 200 |
| `github.com/aigora-de/marvin-ns` (HTML fallback) | 200 |

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- Not applicable — this is a new ID directory. -->

## Optional Requests for W3ID Maintainers
<!-- None. -->
