### PR TITLE
fix(health-ri): update metadata schema documentation redirects

### DIFF
--- a/health-ri/.htaccess
+++ b/health-ri/.htaccess
@@ -28,7 +28,9 @@ RewriteRule ^metadata/releases/([^/]+)/?$ https://github.com/Health-RI/health-ri
 # --------------------------------------------------------------------------------------------------------------
 
 # Health-RI Metadata Schema
-RewriteRule ^metadata/?$ https://github.com/Health-RI/health-ri-metadata/ [R=302,L]
+RewriteRule ^metadata/?$ https://health-ri.github.io/metadata-documentation/ [R=302,L]
+RewriteRule ^metadata/(doc|docs|documentation)/?$ https://health-ri.github.io/metadata-documentation/ [R=302,L]
+RewriteRule ^metadata/(doc|docs|documentation)/(git|repo)/?$ https://github.com/Health-RI/metadata-documentation/ [R=302,L]
 RewriteRule ^metadata/(git|repo)/?$ https://github.com/Health-RI/health-ri-metadata/ [R=302,L]
 
 # Health-RI Semantic Interoperability


### PR DESCRIPTION
update metadata schema documentation redirects

## General Checklist
- [X] Changes have been tested.
- [X] The number of commits is minimal. Squash if needed.
- [X] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.