### PR TITLE
Add laborchain namespace for LaborChain ontology

### DIFF
--- a/laborchain/.htaccess
+++ b/laborchain/.htaccess
@@ -1,0 +1,7 @@
+Options -MultiViews
+Header set Access-Control-Allow-Origin *
+
+RewriteEngine on
+RewriteRule ^$ https://manabcodes.github.io/laborchain/ [R=303,L]
+RewriteRule ^laborchain\.ttl$ https://manabcodes.github.io/laborchain/laborchain.ttl [R=303,L]
+RewriteRule ^(.*)$ https://manabcodes.github.io/laborchain/$1 [R=303,L]

--- a/laborchain/.htaccess
+++ b/laborchain/.htaccess
@@ -1,7 +1,20 @@
 Options -MultiViews
-Header set Access-Control-Allow-Origin *
+AddType text/turtle .ttl
 
-RewriteEngine on
+RewriteEngine On
+
+# HTML — send to GitHub Pages
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 RewriteRule ^$ https://manabcodes.github.io/laborchain/ [R=303,L]
-RewriteRule ^laborchain\.ttl$ https://manabcodes.github.io/laborchain/laborchain.ttl [R=303,L]
+
+# Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ https://manabcodes.github.io/laborchain/laborchain.ttl [R=303,L]
+
+# Default — send to GitHub Pages
+RewriteRule ^$ https://manabcodes.github.io/laborchain/ [R=303,L]
 RewriteRule ^(.*)$ https://manabcodes.github.io/laborchain/$1 [R=303,L]

--- a/laborchain/README.md
+++ b/laborchain/README.md
@@ -1,0 +1,5 @@
+# LaborChain
+
+Namespace for the LaborChain ontology — an OWL framework for tracing labor exploitation provenance in AI training lineages.
+
+Ontology file: https://manabcodes.github.io/laborchain/laborchain.ttl

--- a/laborchain/README.md
+++ b/laborchain/README.md
@@ -3,3 +3,7 @@
 Namespace for the LaborChain ontology — an OWL framework for tracing labor exploitation provenance in AI training lineages.
 
 Ontology file: https://manabcodes.github.io/laborchain/laborchain.ttl
+
+## Maintainer
+
+- @manabcodes


### PR DESCRIPTION
## Brief Description
Adding a permanent namespace for LaborChain, an OWL ontology for tracing labor exploitation provenance in AI training lineages. Paper submitted to AIES 2026.

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal.
- [x] Commits only include redirects and basic information.

## New ID Directory Checklist
- [x] Maintainer details are in README.md.
- [x] GitHub username ids are listed in the maintainer details.