### PR TITLE
Add earth-data namespace (Data Terra EOSC node)

### DIFF
--- a/earth-data/.htaccess
+++ b/earth-data/.htaccess
@@ -1,0 +1,15 @@
+# Name of the project: Data Terra EOSC Resource Catalogue
+# Description: Permanent identifiers for the Data Terra EOSC node
+# Contacts:
+# - Alessandro Rizzo (alessandro.rizzo@ird.fr) - Coordinator, Data Terra EOSC Node
+# - Christelle Pierkot (christelle.pierkot@cnrs.fr) - Deputy coordinator, Data Terra EOSC Node
+# - Foxcub, Julien Homo (julien.homo@foxcub.fr) - Maintainer
+
+Options -MultiViews
+RewriteEngine on
+
+# Resource identifiers resolve to the catalogue (canonical production host).
+RewriteRule ^resource/(.+)$ https://resources.earth-data.eu/api/resource?uri=https://w3id.org/earth-data/resource/$1 [R=302,L]
+
+# Anything else under the namespace goes to the catalogue.
+RewriteRule ^(.*)$ https://resources.earth-data.eu/ [R=302,L]

--- a/earth-data/README.md
+++ b/earth-data/README.md
@@ -1,0 +1,20 @@
+# /earth-data
+
+Permanent identifier namespace for the EOSC node of Data Terra, the French
+research infrastructure for Earth and environmental data
+(https://www.data-terra.org), starting with its resource catalogue.
+
+URI patterns currently in use:
+
+- `/earth-data/catalog` - the catalogue itself (dcat:Catalog)
+- `/earth-data/resource/{uuid}` - a catalogued resource (Dataset, Software,
+  Publication, Project, Semantic Artefact, Service)
+
+Further sub-paths (datasources, organizations, vocabularies) will be added
+under the same top-level.
+
+# Contacts
+
+- **Alessandro Rizzo** - Coordinator, Data Terra EOSC Node - [alessandro.rizzo@ird.fr](mailto:alessandro.rizzo@ird.fr)
+- **Christelle Pierkot** - Deputy coordinator, Data Terra EOSC Node - [christelle.pierkot@cnrs.fr](mailto:christelle.pierkot@cnrs.fr)
+- **Foxcub** (Julien Homo) - Maintainer - [julien.homo@foxcub.fr](mailto:julien.homo@foxcub.fr)


### PR DESCRIPTION
This adds the `earth-data` namespace for the Data Terra EOSC Resource Catalogue
(thematic node of the EOSC Federation). It is the permanent identifier namespace
for the catalogue's resources (/earth-data/resource/{uuid}), redirecting to the
canonical production host resources.earth-data.eu.

Contacts:
- Alessandro Rizzo (IRD) - Coordinator, Data Terra EOSC Node
- Christelle Pierkot (CNRS) - Deputy coordinator, Data Terra EOSC Node
- Julien Homo, Kévin Darty (Foxcub) - Maintainer