### PR TITLE
Fix /prism content negotiation redirect paths

### DIFF
--- a/prism/.htaccess
+++ b/prism/.htaccess
@@ -7,21 +7,31 @@ Options -Indexes
 Header set Access-Control-Allow-Origin *
 RewriteEngine on
 
-# Versioned ontology
-RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+# Versioned ontology — RDF serialisations
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^0\.3\.0$ https://itsbigspark.github.io/prism-ontology/0.3.0/ontology.ttl [R=303,L]
+
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^0\.1\.0$ https://itsbigspark.github.io/prism-ontology/ontology/prism-0.1.0.ttl [R=303,L]
-RewriteRule ^0\.1\.0$ https://itsbigspark.github.io/prism-ontology/0.1.0/ [R=303,L]
+RewriteRule ^0\.3\.0$ https://itsbigspark.github.io/prism-ontology/0.3.0/ontology.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^0\.3\.0$ https://itsbigspark.github.io/prism-ontology/0.3.0/ontology.nt [R=303,L]
+
+# Versioned ontology — HTML
+RewriteRule ^0\.3\.0$ https://itsbigspark.github.io/prism-ontology/0.3.0/ [R=303,L]
 
 # SHACL shapes
 RewriteRule ^shacl/(.*)$ https://itsbigspark.github.io/prism-ontology/shacl/$1 [R=303,L]
 
-# Default — Turtle for semantic web clients
-RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+# Default — RDF serialisations
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^$ https://itsbigspark.github.io/prism-ontology/ontology.ttl [R=303,L]
+
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^$ https://itsbigspark.github.io/prism-ontology/ontology/prism.ttl [R=303,L]
+RewriteRule ^$ https://itsbigspark.github.io/prism-ontology/ontology.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://itsbigspark.github.io/prism-ontology/ontology.nt [R=303,L]
 
 # Default — HTML for browsers
 RewriteRule ^$ https://itsbigspark.github.io/prism-ontology/ [R=303,L]

--- a/prism/README.md
+++ b/prism/README.md
@@ -1,7 +1,9 @@
 # PRISM
+
 PRISM is an EU AI Act compliance record-keeping ontology that extends the W3C Data Privacy Vocabulary (DPV) and its EU AI Act extension with structured mappings from legal obligations to compliance record types, attestation workflows, and SHACL validation shapes.
 
 https://github.com/itsbigspark/prism-ontology
 
-## Contacts
-* Paola Arce <paola.arce@bigspark.dev> (GitHub: mapsa)
+## Maintainers
+
+* Paola Arce ([@mapsa](https://github.com/mapsa)) — paola.arce@bigspark.dev


### PR DESCRIPTION
## Brief Description

Fix content negotiation redirect paths for \`/prism\`. The redirect rules currently point to paths that return 404 on GitHub Pages — the ontology files are published under \`docs/\` at the repository root, not under \`ontology/\`.

**Before (broken):**
- All RDF \`Accept\` headers → \`…/prism-ontology/ontology/prism.ttl\` (404)

**After (correct):**
- \`text/turtle\` → \`…/prism-ontology/ontology.ttl\` (200)
- \`application/ld+json\` → \`…/prism-ontology/ontology.jsonld\` (200)
- \`application/n-triples\` → \`…/prism-ontology/ontology.nt\` (200)
- Each serialisation has its own rule rather than a single catch-all
- Versioned rules updated to 0.3.0 (previously referenced 0.1.0)

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in \`.htaccess\` or \`README.md\`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist

- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers

- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.