### PR TITLE
Add zkp-uc namespace.

### DIFF
--- a/zkp-uc/.htaccess
+++ b/zkp-uc/.htaccess
@@ -1,0 +1,29 @@
+# ZKP-UC: Zero-Knowledge Proof Usage-Control profile for ODRL
+#
+# Persistent namespace: https://w3id.org/zkp-uc/v1/
+# Source repository:    https://github.com/anhelinakovach/zkp-uc-profile
+#
+# ## Contact
+# This space is administered by:
+#
+# Anhelina Kovach
+# akovach@ikerlan.es
+# GitHub username: anhelinakovach
+
+Options +FollowSymLinks
+AddType text/turtle .ttl
+AddType application/ld+json .jsonld
+
+RewriteEngine On
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^v1/?$ https://anhelinakovach.github.io/zkp-uc-profile/profile.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^v1/?$ https://anhelinakovach.github.io/zkp-uc-profile/context.jsonld [R=303,L]
+
+RewriteRule ^v1/?$ https://anhelinakovach.github.io/zkp-uc-profile/index.html [R=303,L]
+
+RewriteRule ^v1/profile.ttl$    https://anhelinakovach.github.io/zkp-uc-profile/profile.ttl    [R=302,L]
+RewriteRule ^v1/context.jsonld$ https://anhelinakovach.github.io/zkp-uc-profile/context.jsonld [R=302,L]
+RewriteRule ^v1/index.html$     https://anhelinakovach.github.io/zkp-uc-profile/index.html     [R=302,L]

--- a/zkp-uc/README.md
+++ b/zkp-uc/README.md
@@ -1,0 +1,17 @@
+# /zkp-uc
+
+This [w3id](https://w3id.org/) provides a persistent URI namespace for the **Zero-Knowledge Proof Usage-Control (ZKP-UC) profile for ODRL**.
+
+ZKP-UC extends the [W3C ODRL Information Model](https://www.w3.org/TR/odrl-model/) with the vocabulary required to declare cryptographically verifiable usage-control policies. The profile and its serialisations are published on GitHub Pages and resolved through this namespace via content negotiation.
+
+## Source
+
+The profile sources (Turtle definition, JSON-LD `@context`, and the HTML specification) are maintained at: <https://github.com/anhelinakovach/zkp-uc-profile>
+
+## Contact
+
+This space is administered by:
+
+**Anhelina Kovach** 
+- akovach@ikerlan.es 
+- GitHub: [@anhelinakovach](https://github.com/anhelinakovach)


### PR DESCRIPTION
Adds a new persistent-identifier namespace under `zkp-uc/` for the Zero-Knowledge Proof Usage-Control profile for ODRL. 
The profile extends the W3C ODRL Information Model with the vocabulary required to declare cryptographically verifiable usage-control policies. The persistent URI `https://w3id.org/zkp-uc/v1/` is referenced from the profile's RDF and JSON-LD serialisations and from external policy documents that bind to the profile.
Content negotiation in the `.htaccess` redirects to a GitHub Pages site that hosts the HTML documentation, the RDF/Turtle definition, and the JSON-LD `@context`.

Maintainer contact: see the `.htaccess` source comment.