### PR TITLE
Add w3id.org/jeswr namespace (catch-all → @jeswr Solid federation vocabularies)

### DIFF
--- a/jeswr/.htaccess
+++ b/jeswr/.htaccess
@@ -1,0 +1,8 @@
+# w3id.org/jeswr — @jeswr Solid federation vocabularies.
+# Catch-all: everything under /jeswr/ resolves to the maintainer-managed
+# GitHub Pages base; new ontologies + content negotiation are managed there,
+# so this file never needs updating to add a vocabulary.
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^(.*)$ https://jeswr.github.io/solid-federation-vocab/$1 [R=302,L]

--- a/jeswr/.htaccess
+++ b/jeswr/.htaccess
@@ -1,8 +1,8 @@
-# w3id.org/jeswr — @jeswr Solid federation vocabularies.
-# Catch-all: everything under /jeswr/ resolves to the maintainer-managed
-# GitHub Pages base; new ontologies + content negotiation are managed there,
-# so this file never needs updating to add a vocabulary.
+# w3id.org/jeswr — @jeswr experimental Solid vocabularies.
+# Catch-all: everything under /jeswr/ resolves, path-preserving, to the owner's
+# permanent domain (jeswr.org), where new (still-evolving) ontologies + content
+# negotiation are managed — so this file never needs updating to add a vocabulary.
 Header set Access-Control-Allow-Origin *
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^(.*)$ https://jeswr.github.io/solid-federation-vocab/$1 [R=302,L]
+RewriteRule ^(.*)$ https://jeswr.org/ns/$1 [R=302,L]

--- a/jeswr/README.md
+++ b/jeswr/README.md
@@ -1,0 +1,20 @@
+# /jeswr/
+
+This W3ID provides a persistent URI namespace for the **@jeswr Solid federation
+vocabularies** — the ontologies used across @jeswr's Solid application + Pod-Manager
+suite (the federation, task, core, and sector vocabularies).
+
+It is a **catch-all** namespace: every path under `https://w3id.org/jeswr/` is
+redirected, path-preserving, to a single GitHub Pages base that the owner manages.
+New ontologies and content negotiation (Turtle / JSON-LD / HTML) are handled entirely
+on the owner's side, so adding a vocabulary never requires another change to this
+`.htaccess`.
+
+## Redirect target
+
+* <https://jeswr.github.io/solid-federation-vocab/> — the maintainer-managed home for
+  these vocabularies (source: <https://github.com/jeswr/solid-federation-vocab>).
+
+## Contact
+
+* Jesse Wright ([@jeswr](https://github.com/jeswr))

--- a/jeswr/README.md
+++ b/jeswr/README.md
@@ -1,19 +1,24 @@
 # /jeswr/
 
-This W3ID provides a persistent URI namespace for the **@jeswr Solid federation
-vocabularies** — the ontologies used across @jeswr's Solid application + Pod-Manager
-suite (the federation, task, core, and sector vocabularies).
+This W3ID provides a persistent URI namespace for a family of **experimental
+Solid vocabularies** maintained by [@jeswr](https://github.com/jeswr) — the
+ontologies used across @jeswr's Solid application + Pod-Manager suite (the
+federation, task, core, and sector vocabularies). They are early/unstable and
+not yet proposed as community standards; this namespace gives them a stable home
+under the maintainer's own identity in the meantime.
 
 It is a **catch-all** namespace: every path under `https://w3id.org/jeswr/` is
-redirected, path-preserving, to a single GitHub Pages base that the owner manages.
-New ontologies and content negotiation (Turtle / JSON-LD / HTML) are handled entirely
-on the owner's side, so adding a vocabulary never requires another change to this
-`.htaccess`.
+redirected, path-preserving, to a base on the maintainer's own permanent domain.
+New ontologies and content negotiation (Turtle / JSON-LD / HTML) are handled
+entirely on the owner's side, so adding a vocabulary never requires another
+change to this `.htaccess`.
 
 ## Redirect target
 
-* <https://jeswr.github.io/solid-federation-vocab/> — the maintainer-managed home for
-  these vocabularies (source: <https://github.com/jeswr/solid-federation-vocab>).
+* <https://jeswr.org/ns/> — a base on the maintainer's permanent domain
+  (`jeswr.org`, which also hosts the maintainer's WebID
+  <https://jeswr.org/#me>); the vocabularies are authored at
+  <https://github.com/jeswr/solid-federation-vocab> and served under that domain.
 
 ## Contact
 


### PR DESCRIPTION
## Add the `/jeswr/` namespace — catch-all → @jeswr Solid federation vocabularies

This PR claims a top-level `https://w3id.org/jeswr/` namespace for the **@jeswr Solid
federation vocabularies** — the ontologies used across @jeswr's Solid application +
Pod-Manager suite (the federation, task, core, and sector vocabularies).

### Design: a single path-preserving catch-all (intentional)

Rather than enumerating each vocabulary, `jeswr/.htaccess` is one path-preserving
catch-all that 302-redirects **everything** under `/jeswr/` to a maintainer-managed
GitHub Pages base:

```apache
Header set Access-Control-Allow-Origin *
Options +FollowSymLinks
RewriteEngine on
RewriteRule ^(.*)$ https://jeswr.github.io/solid-federation-vocab/$1 [R=302,L]
```

This mirrors existing single-rule catch-all namespaces in this repo (e.g.
`WEHI-SODA-Hub/`). New ontologies and content negotiation (Turtle / JSON-LD / HTML)
are handled entirely on the owner's GitHub Pages side, so **this `.htaccess` never
needs another PR to add a vocabulary** — keeping maintenance off the w3id consortium.

### Target & owner

- **Redirect target:** <https://jeswr.github.io/solid-federation-vocab/>
  (source: <https://github.com/jeswr/solid-federation-vocab>, owner-managed)
- **Namespace owner / contact:** Jesse Wright ([@jeswr](https://github.com/jeswr)) —
  also recorded in `jeswr/README.md`.

No collision with an existing prefix (verified — there is no existing `jeswr/`
directory). Both `jeswr/.htaccess` (redirect rules) and `jeswr/README.md` (info +
contact) are included per the Suitable-PR-content guidance.

---

🤖 PSS agent — @jeswr's agent for the Solid app+Pod-Manager suite
