### PR TITLE
cdisc/usdm/v4: re-pin canonical Turtle to v0.4.0

### DIFF
--- a/cdisc/usdm/v4/.htaccess
+++ b/cdisc/usdm/v4/.htaccess
@@ -5,7 +5,7 @@
 # source. Slash semantics (since v0.3): each minted IRI dereferences
 # individually — class IRIs to per-class HTML anchors, property IRIs
 # to property anchors on the rendered page; the canonical Turtle
-# (version-pinned at the v0.3.1 tag) is served for tools requesting
+# (version-pinned at the v0.4.0 tag) is served for tools requesting
 # RDF. Version IRIs (bare-numeric paths, e.g. /0.3.1) dereference to
 # their own tag-pinned Turtle via one generic rule.
 #
@@ -23,8 +23,9 @@ RewriteBase /cdisc/usdm/v4
 
 # versionIRI dereference — must precede the Accept-based rules so a
 # version-pinned IRI resolves to its own tag regardless of Accept
-# header. One generic rule covers all releases; no per-release PR
+# header. One generic rule covers all releases; no per-release w3id PR
 # needed. owl:versionIRI form: https://w3id.org/cdisc/usdm/v4/X.Y.Z
+# (decision D3, docs/iri-and-governance.md).
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v$1/usdm_v4.ttl [R=303,L]
 
 # JSON-LD
@@ -39,9 +40,9 @@ RewriteRule ^(.*)$ https://kerfors.github.io/usdm-rdf/ontology.owl [R=303,L]
 RewriteCond %{HTTP_ACCEPT} application/n-triples
 RewriteRule ^(.*)$ https://kerfors.github.io/usdm-rdf/ontology.nt [R=303,L]
 
-# Turtle — canonical, version-pinned at the v0.3.1 tag
+# Turtle — canonical, version-pinned at the v0.4.0 tag
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^(.*)$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.3.1/usdm_v4.ttl [R=303,L]
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.4.0/usdm_v4.ttl [R=303,L]
 
 # HTML for browsers — namespace root and per-IRI variants
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
@@ -54,4 +55,4 @@ RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 RewriteRule ^(.+)$ https://kerfors.github.io/usdm-rdf/index.html#$1 [R=303,NE,L]
 
 # Default fallback (no Accept header, programmatic clients): canonical Turtle
-RewriteRule ^(.*)$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.3.1/usdm_v4.ttl [R=303,L]
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.4.0/usdm_v4.ttl [R=303,L]


### PR DESCRIPTION
## Brief Description
v0.4.0 re-pin for the existing cdisc/usdm/v4 redirect set: the two
version-pinned Turtle targets move from refs/tags/v0.3.1 to
refs/tags/v0.4.0 (plus the matching comment line). v0.4.0 adds dual
NCIt anchoring to the ontology (+441 triples, structural counts
unchanged); the re-pin keeps the canonical Turtle consistent with the
GitHub Pages serializations built from the same tag. The generic
versionIRI rule from #6189 is untouched. No minted IRI changes.
Maintainer contact unchanged: kerfors, kerstin.l.forsberg@gmail.com.

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- Not applicable — update to an existing directory. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.