### PR TITLE
Add redirect for DPP Access Control ontology

### DIFF
--- a/dpp/.htaccess
+++ b/dpp/.htaccess
@@ -316,6 +316,48 @@ RewriteRule ^alignment/(.+)$ https://richzele.github.io/dpp-ontology-site/alignm
 # Default fallback - HTML documentation
 RewriteRule ^alignment$ https://richzele.github.io/dpp-ontology-site/alignment-doc/index.html [R=303,L]
 
+############################################################################
+# ACCESS CONTROL MODULE: /dpp/access-control (version 1.0.0)
+# URI: http://w3id.org/dpp/access-control
+############################################################################
+
+# JSON-LD for access-control module
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^access-control/?$ https://richzele.github.io/dpp-ontology-site/access-control-doc/core/1.0.0/ontology.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^access-control/(.+)$ https://richzele.github.io/dpp-ontology-site/access-control-doc/core/1.0.0/ontology.jsonld [R=303,NE,L]
+
+# HTML documentation for access-control module
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteRule ^access-control/?$ https://richzele.github.io/dpp-ontology-site/access-control-doc/1.0.0/index-en.html [R=303,L]
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteRule ^access-control/(.+)$ https://richzele.github.io/dpp-ontology-site/access-control-doc/1.0.0/index-en.html#$1 [R=303,NE,L]
+
+# RDF/XML for access-control module
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^access-control/?$ https://richzele.github.io/dpp-ontology-site/access-control-doc/core/1.0.0/ontology.owl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^access-control/(.+)$ https://richzele.github.io/dpp-ontology-site/access-control-doc/core/1.0.0/ontology.owl [R=303,NE,L]
+
+# Turtle for access-control module
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^access-control/?$ https://richzele.github.io/dpp-ontology-site/access-control-doc/core/1.0.0/ontology.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^access-control/(.+)$ https://richzele.github.io/dpp-ontology-site/access-control-doc/core/1.0.0/ontology.ttl [R=303,NE,L]
+
+# N-Triples for access-control module
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^access-control/?$ https://richzele.github.io/dpp-ontology-site/access-control-doc/core/1.0.0/ontology.nt [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^access-control/(.+)$ https://richzele.github.io/dpp-ontology-site/access-control-doc/core/1.0.0/ontology.nt [R=303,NE,L]
+
+# Default for access-control module
+RewriteRule ^access-control/?$ https://richzele.github.io/dpp-ontology-site/access-control-doc/1.0.0/index-en.html [R=303,L]
+RewriteRule ^access-control/(.+)$ https://richzele.github.io/dpp-ontology-site/access-control-doc/1.0.0/index-en.html#$1 [R=303,NE,L]
 
 ############################################################################
 # MAIN DPP NAMESPACE: /dpp/ (version 1.0)


### PR DESCRIPTION
## Brief Description

This pull request updates the existing `/dpp/` namespace by adding redirects for the DPP Access Control ontology module at `/dpp/access-control`.

The human readable documentation redirects to:

`https://richzele.github.io/dpp-ontology-site/access-control-doc/1.0.0/index-en.html`

The redirect also supports content negotiation for RDF serializations, including Turtle, RDF/XML, JSON-LD, and N-Triples.

## General Checklist

* [ ] Changes have been tested.
* [x] The number of commits is minimal. Squash if needed.
* [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

Not applicable. This pull request does not create a new ID directory. It updates the existing `/dpp/` namespace.

* [ ] Maintainer details are in `.htaccess` or `README.md`.
* [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist

* [ ] GitHub username ids are listed in the changed maintainer details.
* [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers

* [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
