### PR TITLE
Removed forward slash to fix inconsistent redirection

### DIFF
--- a/emi/.htaccess
+++ b/emi/.htaccess
@@ -16,7 +16,7 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://www.earthmetabolome.org/earth_metabolome_ontology/ [R=303,L]
+RewriteRule ^$ https://www.earthmetabolome.org/earth_metabolome_ontology [R=303,L]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
Currently redirections are slightly off. e.g: https://w3id.org/emi#hasSource. This might be due to a forward slash in the path. Removed forward slash to fix inconsistent redirection
<!-- Brief description of the purpose of this PR. -->


