### PR TITLE
Add voices namespace

### DIFF
--- a/voices/.htaccess
+++ b/voices/.htaccess
@@ -1,0 +1,23 @@
+# w3id.org/voices — VOICES ontology namespace (persistent redirect)
+#
+# Submit this directory as `voices/` via a PR to https://github.com/perma-id/w3id.org
+# Once merged, https://w3id.org/voices/ontology resolves (content-negotiated).
+# Re-point the targets below if the canonical hosting moves (e.g. to voices.list.lu).
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# --- Ontology: content negotiation -------------------------------------------
+# Turtle / RDF clients -> the .ttl ; browsers -> human-readable page.
+RewriteRule ^ontology\.ttl$ https://raw.githubusercontent.com/mlaib/voices-kg/main/schema/voices_ontology_v2.ttl [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/n-triples [OR]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^ontology$ https://raw.githubusercontent.com/mlaib/voices-kg/main/schema/voices_ontology_v2.ttl [R=302,L]
+
+RewriteRule ^ontology$ https://github.com/mlaib/voices-kg/blob/main/schema/voices_ontology_v2.ttl [R=302,L]
+
+# --- Version IRI -------------------------------------------------------------
+RewriteRule ^ontology/2\.1$ https://raw.githubusercontent.com/mlaib/voices-kg/main/schema/voices_ontology_v2.ttl [R=302,L]

--- a/voices/.htaccess
+++ b/voices/.htaccess
@@ -1,5 +1,8 @@
 # w3id.org/voices — VOICES ontology namespace (persistent redirect)
 #
+# Maintainer: Mohamed Laib (GitHub: @mlaib), Luxembourg Institute of Science and
+#             Technology (LIST). Contact: mohamed.laib@list.lu
+#
 # Submit this directory as `voices/` via a PR to https://github.com/perma-id/w3id.org
 # Once merged, https://w3id.org/voices/ontology resolves (content-negotiated).
 # Re-point the targets below if the canonical hosting moves (e.g. to voices.list.lu).


### PR DESCRIPTION
## Brief Description
Registers the `https://w3id.org/voices/` namespace for the VOICES ontology — an OWL 2 ontology for multimodal Holocaust survivor testimonies (ISWC 2026 Resources Track). `voices/.htaccess` content-negotiates `https://w3id.org/voices/ontology` to the ontology Turtle on GitHub (and the versioned IRI `.../ontology/2.1`). New ID directory; single maintainer (@mlaib).

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist

## Optional Requests for W3ID Maintainers
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.