### PR TITLE
Route the CACAO-RS ODRL profile URI

### DIFF
--- a/cacao/.htaccess
+++ b/cacao/.htaccess
@@ -12,4 +12,5 @@
 
 
 RewriteEngine on
+RewriteRule ^profile/rights/?$ https://raw.githubusercontent.com/REEVALUATE/CACAO-RS/main/cacao-rs-profile.ttl [R=302,L]
 RewriteRule ^ https://reevaluate.github.io/cacao-ontology/index-en.html [R=302,L]

--- a/cacao/README.md
+++ b/cacao/README.md
@@ -4,6 +4,9 @@
 ## Uses
 This [W3ID](https://w3id.org) provides a persistent URI namespace for the Cultural Artifacts Contextual Ontology (CACAO) resources.
 
+The CACAO-RS ODRL profile is available at
+<https://w3id.org/cacao/profile/rights>.
+
 ## Contact
 This space is administered by:
 


### PR DESCRIPTION
Adds a specific redirect for `https://w3id.org/cacao/profile/rights` before the existing CACAO catch-all rule. The target profile is introduced by REEVALUATE/CACAO-RS#1.