### PR TITLE
Add /seqmake/ namespace (SeqMake Parts — w3id.org/seqmake/parts)

### DIFF
--- a/seqmake/.htaccess
+++ b/seqmake/.htaccess
@@ -1,0 +1,29 @@
+# https://w3id.org/seqmake/parts  —  SeqMake Parts (biological parts knowledge base)
+#
+# Permanent, host-independent IRIs for the catalog, namespaced under the SeqMake
+# house brand. This redirect forwards them to the live site (currently GitHub
+# Pages); if hosting or the repo name ever changes, only this file changes and
+# every published/cited IRI keeps resolving.
+#
+# Registered at w3id.org/seqmake/, so the paths below are matched relative to
+# that base (i.e. they begin with `parts/`). Maintained in
+# https://github.com/dbikard/seqmake-parts (w3id/seqmake/) and submitted as a
+# PR to https://github.com/perma-id/w3id.org
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# Local vocabulary terms (cat:) and the namespace document -> the RDF graph.
+RewriteRule ^parts/ns https://dbikard.github.io/seqmake-parts/catalog.ttl [R=302,L,NE]
+
+# Part and collection IRIs -> their page on the site.
+RewriteRule ^parts/part/(.+)$ https://dbikard.github.io/seqmake-parts/parts/$1/ [R=302,L,NE]
+RewriteRule ^parts/collection/(.+)$ https://dbikard.github.io/seqmake-parts/collections/$1/ [R=302,L,NE]
+
+# Machine artifacts.
+RewriteRule ^parts/catalog\.(ttl|jsonld|json)$ https://dbikard.github.io/seqmake-parts/catalog.$1 [R=302,L,NE]
+
+# The parts base, the seqmake root, and anything else -> the site.
+RewriteRule ^parts/?$ https://dbikard.github.io/seqmake-parts/ [R=302,L]
+RewriteRule ^parts/(.*)$ https://dbikard.github.io/seqmake-parts/$1 [R=302,L]
+RewriteRule ^$ https://dbikard.github.io/seqmake-parts/ [R=302,L]

--- a/seqmake/README.md
+++ b/seqmake/README.md
@@ -1,0 +1,29 @@
+# `/seqmake/` — SeqMake permanent identifiers
+
+`https://w3id.org/seqmake/parts/` is the permanent base IRI of the **SeqMake
+Parts** catalog — a knowledge base of biological DNA parts projected to RDF
+(SBOL3 + Sequence Ontology + SBO). These host-independent IRIs are what the data
+publishes and cites; the [`.htaccess`](.htaccess) here forwards them to the live
+site (currently GitHub Pages), so the host or repo name can change without
+breaking any IRI. The `seqmake/` prefix is reserved for SeqMake datasets;
+`parts/…` is the first.
+
+## Resolution
+
+| IRI | Redirects to |
+|---|---|
+| `https://w3id.org/seqmake/parts/` | catalog home |
+| `https://w3id.org/seqmake/parts/part/<slug>` | that part's page |
+| `https://w3id.org/seqmake/parts/collection/<id>` | that collection's page |
+| `https://w3id.org/seqmake/parts/ns#<term>` | `catalog.ttl` (the `cat:` vocabulary) |
+| `https://w3id.org/seqmake/parts/catalog.ttl` (`.jsonld` / `.json`) | the published artifact |
+
+All redirects are `302` — the target host may change while the IRIs stay fixed.
+
+## Contact
+
+This space is administered by:
+
+David Bikard
+GitHub username: [dbikard](https://github.com/dbikard)
+Source / maintenance: <https://github.com/dbikard/seqmake-parts> (`w3id/` directory)


### PR DESCRIPTION
Registers the **`seqmake/`** top-level namespace for **SeqMake Parts**, an
open knowledge base of biological DNA parts published as RDF (SBOL3 + Sequence
Ontology + SBO).

**Base IRI:** `https://w3id.org/seqmake/parts/`

`seqmake/.htaccess` 302-redirects the catalog's IRIs to the live site (currently
GitHub Pages). The IRIs are host-independent on purpose: if the hosting or the
repo name changes, only this `.htaccess` changes and every published/cited IRI
keeps resolving.

Resolution:

| IRI | → |
|---|---|
| `…/seqmake/parts/` | catalog home |
| `…/seqmake/parts/part/<slug>` | a part's page |
| `…/seqmake/parts/collection/<id>` | a collection's page |
| `…/seqmake/parts/ns#<term>` | `catalog.ttl` (the `cat:` vocabulary) |
| `…/seqmake/parts/catalog.ttl` (`.jsonld`/`.json`) | the published artifact |

- New directory only (`seqmake/`); nothing else touched, no collision with an
  existing namespace.
- Both `.htaccess` and `README.md` included; **contact info** is in
  `seqmake/README.md`.
- Single commit.

Maintainer: David Bikard (GitHub: @dbikard).
Source of truth for this redirect: https://github.com/dbikard/seqmake-parts (`w3id/` directory).