### PR TITLE
fix: add explicit did:ixo DID-specific context redirect in /ixo/.htaccess

### DIFF
--- a/ixo/.htaccess
+++ b/ixo/.htaccess
@@ -45,6 +45,13 @@ RewriteEngine On
 # The bare form (no "ns/") also resolves, so both spellings dereference.
 RewriteRule ^(?:ns/)?interchain-identifiers(?:/v1)?/?$ https://ixofoundation.github.io/ns/interchain-identifiers/v1/index.jsonld [R=303,L]
 
+# --- 0b. did:ixo DID-specific context -----------------------------------------
+# The DID-method-specific JSON-LD context for did:ixo (CosmosAccountAddress,
+# blockchainAccountId, linkedResource, linkedClaim, linkedEntity, accordedRight).
+# Registered in the W3C DID Extensions registry. Both the "ns/" form and the
+# canonical bare form resolve to the concrete JSON-LD artifact.
+RewriteRule ^(?:ns/)?did(?:/v1)?/?$ https://ixofoundation.github.io/ns/did/v1/index.jsonld [R=303,L]
+
 # --- 1. Legacy "ns/" prefix  →  canonical bare form (single 301) --------------
 RewriteRule ^ns/(.*)$ https://w3id.org/ixo/$1 [R=301,L]
 


### PR DESCRIPTION
## Problem

`https://w3id.org/ixo/ns/did/v1` (and the canonical bare form `https://w3id.org/ixo/did/v1`) currently falls through to the catch-all rule, which redirects to the bare directory `https://ixofoundation.github.io/ns/did/v1/`. GitHub Pages serves an HTML directory index at that URL, not the JSON-LD context file.

The `/ixo/.htaccess` policy states explicitly:
> Every rule targets a concrete file (…/index.jsonld or …/<name>.json), never a bare directory.

## Fix

Add an explicit rule (Rule 0b) for `did/v1` — following the same pattern as the existing `interchain-identifiers` rule (Rule 0):

```apache
RewriteRule ^(?:ns/)?did(?:/v1)?/?$ https://ixofoundation.github.io/ns/did/v1/index.jsonld [R=303,L]
```

This rule:
- Handles both `https://w3id.org/ixo/did/v1` (bare form) and `https://w3id.org/ixo/ns/did/v1` (legacy `ns/` form)
- Redirects with 303 See Other to the concrete JSON-LD artifact
- Is placed before the Rule 1 `ns/` collapse, so `ns/did/v1` does not 301 to the bare form first

## Verification

The target `https://ixofoundation.github.io/ns/did/v1/index.jsonld` is live and returns HTTP 200 with `Content-Type: application/ld+json`.

```sh
curl -sI https://ixofoundation.github.io/ns/did/v1/index.jsonld | grep content-type
# content-type: application/ld+json
```

## Context

- This context is registered by the `did:ixo` DID method (W3C DID Extensions PR: https://github.com/w3c/did-extensions/pull/725)
- Method specification: https://github.com/ixofoundation/ixo-did-method/blob/main/README.md