### PR TITLE
Add COEL v2.0 namespace redirects

### DIFF
--- a/coel/.htaccess
+++ b/coel/.htaccess
@@ -1,0 +1,38 @@
+Options +FollowSymLinks
+RewriteEngine On
+
+# COEL v2.0 namespace and collection pages.
+RewriteRule ^$ https://miltheo.github.io/coel/ [R=302,L]
+RewriteRule ^namespace/?$ https://miltheo.github.io/coel/namespace/ [R=302,L]
+RewriteRule ^atom/2\.0/?$ https://miltheo.github.io/coel/atom/2.0/ [R=302,L]
+RewriteRule ^models/?$ https://miltheo.github.io/coel/models/ [R=302,L]
+RewriteRule ^models/coel/2\.0/?$ https://miltheo.github.io/coel/models/coel/2.0/ [R=302,L]
+RewriteRule ^models/activinsights/?$ https://miltheo.github.io/coel/models/activinsights/ [R=302,L]
+RewriteRule ^models/activinsights/behavioural_bout/1\.0/?$ https://miltheo.github.io/coel/models/activinsights/behavioural_bout/1.0/ [R=302,L]
+RewriteRule ^models/activinsights/rest_activity/1\.0/?$ https://miltheo.github.io/coel/models/activinsights/rest_activity/1.0/ [R=302,L]
+RewriteRule ^mapping/?$ https://miltheo.github.io/coel/mapping/ [R=302,L]
+RewriteRule ^utilities/?$ https://miltheo.github.io/coel/utilities/ [R=302,L]
+RewriteRule ^utilities/jsonld/?$ https://miltheo.github.io/coel/utilities/jsonld/ [R=302,L]
+
+# COEL Behavioural Atom v2.0 artefacts.
+RewriteRule ^atom/2\.0/coel-atom\.json$ https://raw.githubusercontent.com/miltheo/coel/main/atom/2.0/coel-atom.json [R=302,L]
+RewriteRule ^atom/2\.0/extension-registry\.csv$ https://raw.githubusercontent.com/miltheo/coel/main/atom/2.0/extension-registry.csv [R=302,L]
+
+# Canonical model registry CSV artefacts.
+RewriteRule ^models/coel/2\.0/coel-model-v2\.0\.csv$ https://raw.githubusercontent.com/miltheo/coel/main/models/coel/2.0/coel-model-v2.0.csv [R=302,L]
+RewriteRule ^models/activinsights/behavioural_bout/1\.0/behavioural-bout-model-v1\.0\.csv$ https://raw.githubusercontent.com/miltheo/coel/main/models/activinsights/behavioural_bout/1.0/behavioural-bout-model-v1.0.csv [R=302,L]
+RewriteRule ^models/activinsights/rest_activity/1\.0/rest-activity-model-v1\.0\.csv$ https://raw.githubusercontent.com/miltheo/coel/main/models/activinsights/rest_activity/1.0/rest-activity-model-v1.0.csv [R=302,L]
+
+# Mapping CSV artefacts.
+RewriteRule ^mapping/behavioural-bout-model-v1\.0-to-coel-model-v2\.0\.csv$ https://raw.githubusercontent.com/miltheo/coel/main/mapping/behavioural-bout-model-v1.0-to-coel-model-v2.0.csv [R=302,L]
+RewriteRule ^mapping/rest-activity-model-v1\.0-to-coel-model-v2\.0\.csv$ https://raw.githubusercontent.com/miltheo/coel/main/mapping/rest-activity-model-v1.0-to-coel-model-v2.0.csv [R=302,L]
+
+# Derived TTL serialisations in the release bundle.
+RewriteRule ^models/coel/2\.0/coel-model-v2\.0\.ttl$ https://raw.githubusercontent.com/miltheo/coel/main/models/coel/2.0/coel-model-v2.0.ttl [R=302,L]
+RewriteRule ^models/activinsights/behavioural_bout/1\.0/behavioural-bout-model-v1\.0\.ttl$ https://raw.githubusercontent.com/miltheo/coel/main/models/activinsights/behavioural_bout/1.0/behavioural-bout-model-v1.0.ttl [R=302,L]
+RewriteRule ^models/activinsights/rest_activity/1\.0/rest-activity-model-v1\.0\.ttl$ https://raw.githubusercontent.com/miltheo/coel/main/models/activinsights/rest_activity/1.0/rest-activity-model-v1.0.ttl [R=302,L]
+RewriteRule ^mapping/behavioural-bout-model-v1\.0-to-coel-model-v2\.0\.ttl$ https://raw.githubusercontent.com/miltheo/coel/main/mapping/behavioural-bout-model-v1.0-to-coel-model-v2.0.ttl [R=302,L]
+RewriteRule ^mapping/rest-activity-model-v1\.0-to-coel-model-v2\.0\.ttl$ https://raw.githubusercontent.com/miltheo/coel/main/mapping/rest-activity-model-v1.0-to-coel-model-v2.0.ttl [R=302,L]
+
+# Optional JSON-LD projection support.
+RewriteRule ^utilities/jsonld/context\.jsonld$ https://raw.githubusercontent.com/miltheo/coel/main/utilities/jsonld/context.jsonld [R=302,L]

--- a/coel/README.md
+++ b/coel/README.md
@@ -1,0 +1,76 @@
+# COEL v2.0 w3id Configuration
+
+This directory contains the proposed w3id.org redirect configuration for the COEL v2.0 public artefact bundle.
+
+Namespace root:
+
+```text
+https://w3id.org/coel/
+```
+
+GitHub Pages target:
+
+```text
+https://miltheo.github.io/coel/
+```
+
+Repository:
+
+```text
+https://github.com/miltheo/coel
+```
+
+Redirects currently use HTTP `302` status codes.
+
+## Maintainer
+
+- Millen J. Theophilus
+- GitHub: https://github.com/miltheo
+- Repository issues: https://github.com/miltheo/coel/issues
+
+## Route Policy
+
+- Namespace and collection/document paths redirect to GitHub Pages HTML pages.
+- Concrete schema, registry, mapping, and derived TTL artefact paths redirect to raw GitHub files.
+- Model term IRIs use fragment identifiers from the registry CSV `iri` columns. Fragments are resolved by clients after the base model path redirects.
+- JSON-LD is included only as optional projection support.
+- Non-public implementation routes, slug aliases, and derived JSON serialisation routes are intentionally excluded.
+
+## HTML Routes
+
+| w3id route | Target |
+|---|---|
+| `https://w3id.org/coel/` | `https://miltheo.github.io/coel/` |
+| `https://w3id.org/coel/namespace/` | `https://miltheo.github.io/coel/namespace/` |
+| `https://w3id.org/coel/atom/2.0/` | `https://miltheo.github.io/coel/atom/2.0/` |
+| `https://w3id.org/coel/models/` | `https://miltheo.github.io/coel/models/` |
+| `https://w3id.org/coel/models/coel/2.0/` | `https://miltheo.github.io/coel/models/coel/2.0/` |
+| `https://w3id.org/coel/models/activinsights/` | `https://miltheo.github.io/coel/models/activinsights/` |
+| `https://w3id.org/coel/models/activinsights/behavioural_bout/1.0/` | `https://miltheo.github.io/coel/models/activinsights/behavioural_bout/1.0/` |
+| `https://w3id.org/coel/models/activinsights/rest_activity/1.0/` | `https://miltheo.github.io/coel/models/activinsights/rest_activity/1.0/` |
+| `https://w3id.org/coel/mapping/` | `https://miltheo.github.io/coel/mapping/` |
+| `https://w3id.org/coel/utilities/` | `https://miltheo.github.io/coel/utilities/` |
+| `https://w3id.org/coel/utilities/jsonld/` | `https://miltheo.github.io/coel/utilities/jsonld/` |
+
+## Raw Artefact Routes
+
+| w3id route | Target |
+|---|---|
+| `https://w3id.org/coel/atom/2.0/coel-atom.json` | `https://raw.githubusercontent.com/miltheo/coel/main/atom/2.0/coel-atom.json` |
+| `https://w3id.org/coel/atom/2.0/extension-registry.csv` | `https://raw.githubusercontent.com/miltheo/coel/main/atom/2.0/extension-registry.csv` |
+| `https://w3id.org/coel/models/coel/2.0/coel-model-v2.0.csv` | `https://raw.githubusercontent.com/miltheo/coel/main/models/coel/2.0/coel-model-v2.0.csv` |
+| `https://w3id.org/coel/models/activinsights/behavioural_bout/1.0/behavioural-bout-model-v1.0.csv` | `https://raw.githubusercontent.com/miltheo/coel/main/models/activinsights/behavioural_bout/1.0/behavioural-bout-model-v1.0.csv` |
+| `https://w3id.org/coel/models/activinsights/rest_activity/1.0/rest-activity-model-v1.0.csv` | `https://raw.githubusercontent.com/miltheo/coel/main/models/activinsights/rest_activity/1.0/rest-activity-model-v1.0.csv` |
+| `https://w3id.org/coel/mapping/behavioural-bout-model-v1.0-to-coel-model-v2.0.csv` | `https://raw.githubusercontent.com/miltheo/coel/main/mapping/behavioural-bout-model-v1.0-to-coel-model-v2.0.csv` |
+| `https://w3id.org/coel/mapping/rest-activity-model-v1.0-to-coel-model-v2.0.csv` | `https://raw.githubusercontent.com/miltheo/coel/main/mapping/rest-activity-model-v1.0-to-coel-model-v2.0.csv` |
+| `https://w3id.org/coel/models/coel/2.0/coel-model-v2.0.ttl` | `https://raw.githubusercontent.com/miltheo/coel/main/models/coel/2.0/coel-model-v2.0.ttl` |
+| `https://w3id.org/coel/models/activinsights/behavioural_bout/1.0/behavioural-bout-model-v1.0.ttl` | `https://raw.githubusercontent.com/miltheo/coel/main/models/activinsights/behavioural_bout/1.0/behavioural-bout-model-v1.0.ttl` |
+| `https://w3id.org/coel/models/activinsights/rest_activity/1.0/rest-activity-model-v1.0.ttl` | `https://raw.githubusercontent.com/miltheo/coel/main/models/activinsights/rest_activity/1.0/rest-activity-model-v1.0.ttl` |
+| `https://w3id.org/coel/mapping/behavioural-bout-model-v1.0-to-coel-model-v2.0.ttl` | `https://raw.githubusercontent.com/miltheo/coel/main/mapping/behavioural-bout-model-v1.0-to-coel-model-v2.0.ttl` |
+| `https://w3id.org/coel/mapping/rest-activity-model-v1.0-to-coel-model-v2.0.ttl` | `https://raw.githubusercontent.com/miltheo/coel/main/mapping/rest-activity-model-v1.0-to-coel-model-v2.0.ttl` |
+
+## Optional Projection Route
+
+| w3id route | Target |
+|---|---|
+| `https://w3id.org/coel/utilities/jsonld/context.jsonld` | `https://raw.githubusercontent.com/miltheo/coel/main/utilities/jsonld/context.jsonld` |


### PR DESCRIPTION
This pull request adds the `https://w3id.org/coel/` namespace for the COEL v2.0 public artefact bundle.

The namespace resolves documentation and collection paths to the public GitHub Pages deployment:

https://miltheo.github.io/coel/

Concrete artefact paths resolve to raw GitHub files for the COEL Behavioural Atom v2.0 JSON Schema, canonical CSV registries, mapping CSVs, derived TTL serialisations, and the optional JSON-LD context.

Redirects are configured as HTTP 302 for initial release testing and verification.

Maintainer: Millen J. Theophilus  
Repository: https://github.com/miltheo/coel