### PR TITLE
Add OntoSF namespace

### DIFF
--- a/ontosf/.htaccess
+++ b/ontosf/.htaccess
@@ -1,0 +1,18 @@
+Options -MultiViews
+Require all granted
+
+Header set Access-Control-Allow-Origin *
+Header set Cache-Control "max-age=3600"
+  
+# Redirect ontology URI to raw GitHub file
+RewriteEngine on
+
+# If request accepts text/html, redirect to GitHub page
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^ontology$ [https://github.com/mducos/OntoSF/blob/main/SF_ontology.ttl](https://github.com/mducos/OntoSF/blob/main/SF_ontology.ttl) [R=303,L]
+
+# Otherwise redirect to raw TTL file
+RewriteRule ^ontology$ [https://raw.githubusercontent.com/mducos/OntoSF/main/SF_ontology.ttl](https://raw.githubusercontent.com/mducos/OntoSF/main/SF_ontology.ttl) [R=303,L]
+
+## Contact
+# This space is administered by:  Mathilde Ducos (mathilde.ducos@sorbonne-nouvelle.fr / Github: mducos)

--- a/ontosf/README.md
+++ b/ontosf/README.md
@@ -1,0 +1,9 @@
+# OntoSF
+
+Ontology for the content of French science-fiction narratives before 1950.
+
+- **Namespace**: https://w3id.org/ontosf/ontology#
+- **Author**: Mathilde Ducos
+- **Github**: http://github.com/mducos/
+- **Institution**: University Sorbonne Nouvelle, France
+- **License**: CC BY 4.0


### PR DESCRIPTION
## Brief Description
Add a persistent W3ID for the Onto-SF ontology, including redirects to its documentation and RDF resources. Onto-SF is based on the GOLEM ontology (https://w3id.org/golem/ontology) and is specifically tailored to science fiction novels.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
