### PR TITLE
Fix config and links.

### DIFF
--- a/ontosf/.htaccess
+++ b/ontosf/.htaccess
@@ -1,18 +1,17 @@
 Options -MultiViews
-Require all granted
 
 Header set Access-Control-Allow-Origin *
 Header set Cache-Control "max-age=3600"
-  
+
 # Redirect ontology URI to raw GitHub file
 RewriteEngine on
 
 # If request accepts text/html, redirect to GitHub page
 RewriteCond %{HTTP_ACCEPT} text/html
-RewriteRule ^ontology$ [https://github.com/mducos/OntoSF/blob/main/SF_ontology.ttl](https://github.com/mducos/OntoSF/blob/main/SF_ontology.ttl) [R=303,L]
+RewriteRule ^ontology$ https://github.com/mducos/OntoSF/blob/main/SF_ontology.ttl [R=303,L]
 
 # Otherwise redirect to raw TTL file
-RewriteRule ^ontology$ [https://raw.githubusercontent.com/mducos/OntoSF/main/SF_ontology.ttl](https://raw.githubusercontent.com/mducos/OntoSF/main/SF_ontology.ttl) [R=303,L]
+RewriteRule ^ontology$ https://raw.githubusercontent.com/mducos/OntoSF/main/SF_ontology.ttl [R=303,L]
 
 ## Contact
 # This space is administered by:  Mathilde Ducos (mathilde.ducos@sorbonne-nouvelle.fr / Github: mducos)


### PR DESCRIPTION
@mducos Fixing the ontosf setup for you.
- Surprisingly it almost tried to work.  Output was local server paths and encoded nonsense.
- Markdown links won't work here.
- It doesn't seem the `Require` config is needed.
- Open another PR if something needs further fixing.