### PR TITLE
Add NDE (Netwerk Digitaal Erfgoed) namespace

### DIFF
--- a/nde/.htaccess
+++ b/nde/.htaccess
@@ -1,0 +1,9 @@
+# NDE (Netwerk Digitaal Erfgoed) — persistent identifier namespace
+# Delegates every sub-path to the canonical host def.nde.nl.
+# Maintainer: Netwerk Digitaal Erfgoed <tech@netwerkdigitaalerfgoed.nl>
+# GitHub: @netwerk-digitaal-erfgoed, @ddeboer
+
+Options +FollowSymLinks
+RewriteEngine on
+
+RewriteRule ^(.*)$ https://def.nde.nl/$1 [R=302,L]

--- a/nde/README.md
+++ b/nde/README.md
@@ -1,0 +1,16 @@
+# NDE namespace
+
+Persistent identifiers for Netwerk Digitaal Erfgoed (NDE),
+https://netwerkdigitaalerfgoed.nl/.
+
+`https://w3id.org/nde/…` redirects (302) to the canonical NDE definitions host
+`https://def.nde.nl/…`, where NDE publishes its RDF vocabularies (e.g. `probe#`,
+`metric#`, `pid-scheme#`, `iiif#`). The redirect delegates the entire sub-tree to
+a domain NDE controls, so new terms are added at `def.nde.nl` without further
+changes to this repository.
+
+## Maintainer
+
+Netwerk Digitaal Erfgoed – tech@netwerkdigitaalerfgoed.nl
+
+GitHub maintainers: @netwerk-digitaal-erfgoed, @ddeboer


### PR DESCRIPTION
## Brief Description

Adds the `nde/` namespace for Netwerk Digitaal Erfgoed (NDE), the Dutch heritage network (https://netwerkdigitaalerfgoed.nl/). `https://w3id.org/nde/…` redirects (302) to the canonical NDE definitions host `https://def.nde.nl/…`, where NDE publishes its RDF vocabularies (`probe#`, `metric#`, `pid-scheme#`, `iiif#`). The single catch-all rule delegates the whole sub-tree to a domain NDE controls, so new terms are managed there without further PRs here. This mirrors the accepted delegating pattern used by e.g. the `CARE-SM` namespace.

## General Checklist

- [ ] Changes have been tested. <!-- single mod_rewrite catch-all; not run against a local site checkout -->
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.
