### PR TITLE
Add redirection rules for Pokemon Ontology 

### DIFF
--- a/doisr/pokemon/.htaccess
+++ b/doisr/pokemon/.htaccess
@@ -1,25 +1,20 @@
-# .htaccess for https://w3id.org/doisr/pokemon
-# Replace GITHUBUSER and the repo name (pokemon-ontology) with yours.
  
 Options -MultiViews
 AddType text/turtle .ttl
 AddType application/rdf+xml .owl
 RewriteEngine on
  
-# --- HTML documentation (browsers) ---
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://GITHUBUSER.github.io/pokemon-ontology/release/1.0.0/index-en.html [R=303,L]
+RewriteRule ^$ https://Miguellf02.github.io/pokemon-ontology/release/1.0.0/index-en.html [R=303,L]
  
-# --- Turtle ---
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle
-RewriteRule ^$ https://GITHUBUSER.github.io/pokemon-ontology/release/1.0.0/ontology.ttl [R=303,L]
+RewriteRule ^$ https://Miguellf02.github.io/pokemon-ontology/release/1.0.0/ontology.ttl [R=303,L]
  
-# --- RDF/XML (default for machines) ---
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} \*/\*
-RewriteRule ^$ https://GITHUBUSER.github.io/pokemon-ontology/release/1.0.0/ontology.owl [R=303,L]
+RewriteRule ^$ https://Miguellf02.github.io/pokemon-ontology/release/1.0.0/ontology.owl [R=303,L]

--- a/doisr/pokemon/.htaccess
+++ b/doisr/pokemon/.htaccess
@@ -1,0 +1,25 @@
+# .htaccess for https://w3id.org/doisr/pokemon
+# Replace GITHUBUSER and the repo name (pokemon-ontology) with yours.
+ 
+Options -MultiViews
+AddType text/turtle .ttl
+AddType application/rdf+xml .owl
+RewriteEngine on
+ 
+# --- HTML documentation (browsers) ---
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://GITHUBUSER.github.io/pokemon-ontology/release/1.0.0/index-en.html [R=303,L]
+ 
+# --- Turtle ---
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ https://GITHUBUSER.github.io/pokemon-ontology/release/1.0.0/ontology.ttl [R=303,L]
+ 
+# --- RDF/XML (default for machines) ---
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\*
+RewriteRule ^$ https://GITHUBUSER.github.io/pokemon-ontology/release/1.0.0/ontology.owl [R=303,L]


### PR DESCRIPTION
## Brief Description
This PR adds a new identifier directory (`doisr/pokemon`) and configuration rules (`.htaccess`) to enable content negotiation for the Pokemon Ontology, developed as a final project for  Universidad Politécnica de Madrid (UPM).

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.