### PR TITLE
byzfrontier: fix redirect targets to point at raw.githubusercontent.com

### DIFF
--- a/byzfrontier/.htaccess
+++ b/byzfrontier/.htaccess
@@ -1,29 +1,29 @@
 # Byzantine-Islamic Frontier Database
 # Namespace: byzfrontier
-# Contact: Curtis Lisle curtisjohnlisle@gmail.com
+# Contact: Curtis Lisle <curtisjohnlisle@gmail.com>
 # Project: https://github.com/byzantine-frontier-db/database
 # Documentation: https://byzantine-frontier-db.github.io/database/
 
 Options +FollowSymLinks
 RewriteEngine On
 
-# Schema (versioned)
-RewriteRule ^schema/v1\.0\.0/?$ https://byzantine-frontier-db.github.io/database/schema/byzfrontier_schema_v1.json [R=302,L]
-RewriteRule ^schema/?$ https://byzantine-frontier-db.github.io/database/schema/byzfrontier_schema_v1.json [R=302,L]
-
-# Vocabularies (versioned)
-RewriteRule ^vocab/v1\.1\.0/?$ https://byzantine-frontier-db.github.io/database/vocabularies/byzfrontier_vocabularies_v1_1.ttl [R=302,L]
-RewriteRule ^vocab/?$ https://byzantine-frontier-db.github.io/database/vocabularies/byzfrontier_vocabularies_v1_1.ttl [R=302,L]
-
-# Records by type and ID
-RewriteRule ^place/(.+)$ https://byzantine-frontier-db.github.io/database/records/places/$1.yaml [R=302,L]
-RewriteRule ^person/(.+)$ https://byzantine-frontier-db.github.io/database/records/persons/$1.yaml [R=302,L]
-RewriteRule ^source/(.+)$ https://byzantine-frontier-db.github.io/database/records/sources/$1.yaml [R=302,L]
-RewriteRule ^event/(.+)$ https://byzantine-frontier-db.github.io/database/records/events/$1.yaml [R=302,L]
-RewriteRule ^observation/(.+)$ https://byzantine-frontier-db.github.io/database/records/observations/$1.yaml [R=302,L]
-RewriteRule ^attestation/(.+)$ https://byzantine-frontier-db.github.io/database/records/attestations/$1.yaml [R=302,L]
-RewriteRule ^interpretation/(.+)$ https://byzantine-frontier-db.github.io/database/records/interpretations/$1.yaml [R=302,L]
-RewriteRule ^relationship/(.+)$ https://byzantine-frontier-db.github.io/database/records/relationships/$1.yaml [R=302,L]
-
 # Default: project homepage
 RewriteRule ^$ https://byzantine-frontier-db.github.io/database/ [R=302,L]
+
+# Schema (versioned and unversioned)
+RewriteRule ^schema/v1\.0\.0/?$ https://raw.githubusercontent.com/byzantine-frontier-db/database/v1.0.0/schema/byzfrontier_schema_v1.json [R=302,L]
+RewriteRule ^schema/?$ https://raw.githubusercontent.com/byzantine-frontier-db/database/main/schema/byzfrontier_schema_v1.json [R=302,L]
+
+# Vocabularies (versioned and unversioned)
+RewriteRule ^vocab/v1\.1\.0/?$ https://raw.githubusercontent.com/byzantine-frontier-db/database/v1.0.0/vocabularies/byzfrontier_vocabularies_v1_1.ttl [R=302,L]
+RewriteRule ^vocab/?$ https://raw.githubusercontent.com/byzantine-frontier-db/database/main/vocabularies/byzfrontier_vocabularies_v1_1.ttl [R=302,L]
+
+# Records by type and ID
+RewriteRule ^place/(.+)$ https://raw.githubusercontent.com/byzantine-frontier-db/database/main/records/places/$1.yaml [R=302,L]
+RewriteRule ^person/(.+)$ https://raw.githubusercontent.com/byzantine-frontier-db/database/main/records/persons/$1.yaml [R=302,L]
+RewriteRule ^source/(.+)$ https://raw.githubusercontent.com/byzantine-frontier-db/database/main/records/sources/$1.yaml [R=302,L]
+RewriteRule ^event/(.+)$ https://raw.githubusercontent.com/byzantine-frontier-db/database/main/records/events/$1.yaml [R=302,L]
+RewriteRule ^observation/(.+)$ https://raw.githubusercontent.com/byzantine-frontier-db/database/main/records/observations/$1.yaml [R=302,L]
+RewriteRule ^attestation/(.+)$ https://raw.githubusercontent.com/byzantine-frontier-db/database/main/records/attestations/$1.yaml [R=302,L]
+RewriteRule ^interpretation/(.+)$ https://raw.githubusercontent.com/byzantine-frontier-db/database/main/records/interpretations/$1.yaml [R=302,L]
+RewriteRule ^relationship/(.+)$ https://raw.githubusercontent.com/byzantine-frontier-db/database/main/records/relationships/$1.yaml [R=302,L]

--- a/byzfrontier/.htaccess
+++ b/byzfrontier/.htaccess
@@ -1,6 +1,6 @@
 # Byzantine-Islamic Frontier Database
 # Namespace: byzfrontier
-# Contact: Curtis Lisle <curtisjohnlisle@gmail.com>
+# Contact: Curtis Lisle <curtisjohnlisle@gmail.com> (GitHub: @CXL274)
 # Project: https://github.com/byzantine-frontier-db/database
 # Documentation: https://byzantine-frontier-db.github.io/database/
 


### PR DESCRIPTION
## Brief Description

Follow-up to PR #6168 (byzfrontier namespace, recently merged).

The original `.htaccess` pointed at URLs of the form `https://byzantine-frontier-db.github.io/database/records/...`, but GitHub Pages serves only content under the project's `docs/` folder. Records, schema, and vocabularies live in sibling folders and aren't served by Pages, so the record-level redirects returned 404.

This PR updates the redirect targets to use `raw.githubusercontent.com` URLs, which serve any file in the repository regardless of folder structure.

Notable design choices:
- The project homepage redirect (`^$`) still points at the docs site (unchanged).
- Versioned schema/vocab paths point at the immutable `v1.0.0` tag.
- Unversioned schema/vocab paths and all record paths point at `main`, which tracks the latest published content.

Maintainer: Curtis Lisle (GitHub: @CXL274), ORCID 0009-0005-9539-2362.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## Update ID Directory Checklist

- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers

- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.