### PR TITLE
Add /ogc/ladm sub-namespace

### DIFF
--- a/ogc/.htaccess
+++ b/ogc/.htaccess
@@ -21,5 +21,7 @@ RewriteRule ^hosted/?$ https://defs-hosted.opengis.net/prez-hosted-b/ [R=303,L]
 RewriteRule ^hosted/(.+)$ https://defs-hosted.opengis.net/prez-hosted-b/object?uri=https://w3id.org/ogc/hosted/$1 [R=303,L]
 
 ## stac
-# RewriteRule ^stac/?$ https://defs-hosted.opengis.net/prez-hosted-b/ [R=303,L]
 RewriteRule ^stac/(.+)$ https://defs-dev.opengis.net/prez-b/object?uri=https://w3id.org/ogc/stac/$1 [R=303,L]
+
+## ladm
+RewriteRule ^ladm/(.+)$ https://defs-dev.opengis.net/prez-b/object?uri=https://w3id.org/ogc/ladm/$1 [R=303,L]

--- a/ogc/README.md
+++ b/ogc/README.md
@@ -5,6 +5,8 @@ The following sub-namespaces are defined:
 
 * OGC
   * `/geopose`
+  * `/ladm`
+  * `/stac`
 * Hosted by OGC
   * `/hosted`
 


### PR DESCRIPTION
## Brief Description

Adds redirect rules for the `/ogc/ladm` sub-namespace (Land Administration Domain Model), redirecting sub-paths to `defs-dev.opengis.net`.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## Update ID Directory Checklist

- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.