### PR TITLE
chore: switch the v1 redirection to HEAD

### DIFF
--- a/dspace-sig/.htaccess
+++ b/dspace-sig/.htaccess
@@ -12,7 +12,7 @@ RewriteEngine On
 RewriteBase /
 
 ## Redirect JSON Schemas for 1.0
-RewriteRule ^v1.0/([\w.-]+schema.json) https://eclipse-dataplane-signaling.github.io/dataplane-signaling/schemas/$1 [R=302,L]
+RewriteRule ^v1.0/([\w.-]+schema.json) https://eclipse-dataplane-signaling.github.io/dataplane-signaling/HEAD/schemas/$1 [R=302,L]
 
 # Rewrite rule to default to the signaling spec page
 RewriteRule ^(.*)$ https://eclipse-dataplane-signaling.github.io/dataplane-signaling [R=303,L]


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description

Changes the `v1` redirect to point to `HEAD`  

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
