### PR TITLE
chore: reserve linuxfoundation/finos namespace

### DIFF
--- a/finos/.htaccess
+++ b/finos/.htaccess
@@ -1,0 +1,44 @@
+## template
+
+Options +FollowSymLinks
+RewriteEngine on
+
+## Mime type registrations
+# w3id mostly redirects (3xx) to GitHub raw, which sets its own Content-Type,
+# so these are belt-and-braces - useful only if a representation is ever
+# served directly from this host.
+##
+AppType application/rdf+xml        .rdf
+AppType application/rdf+xml        .owl
+AppType text/turtle                .ttl
+AppType application/n-triples      .nt
+AppType application/ld+json        .jsonld
+AppType text/shex                  .shex
+AppType application/yaml           .yaml
+
+# Rewrite Base URL
+RewriteRule ^(.*)$ https://www.finos.org/$1 [R=301,L]
+
+## Section: Core Linked Data Artifacts - representations of the model (non-information
+# resource) -> 303 See Other. All use [^/]+ for the repo segment to avoid
+# greedy capture across nested paths.
+##
+
+## Section: Non-Core artifacts - concrete information sources / code-gen outputs.
+# Use 302 (cacheable). Not in scope for content negoitation: MIME type
+# collide across path-segmented outputs (.py: pandear/sqla/namespaces;
+# .yaml: schema/golr/prefixmap; .md: mermaid/markdown-datadict;
+# .sql: sqlschema/sqlvalidation) - only the URL path disambiguates
+
+## Section: Content negotiation: Linked Data representations ONLY.
+# Fires only when the request URI has no file extension (the client is
+# asking for the model as an abstract resource and letting the server
+# choose the representation). Each rule emits a single 303 See Other to
+# the canonical raw artifact (or to the docs site for HTML).
+#
+# Scope: repo root AND any depth - so class/slots IRIs like
+# /finos/<repo>/<TermName> also content-negotiate. The repo segment
+# determines the artifact stem (gen-project convention).
+#
+##
+

--- a/finos/README.md
+++ b/finos/README.md
@@ -1,0 +1,19 @@
+# /finos/
+This [W3ID](https://w3id.org) persistent URI namespace is reserved by "Fintech Open Source Foundation" (FINOS).
+
+## Uses
+Implement Open Linked Data Persistent Identifiers content negotiation as a W3ID PURL, and optionally non-LD content by extension. Starts with template .htaccess.
+
+## Contact
+This space is administered by:  
+
+**Noel McLoughlin**
+*Site Reliability Engineering*
+[TD Securities](https://tdsecurities.com)  
+<noel.mcloughlin@tdsecurities.com>  
+GitHub: [noelmcloughlin](https://github.com/noelmcloughlin)
+
+**Another person tbc**
+*Jane Doe*
+[FINOS](https://www.finos.org/)
+<jane.doe@finos.org>

--- a/finos/aigf/.htaccess
+++ b/finos/aigf/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine On
+RewriteRule ^(.*)$ https://air-governance-framework.finos.org/ [L,R=301]

--- a/finos/aigf/README.md
+++ b/finos/aigf/README.md
@@ -1,0 +1,1 @@
+# FINOS AI Governance Framework

--- a/linuxfoundation/.htaccess
+++ b/linuxfoundation/.htaccess
@@ -1,0 +1,44 @@
+## template
+
+Options +FollowSymLinks
+RewriteEngine on
+
+## Mime type registrations
+# w3id mostly redirects (3xx) to GitHub raw, which sets its own Content-Type,
+# so these are belt-and-braces - useful only if a representation is ever
+# served directly from this host.
+##
+AppType application/rdf+xml        .rdf
+AppType application/rdf+xml        .owl
+AppType text/turtle                .ttl
+AppType application/n-triples      .nt
+AppType application/ld+json        .jsonld
+AppType text/shex                  .shex
+AppType application/yaml           .yaml
+
+# Rewrite Base URL
+RewriteRule ^(.*)$ https://www.linuxfoundation.org/$1 [R=301,L]
+
+## Section: Core Linked Data Artifacts - representations of the model (non-information
+# resource) -> 303 See Other. All use [^/]+ for the repo segment to avoid
+# greedy capture across nested paths.
+##
+
+## Section: Non-Core artifacts - concrete information sources / code-gen outputs.
+# Use 302 (cacheable). Not in scope for content negoitation: MIME type
+# collide across path-segmented outputs (.py: pandear/sqla/namespaces;
+# .yaml: schema/golr/prefixmap; .md: mermaid/markdown-datadict;
+# .sql: sqlschema/sqlvalidation) - only the URL path disambiguates
+
+## Section: Content negotiation: Linked Data representations ONLY.
+# Fires only when the request URI has no file extension (the client is
+# asking for the model as an abstract resource and letting the server
+# choose the representation). Each rule emits a single 303 See Other to
+# the canonical raw artifact (or to the docs site for HTML).
+#
+# Scope: repo root AND any depth - so class/slots IRIs like
+# /linuxfoundation/<repo>/<TermName> also content-negotiate. The repo segment
+# determines the artifact stem (gen-project convention).
+#
+##
+

--- a/linuxfoundation/README.md
+++ b/linuxfoundation/README.md
@@ -1,0 +1,19 @@
+# /linuxfoundation/
+This [W3ID](https://w3id.org) persistent URI namespace is reserved for Linux Foundation (LF).
+
+## Uses
+Implement Open Linked Data Persistent Identifiers content negotiation as a W3ID PURL, and optionally non-LD content by extension. Starts with template .htaccess.
+
+## Contact
+This space is administered by:  
+
+**Noel McLoughlin**
+*Site Reliability Engineering*
+[TD Securities](https://tdsecurities.com)  
+<noel.mcloughlin@tdsecurities.com>  
+GitHub: [noelmcloughlin](https://github.com/noelmcloughlin)
+
+**Another tbc**
+*Jane Doe*
+<jane.doe@linuxfoundation.org>
+[Linux Foundation](https://www.linuxfoundation.org/)


### PR DESCRIPTION

## Brief Description
Reserve `w3id.org/finos` and `w3id.org/linuxfoundation` namespaces.

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.