### PR TITLE
Update /ontodisinfo/ with /1.7.0/* redirects and repoint unversioned IRIs to v1.7.0

### DIFF
--- a/ontodisinfo/.htaccess
+++ b/ontodisinfo/.htaccess
@@ -37,9 +37,9 @@ RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/  [R=302,L]
 # RDF tools -> consolidated Turtle pinned to the latest release tag
 RewriteCond %{HTTP_ACCEPT} (text/turtle|application/(rdf\+xml|x-turtle|ld\+json|n-triples|n-quads))
-RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.6.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 # Default (no Accept header, curl, etc.) -> Turtle, Linked Data convention
-RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.6.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 
 # =============================================================================
 # 2. Individual modules with content negotiation
@@ -49,38 +49,38 @@ RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.6
 # --- core ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^core/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/core/  [R=302,L]
-RewriteRule ^core/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.6.0/ontology/domain/core/ontodis-core.ttl  [R=302,L]
+RewriteRule ^core/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/domain/core/ontodis-core.ttl  [R=302,L]
 
 # --- ml ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^ml/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/ml/  [R=302,L]
-RewriteRule ^ml/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.6.0/ontology/domain/ml/ontodis-ml.ttl  [R=302,L]
+RewriteRule ^ml/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/domain/ml/ontodis-ml.ttl  [R=302,L]
 
 # --- electoral ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^electoral/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/electoral/  [R=302,L]
-RewriteRule ^electoral/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.6.0/ontology/domain/electoral/ontodis-elec.ttl  [R=302,L]
+RewriteRule ^electoral/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/domain/electoral/ontodis-elec.ttl  [R=302,L]
 
 # --- legal ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^legal/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/legal/  [R=302,L]
-RewriteRule ^legal/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.6.0/ontology/domain/legal/ontodis-legal.ttl  [R=302,L]
+RewriteRule ^legal/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/domain/legal/ontodis-legal.ttl  [R=302,L]
 
 # --- inference ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^inference/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/inference/  [R=302,L]
-RewriteRule ^inference/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.6.0/ontology/application/ontodis-inference.ttl  [R=302,L]
+RewriteRule ^inference/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/application/ontodis-inference.ttl  [R=302,L]
 
 # --- alignments (external) ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^alignments/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/reference/alignments/  [R=302,L]
-RewriteRule ^alignments/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.6.0/ontology/adapter/ontodis-alignments.ttl  [R=302,L]
+RewriteRule ^alignments/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/adapter/ontodis-alignments.ttl  [R=302,L]
 
 # --- gufo-alignment (no dedicated doc page; always Turtle) ---
-RewriteRule ^gufo-alignment/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.6.0/ontology/adapter/ontodis-gufo-alignment.ttl  [R=302,L]
+RewriteRule ^gufo-alignment/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/adapter/ontodis-gufo-alignment.ttl  [R=302,L]
 
 # --- full integrated (entry point for Protege/reasoners) ---
-RewriteRule ^full/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.6.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^full/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 
 # =============================================================================
 # 3. Versioned IRIs (owl:versionIRI)
@@ -183,6 +183,24 @@ RewriteRule ^1\.6\.0/alignments$      https://gitlab.com/gustavosouto/ontodisinf
 RewriteRule ^1\.6\.0/gufo-alignment$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.6.0/ontology/adapter/ontodis-gufo-alignment.ttl    [R=302,L]
 RewriteRule ^1\.6\.0/full$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.6.0/ontology/composition/ontodis-full.ttl          [R=302,L]
 
+# --- 1.7.0 ---
+# Modelo temporal de norma completo: anterioridade eleitoral (art. 16 da CF) e
+# validade constitucional (controle de constitucionalidade do STF), somadas a
+# vigencia da v1.4.0. Adiciona elec:dataPrimeiroTurno, legal:alteraProcessoEleitoral,
+# legal:anterioridadeControversa, o enum legal:StatusConstitucionalidade com
+# legal:temStatusConstitucionalidade/constitucionalidadeDecididaPor/
+# dataEfeitoConstitucionalidade, e quatro shapes (Anterioridade/AplicabilidadeContestada
+# e ValidadeConstitucional/EficaciaSuspensa). CQ15 e corpus de evaluation com 31 casos.
+RewriteRule ^1\.7\.0/core$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/domain/core/ontodis-core.ttl          [R=302,L]
+RewriteRule ^1\.7\.0/ml$              https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/domain/ml/ontodis-ml.ttl              [R=302,L]
+RewriteRule ^1\.7\.0/electoral$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/domain/electoral/ontodis-elec.ttl     [R=302,L]
+RewriteRule ^1\.7\.0/legal$           https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/domain/legal/ontodis-legal.ttl        [R=302,L]
+RewriteRule ^1\.7\.0/inference$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/application/ontodis-inference.ttl     [R=302,L]
+RewriteRule ^1\.7\.0/alignments$      https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/adapter/ontodis-alignments.ttl        [R=302,L]
+RewriteRule ^1\.7\.0/gufo-alignment$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/adapter/ontodis-gufo-alignment.ttl    [R=302,L]
+RewriteRule ^1\.7\.0/full$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/composition/ontodis-full.ttl          [R=302,L]
+
+
 
 
 # =============================================================================
@@ -200,5 +218,5 @@ RewriteRule ^metrics/?$          https://gustavosouto.gitlab.io/ontodisinfo-elec
 # =============================================================================
 # 5. Convenience redirects
 # =============================================================================
-RewriteRule ^latest/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.6.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^latest/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 RewriteRule ^repo/?$    https://gitlab.com/gustavosouto/ontodisinfo-electoral                                                      [R=302,L]


### PR DESCRIPTION
#### Purpose of this update

Same release pattern as the previous version PRs for the `/ontodisinfo/`
namespace, now for release **v1.7.0** of OntoDisinfo-Electoral:

1. **New fixed redirects `/1.7.0/*`** for the eight module IRIs (core, ml,
   electoral, legal, inference, alignments, gufo-alignment, full), pinned to
   the Git tag `v1.7.0` of the source repository.

2. **Repoint of the unversioned IRIs** (namespace root, the eight modules and
   `/latest`) from tag `v1.6.0` to tag `v1.7.0`, keeping the policy that
   unversioned IRIs always serve the latest release while versioned IRIs stay
   immutable.

Release v1.7.0 completes the temporal model of legal norms: on top of the
in-force validity (tempus regit actum) from v1.4.0, it adds electoral
anteriority (art. 16 of the Brazilian Constitution, which distinguishes a norm
in force from a norm applicable to a given election) and constitutional
validity (Supreme Court review, with ex tunc or ex nunc effects), with four new
SHACL shapes and one new competency question (15 in total). The evaluation
corpus grows from 27 to 31 cases. Minor, additive release: no IRI removed or
renamed.

#### What is preserved

- All versioned IRIs `/1.0.0/*` through `/1.6.0/*` remain pinned to their
  original tags.
- Documentation shortcuts (`/docs`, `/about`, `/cite`, `/scenarios`,
  `/pipeline`, `/reproducibility`, `/metrics`) unchanged.
- Content negotiation rules unchanged.
- License (CC BY 4.0), serialization (Turtle), OWL 2 DL profile and
  maintainer remain the same.

#### Backwards compatibility

Zero breaking changes: every IRI that resolved before continues to resolve.
Unversioned IRIs now serve the v1.7.0 artifacts, consistent with the
namespace policy established in PR #5978.

#### Maintainer

- **Name:** Gustavo Souto Silva de Barros Santos
- **Affiliation:** Center for Informatics (CIn), Federal University of
  Pernambuco (UFPE), Brazil
- **Email:** gssbs@cin.ufpe.br
- **GitLab:** [@gustavosouto](https://gitlab.com/gustavosouto)
- **GitHub:** [@gustavosouto](https://github.com/gustavosouto)

#### Checklist

- [x] `.htaccess` updated in place (no new directories added)
- [x] All existing redirects preserved
- [x] `/1.7.0/*` block follows the exact pattern of `/1.6.0/*`
- [x] `ontodisinfo/README.md` (maintainer information) remains valid