### PR TITLE
Add cco-gro namespace for Unified Legislation Regulatory Ontology

### DIFF
--- a/cco-gro/.htaccess
+++ b/cco-gro/.htaccess
@@ -1,0 +1,16 @@
+Options -MultiViews
+RewriteEngine On
+
+# /cco-gro/ -> documentation homepage
+RewriteRule ^$ https://rgu-computing.github.io/Synthesising-Regulatory-Ontologies/index-en.html [R=303,L]
+
+# /cco-gro/onto -> documentation homepage
+RewriteRule ^onto/?$ https://rgu-computing.github.io/Synthesising-Regulatory-Ontologies/index-en.html [R=303,L]
+
+# /cco-gro/onto/... -> map directly
+RewriteRule ^onto/(.*)$ https://rgu-computing.github.io/Synthesising-Regulatory-Ontologies/$1 [R=303,L]
+
+
+
+
+

--- a/cco-gro/.htaccess
+++ b/cco-gro/.htaccess
@@ -7,10 +7,17 @@ RewriteRule ^$ https://rgu-computing.github.io/Synthesising-Regulatory-Ontologie
 # /cco-gro/onto -> documentation homepage
 RewriteRule ^onto/?$ https://rgu-computing.github.io/Synthesising-Regulatory-Ontologies/index-en.html [R=303,L]
 
+# /cco-gro/onto/uk -> documentation
+RewriteRule ^onto/uk/?$ https://rgu-computing.github.io/Synthesising-Regulatory-Ontologies/index-en.html [R=303,L]
+
+# /cco-gro/onto/us -> documentation
+RewriteRule ^onto/us/?$ https://rgu-computing.github.io/Synthesising-Regulatory-Ontologies/index-en.html [R=303,L]
+
+# /cco-gro/onto/ca -> documentation
+RewriteRule ^onto/ca/?$ https://rgu-computing.github.io/Synthesising-Regulatory-Ontologies/index-en.html [R=303,L]
+
+# /cco-gro/onto/au -> documentation
+RewriteRule ^onto/au/?$ https://rgu-computing.github.io/Synthesising-Regulatory-Ontologies/index-en.html [R=303,L]
+
 # /cco-gro/onto/... -> map directly
 RewriteRule ^onto/(.*)$ https://rgu-computing.github.io/Synthesising-Regulatory-Ontologies/$1 [R=303,L]
-
-
-
-
-

--- a/cco-gro/README.md
+++ b/cco-gro/README.md
@@ -1,9 +1,16 @@
 # CCO-GRO Namespace
 
 Maintainer: Umair Arshad
-
 Contact: u.arshad1@rgu.ac.uk
-
 GitHub: https://github.com/RGU-Computing/Synthesising-Regulatory-Ontologies
-
 Ontology IRI: https://w3id.org/cco-gro/onto
+
+## Namespaces
+
+| Prefix | Namespace |
+|---|---|
+| gro: | https://w3id.org/cco-gro/onto# |
+| gro-uk: | https://w3id.org/cco-gro/onto/uk# |
+| gro-us: | https://w3id.org/cco-gro/onto/us# |
+| gro-ca: | https://w3id.org/cco-gro/onto/ca# |
+| gro-au: | https://w3id.org/cco-gro/onto/au# |

--- a/cco-gro/README.md
+++ b/cco-gro/README.md
@@ -1,0 +1,6 @@
+# CCO-GRO Namespace
+
+Maintainer: Umair Arshad
+Contact: u.arshad1@rgu.ac.uk
+GitHub: https://github.com/RGU-Computing/Synthesising-Regulatory-Ontologies
+Ontology IRI: https://w3id.org/cco-gro/onto

--- a/cco-gro/README.md
+++ b/cco-gro/README.md
@@ -1,8 +1,11 @@
 # CCO-GRO Namespace
 
 Maintainer: Umair Arshad
+
 Contact: u.arshad1@rgu.ac.uk
+
 GitHub: https://github.com/RGU-Computing/Synthesising-Regulatory-Ontologies
+
 Ontology IRI: https://w3id.org/cco-gro/onto
 
 ## Namespaces

--- a/cco-gro/README.md
+++ b/cco-gro/README.md
@@ -1,6 +1,9 @@
 # CCO-GRO Namespace
 
 Maintainer: Umair Arshad
+
 Contact: u.arshad1@rgu.ac.uk
+
 GitHub: https://github.com/RGU-Computing/Synthesising-Regulatory-Ontologies
+
 Ontology IRI: https://w3id.org/cco-gro/onto

--- a/cco-gro/README.md
+++ b/cco-gro/README.md
@@ -2,6 +2,8 @@
 
 Maintainer: Umair Arshad
 
+GitHub user: https://github.com/UmairMarry
+
 Contact: u.arshad1@rgu.ac.uk
 
 GitHub: https://github.com/RGU-Computing/Synthesising-Regulatory-Ontologies


### PR DESCRIPTION
Adding .htaccess and README for cco-gro namespace.

Namespace: https://w3id.org/cco-gro/
Ontology IRI: https://w3id.org/cco-gro/onto
Jurisdiction namespaces:
  - https://w3id.org/cco-gro/onto/uk#
  - https://w3id.org/cco-gro/onto/us#
  - https://w3id.org/cco-gro/onto/ca#
  - https://w3id.org/cco-gro/onto/au#
Redirects to: https://rgu-computing.github.io/Synthesising-Regulatory-Ontologies/index-en.html
Maintainer: Umair Arshad, Robert Gordon University, UK
Contact: u.arshad1@rgu.ac.uk