### PR TITLE
ixo: add did/v1 context redirect with HTML/JSON-LD negotiation

### DIFF
--- a/ixo/.htaccess
+++ b/ixo/.htaccess
@@ -34,15 +34,33 @@ AddType application/ld+json .jsonld
 
 RewriteEngine On
 
-# --- 0. did:ixo method context (interchain-identifiers) ------------------------
-# The IID JSON-LD context that defines the did:ixo method-specific terms
-# (linkedResource, linkedClaim, linkedEntity, accordedRight, blockchainAccountID,
-# CosmosAccountAddress). Published WITH the "ns/" segment by request, so this
-# explicit 303 must precede the rule-1 "ns/" collapse below — otherwise the IRI
-# would be 301'd to the bare form before it could resolve to a document.
-# Registered in the DID Specification Registries; appended to the @context array
+# --- 0. did:ixo DID method context --------------------------------------------
+# The canonical JSON-LD context for the did:ixo method, defining the
+# method-specific terms (linkedResource, linkedClaim, linkedEntity,
+# accordedRight, blockchainAccountId, CosmosAccountAddress, …). Published WITH
+# the "ns/" segment as the canonical form, so these explicit 303s must precede
+# the rule-1 "ns/" collapse — otherwise the IRI would be 301'd to the bare
+# form before it could resolve to a document. Appended to the @context array
 # of every resolved did:ixo document (W3C DID Core §6.3.1 JSON-LD production).
 # The bare form (no "ns/") also resolves, so both spellings dereference.
+#
+# Accept-based content negotiation:
+#   * Browsers (Accept: text/html…) → Jekyll-rendered spec page
+#   * Everything else (JSON-LD processors, curl with no Accept, */*) → the
+#     canonical JSON-LD context document
+# The text/html rule MUST come first; a RewriteCond only attaches to the
+# immediately-following RewriteRule.
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^(?:ns/)?did(?:/v1)?/?$ https://ixofoundation.github.io/ns/did/v1/ [R=303,L]
+RewriteRule ^(?:ns/)?did(?:/v1)?/?$ https://ixofoundation.github.io/ns/did/v1/index.jsonld [R=303,L]
+
+# --- 0b. did:ixo legacy interchain-identifiers context ------------------------
+# The earlier IID umbrella context, kept resolvable for back-compat with
+# already-resolved did:ixo documents that reference it. New documents
+# reference the did/v1 context above instead. Same negotiation pattern as
+# rule 0 — browsers get the spec page, everything else gets the JSON-LD.
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^(?:ns/)?interchain-identifiers(?:/v1)?/?$ https://ixofoundation.github.io/ns/interchain-identifiers/v1/ [R=303,L]
 RewriteRule ^(?:ns/)?interchain-identifiers(?:/v1)?/?$ https://ixofoundation.github.io/ns/interchain-identifiers/v1/index.jsonld [R=303,L]
 
 # --- 1. Legacy "ns/" prefix  →  canonical bare form (single 301) --------------

--- a/ixo/readme.md
+++ b/ixo/readme.md
@@ -24,7 +24,7 @@ There is **one** canonical form, with no `ns/` prefix. For example:
 | Core vocabulary | `https://w3id.org/ixo/vocab/v1` |
 | A concept scheme | `https://w3id.org/ixo/protocol/methods/v1` |
 | A concept in it | `https://w3id.org/ixo/protocol/methods/v1#CosmosAccountAddress` |
-| The `did:ixo` method context | `https://w3id.org/ixo/ns/interchain-identifiers/v1` |
+| The `did:ixo` method context | `https://w3id.org/ixo/ns/did/v1` |
 | A JSON Schema | `https://w3id.org/ixo/schema/v1/domainCard` |
 | A SHACL shape | `https://w3id.org/ixo/schema/shapes/v1/DomainCardShape` |
 
@@ -32,10 +32,11 @@ The legacy `https://w3id.org/ixo/ns/<path>` variant is collapsed to the
 canonical bare form with a single **301**. Do not use it in new code.
 
 **One registered exception**: the `did:ixo` method context keeps the `ns/`
-segment in its canonical IRI —
-`https://w3id.org/ixo/ns/interchain-identifiers/v1` — because that form is
-published in DID documents and registered externally. An explicit 303 rule
-resolves it ahead of the `ns/` collapse.
+segment in its canonical IRI — `https://w3id.org/ixo/ns/did/v1` — because
+that form is published in DID documents and registered externally. An
+explicit 303 rule resolves it ahead of the `ns/` collapse. The earlier
+`…/ns/interchain-identifiers/v1` context remains resolvable for back-compat
+with already-issued DID documents that reference it.
 
 ## Redirect-code policy
 


### PR DESCRIPTION
## Summary

Adds an explicit redirect rule for the new canonical `did:ixo` JSON-LD context at `https://w3id.org/ixo/ns/did/v1`, with Apache-level Accept negotiation so browsers and JSON-LD processors both get something useful. Also applies the same negotiation pattern to the existing `interchain-identifiers/v1` rule for consistency.

The new context document is published at [ixofoundation/ns](https://github.com/ixofoundation/ns/blob/main/did/v1/index.jsonld) and served via GitHub Pages.

## Problem

Before this change, `https://w3id.org/ixo/ns/did/v1` had no explicit rule in `ixo/.htaccess`. It fell through:
1. Rule 1 (`ns/` collapse) → 301 to `https://w3id.org/ixo/did/v1`
2. Rule 8 (catch-all) → 303 to `https://ixofoundation.github.io/ns/did/v1/` (the bare directory)

GitHub Pages serves the Jekyll-rendered HTML spec page at that bare directory — fine for browsers, but a JSON-LD processor following the redirect with `Accept: application/ld+json` would get HTML and reject the document. This breaks JSON-LD consumers of resolved `did:ixo` documents, because [W3C DID Core §6.3.1](https://www.w3.org/TR/did-1.0/#production-0) requires every emitted term to be defined by the `@context` URL.

## Fix

Adds rule 0 with Apache content negotiation matching the convention already used elsewhere in the `ixo/` namespace:

```apache
RewriteCond %{HTTP_ACCEPT} text/html
RewriteRule ^(?:ns/)?did(?:/v1)?/?$ https://ixofoundation.github.io/ns/did/v1/ [R=303,L]
RewriteRule ^(?:ns/)?did(?:/v1)?/?$ https://ixofoundation.github.io/ns/did/v1/index.jsonld [R=303,L]
```

The `RewriteCond` attaches only to the immediately-following `RewriteRule`, so the second rule is the catch-all default for any non-HTML Accept value.

Behavior:

| Request | Target |
|---|---|
| Browser (`Accept: text/html…`) | Jekyll spec page |
| JSON-LD processor (`Accept: application/ld+json`) | `index.jsonld` document |
| `curl` with no Accept (`*/*`) | `index.jsonld` document |
| DIF Universal Resolver | `index.jsonld` document |

The same pattern is applied to the existing `interchain-identifiers/v1` rule (rule 0b). The interchain-identifiers context is kept resolvable for back-compat with already-issued `did:ixo` documents that reference it.

Both rules accept the bare form (`did/v1`) and the `ns/`-prefixed form (`ns/did/v1`) since both spellings appear in published documents.

Verified both content hosts return HTTP 200:

```
$ curl -sI https://ixofoundation.github.io/ns/did/v1/
HTTP/2 200 ... Content-Type: text/html

$ curl -sI https://ixofoundation.github.io/ns/did/v1/index.jsonld
HTTP/2 200 ... Content-Type: application/ld+json
```

## Files changed

- `ixo/.htaccess` — added rule 0 (did/v1 with negotiation), updated rule 0b (interchain-identifiers with the same negotiation pattern)
- `ixo/readme.md` — updated the canonical IRI table and the registered-exception note

## Why this matters

The IXO Foundation is preparing the `did:ixo` method for submission to the W3C DID Method Registry. The resolver emits `https://w3id.org/ixo/ns/did/v1` in the `@context` array of every resolved DID document, so this URL needs to serve the canonical JSON-LD context for W3C DID Core conformance.

Authored by: Michael Pretorius <michael@ixo.world>