### PR TITLE
Add collabri prefix

### DIFF
--- a/collabri/.htaccess
+++ b/collabri/.htaccess
@@ -1,0 +1,19 @@
+# /collabri/ — Permanent identifiers for Collabri schemas
+# https://w3id.org/collabri/
+
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine On
+
+# -----------------------------------------------------------------------------
+# Root: schema browser landing page
+# -----------------------------------------------------------------------------
+RewriteRule ^$ https://collabri-io.github.io/ [R=302,L]
+
+# -----------------------------------------------------------------------------
+# Statement of Work (SOW) schema
+#   /collabri/sow            -> schema home
+#   /collabri/sow/{Term}     -> per-term documentation page
+# -----------------------------------------------------------------------------
+RewriteRule ^sow/?$ https://collabri-io.github.io/sow/ [R=303,L]
+RewriteRule ^sow/(.+)$ https://collabri-io.github.io/sow/$1.html [R=303,L]

--- a/collabri/README.md
+++ b/collabri/README.md
@@ -1,0 +1,34 @@
+# /collabri/
+
+This [W3ID](https://w3id.org) namespace provides persistent URIs for schemas
+published by Collabri ([github.com/collabri-io](https://github.com/collabri-io)).
+
+## Uses
+
+The namespace resolves locally-minted terms in Collabri's LinkML schemas.
+Terms whose identity already lives in an external ontology (FIBO, ODRL,
+FRAPO, PROV-O, PAV, SPAR/FaBiO, DCAT, DOAP, IAO, ADMS, schema.org, etc.) are
+referenced by their canonical IRIs and are not minted under `/collabri/`.
+
+Current schemas:
+
+- **Statement of Work (SOW)** &mdash; `https://w3id.org/collabri/sow/`
+  LinkML schema for contract-scoped Statements of Work: TaskTeam (root) →
+  Task → recursive Subtasks → typed Deliverables, with PROV/PAV versioning
+  and a ChangeProposal / Approval layer (&ldquo;GitHub for contracts&rdquo;).
+  Aligned with FIBO Contracts, ODRL, FRAPO, PROV-O, PAV, and others.
+
+Term URIs resolve to per-term documentation pages in the LinkML-generated
+schema browser hosted at
+[collabri-io.github.io](https://collabri-io.github.io/).
+
+## Contact
+
+This namespace is administered by the following GitHub-handle maintainers
+at [TISLab](https://tislab.org/):
+
+- [@jmcmurry](https://github.com/jmcmurry)
+- [@mellybelly](https://github.com/mellybelly)
+
+Open an issue on [perma-id/w3id.org](https://github.com/perma-id/w3id.org)
+or ping either maintainer on GitHub.


### PR DESCRIPTION
## Summary
Adds the `/collabri/` prefix for permanent identifiers used by schemas published at github.com/collabri-io.

Resolves locally-minted terms in Collabri LinkML schemas. The current schema is the Statement of Work (SOW) schema, with terms at `https://w3id.org/collabri/sow/{Term}` resolving to the LinkML-generated documentation hosted at `https://collabri-io.github.io/sow/`.

Terms whose identity already lives in an external ontology (FIBO, ODRL, FRAPO, PROV-O, PAV, SPAR/FaBiO, DCAT, DOAP, IAO, ADMS, schema.org, etc.) are referenced by their canonical IRIs and are not minted under `/collabri/`.

## Files
- `collabri/.htaccess` — redirect rules (root, `/sow/`, `/sow/{Term}`)
- `collabri/README.md` — purpose and contact

## Test plan
- [ ] `https://w3id.org/collabri/` → schema browser landing
- [ ] `https://w3id.org/collabri/sow/` → SOW schema home
- [ ] `https://w3id.org/collabri/sow/TaskTeam` → TaskTeam term page

## Notes for maintainers
A second maintainer per the two-person rule will be added before this is merged; the README has a TODO marker for it.