### PR TITLE
Add fallback rules for serving HTML content

### DIFF
--- a/music-annotation/.htaccess
+++ b/music-annotation/.htaccess
@@ -34,6 +34,9 @@ RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/1.0/music-annot
 RewriteCond %{HTTP_ACCEPT} text/turtle
 RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/1.0/music-annotation-ontology.ttl [R=303,L]
 
+# Fallback: serve HTML if no recognised format is requested
+RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/1.0/music-annotation-ontology.html [R=303,L]
+
 ## We assume that a path of the form [0-9]+.[0-9]+ is a version number and should be persisted
 
 # Rewrite rule to serve RDF/XML content if requested
@@ -55,3 +58,6 @@ RewriteRule ^([0-9]+[.][0-9]+)/?$ https://domestic-beethoven.eu/ontology/$1/musi
 # Rewrite rule to serve Turtle content if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle
 RewriteRule ^([0-9]+[.][0-9]+)/?$ https://domestic-beethoven.eu/ontology/$1/music-annotation-ontology.ttl [R=303,L]
+
+# Fallback: serve HTML if no recognised format is requested
+RewriteRule ^([0-9]+[.][0-9]+)/?$ https://domestic-beethoven.eu/ontology/$1/music-annotation-ontology.html [R=303,L]


### PR DESCRIPTION
Edited .htaccess to add fallback rewrite rules to serve HTML content when no recognized format is requested.

<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
