### PR TITLE
collabri: update org to collabri-community, sow → core

### DIFF
--- a/collabri/.htaccess
+++ b/collabri/.htaccess
@@ -8,12 +8,12 @@ RewriteEngine On
 # -----------------------------------------------------------------------------
 # Root: schema browser landing page
 # -----------------------------------------------------------------------------
-RewriteRule ^$ https://collabri-io.github.io/ [R=302,L]
+RewriteRule ^$ https://collabri-community.github.io/ [R=302,L]
 
 # -----------------------------------------------------------------------------
-# Statement of Work (SOW) schema
-#   /collabri/sow            -> schema home
-#   /collabri/sow/{Term}     -> per-term documentation page
+# Core schema
+#   /collabri/core           -> schema home
+#   /collabri/core/{Term}    -> per-term documentation page
 # -----------------------------------------------------------------------------
-RewriteRule ^sow/?$ https://collabri-io.github.io/sow/ [R=303,L]
-RewriteRule ^sow/(.+)$ https://collabri-io.github.io/sow/$1.html [R=303,L]
+RewriteRule ^core/?$ https://collabri-community.github.io/core/ [R=303,L]
+RewriteRule ^core/(.+)$ https://collabri-community.github.io/core/$1.html [R=303,L]

--- a/collabri/README.md
+++ b/collabri/README.md
@@ -1,7 +1,8 @@
 # /collabri/
 
 This [W3ID](https://w3id.org) namespace provides persistent URIs for schemas
-published by Collabri ([github.com/collabri-io](https://github.com/collabri-io)).
+published by the Collabri open-source community
+([github.com/collabri-community](https://github.com/collabri-community)).
 
 ## Uses
 
@@ -12,15 +13,20 @@ referenced by their canonical IRIs and are not minted under `/collabri/`.
 
 Current schemas:
 
-- **Statement of Work (SOW)** &mdash; `https://w3id.org/collabri/sow/`
-  LinkML schema for contract-scoped Statements of Work: TaskTeam (root) →
-  Task → recursive Subtasks → typed Deliverables, with PROV/PAV versioning
-  and a ChangeProposal / Approval layer (&ldquo;GitHub for contracts&rdquo;).
-  Aligned with FIBO Contracts, ODRL, FRAPO, PROV-O, PAV, and others.
+- **Core** &mdash; `https://w3id.org/collabri/core/`
+  Foundational LinkML schema for contract-scoped Statements of Work:
+  TaskTeam → Task → recursive Subtask → typed Deliverable subclasses
+  (Activity, Data, Method, NarrativeDocument, Software, Standard);
+  structured Objective / Metric / AcceptanceCriterion evaluation;
+  datestamped BudgetEntry snapshots covering proposed / awarded / working /
+  actual / encumbrance views; Milestone-gated Payment obligations; and a
+  ChangeProposal / Approval layer ("GitHub for contracts"). Aligned with
+  FIBO Contracts, ODRL, FRAPO, PROV-O, PAV, and others.
+  Source: [collabri-community/core](https://github.com/collabri-community/core)
 
 Term URIs resolve to per-term documentation pages in the LinkML-generated
 schema browser hosted at
-[collabri-io.github.io](https://collabri-io.github.io/).
+[collabri-community.github.io](https://collabri-community.github.io/).
 
 ## Contact
 


### PR DESCRIPTION
## Summary

The Collabri schema repository has moved from the `collabri-io` GitHub organization to the neutral open-source org `collabri-community`, and the schema has been renamed from **SOW** to **Core** (v0.5.4).

**`.htaccess` changes:**
- Root redirect: `collabri-io.github.io` → `collabri-community.github.io`
- Replace `^sow/` rules with `^core/` rules pointing to the new Pages host

**`README.md` changes:**
- Org link updated: `collabri-io` → `collabri-community`
- Schema entry updated: SOW → Core, with new description and source link
- Hosted-at link updated to `collabri-community.github.io`

## Maintainers

- @jmcmurry
- @mellybelly