### PR TITLE
Add byzfrontier namespace for Byzantine-Islamic Frontier Database

### DIFF
--- a/byzfrontier/.htaccess
+++ b/byzfrontier/.htaccess
@@ -1,0 +1,29 @@
+# Byzantine-Islamic Frontier Database
+# Namespace: byzfrontier
+# Contact: Curtis Lisle curtisjohnlisle@gmail.com
+# Project: https://github.com/byzantine-frontier-db/database
+# Documentation: https://byzantine-frontier-db.github.io/database/
+
+Options +FollowSymLinks
+RewriteEngine On
+
+# Schema (versioned)
+RewriteRule ^schema/v1\.0\.0/?$ https://byzantine-frontier-db.github.io/database/schema/byzfrontier_schema_v1.json [R=302,L]
+RewriteRule ^schema/?$ https://byzantine-frontier-db.github.io/database/schema/byzfrontier_schema_v1.json [R=302,L]
+
+# Vocabularies (versioned)
+RewriteRule ^vocab/v1\.1\.0/?$ https://byzantine-frontier-db.github.io/database/vocabularies/byzfrontier_vocabularies_v1_1.ttl [R=302,L]
+RewriteRule ^vocab/?$ https://byzantine-frontier-db.github.io/database/vocabularies/byzfrontier_vocabularies_v1_1.ttl [R=302,L]
+
+# Records by type and ID
+RewriteRule ^place/(.+)$ https://byzantine-frontier-db.github.io/database/records/places/$1.yaml [R=302,L]
+RewriteRule ^person/(.+)$ https://byzantine-frontier-db.github.io/database/records/persons/$1.yaml [R=302,L]
+RewriteRule ^source/(.+)$ https://byzantine-frontier-db.github.io/database/records/sources/$1.yaml [R=302,L]
+RewriteRule ^event/(.+)$ https://byzantine-frontier-db.github.io/database/records/events/$1.yaml [R=302,L]
+RewriteRule ^observation/(.+)$ https://byzantine-frontier-db.github.io/database/records/observations/$1.yaml [R=302,L]
+RewriteRule ^attestation/(.+)$ https://byzantine-frontier-db.github.io/database/records/attestations/$1.yaml [R=302,L]
+RewriteRule ^interpretation/(.+)$ https://byzantine-frontier-db.github.io/database/records/interpretations/$1.yaml [R=302,L]
+RewriteRule ^relationship/(.+)$ https://byzantine-frontier-db.github.io/database/records/relationships/$1.yaml [R=302,L]
+
+# Default: project homepage
+RewriteRule ^$ https://byzantine-frontier-db.github.io/database/ [R=302,L]

--- a/byzfrontier/README.md
+++ b/byzfrontier/README.md
@@ -1,0 +1,30 @@
+# byzfrontier namespace
+
+Permanent URIs for the **Byzantine-Islamic Frontier Database**, a provenance-aware historical knowledge graph covering the Byzantine-Islamic frontier between the seventh and eleventh centuries.
+
+## Project information
+
+- Repository: https://github.com/byzantine-frontier-db/database
+- Documentation: https://byzantine-frontier-db.github.io/database/
+- Zenodo (DOI): https://doi.org/10.5281/zenodo.20584723
+
+## URI pattern
+
+URIs in this namespace resolve to content hosted on the project's GitHub Pages site. The redirect targets may change in future (for example, if the project moves to an institutional host); the w3id.org URIs themselves are stable.
+
+Examples:
+
+- `https://w3id.org/byzfrontier/place/ENT-PLC-0001` → Amorium record (YAML)
+- `https://w3id.org/byzfrontier/person/ENT-PERS-0001` → al-Muʿtaṣim record (YAML)
+- `https://w3id.org/byzfrontier/schema/v1.0.0` → JSON Schema
+- `https://w3id.org/byzfrontier/vocab/v1.1.0` → SKOS vocabularies (Turtle)
+
+## Maintainer
+
+Curtis Lisle, Archaeology Warwickshire.
+GitHub: @CXL274
+ORCID: https://orcid.org/0009-0005-9539-2362
+
+## Licence
+
+The redirect configuration in this folder is dedicated to the public domain (CC0). The content the URIs resolve to is licensed per the source project (CC BY 4.0 for data, Apache 2.0 for code, CC0 for vocabularies).


### PR DESCRIPTION
This PR adds a new namespace, `byzfrontier`, for the Byzantine-Islamic
  Frontier Database — a provenance-aware historical knowledge graph
  covering the Byzantine-Islamic frontier, seventh through eleventh centuries.

  The folder contains:
  - `.htaccess` with redirect rules for schema, vocabularies, and record types
  - `README.md` with project context, maintainer details, and licence

  Project resources:
  - Repository: https://github.com/byzantine-frontier-db/database
  - Documentation: https://byzantine-frontier-db.github.io/database/
  - Zenodo (DOI): https://doi.org/10.5281/zenodo.20584723

  Maintainer: Curtis Lisle, ORCID 0009-0005-9539-2362.

  I confirm I've read the contribution guidelines and that my redirects
  target a stable hosting location with no third-party tracking.