### PR TITLE
Add TIB DataCite metadata vocabulary redirects

### DIFF
--- a/tib/datacite/.htaccess
+++ b/tib/datacite/.htaccess
@@ -1,0 +1,22 @@
+RewriteEngine on
+
+# Namespace landing page
+RewriteRule ^$ https://tibhannover.github.io/datacite/ [R=302,L]
+
+# RDF classes and properties
+RewriteRule ^class/([^/.]+)$ https://tibhannover.github.io/datacite/class/$1.jsonld [R=303,L]
+RewriteRule ^property/([^/.]+)$ https://tibhannover.github.io/datacite/property/$1.jsonld [R=303,L]
+
+# SKOS ConceptScheme IRIs:
+# /vocab/resourceTypeGeneral -> /vocab/resourceTypeGeneral/resourceTypeGeneral.jsonld
+RewriteRule ^vocab/([^/.]+)$ https://tibhannover.github.io/datacite/vocab/$1/$1.jsonld [R=303,L]
+
+# SKOS Concept IRIs:
+# /vocab/resourceTypeGeneral/Dataset -> /vocab/resourceTypeGeneral/Dataset.jsonld
+RewriteRule ^vocab/([^/]+)/([^/.]+)$ https://tibhannover.github.io/datacite/vocab/$1/$2.jsonld [R=303,L]
+
+# Concrete JSON-LD files under class/property/vocab, if requested directly
+RewriteRule ^(class|property|vocab)/(.*\.jsonld)$ https://tibhannover.github.io/datacite/$1/$2 [R=302,L]
+
+# Concrete supporting documents
+RewriteRule ^(context|manifest|dist)/(.*)$ https://tibhannover.github.io/datacite/$1/$2 [R=302,L]

--- a/tib/datacite/README.md
+++ b/tib/datacite/README.md
@@ -1,0 +1,37 @@
+# TIB DataCite Metadata Vocabulary
+
+This w3id namespace provides persistent identifiers for the TIB-hosted DataCite metadata linked-data vocabulary.
+
+Canonical namespace:
+
+```text
+https://w3id.org/tib/datacite/
+```
+
+Publication backend:
+
+```text
+https://tibhannover.github.io/datacite/
+```
+
+Examples:
+
+```text
+https://w3id.org/tib/datacite/class/Resource
+https://w3id.org/tib/datacite/property/identifier
+https://w3id.org/tib/datacite/vocab/resourceTypeGeneral
+https://w3id.org/tib/datacite/vocab/resourceTypeGeneral/Dataset
+https://w3id.org/tib/datacite/context/fullcontext.jsonld
+https://w3id.org/tib/datacite/manifest/datacite-current.json
+```
+
+The canonical RDF identifiers use `https://w3id.org/tib/datacite/`. GitHub Pages serves the concrete JSON-LD, Turtle, RDF/XML, manifest, and context files from `https://tibhannover.github.io/datacite/`.
+
+Contact / Maintainer:
+
+- Project: PID4NFDI (TIB Hannover)
+- Lead for this work: Sara El-Gebali
+  - Email: <sara.elgebali@datacite.org>
+  - GitHub: [selgebali](https://github.com/selgebali)
+  - ORCID: [0000-0003-1378-5495](https://orcid.org/0000-0003-1378-5495)
+- Vocabulary source: https://github.com/TIBHannover/datacite-metadata-toolkit


### PR DESCRIPTION
## Brief Description

Adds the `https://w3id.org/tib/datacite/` namespace for the TIB-hosted DataCite metadata linked-data vocabulary.

The redirects cover:

- The namespace landing page.
- RDF class and property identifiers.
- SKOS concept scheme and concept identifiers.
- Concrete JSON-LD, context, manifest, Turtle, and RDF/XML resources.

The publication backend is `https://tibhannover.github.io/datacite/`.

## Testing

- Validated the repository and new rules with Apache HTTP Server 2.4.66.
- Exercised representative routes locally and confirmed the expected `302` and `303` responses and destinations.
- Confirmed the existing `/tib/oais/ip` redirect is unaffected.
- Confirmed representative live backend resources return `200`.
- Parsed representative JSON and JSON-LD resources and confirmed they contain the canonical `https://w3id.org/tib/datacite/` identifiers.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. The change is a single commit.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in `README.md`.
- [x] The maintainer's GitHub username is listed.

This adds a project-specific child namespace beneath the existing `/tib` prefix. Tagging @mmannings for visibility as the listed maintainer of that parent namespace.
