### PR TITLE
Add fairscape namespace for the Fairscape RO-Crate Profile

### DIFF
--- a/fairscape/.htaccess
+++ b/fairscape/.htaccess
@@ -1,0 +1,22 @@
+Options +FollowSymLinks
+RewriteEngine On
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fairscape namespace — persistent identifiers for the Fairscape RO-Crate
+# Profile and related artifacts. Content is served from GitHub Pages at
+# https://fairscape.github.io/profile/ ; this file is just the redirect layer.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Profile identifier URIs, e.g. /fairscape/profile/0.1
+# RDF clients get the W3C PROF manifest (Turtle)...
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/ld\+json|application/n-triples) [NC]
+RewriteRule ^profile/([^/]+)/?$ https://fairscape.github.io/profile/$1/profile.ttl [R=303,L]
+
+# ...everyone else (browsers, etc.) gets the rendered HTML specification.
+RewriteRule ^profile/([^/]+)/?$ https://fairscape.github.io/profile/$1/ [R=303,L]
+
+# All other artifacts pass straight through to the published files, e.g.
+#   /fairscape/profile/0.1/evi-vocabulary.ttl
+#   /fairscape/profile/0.1/schemas/Dataset.json
+#   /fairscape/profile/0.1/examples/release/ro-crate-metadata.json
+RewriteRule ^(.*)$ https://fairscape.github.io/$1 [R=302,L]

--- a/fairscape/README.md
+++ b/fairscape/README.md
@@ -1,0 +1,18 @@
+# Fairscape
+
+Persistent identifiers for the [Fairscape](https://fairscape.github.io) framework,
+beginning with the **Fairscape Release RO-Crate Profile** — the structural and
+semantic constraints an RO-Crate must satisfy to be considered a Fairscape release.
+Content is published on GitHub Pages and served from these `w3id.org/fairscape/...`
+URIs.
+
+Profile (W3C PROF manifest + vocabulary, JSON Schemas, example crate, validator):
+* https://w3id.org/fairscape/profile/0.1
+
+Specification source:
+* https://github.com/fairscape/profile
+
+Contact:
+* [Justin Niestroy](https://github.com/jniestroy) <jniestroy@gmail.com>, University of Virginia, USA
+* [Tim Clark](https://github.com/timwclark) <twclark@virginia.edu>, University of Virginia, USA
+* [Maxwell Adam Levinson](https://github.com/mlev71) <mal8ch@virginia.edu>, University of Virginia, USA


### PR DESCRIPTION
Redirects w3id.org/fairscape/* to the published artifacts on GitHub Pages (https://fairscape.github.io/profile/). The profile identifier URI content- negotiates between the Turtle PROF manifest and the rendered HTML spec.

<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [ ] Changes have been tested.
- [ ] The number of commits is minimal. Squash if needed.
- [ ] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
