### PR TITLE
Update .htaccess for ReportDCAT-AP.de V1.1.0

### DIFF
--- a/reportdcat-ap-de/.htaccess
+++ b/reportdcat-ap-de/.htaccess
@@ -1,9 +1,10 @@
 # # ReportDCAT-AP.de
 #
 # ## Contact
-# Email:  <ludger.rinsche@init.de>
-# GitLab: https://gitlab.opencode.de/fhh-data/reportdcat-ap.de
-# Web:    https://reportdcat-ap.de/
+# Email:   <ludger.rinsche@init.de>
+# GitLab:  https://gitlab.opencode.de/fhh-data/reportdcat-ap.de
+# Web:     https://reportdcat-ap.de/
+# Version: 1.1.0
 
 RewriteEngine On
 
@@ -19,6 +20,7 @@ RewriteRule ^def/erhebungsgrund$           https://reportdcat-ap.de/#sd-erhebung
 RewriteRule ^def/rechtsgrundlage$          https://reportdcat-ap.de/#sd-rechtsgrundlage             [R=302,NE,L]
 
 # controlled vocabularies
+RewriteRule ^def/art-der-reihe(/.*)?$      https://reportdcat-ap.de/#kv-art-der-reihe               [R=302,NE,L]
 RewriteRule ^def/datendomaene-fhh(/.*)?$   https://reportdcat-ap.de/#kv-datendomaene-fhh            [R=302,NE,L]
 RewriteRule ^def/id-schema(/.*)?$          https://reportdcat-ap.de/#kv-id-schema                   [R=302,NE,L]
 


### PR DESCRIPTION
Update .htaccess for ReportDCAT-AP.de V1.1.0:
Added redirect for controlled vocabulary `art-der-reihe`.