### PR TITLE
Add SSTIM versioned snapshot routes

### DIFF
--- a/sstim/.htaccess
+++ b/sstim/.htaccess
@@ -18,6 +18,14 @@ Header set Access-Control-Allow-Origin *
 RewriteEngine On
 
 # -------------------------------------------------------------------------
+# Versioned immutable snapshots. These routes back owl:versionIRI values such
+# as /sstim/0.1.0 and direct frozen-file URLs such as
+# /sstim/0.1.0/sstim-core.ttl.
+# -------------------------------------------------------------------------
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/([A-Za-z0-9._-]+\.ttl)$ https://labiosyncare.github.io/ontology/$1/$2 [R=302,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://labiosyncare.github.io/ontology/$1/sstim-core.ttl [R=302,L]
+
+# -------------------------------------------------------------------------
 # /sstim/vocab — SKOS vocabulary (frequency bands, groups, sub-bands, …)
 # -------------------------------------------------------------------------
 RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
@@ -40,6 +48,14 @@ RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
 RewriteRule ^alignments$ https://labiosyncare.github.io/ [R=303,L]
 
 RewriteRule ^alignments$ https://labiosyncare.github.io/ontology/sstim-alignments.ttl [R=303,L]
+
+# -------------------------------------------------------------------------
+# /sstim/patch-studio — Patch Studio authoring-model vocabulary
+# -------------------------------------------------------------------------
+RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
+RewriteRule ^patch-studio$ https://labiosyncare.github.io/ [R=303,L]
+
+RewriteRule ^patch-studio$ https://labiosyncare.github.io/ontology/sstim-patch-studio.ttl [R=303,L]
 
 # -------------------------------------------------------------------------
 # /sstim — core ontology (OWL classes and properties). Fragment IRIs such


### PR DESCRIPTION
## Summary

Add SSTIM redirect rules for immutable versioned ontology snapshots and the Patch Studio ontology module.

## Details

- Adds /sstim/<semver> redirects to the frozen sstim-core.ttl snapshot on GitHub Pages.
- Adds /sstim/<semver>/<file>.ttl passthrough redirects for frozen snapshot files.
- Adds /sstim/patch-studio routing for the Patch Studio authoring-model vocabulary.
- Preserves the existing SSTIM root, vocab, shapes, alignments, CORS, and MIME-type behavior.

## Validation

- Confirmed GitHub Pages serves https://labiosyncare.github.io/ontology/0.1.0/sstim-core.ttl as 200 text/turtle.
- Confirmed current live https://w3id.org/sstim/0.1.0 and https://w3id.org/sstim/0.1.0/sstim-core.ttl return 404, which these rules address.