### PR TITLE
Add explicit file-style serialization IRIs for OSO

### DIFF
--- a/earthsemantics/OSO/.htaccess
+++ b/earthsemantics/OSO/.htaccess
@@ -90,7 +90,14 @@ RewriteRule ^$ https://emso-eric.github.io/oso-ontology/ [R=303,L]
 # ====================================================================
 # Explicit serialization URLs
 # ====================================================================
-
+RewriteRule ^OSO\.ttl/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.ttl [R=303,L]
+RewriteRule ^OSO\.owl/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.owl [R=303,L]
+RewriteRule ^OSO\.rdf/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.owl [R=303,L]
+RewriteRule ^OSO\.jsonld/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.jsonld [R=303,L]
+RewriteRule ^OSO\.rdfjson/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.rdfjson [R=303,L]
+RewriteRule ^OSO\.nt/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.nt [R=303,L]
+RewriteRule ^OSO\.n3/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.n3 [R=303,L]
+RewriteRule ^OSO\.trig/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.trig [R=303,L]
 RewriteRule ^ttl/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.ttl [R=303,L]
 RewriteRule ^owl/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.owl [R=303,L]
 RewriteRule ^rdf/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/OSO.owl [R=303,L]


### PR DESCRIPTION
This PR adds explicit rewrite rules for file-style serialization IRIs such as:

* /OSO.owl
* /OSO.ttl
* /OSO.jsonld
* /OSO.nt
* /OSO.n3
* /OSO.trig

These URLs now directly resolve to the corresponding RDF serializations hosted on GitHub raw content.

This improves:

* RDF dereferenceability,
* FAIR interoperability,
* compatibility with Semantic Web tooling,
* and support for ontology repositories and FAIR assessment tools expecting explicit serialization URLs.
