### PR TITLE
added automatce ontology

### DIFF
--- a/pmd/README.md
+++ b/pmd/README.md
@@ -14,6 +14,7 @@ This namespace represents a general ontology namespace for the platform material
 - `log`: Logistics Ontology alligned from IOF SupplyChain module (LOG)
 - `hto`: Heat Treatment Ontology (HTO)
 - `noes`: Nonoriented Electrical Steel Ontology (NOES)
+- `automatce`: Automotive Circular Economy Ontology (AUTOMATCE)
 
 ## Contact
 Current maintainers are:

--- a/pmd/automatce/.htaccess
+++ b/pmd/automatce/.htaccess
@@ -1,0 +1,46 @@
+# .htaccess for platform material digital vocabs
+RewriteEngine On
+
+##
+## Edit the following two lines accordingly:
+##     ^/ont_pub_tmplt/... is the name of your ontology in your name resolver (e.g. for https://w3id.org/pmd/tto it's 'tto')
+##     ONT_BASE points to the address that delivers your ontology documentation and files, if you
+##       deploy in the materialdigital github community only 'ontology_publication_template' needs to be changed to your repo
+##
+SetEnvIf Request_URI ^/pmd/automatce$ ONT_BASE=https://materialdigital.github.io/automatce 
+SetEnvIf Request_URI ^/pmd/automatce/(.*)$ ONT_ANCHOR=$1 ONT_BASE=https://materialdigital.github.io/automatce 
+SetEnvIf Request_URI ^/pmd/automatce/(\d+\.\d+\.\d+)$ ONT_VERSION=/$1 ONT_BASE=https://materialdigital.github.io/automatce 
+SetEnvIf Request_URI ^/pmd/automatce/(\d+\.\d+\.\d+)/(.*)$ ONT_VERSION=/$1 ONT_ANCHOR=$2 ONT_BASE=https://materialdigital.github.io/automatce 
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml 
+RewriteRule ^(.*)$ %{ENV:ONT_BASE}%{ENV:ONT_VERSION}/index-en.html#%{ENV:ONT_ANCHOR} [R=303,L,NE]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(.*)$ %{ENV:ONT_BASE}%{ENV:ONT_VERSION}/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(.*)$ %{ENV:ONT_BASE}%{ENV:ONT_VERSION}/ontology.owl [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(.*)$ %{ENV:ONT_BASE}%{ENV:ONT_VERSION}/ontology.nt [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^(.*)$ %{ENV:ONT_BASE}%{ENV:ONT_VERSION}/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^.*$ %{ENV:ONT_BASE}%{ENV:ONT_VERSION}/406.html [R=406,L]
+
+# Default response
+# ---------------------------
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule ^(.*)$ %{ENV:ONT_BASE}%{ENV:ONT_VERSION}/base_ontology.rdf [R=303,L]


### PR DESCRIPTION
## Brief Description
Added `pmd/automatce/.htaccess` s new ontology url in sub domain
documentation structure. Dev/latest builds now serve from `/dev/doc/`, semver
releases from `/{version}/doc/`.

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information.

## Update ID Directory Checklist
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer (@ThHanke).