### PR TITLE
Add a redirect to the predefined contexts on github pages

### DIFF
--- a/aggregator/.htaccess
+++ b/aggregator/.htaccess
@@ -9,3 +9,6 @@ RewriteRule ^latest/?$ https://spec.knows.idlab.ugent.be/aggregator-protocol/lat
 
 # Redirect all/<id>/ to the matching external all/<id>/ path
 RewriteRule ^all/([^/]+)/?$ https://spec.knows.idlab.ugent.be/aggregator-protocol/all/$1/ [R=302,L]
+
+# Redirect individual context files to the github pages location
+RewriteRule ^contexts/(.+)$ https://solidlabresearch.github.io/aggregator-spec/contexts/$1 [R=302,L]


### PR DESCRIPTION
## Brief Description
Added a redirect rule to the predefined JSON-LD contexts. These are hosted on the github pages of the specification repository.

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## Update ID Directory Checklist
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.
