### PR TITLE
Update .htaccess for documentation page redirection

### DIFF
--- a/climoo/.htaccess
+++ b/climoo/.htaccess
@@ -23,7 +23,7 @@ RedirectMatch 302 ^/climoo/?$ https://raw.githubusercontent.com/ClimOO/ClimOO-On
 RedirectMatch 302 ^/climoo/(climoo[^/]*)$ https://raw.githubusercontent.com/ClimOO/ClimOO-Ontology/refs/heads/main/$1.ttl
 
 ## Redirect documentation requests explicitly
-RedirectMatch 302 ^/climoo/docs/?$ https://github.com/ClimOO/ClimOO-Ontology/docs/index.html
+RedirectMatch 302 ^/climoo/docs/?$  https://climoo.github.io/ClimOO-Ontology/
 
 ## Repository links
 RedirectMatch 302 ^/climoo/(git|repo)/?$  https://github.com/ClimOO/ClimOO-Ontology


### PR DESCRIPTION
We updated the .htaccess to ensure redirection to the ClimOO documentation webpage.