### PR TITLE
Add shinra namespace for Shinra Ontology

### DIFF
--- a/shinra/.htaccess
+++ b/shinra/.htaccess
@@ -1,0 +1,11 @@
+Options -MultiViews
+Require all granted
+
+Header set Access-Control-Allow-Origin *
+Header set Cache-Control "max-age=3600"
+
+RewriteEngine on
+
+RewriteRule ^ont/(.*)$  https://katsuki-318.github.io/shinra-ontology/ont/$1 [R=303,L]
+RewriteRule ^data/(.*)$ https://katsuki-318.github.io/shinra-ontology/data/$1 [R=303,L]
+RewriteRule ^$          https://katsuki-318.github.io/shinra-ontology/          [R=303,L]

--- a/shinra/.htaccess
+++ b/shinra/.htaccess
@@ -6,6 +6,6 @@ Header set Cache-Control "max-age=3600"
 
 RewriteEngine on
 
-RewriteRule ^ont/(.*)$  https://katsuki-318.github.io/shinra-ontology/ont/$1 [R=303,L]
-RewriteRule ^data/(.*)$ https://katsuki-318.github.io/shinra-ontology/data/$1 [R=303,L]
-RewriteRule ^$          https://katsuki-318.github.io/shinra-ontology/          [R=303,L]
+RewriteRule ^ont/(.*)$  https://katsuki-318.github.io/shinra-ontology/src/$1 [R=303,L]
+RewriteRule ^data/(.*)$ https://katsuki-318.github.io/shinra-ontology/src/$1 [R=303,L]
+RewriteRule ^$          https://katsuki-318.github.io/shinra-ontology/        [R=303,L]

--- a/shinra/README.md
+++ b/shinra/README.md
@@ -1,0 +1,8 @@
+# shinra
+
+神羅万象オントロジー (Shinra Ontology) の永続 URI ディレクトリ。
+
+- Ontology: <https://w3id.org/shinra/ont/>
+- Data: <https://w3id.org/shinra/data/>
+- Source: https://github.com/katsuki-318/shinra-ontology
+- Contact: katsuki_miwa@caddi.com


### PR DESCRIPTION
Adding persistent URI namespace for the Shinra Ontology project.

- Namespace: https://w3id.org/shinra/
- Redirects to: https://katsuki-318.github.io/shinra-ontology/
- Contact: katsuki_miwa@caddi.com
- License: CC-BY 4.0