### PR TITLE
Add aktagon ontology family redirect

### DIFF
--- a/aktagon/.htaccess
+++ b/aktagon/.htaccess
@@ -1,6 +1,13 @@
 # w3id.org permanent identifiers for the aktagon ontology family
-# Project: aktagon ontology family
-# Contact: Christian Hellsten <christian@aktagon.com>
+#
+# https://w3id.org/aktagon/ redirects to https://ontology.aktagon.com/
+#
+# ## Contact
+# This space is administered by:
+#
+# Christian Hellsten
+# christian@aktagon.com
+# GitHub username: christianhellsten
 
 Options -MultiViews
 

--- a/aktagon/.htaccess
+++ b/aktagon/.htaccess
@@ -1,0 +1,21 @@
+# w3id.org permanent identifiers for the aktagon ontology family
+# Project: aktagon ontology family
+# Contact: Christian Hellsten <christian@aktagon.com>
+
+Options -MultiViews
+
+RewriteEngine On
+RewriteBase /aktagon
+
+# Bare authority -> human-readable index
+RewriteRule ^$ https://ontology.aktagon.com/ [R=302,L]
+
+# Linked-data clients (Turtle / JSON-LD): 303 per httpRange-14,
+# since these IRIs name concepts, not the documents describing them.
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(.+)$ https://ontology.aktagon.com/$1 [R=303,L]
+
+# Default (browsers and everything else), path-preserving
+RewriteRule ^(.+)$ https://ontology.aktagon.com/$1 [R=302,L]

--- a/aktagon/README.md
+++ b/aktagon/README.md
@@ -19,4 +19,4 @@ the stable identifier.
 
 ## Contact
 
-Christian Hellsten — christian@aktagon.com
+Christian Hellsten (GitHub: @christianhellsten) — christian@aktagon.com

--- a/aktagon/README.md
+++ b/aktagon/README.md
@@ -1,0 +1,22 @@
+# aktagon
+
+Permanent identifiers for the aktagon ontology family
+(`https://w3id.org/aktagon/`). These IRIs resolve to the canonical
+Turtle/JSON-LD served at <https://ontology.aktagon.com/>.
+
+## Namespace structure
+
+| IRI pattern                                      | Purpose                                            |
+| ------------------------------------------------ | -------------------------------------------------- |
+| `https://w3id.org/aktagon/{domain}#`             | Vocabulary (T-Box), e.g. `writing#`, `operations#` |
+| `https://w3id.org/aktagon/{domain}/{module}#`    | Multi-module vocabulary, e.g. `ui/core#`           |
+| `https://w3id.org/aktagon/id/{domain}/{id}`      | Instance data (A-Box)                              |
+| `https://w3id.org/aktagon/example/{domain}/{id}` | Examples and fixtures                              |
+
+Versions are pinned via `owl:versionIRI`
+(`https://w3id.org/aktagon/{domain}/{YYYY-MM-DD}`); the unversioned IRI is
+the stable identifier.
+
+## Contact
+
+Christian Hellsten — christian@aktagon.com


### PR DESCRIPTION
Adds a permanent identifier namespace for the aktagon ontology family.

- Path: `https://w3id.org/aktagon/`
- Redirects path-preserving to `https://ontology.aktagon.com/` (302 default, 303 for `text/turtle`/`application/ld+json` per httpRange-14).
- New directory only (`aktagon/.htaccess`, `aktagon/README.md`); no other paths touched.

Verified live: `curl -H "Accept: text/turtle" https://ontology.aktagon.com/core` returns the core ontology as Turtle.

Contact: Christian Hellsten <christian@aktagon.com>