### PR TITLE
Add CIRPO ontology namespace

### DIFF
--- a/cirpo/.htaccess
+++ b/cirpo/.htaccess
@@ -2,4 +2,4 @@ RewriteEngine On
 
 RewriteRule ^$ https://haulaah.github.io/CIRPO/ [R=303,L]
 
-RewriteRule ^6\.0/?$ https://haulaah.github.io/CIRPO/ [R=303,L]
+RewriteRule ^6\.0/?$ https://haulaah.github.io/CIRPO/ [R=303,L] 

--- a/cirpo/.htaccess
+++ b/cirpo/.htaccess
@@ -1,0 +1,5 @@
+RewriteEngine On
+
+RewriteRule ^$ https://haulaah.github.io/CIRPO/ [R=303,L]
+
+RewriteRule ^6\.0/?$ https://haulaah.github.io/CIRPO/ [R=303,L]

--- a/cirpo/README.md
+++ b/cirpo/README.md
@@ -1,0 +1,15 @@
+# CIRPO
+
+Permanent identifier for the CIRPO ontology.
+
+Maintainer:
+- Haula Galadima
+
+GitHub:
+- haulaah
+
+Repository:
+- https://github.com/haulaah/CIRPO
+
+Target:
+- https://haulaah.github.io/CIRPO/


### PR DESCRIPTION
This PR adds a permanent W3ID identifier for the CIRPO ontology.


Target redirect:

https://w3id.org/cirpo ----> https://haulaah.github.io/CIRPO/