### PR TITLE
Add DMFO namespace

### DIFF
--- a/dmfo/.htaccess
+++ b/dmfo/.htaccess
@@ -1,0 +1,96 @@
+# =============================================================
+# w3id.org/dmfo — DMFO Ontology
+#
+# Maintainer: Jan Christian Redlich <jan.redlich@bonnsystems.com>
+# Source repo: https://github.com/JanChristianRedlich/DMFO
+# License: CC-BY-4.0
+#
+# Resolution scheme:
+#   /dmfo                          → aggregated TBox (dmfo-full)
+#   /dmfo/{module}                 → module TBox (latest on main)
+#   /dmfo/{module}/{version}       → module TBox at that version tag
+#   /dmfo/full/{version}           → aggregated TBox at that version
+#   /dmfo/profiles/{profile}       → profile TBox (latest on main)
+#   /dmfo/profiles/{profile}/{version}
+#                                  → profile TBox at that version
+#
+#   Modules: identity, state, evidence, context, activity, location,
+#            identity-deriv
+#   Profiles: maritime, food
+#
+# HTML clients (browsers, Accept: text/html) are redirected to the
+# GitHub repo as the human-readable landing page; all other Accept
+# headers (text/turtle, application/rdf+xml, application/ld+json,
+# */*) receive the Turtle source.
+# =============================================================
+
+Options +FollowSymLinks
+Options -MultiViews
+
+AddType text/turtle               .ttl
+AddType application/rdf+xml       .rdf
+AddType application/ld+json       .jsonld
+AddType text/n3                   .n3
+
+RewriteEngine On
+
+# ------------------------------------------------------------------
+# 1. HTML clients — send to GitHub landing page
+# ------------------------------------------------------------------
+RewriteCond %{HTTP_ACCEPT}  text/html
+RewriteRule ^$  https://github.com/JanChristianRedlich/DMFO  [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT}  text/html
+RewriteRule ^(identity|state|evidence|context|activity|location|identity-deriv)/?$ \
+            https://github.com/JanChristianRedlich/DMFO/blob/main/ontology/dmfo-$1.ttl  [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT}  text/html
+RewriteRule ^profiles/(maritime|food)/?$ \
+            https://github.com/JanChristianRedlich/DMFO/tree/main/profiles/$1  [R=302,L]
+
+# ------------------------------------------------------------------
+# 2. Versioned ontology requests — pin to git tag vX.Y.Z
+# ------------------------------------------------------------------
+
+# Versioned aggregated ontology:  /dmfo/full/1.0.0
+RewriteRule ^full/([0-9]+\.[0-9]+\.[0-9]+)/?$ \
+            https://raw.githubusercontent.com/JanChristianRedlich/DMFO/v$1/ontology/dmfo-full.ttl  [R=302,L]
+
+# Versioned module ontology:  /dmfo/identity/1.0.0  …  /dmfo/identity-deriv/1.0.0
+RewriteRule ^(identity|state|evidence|context|activity|location|identity-deriv)/([0-9]+\.[0-9]+\.[0-9]+)/?$ \
+            https://raw.githubusercontent.com/JanChristianRedlich/DMFO/v$2/ontology/dmfo-$1.ttl  [R=302,L]
+
+# Versioned profile ontology:  /dmfo/profiles/maritime/1.0.0
+# (file stems differ per profile: maritime → mar-tbox, food → food-tbox)
+RewriteRule ^profiles/maritime/([0-9]+\.[0-9]+\.[0-9]+)/?$ \
+            https://raw.githubusercontent.com/JanChristianRedlich/DMFO/v$1/profiles/maritime/mar-tbox.ttl  [R=302,L]
+RewriteRule ^profiles/food/([0-9]+\.[0-9]+\.[0-9]+)/?$ \
+            https://raw.githubusercontent.com/JanChristianRedlich/DMFO/v$1/profiles/food/food-tbox.ttl  [R=302,L]
+
+# ------------------------------------------------------------------
+# 3. Unversioned ontology requests — point at the main branch
+# ------------------------------------------------------------------
+
+# Module TBox:  /dmfo/identity, /dmfo/state, …, /dmfo/identity-deriv
+RewriteRule ^(identity|state|evidence|context|activity|location|identity-deriv)/?$ \
+            https://raw.githubusercontent.com/JanChristianRedlich/DMFO/main/ontology/dmfo-$1.ttl  [R=302,L]
+
+# Aggregated TBox:  /dmfo/full
+RewriteRule ^full/?$ \
+            https://raw.githubusercontent.com/JanChristianRedlich/DMFO/main/ontology/dmfo-full.ttl  [R=302,L]
+
+# Profile TBox:  /dmfo/profiles/maritime, /dmfo/profiles/food
+# (file stems differ per profile: maritime → mar-tbox, food → food-tbox)
+RewriteRule ^profiles/maritime/?$ \
+            https://raw.githubusercontent.com/JanChristianRedlich/DMFO/main/profiles/maritime/mar-tbox.ttl  [R=302,L]
+RewriteRule ^profiles/food/?$ \
+            https://raw.githubusercontent.com/JanChristianRedlich/DMFO/main/profiles/food/food-tbox.ttl  [R=302,L]
+
+# ------------------------------------------------------------------
+# 4. Default — bare /dmfo and hash-fragment requests resolve to the
+#    aggregated Turtle. This is what fetches like
+#    `https://w3id.org/dmfo#TimeVaryingEntity` resolve to (the
+#    fragment is stripped by the HTTP layer before redirection).
+# ------------------------------------------------------------------
+RewriteRule ^$ \
+            https://raw.githubusercontent.com/JanChristianRedlich/DMFO/main/ontology/dmfo-full.ttl  [R=302,L]

--- a/dmfo/README.md
+++ b/dmfo/README.md
@@ -1,0 +1,69 @@
+# /dmfo
+
+Permanent identifier namespace for the **DMFO** ontology
+(*A Modular Alignment Architecture for Situationally Interpretable
+State Representations*) — an OWL 2 DL Ontology Design Pattern
+Network in which a *situation* decomposes into six dimensional slots
+(Identity, State, Location, Activity, Context, Evidence) connected
+by typed bridge relations binding domain classes to PROV-O,
+SOSA/SSN, DUL/DnS, GeoSPARQL, and OWL-Time.
+
+## Maintainer
+
+- **Name:** Jan Christian Redlich
+- **Affiliation:** Bonn Systems GmbH, Bonn, Germany
+- **E-mail:** jan.redlich@bonnsystems.com
+- **GitHub:** [@JanChristianRedlich](https://github.com/JanChristianRedlich)
+
+## Person submitting this PR
+
+Jan Christian Redlich (same as maintainer).
+
+## Upstream resources
+
+- **Repository (source of truth):** https://github.com/JanChristianRedlich/DMFO
+- **License:** [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)
+- **Versioning:** Semantic Versioning. Each ontology release is tagged
+  `vX.Y.Z` in the repository (current: `v1.0.0`).
+- **Citation:** Redlich, Kloke, Bosse (2026). *DMFO: A Modular
+  Alignment Architecture for Situationally Interpretable State
+  Representations.* Manuscript.
+
+## Resolution scheme
+
+| Pattern | Resolves to |
+| --- | --- |
+| `https://w3id.org/dmfo` | aggregated TBox (`ontology/dmfo-full.ttl`, main branch) |
+| `https://w3id.org/dmfo#TimeVaryingEntity` (and other term IRIs) | same as above; HTTP layer strips the fragment, the client resolves the term in the returned Turtle |
+| `https://w3id.org/dmfo/full/1.0.0` | aggregated TBox at git tag `v1.0.0` |
+| `https://w3id.org/dmfo/{module}` | module TBox on main branch |
+| `https://w3id.org/dmfo/{module}/1.0.0` | module TBox at git tag `v1.0.0` |
+| `https://w3id.org/dmfo/profiles/{profile}` | profile TBox on main branch |
+| `https://w3id.org/dmfo/profiles/{profile}/1.0.0` | profile TBox at git tag `v1.0.0` |
+
+**Modules:** `identity`, `state`, `evidence`, `context`, `activity`,
+`location`, `identity-deriv`.
+**Profiles:** `maritime`, `food`.
+
+HTML clients (browsers sending `Accept: text/html`) are redirected to
+the GitHub repository as the human-readable landing page; all other
+Accept headers — including `text/turtle`, `application/rdf+xml`,
+`application/ld+json`, and `*/*` — receive the Turtle source from
+`raw.githubusercontent.com`.
+
+## Verification
+
+After this PR is merged, the following should return HTTP 302 to the
+documented targets:
+
+```bash
+curl -sI https://w3id.org/dmfo                    # → dmfo-full.ttl (main)
+curl -sI https://w3id.org/dmfo/full/1.0.0         # → dmfo-full.ttl (tag v1.0.0)
+curl -sI https://w3id.org/dmfo/identity           # → dmfo-identity.ttl (main)
+curl -sI https://w3id.org/dmfo/identity/1.0.0     # → dmfo-identity.ttl (tag v1.0.0)
+curl -sI https://w3id.org/dmfo/profiles/maritime  # → mar-tbox.ttl (main)
+
+# HTML landing
+curl -sI -H "Accept: text/html" https://w3id.org/dmfo
+# → https://github.com/JanChristianRedlich/DMFO
+```


### PR DESCRIPTION
## Brief Description
Adds a new permanent identifier namespace `/dmfo` for the **DMFO** ontology (*A Modular Alignment Architecture for Situationally Interpretable State Representations*), an OWL 2 DL ODP network. The `.htaccess` performs content-negotiated 302 redirects: HTML clients (`Accept: text/html`) go to the GitHub repository as a human-readable landing page, all other Accept headers receive the Turtle source from `raw.githubusercontent.com`. It resolves the aggregated TBox, the seven module TBoxes, and the maritime/food profile TBoxes, each available unversioned (main branch) or pinned to a `vX.Y.Z` git tag. Source repo: https://github.com/JanChristianRedlich/DMFO

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.