### PR TITLE
Add /etkl namespace

### DIFF
--- a/etkl/.htaccess
+++ b/etkl/.htaccess
@@ -1,0 +1,39 @@
+# # /etkl/
+#
+# Persistent namespace for the ET(K)L method (Extract, Transform-with-(K)nowledge,
+# Load) and its modules:
+#
+#   https://w3id.org/etkl         — ET(K)L method + umbrella vocabulary
+#   https://w3id.org/etkl/hol     — hol: holonic decision-context vocabulary
+#   https://w3id.org/etkl/iladub  — iladub: assertion/proposition vocabulary
+#
+# Content is negotiated: RDF clients receive Turtle from the source repository
+# (github.com/iladub/iladub), browsers are sent to the documentation site
+# (https://iladub.dev).
+#
+# ## Contact
+# This space is administered by:
+#
+# François Rosselet
+# GitHub username: Frosselet
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# ---- https://w3id.org/etkl/hol ------------------------------------------
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/n-triples|application/ld\+json|text/n3) [NC]
+RewriteRule ^hol/?$ https://raw.githubusercontent.com/iladub/iladub/main/vocab/ontology/hol.ttl [R=302,L]
+RewriteRule ^hol/?$ https://iladub.dev/hol/ [R=302,L]
+
+# ---- https://w3id.org/etkl/iladub ---------------------------------------
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/n-triples|application/ld\+json|text/n3) [NC]
+RewriteRule ^iladub/?$ https://raw.githubusercontent.com/iladub/iladub/main/vocab/ontology/iladub.ttl [R=302,L]
+RewriteRule ^iladub/?$ https://iladub.dev/assertion-proposition/ [R=302,L]
+
+# ---- https://w3id.org/etkl (umbrella) -----------------------------------
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/n-triples|application/ld\+json|text/n3) [NC]
+RewriteRule ^$ https://raw.githubusercontent.com/iladub/iladub/main/vocab/ontology/etkl.ttl [R=302,L]
+RewriteRule ^$ https://iladub.dev/etkl/ [R=302,L]
+
+# ---- fallback: any other /etkl/* path -> documentation site -------------
+RewriteRule ^(.*)$ https://iladub.dev/ [R=302,L]

--- a/etkl/README.md
+++ b/etkl/README.md
@@ -1,0 +1,25 @@
+# /etkl/
+
+Persistent namespace for the **ET(K)L** method — *Extract, Transform-with-(K)nowledge,
+Load* — and its ontology modules. Knowledge engineering is the first milestone of the
+pipeline: a semantic data contract declares the target semantics and a knowledge module
+is passed as an argument to the transform.
+
+| Persistent IRI | Resolves to |
+| --- | --- |
+| `https://w3id.org/etkl` | ET(K)L method + umbrella vocabulary |
+| `https://w3id.org/etkl/hol` | `hol` — holonic decision-context vocabulary |
+| `https://w3id.org/etkl/iladub` | `iladub` — assertion/proposition vocabulary |
+
+Requests are **content-negotiated**: clients asking for RDF (`Accept: text/turtle`,
+`application/rdf+xml`, `application/ld+json`, …) are redirected to the Turtle ontology
+files in the source repository; browsers are redirected to the documentation site.
+
+- **Documentation:** https://iladub.dev
+- **Source & ontologies:** https://github.com/iladub/iladub (under `vocab/ontology/`)
+- **License:** ontologies are CC-BY-4.0; code is Apache-2.0.
+
+## Maintainer
+
+- **François Rosselet**
+- GitHub: [@Frosselet](https://github.com/Frosselet)


### PR DESCRIPTION
## Brief description

Adds the `/etkl/` namespace — the persistent identifier for the **ET(K)L** method (*Extract, Transform-with-(K)nowledge, Load*) and its two ontology modules:

| IRI | Resolves to |
| --- | --- |
| `https://w3id.org/etkl` | ET(K)L method + umbrella vocabulary |
| `https://w3id.org/etkl/hol` | `hol` — holonic decision-context vocabulary |
| `https://w3id.org/etkl/iladub` | `iladub` — assertion/proposition vocabulary |

Requests are content-negotiated: RDF clients (`Accept: text/turtle`, `application/rdf+xml`, `application/ld+json`, …) are redirected to the Turtle ontology files; browsers are redirected to the documentation site (https://iladub.dev). All redirect targets are live.

## Checklist

- [x] This PR adds a **new ID directory** (`etkl/`) containing `.htaccess` and `README.md`.
- [x] Maintainer name and **GitHub username** (`@Frosselet`) are documented in `etkl/README.md` and `.htaccess`.
- [x] The `.htaccess` only affects the `/etkl/` subpath.
- [x] Contains only redirects and basic information (no content hosting on this service).
- [x] Tested locally.
- [x] Squashed into a single commit with a descriptive message.