### PR TITLE
chore(lmodel): minor update to match sub-schemas

### DIFF
--- a/lmodel/.htaccess
+++ b/lmodel/.htaccess
@@ -77,9 +77,16 @@ RewriteRule ^common-domain-model(?:/|$)   - [E=STEM:common_domain_model,E=BRANCH
 # Variant B: artifacts at branch root. E=STEM:...,E=BRANCH:artifacts,E=PROJECT:
 # Variant C: artifacts on `gh-pages` (requires custom deploy). E=STEM:...,E=BRANCH:gh-pages
 
-# Schemas - explicit filename honors $2 (supports multi-file schemas, e.g. common-domain-model's
-# cdm_legaldocumentation_csa.yaml); bare /schema or /schema/<no-extension> canonicalizes to root schema.
+# Schemas - explicit filename honors $2 (supports multi-file schemas)
+#   $2's `(.+)` is greedy and spans `/`, so nested module
+#   layouts also resolve (e.g. dpvs/schema/modules/mymodule.yaml ->
+#   src/dpvs/schema/modules/mymodule.yaml).
+#
+# Bare /schema canonicalizes to root schema (+ .yaml extension).
+# And /schema/<nested/path> (multi-segment) resolves to sub-directory schema (+ .yaml extension).
 RewriteRule ^([^/]+)/schema/(.+)\.yaml$  https://raw.githubusercontent.com/lmodel/$1/%{ENV:BRANCH}/src/%{ENV:STEM}/schema/$2.yaml [R=303,NE,L]
+RewriteCond %{REQUEST_URI} !\.[^/]+$
+RewriteRule ^([^/]+)/schema/(.*/.+?)/?$   https://github.com/lmodel/$1/blob/%{ENV:BRANCH}/src/%{ENV:STEM}/schema/$2.yaml [R=303,NE,L]
 RewriteRule ^([^/]+)/schema(?:/[^.]*)?$  https://raw.githubusercontent.com/lmodel/$1/%{ENV:BRANCH}/src/%{ENV:STEM}/schema/%{ENV:STEM}.yaml [R=303,NE,L]
 
 # Bare <repo>/<anything>.yaml fallback (excludes prefixmap, golr, yaml, .linkml.yaml)


### PR DESCRIPTION

## Brief Description
This PR add rule to match sub-schemas -  under `/schema/<name>` or `/schema/modules/<name>`. 

Smoke tested.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.