### PR TITLE
Add bcso ontology

### DIFF
--- a/BCSO/.htaccess
+++ b/BCSO/.htaccess
@@ -1,0 +1,15 @@
+# BCSO - Bronze Casting Site Ontology
+# Redirects to GitHub Pages documentation
+
+RewriteEngine On
+
+# Base redirect to documentation
+RewriteRule ^$ https://mengj97.github.io/bcso-ontology/ [R=302,L]
+
+# Redirect ontology file requests
+RewriteRule ^ontology$ https://mengj97.github.io/bcso-ontology/bcso.owl [R=302,L]
+RewriteRule ^ontology/$ https://mengj97.github.io/bcso-ontology/bcso.owl [R=302,L]
+
+# Redirect to specific versions or resources
+RewriteRule ^doc$ https://mengj97.github.io/bcso-ontology/ [R=302,L]
+RewriteRule ^doc/$ https://mengj97.github.io/bcso-ontology/ [R=302,L]

--- a/BCSO/README.md
+++ b/BCSO/README.md
@@ -1,0 +1,19 @@
+# BCSO - Bronze Casting Site Ontology
+
+BCSO (Bronze Casting Site Ontology) is a bilingual ontology designed to systematically represent knowledge about bronze casting sites in ancient China.
+
+## Namespace
+
+https://w3id.org/BCSO
+
+## Documentation
+
+https://mengj97.github.io/bcso-ontology
+
+## Source Repository
+
+https://github.com/MengJ97/bcso-ontology
+
+## Contact
+
+Meng Jiang <mengjiang97@qq.com>

--- a/OSDBA/.htaccess
+++ b/OSDBA/.htaccess
@@ -1,2 +1,3 @@
+# Added by MengJ97 (GitHub)
 RewriteEngine On
 RewriteRule ^(.*)$ https://github.com/MengJ97/bronze-researcher.github.io/releases/download/v1.0/OSDBA.owl [R=302,L]

--- a/OSDBA/.htaccess
+++ b/OSDBA/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine On
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/MengJ97/bronze-researcher.github.io/main/ShangDynastyBronzeOntology.owl [R=302,L]

--- a/OSDBA/.htaccess
+++ b/OSDBA/.htaccess
@@ -1,2 +1,2 @@
 RewriteEngine On
-RewriteRule ^(.*)$ https://raw.githubusercontent.com/MengJ97/bronze-researcher.github.io/main/OSDBA.owl [R=302,L]
+RewriteRule ^(.*)$ https://github.com/MengJ97/bronze-researcher.github.io/releases/download/v1.0/OSDBA.owl [R=302,L]

--- a/OSDBA/.htaccess
+++ b/OSDBA/.htaccess
@@ -1,2 +1,2 @@
 RewriteEngine On
-RewriteRule ^(.*)$ https://raw.githubusercontent.com/MengJ97/bronze-researcher.github.io/main/ShangDynastyBronzeOntology.owl [R=302,L]
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/MengJ97/bronze-researcher.github.io/main/OSDBA.owl [R=302,L]

--- a/OSDBA/README.md
+++ b/OSDBA/README.md
@@ -1,0 +1,14 @@
+# Permanent Redirect for OSDBA
+
+This directory contains the rewrite rules for the persistent identifier:
+**`https://w3id.org/OSDBA`**
+
+## Maintainer
+*   **GitHub Username**: MengJ97
+
+## Purpose
+This redirect provides a stable, permanent URI for the **OSDBA (Ontology of Shang Dynasty Bronze Artifacts)**, a bilingual ontology for Shang Dynasty bronze research.
+
+## Target
+The redirect points to the versioned release of the ontology:
+`https://github.com/MengJ97/bronze-researcher.github.io/releases/download/v1.0/OSDBA.owl`


### PR DESCRIPTION
Add BCSO (Bronze Casting Site Ontology) redirect

This PR adds a redirect for the BCSO ontology to GitHub Pages documentation.

- Repository: https://github.com/MengJ97/bcso-ontology
- Documentation: https://mengj97.github.io/bcso-ontology
