### PR TITLE
Add SciSchema namespace

### DIFF
--- a/scischema/.htaccess
+++ b/scischema/.htaccess
@@ -1,0 +1,18 @@
+# SciSchema
+# Homepage: https://scischema.org
+# Maintainer: Jennifer D'Souza
+# GitHub: https://github.com/scischema
+
+RewriteEngine On
+
+# Homepage
+RewriteRule ^$ https://scischema.org/ [R=301,L]
+
+# About page
+RewriteRule ^about/?$ https://scischema.org/about/ [R=301,L]
+
+# Schemas index
+RewriteRule ^schemas/?$ https://scischema.org/schemas/ [R=301,L]
+
+# Individual schema pages
+RewriteRule ^schema/([^/]+)/([^/]+)/?$ https://scischema.org/schemas/$1/$2/ [R=301,L]

--- a/scischema/.htaccess
+++ b/scischema/.htaccess
@@ -1,7 +1,8 @@
-# SciSchema
+# SciSchema.org
 # Homepage: https://scischema.org
+# GitHub project: https://github.com/scischema
 # Maintainer: Jennifer D'Souza
-# GitHub: https://github.com/scischema
+# GitHub username: @jd-coderepos
 
 RewriteEngine On
 

--- a/scischema/README.md
+++ b/scischema/README.md
@@ -1,0 +1,15 @@
+# SciSchema
+
+Persistent identifiers for SciSchema.org scientific process schemas.
+
+Homepage:
+https://scischema.org
+
+Maintainer:
+Jennifer D'Souza
+
+Contact:
+sciknoworg@gmail.com
+
+Project:
+https://github.com/scischema

--- a/scischema/README.md
+++ b/scischema/README.md
@@ -1,15 +1,18 @@
-# SciSchema
+# SciSchema.org
 
 Persistent identifiers for SciSchema.org scientific process schemas.
 
 Homepage:
 https://scischema.org
 
+GitHub project:
+https://github.com/scischema
+
 Maintainer:
 Jennifer D'Souza
 
+GitHub username:
+@jd-coderepos
+
 Contact:
 sciknoworg@gmail.com
-
-Project:
-https://github.com/scischema


### PR DESCRIPTION
## Brief Description

Register the SciSchema namespace.

SciSchema provides persistent identifiers for scientific process schemas hosted at https://scischema.org/.

The namespace will be used for the SciSchema homepage, schema catalog, and individual schema pages.

Examples:

- https://w3id.org/scischema/
- https://w3id.org/scischema/schemas
- https://w3id.org/scischema/schema/biology/pcr
- https://w3id.org/scischema/schema/materials/steam-reforming

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
Not applicable (new namespace registration).

## Optional Requests for W3ID Maintainers
None.