### PR TITLE
Add 'crima-ontology' namespace to serve CRIMA Ontology modules (https://github.com/crima-ontology/ontology)

### DIFF
--- a/crima-ontology/.htaccess
+++ b/crima-ontology/.htaccess
@@ -1,0 +1,40 @@
+Options -MultiViews
+RewriteEngine on
+
+# Extension-based routing without version (with .n3=>.ttl .owl|.xml=>.rdf .jsonld=>.rdf)
+# https://w3id.org/crima-ontology/{module}.{ext} -> https://crima-ontology.github.io/latest/modules/{module}/{module}.{ext}
+RewriteRule ^([^./]+)\.(ttl|n3)$ https://crima-ontology.github.io/latest/modules/$1/$1.ttl [R=303,L]
+RewriteRule ^([^./]+)\.(rdf|owl|xml)$ https://crima-ontology.github.io/latest/modules/$1/$1.rdf [R=303,L]
+RewriteRule ^([^./]+)\.(json|jsonld)$ https://crima-ontology.github.io/latest/modules/$1/$1.json [R=303,L]
+RewriteRule ^([^./]+)\.([^/]+)$ https://crima-ontology.github.io/latest/modules/$1/$1.$2 [R=303,L]
+
+# Extension-based routing with version (with .n3=>.ttl .owl|.xml=>.rdf .jsonld=>.rdf)
+# https://w3id.org/crima-ontology/{version}/{module}.{ext} => https://crima-ontology.github.io/{version}/modules/{module}/{module}.{ext}
+RewriteRule ^([^/]+)/([^./]+)\.(ttl|n3)$ https://crima-ontology.github.io/$1/modules/$2/$2.ttl [R=303,L]
+RewriteRule ^([^/]+)/([^./]+)\.(rdf|owl|xml)$ https://crima-ontology.github.io/$1/modules/$2/$2.rdf [R=303,L]
+RewriteRule ^([^/]+)/([^./]+)\.(json|jsonld)$ https://crima-ontology.github.io/$1/modules/$2/$2.json [R=303,L]
+RewriteRule ^([^/]+)/([^./]+)\.([^/]+)$ https://crima-ontology.github.io/$1/modules/$2/$2.$3 [R=303,L]
+
+# Content negotiation without version ({ext} determined from Accept header, with fallback to .ttl)
+# https://w3id.org/crima-ontology/{module} => https://crima-ontology.github.io/latest/modules/{module}/{module}.{ext}
+RewriteCond %{HTTP_ACCEPT} text/html|application/xhtml\+xml
+RewriteRule ^([^./]+)$ https://crima-ontology.github.io/latest/modules/$1/$1.html [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^([^./]+)$ https://crima-ontology.github.io/latest/modules/$1/$1.rdf [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json|application/json
+RewriteRule ^([^./]+)$ https://crima-ontology.github.io/latest/modules/$1/$1.json [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^([^./]+)$ https://crima-ontology.github.io/latest/modules/$1/$1.nt [R=303,L]
+RewriteRule ^([^./]+)$ https://crima-ontology.github.io/latest/modules/$1/$1.ttl [R=303,L]
+
+# Content negotiation with version ({ext} determined from Accept header, with fallback to .ttl)
+# https://w3id.org/crima-ontology/{version}{module} => https://crima-ontology.github.io/{version}/modules/{module}/{module}.{ext}
+RewriteCond %{HTTP_ACCEPT} text/html|application/xhtml\+xml
+RewriteRule ^([^/]+)/([^./]+)$ https://crima-ontology.github.io/$1/modules/$2/$2.html [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^([^/]+)/([^./]+)$ https://crima-ontology.github.io/$1/modules/$2/$2.rdf [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json|application/json
+RewriteRule ^([^/]+)/([^./]+)$ https://crima-ontology.github.io/$1/modules/$2/$2.json [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^([^/]+)/([^./]+)$ https://crima-ontology.github.io/$1/modules/$2/$2.nt [R=303,L]
+RewriteRule ^([^/]+)/([^./]+)$ https://crima-ontology.github.io/$1/modules/$2/$2.ttl [R=303,L]

--- a/crima-ontology/README.md
+++ b/crima-ontology/README.md
@@ -1,0 +1,21 @@
+# CRIMA Ontology
+
+Permanent identifier for the [CRIMA Ontology](https://github.com/crima-ontology/ontology) for evidence-based management of climate risks.
+
+## URI Patterns
+
+Rules in file `.htaccess` match W3ID URIs of the form `https://w3id.org/crima-ontology/[{version}]/{module}[.{ext}]`, where
+
+* `{module}` is mandatory and identifies a module of the CRIMA ontology, e.g., `ccore`
+* `{version}` can be omitted, defaulting to `latest`
+* `{ext}` can be omitted, triggering content negotiation
+
+Requests to these URIs are redirected (HTTP 303) to ontology module files published at https://crima-ontology.github.io/.
+
+## Maintainers
+
+* Alessandro Mosca - [@al3barna](https://github.com/al3barna)
+* Greta Adamo - [@gretaAd](https://github.com/gretaAd)
+* Davide Lanti - [@tirrolo](https://github.com/tirrolo)
+* Maria Assunta Cappelli - [@MariaWaria1](https://github.com/MariaWaria1)
+* Francesco Corcoglioniti - [@fracorco](https://github.com/fracorco)


### PR DESCRIPTION
## Brief Description

This PR adds a `/crima-ontology/` namespace to provide persistent URIs for the modules of the [CRIMA Ontology](https://github.com/crima-ontology/ontology) for evidence-based management of climate risks.

Rules in file `.htaccess` match W3ID URIs of the form `https://w3id.org/crima-ontology/[{version}]/{module}[.{ext}]`, where

* `{module}` is mandatory and identifies a module of the CRIMA ontology, e.g., `ccore`
* `{version}` can be omitted, defaulting to `latest`
* `{ext}` can be omitted, triggering content negotiation

Requests to these URIs are redirected (HTTP 303) to ontology module files published at https://crima-ontology.github.io/.

Maintainers:

* Alessandro Mosca - [@al3barna](https://github.com/al3barna)
* Greta Adamo - [@gretaAd](https://github.com/gretaAd)
* Davide Lanti - [@tirrolo](https://github.com/tirrolo)
* Maria Assunta Cappelli - [@MariaWaria1](https://github.com/MariaWaria1)
* Francesco Corcoglioniti - [@fracorco](https://github.com/fracorco)

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.