### PR TITLE
Add /lde/ redirect for the LDElements (LDE) vocabularies

### DIFF
--- a/lde/.htaccess
+++ b/lde/.htaccess
@@ -1,0 +1,15 @@
+# # /lde/
+#
+# Permanent identifiers for the LDElements (LDE) vocabularies.
+#
+# https://w3id.org/lde/ and its sub-paths redirect to
+# https://ldelements.github.io/lde/
+#
+# ## Contact
+# This space is administered by:
+#
+# David de Boer
+# GitHub username: ddeboer
+
+RewriteEngine on
+RewriteRule ^(.*)$ https://ldelements.github.io/lde/$1 [R=302,L]

--- a/lde/README.md
+++ b/lde/README.md
@@ -1,0 +1,16 @@
+# /lde/
+
+Permanent identifiers for the [LDElements (LDE)](https://github.com/ldelements/lde) vocabularies – composable building blocks for linked-data pipelines.
+
+`https://w3id.org/lde/` and its sub-paths currently redirect (HTTP 302) to <https://ldelements.github.io/lde/>, where the vocabulary documents are published. The redirect is temporary (302) while the vocabularies are being published, and will be made permanent once they stabilise.
+
+Sub-namespaces in use include:
+
+- `https://w3id.org/lde/provenance#` – pipeline provenance terms (e.g. `sourceFingerprint`, `pipelineVersion`, `status`, `validatedFingerprint`)
+- `https://w3id.org/lde/metric#` – DQV quality metrics
+- `https://w3id.org/lde/failure#` – failure-reason predicate
+- `https://w3id.org/lde/distribution-validity-failure#` – RDF-distribution validity failure concepts
+
+## Contact
+
+Maintained by David de Boer (GitHub: [@ddeboer](https://github.com/ddeboer)) on behalf of the LDElements project.


### PR DESCRIPTION
Adds a new permanent identifier `/lde/` for the [LDElements (LDE)](https://github.com/ldelements/lde) vocabularies – composable building blocks for linked-data pipelines.

- `lde/.htaccess` – redirects `https://w3id.org/lde/` and its sub-paths (302, path-preserving) to <https://ldelements.github.io/lde/>, where the vocabulary documents are published.
- `lde/README.md` – identifier description, the sub-namespaces in use (`provenance#`, `metric#`, `failure#`, `distribution-validity-failure#`), and maintainer contact.

The redirect is intentionally temporary (302) while the vocabularies are being published; it will be switched to a permanent code once stable. Contact info is in both the `.htaccess` comment and the `README.md`.
