### PR TITLE
Add /bco/bridge/ redirect for Bridge Compliance Ontology (BCO)

### DIFF
--- a/bco/bridge/.htaccess
+++ b/bco/bridge/.htaccess
@@ -1,0 +1,9 @@
+Options +FollowSymLinks
+RewriteEngine On
+
+# BCO Bridge Compliance Ontology
+# Maintainer: Dongwook Kim (ORCID: 0000-0002-0721-5114)
+# Contact: clearup7@nate.com
+
+RewriteRule ^$ https://doi.org/10.5281/zenodo.20585467 [R=303,L]
+RewriteRule ^(.*)$ https://doi.org/10.5281/zenodo.20585467 [R=303,L]

--- a/bco/bridge/README.md
+++ b/bco/bridge/README.md
@@ -1,0 +1,14 @@
+# BCO — Bridge Compliance Ontology
+
+**Persistent IRI:** https://w3id.org/bco/bridge/
+
+**Description:** OWL 2 DL ontology for automated regulatory compliance checking of bridge infrastructure BIM models.
+
+**Maintainer:** Dongwook Kim
+**ORCID:** 0000-0002-0721-5114
+**Email:** clearup7@nate.com
+
+**License:** CC BY 4.0
+**Version:** 1.0.0
+
+**Zenodo deposit:** https://doi.org/10.5281/zenodo.20585467

--- a/bco/bridge/README.md
+++ b/bco/bridge/README.md
@@ -5,6 +5,8 @@
 **Description:** OWL 2 DL ontology for automated regulatory compliance checking of bridge infrastructure BIM models.
 
 **Maintainer:** Dongwook Kim
+**GitHub:** @Dongwook1982
+**Affiliation:** DL E&C Co., Ltd., Seoul, Republic of Korea
 **ORCID:** 0000-0002-0721-5114
 **Email:** clearup7@nate.com
 


### PR DESCRIPTION
## New namespace: /bco/bridge/

**Ontology:** Bridge Compliance Ontology (BCO)
**Persistent IRI:** https://w3id.org/bco/bridge/
**Redirects to:** https://doi.org/10.5281/zenodo.20585467

**Maintainer:** Dongwook Kim
**ORCID:** 0000-0002-0721-5114
**Email:** [[clearup7@nate.com](mailto:clearup7@nate.com)](mailto:clearup7@nate.com)

**Description:** OWL 2 DL ontology for automated BIM-based regulatory compliance checking of bridge infrastructure models. The ontology provides semantic mappings between IFC4.3 Bridge entities and regulatory requirements derived from AASHTO LRFD Bridge Design Specifications.

I confirm that I am the maintainer of this namespace and will keep the redirect target up to date.