### PR TITLE
Add /bimei/ — BIMei Ontology (ONT)

### DIFF
--- a/bimei/.htaccess
+++ b/bimei/.htaccess
@@ -1,0 +1,21 @@
+# # /bimei/
+#
+# BIMei Ontology (ONT) — the canonical Action Statement registry.
+# https://w3id.org/bimei/{type}/{slug} (e.g. /bimei/action/conduct) redirects to
+# the backing host https://ontology.bimexcellence.org/, which dereferences the
+# IRI (content-negotiates language; serves the live head or a pinned ?version=).
+# Identity is language- and version-neutral; the register is never in the IRI.
+#
+# ## Contact
+# This space is administered by:
+#
+# Bilal Succar — Change Agents
+# GitHub username: bsuccar
+# Email: bsuccar@changeagents.com.au
+
+RewriteEngine on
+
+# Forward every /bimei/* path to the backing host, preserving the query string
+# (so ?version= pins pass through). 302 (temporary) keeps w3id.org/bimei/* the
+# permanent, citable identity while the backing host stays relocatable.
+RewriteRule ^(.*)$ https://ontology.bimexcellence.org/$1 [R=302,L,QSA]

--- a/bimei/README.md
+++ b/bimei/README.md
@@ -1,0 +1,20 @@
+# /bimei/
+
+Permanent identifiers for the **BIMei Ontology (ONT)** — the canonical Action Statement registry of the BIM
+Excellence ecosystem.
+
+IRIs take the form `https://w3id.org/bimei/{type}/{slug}` — e.g. `https://w3id.org/bimei/action/conduct`,
+`https://w3id.org/bimei/term/...`, `https://w3id.org/bimei/statement/...`. They are readable, **minted once and never
+renamed** (a relabel changes the label, not the slug), and **language- and version-neutral**: language is content-
+negotiated (`Accept-Language`) and a pinned version is selected with `?version=`. The `register`
+(canonical | instrument | communication) is a property of the resolved object, **never part of the IRI**.
+
+`.htaccess` 302-redirects every `/bimei/*` path (query string preserved) to the backing host
+`https://ontology.bimexcellence.org/`, which runs the ONT resolver. 302 (temporary) keeps the `w3id.org/bimei/` IRI the
+permanent citable identity while the backing host remains relocatable.
+
+## Contact
+
+- Bilal Succar — Change Agents
+- GitHub: [@bsuccar](https://github.com/bsuccar)
+- Email: bsuccar@changeagents.com.au


### PR DESCRIPTION
New permanent prefix for the **BIMei Ontology (ONT)** — the canonical Action Statement registry of the BIM Excellence ecosystem.

`https://w3id.org/bimei/{type}/{slug}` (e.g. `/bimei/action/conduct`) 302-redirects to the backing host `https://ontology.bimexcellence.org/` (live over HTTPS), preserving the query string. Both `.htaccess` and `README.md` are included, each with maintainer contact info.

Contact: Bilal Succar — Change Agents · bsuccar@changeagents.com.au