### PR TITLE
Update /conjectures/ redirects for DEC

### DIFF
--- a/conjectures/.htaccess
+++ b/conjectures/.htaccess
@@ -1,4 +1,5 @@
 RewriteEngine On
 
-RewriteRule   "^(.*)$" https://conjectures.altervista.org//$1 [R=303,L,QSA]
-
+# DEC live viewer.
+RewriteRule   "^dec/?$" http://204.216.209.229:3000/ [R=302,L,QSA]
+RewriteRule   "^dec/viewer/?$" http://204.216.209.229:3000/ [R=302,L,QSA]

--- a/conjectures/.htaccess
+++ b/conjectures/.htaccess
@@ -1,5 +1,5 @@
 RewriteEngine On
 
 # DEC live viewer.
-RewriteRule   "^dec/?$" http://204.216.209.229:3000/ [R=302,L,QSA]
-RewriteRule   "^dec/viewer/?$" http://204.216.209.229:3000/ [R=302,L,QSA]
+RewriteRule   "^dec/?$" https://dec.fabiovitali.it/ [R=302,L,QSA]
+RewriteRule   "^dec/viewer/?$" https://dec.fabiovitali.it/ [R=302,L,QSA]

--- a/conjectures/README.md
+++ b/conjectures/README.md
@@ -8,9 +8,9 @@ This namespace is used to provide stable references for DEC resources and to red
 
 Current redirects:
 
-- `https://w3id.org/conjectures/dec` -> `http://204.216.209.229:3000/`
-- `https://w3id.org/conjectures/dec/viewer` -> `http://204.216.209.229:3000/`
-
+- `https://w3id.org/conjectures/dec` -> `https://dec.fabiovitali.it/`
+- `https://w3id.org/conjectures/dec/viewer` -> `https://dec.fabiovitali.it/`
+  
 ## Contact
 
 This space is administered by:

--- a/conjectures/README.md
+++ b/conjectures/README.md
@@ -1,10 +1,18 @@
 # /conjectures/
-This [W3ID](https://w3id.org) provides a persistent URI namespace for Conjectures.
+
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the DEC project.
 
 ## Uses
-This namespace is used to provide a stable reference point for predicates used for Conjectures. See http://conjectures.altervista.org/ for more details.
+
+This namespace is used to provide stable references for DEC resources and to redirect the DEC entry point to the live DEC viewer.
+
+Current redirects:
+
+- `https://w3id.org/conjectures/dec` -> `http://204.216.209.229:3000/`
+- `https://w3id.org/conjectures/dec/viewer` -> `http://204.216.209.229:3000/`
 
 ## Contact
+
 This space is administered by:
 
 **Fabio Vitali**  <br>
@@ -12,5 +20,4 @@ This space is administered by:
 Bologna, Italy  <br>
 <fabio.vitali@unibo.it> <br>
 GitHub: [fvitali](https://github.com/fvitali)  <br>
-ORCID: [0000-0002-7562-5203](https://orcid.org/0000-0002-7562-52030) <br>
-
+ORCID: [0000-0002-7562-5203](https://orcid.org/0000-0002-7562-5203) <br>


### PR DESCRIPTION
This PR updates the existing /conjectures/ namespace, administered by Fabio Vitali, to redirect the DEC entry point to the live DEC viewer.

Changes:

- Replaces the obsolete Altervista catch-all redirect.
- Adds redirects for:
  - https://w3id.org/conjectures/dec
  - https://w3id.org/conjectures/dec/viewer
- Updates the namespace README and contact metadata.

The target is the current public DEC viewer deployment:

http://204.216.209.229:3000/