### PR TITLE
Add odrl-legal namespace (ODRL Legal Profile)

### DIFF
--- a/odrl-legal/.htaccess
+++ b/odrl-legal/.htaccess
@@ -1,4 +1,5 @@
 # ODRL Legal Profile (ODRL-L) - https://w3id.org/odrl-legal/
+# Maintainer: Daham Mustafa (@Daham-Mustaf)
 Options -MultiViews
 RewriteEngine On
 

--- a/odrl-legal/.htaccess
+++ b/odrl-legal/.htaccess
@@ -1,4 +1,4 @@
-# https://w3id.org/odrl-legal/  —  ODRL Legal Profile (ODRL-L)
+# ODRL Legal Profile (ODRL-L) - https://w3id.org/odrl-legal/
 Options -MultiViews
 RewriteEngine On
 

--- a/odrl-legal/.htaccess
+++ b/odrl-legal/.htaccess
@@ -1,0 +1,16 @@
+# https://w3id.org/odrl-legal/  —  ODRL Legal Profile (ODRL-L)
+Options -MultiViews
+RewriteEngine On
+
+# 1) RDF clients -> Turtle serialization
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/turtle|application/x-turtle|application/rdf\+xml|application/ld\+json|application/n-triples|text/n3) [NC]
+RewriteRule ^.*$ https://daham-mustaf.github.io/odrl-ufol-grounding/ontology/odrl-legal-profile.ttl [R=303,L]
+
+# 2) Version IRI -> Turtle serialization
+RewriteRule ^(?:[^/]+/)*1\.0/?$ https://daham-mustaf.github.io/odrl-ufol-grounding/ontology/odrl-legal-profile.ttl [R=303,L]
+
+# 3) Named term (browser) -> its anchor in the docs
+RewriteRule ^(?:[^/]+/)*([A-Za-z][A-Za-z0-9_-]*)/?$ https://daham-mustaf.github.io/odrl-ufol-grounding/#$1 [R=303,NE,L]
+
+# 4) Bare namespace (browser) -> docs home
+RewriteRule ^(?:[^/]+/)*$ https://daham-mustaf.github.io/odrl-ufol-grounding/ [R=303,L]

--- a/odrl-legal/README.md
+++ b/odrl-legal/README.md
@@ -1,7 +1,7 @@
 # w3id.org/odrl-legal
 
-Permanent identifier for the **ODRL Legal Profile (ODRL-L)**, an OWL ODRL 2.2
-profile that grounds ODRL permissions, prohibitions, and duties in UFO-L legal
+Permanent identifier for the **ODRL Legal Profile (ODRL-L)**, an OWL profile of
+ODRL 2.2 that grounds ODRL permissions, prohibitions, and duties in UFO-L legal
 positions.
 
 - Namespace IRI: https://w3id.org/odrl-legal/
@@ -13,4 +13,4 @@ The `.htaccess` performs content negotiation: RDF clients receive the ontology,
 browsers receive the HTML documentation, and term IRIs (e.g. `/odrl-legal/Power`)
 resolve to their definition anchor in the docs. All redirects use HTTP 303.
 
-Maintainer: Daham M. Mustafa (RWTH Aachen University / Fraunhofer FIT).
+Maintainer: Daham M. Mustafa (@Daham-Mustaf), RWTH Aachen University / Fraunhofer FIT.

--- a/odrl-legal/README.md
+++ b/odrl-legal/README.md
@@ -1,0 +1,16 @@
+# w3id.org/odrl-legal
+
+Permanent identifier for the **ODRL Legal Profile (ODRL-L)**, an OWL ODRL 2.2
+profile that grounds ODRL permissions, prohibitions, and duties in UFO-L legal
+positions.
+
+- Namespace IRI: https://w3id.org/odrl-legal/
+- Documentation: https://daham-mustaf.github.io/odrl-ufol-grounding/
+- Ontology (Turtle): https://daham-mustaf.github.io/odrl-ufol-grounding/ontology/odrl-legal-profile.ttl
+- Source & benchmark: https://github.com/Daham-Mustaf/odrl-ufol-grounding
+
+The `.htaccess` performs content negotiation: RDF clients receive the ontology,
+browsers receive the HTML documentation, and term IRIs (e.g. `/odrl-legal/Power`)
+resolve to their definition anchor in the docs. All redirects use HTTP 303.
+
+Maintainer: Daham M. Mustafa (RWTH Aachen University / Fraunhofer FIT).


### PR DESCRIPTION
Registers https://w3id.org/odrl-legal/ for the ODRL Legal Profile.

- Adds .htaccess with 303 redirects
- Supports RDF content negotiation (Turtle, JSON-LD, etc.)
- Browser requests resolve to documentation
- Term IRIs resolve to anchors in the HTML docs

Maintainer: Daham Mustafa
Docs: https://daham-mustaf.github.io/odrl-ufol-grounding/
Ontology: https://daham-mustaf.github.io/odrl-ufol-grounding/ontology/odrl-legal-profile.ttl