### PR TITLE
Create .htaccess

### DIFF
--- a/perkonto/.htaccess
+++ b/perkonto/.htaccess
@@ -1,0 +1,37 @@
+# w3id.org redirect for PERKOnto — submit as: perkonto/.htaccess
+# in a PR to https://github.com/perma-id/w3id.org
+#
+# Files hosted on GitHub Pages at:
+#   https://prantikac.github.io/PERK/ontology/
+
+Options -MultiViews
+RewriteEngine On
+
+# --- Content negotiation on the bare IRI: https://w3id.org/perkonto ---
+
+# Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^$ https://prantikac.github.io/PERK/ontology/PERKOnto.ttl [R=303,L]
+
+# RDF/XML  (PERKOnto.rdf is real RDF/XML; do NOT use PERKOnto.owx — that is OWL/XML)
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://prantikac.github.io/PERK/ontology/PERKOnto.rdf [R=303,L]
+
+# JSON-LD
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^$ https://prantikac.github.io/PERK/ontology/PERKOnto.jsonld [R=303,L]
+
+# OWL/XML  (offered explicitly for OWL tools that request it)
+RewriteCond %{HTTP_ACCEPT} application/owl\+xml
+RewriteRule ^$ https://prantikac.github.io/PERK/ontology/PERKOnto.owx [R=303,L]
+
+# Default (browsers / HTML) -> WIDOCO documentation landing page
+RewriteRule ^$ https://prantikac.github.io/PERK/ontology/ [R=303,L]
+
+# --- Versioned IRI: https://w3id.org/perkonto/1.0.0 -> ontology/1.0.0/ ---
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://prantikac.github.io/PERK/ontology/$1/ [R=303,L]
+
+# --- Direct file access: https://w3id.org/perkonto/PERKOnto.ttl etc. ---
+RewriteRule ^(.+)$ https://prantikac.github.io/PERK/ontology/$1 [R=303,L]

--- a/perkonto/.htaccess
+++ b/perkonto/.htaccess
@@ -1,6 +1,8 @@
 # w3id.org redirect for PERKOnto — submit as: perkonto/.htaccess
 # in a PR to https://github.com/perma-id/w3id.org
 #
+# Maintainer: prantikaC (https://github.com/prantikaC)
+#
 # Files hosted on GitHub Pages at:
 #   https://prantikac.github.io/PERK/ontology/
 


### PR DESCRIPTION
## Brief Description
Registers a new persistent-identifier namespace `/perkonto` for **PERKOnto**
(Personal Email Research Knowledge graph Ontology). The `.htaccess` performs 303
content-negotiated redirects from https://w3id.org/perkonto to the ontology
and its documentation hosted on GitHub Pages
(https://prantikac.github.io/PERK/ontology/).

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.
