### PR TITLE
add faia vocab and ont folders to the config.

### DIFF
--- a/faia-framework/.htaccess
+++ b/faia-framework/.htaccess
@@ -1,0 +1,41 @@
+# FAIA Framework Ontology & Vocabulary Redirects
+# https://w3id.org/faia-framework
+#
+# Repository: https://github.com/faia-framework/w3id.docs
+#
+# Contact:
+#   Kristina Hettne     - https://github.com/kmhettne
+#   Yury Kharytanovich  <yury.kharytanovich.liccium@gmail.com> - https://github.com/yurykharytanovich
+#   Sebastian Post      <info@liccium.com> - https://github.com/sposth
+
+
+# Turn off MultiViews
+Options -MultiViews
+
+# MIME type declarations
+AddType text/turtle .ttl
+
+# Rewrite engine setup
+RewriteEngine On
+RewriteBase /faia-framework/
+
+# ------------------------------
+# FAIA Ontology files
+# ------------------------------
+# Default: faia_ont/ or faia_ont → faia_ont.ttl
+RewriteRule ^faia_ont/?$ https://raw.githubusercontent.com/faia-framework/w3id.docs/main/faia_ont/faia_ont.ttl [R=303,L]
+# Specific file: faia_ont/<version>.ttl
+RewriteRule ^faia_ont/(.+)\.ttl$ https://raw.githubusercontent.com/faia-framework/w3id.docs/main/faia_ont/$1.ttl [R=303,L]
+
+# ------------------------------
+# FAIA Vocabulary files
+# ------------------------------
+# Default: faia_vocab/ or faia_vocab → faia_vocab.ttl
+RewriteRule ^faia_vocab/?$ https://raw.githubusercontent.com/faia-framework/w3id.docs/main/faia_vocab/faia_vocab.ttl [R=303,L]
+# Specific file: faia_vocab/<version>.ttl
+RewriteRule ^faia_vocab/(.+)\.ttl$ https://raw.githubusercontent.com/faia-framework/w3id.docs/main/faia_vocab/$1.ttl [R=303,L]
+
+# ------------------------------
+# Default response (redirect to GitHub repo)
+# ------------------------------
+RewriteRule ^$ https://github.com/faia-framework/w3id.docs [R=303,L]

--- a/faia-framework/README.md
+++ b/faia-framework/README.md
@@ -1,0 +1,49 @@
+# FAIR AI Attribution (FAIA) Framework
+
+Versioned ontology and vocabulary for the FAIA (Fair AI Attribution) framework — machine-readable and persistent disclosure of AI involvement in content creation.
+
+## Contents
+
+- **`faia_ont/`** — OWL ontology files defining data properties and classes (`faiaFlag`, `activityCode`, `systemAttribution`, `systemVersion`)
+- **`faia_vocab/`** — SKOS vocabulary files covering FAIA flags (HCC, AAC, AIG) and activity codes
+
+## Usage
+
+Reference these files via w3id.org persistent URLs:
+
+| Format              | URL                                                          |
+| ------------------- | ------------------------------------------------------------ |
+| **FAIA Ontology**   | https://w3id.org/faia-framework/faia_ont/faia_ont.ttl      |
+| **FAIA Vocabulary** | https://w3id.org/faia-framework/faia_vocab/faia_vocab.ttl  |
+
+### Version 0.6.0
+
+| Format              | URL                                                      |
+| ------------------- | -------------------------------------------------------- |
+| **FAIA Ontology**   | https://w3id.org/faia-framework/faia_ont/0.6.0.ttl       |
+| **FAIA Vocabulary** | https://w3id.org/faia-framework/faia_vocab/0.6.0.ttl   |
+
+### Version 0.5.0
+
+| Format              | URL                                                      |
+| ------------------- | -------------------------------------------------------- |
+| **FAIA Ontology**   | https://w3id.org/faia-framework/faia_ont/0.5.0.ttl       |
+| **FAIA Vocabulary** | https://w3id.org/faia-framework/faia_vocab/0.5.0.ttl   |
+
+**Repository:** https://github.com/faia-framework/w3id.docs
+
+## About
+
+The FAIA framework provides an ontology and vocabulary for machine-readable disclosure of AI involvement. It defines three complementary elements: high-level attribution flags (human-created, AI-assisted, AI-generated), activity codes describing the role AI played in the content lifecycle, and optional system attribution identifying the AI system and version involved.
+
+For more information:
+
+- FAIA statement generator: https://www.faia.io/statement-generator
+- FAIA documentation: https://faia.liccium.com
+- FAIA registry: https://faia.io
+
+## Contact
+
+- **Kristina Hettne** · https://github.com/kmhettne
+- **Yury Kharytanovich** — <yury.kharytanovich.liccium@gmail.com> · https://github.com/yurykharytanovich
+- **Sebastian Posth** — <info@liccium.com> · https://github.com/sposth


### PR DESCRIPTION
## Brief Description

This PR creates a new permanent identifier namespace for the FAIA (Fair AI Attribution) framework at https://w3id.org/faia-framework/.

The FAIA framework provides versioned OWL ontology and SKOS vocabulary definitions for machine-readable disclosure of AI involvement in content creation. The redirects point to:

- https://w3id.org/faia-framework/faia_ont/*.ttl → FAIA ontology files
- https://w3id.org/faia-framework/faia_vocab/*.ttl → FAIA vocabulary files

Source repository: https://github.com/faia-framework/w3id.docs

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist

- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers

- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.

**Maintainers:**

- Kristina Hettne ([@kmhettne](https://github.com/kmhettne))
- Yury Kharytanovich ([@yurykharytanovich](https://github.com/yurykharytanovich)) — yury.kharytanovich.liccium@gmail.com
- Sebastian Posth ([@sposth](https://github.com/sposth)) — info@liccium.com