### PR TITLE
Add NIST CSF 2.0 SKOS taxonomy identifier

### DIFF
--- a/nist-csf2-skos/.htaccess
+++ b/nist-csf2-skos/.htaccess
@@ -1,0 +1,21 @@
+# Code by Gheorghe Turca
+# Persistent redirects for the NIST CSF 2.0 SKOS taxonomy.
+# Project: Creating a Machine-Readable SKOS Taxonomy of the NIST Cybersecurity Framework 2.0
+
+Options +FollowSymLinks
+RewriteEngine On
+
+# Main namespace page
+RewriteRule ^$ https://github.com/georgeturca/nistcsf2.0-skos-taxonomy [R=302,L]
+
+# Full generated Turtle taxonomy
+RewriteRule ^taxonomy$ https://raw.githubusercontent.com/georgeturca/nistcsf2.0-skos-taxonomy/main/output/nist_csf2_taxonomy.ttl [R=302,L]
+
+# Concept scheme URIs
+RewriteRule ^scheme/(.*)$ https://raw.githubusercontent.com/georgeturca/nistcsf2.0-skos-taxonomy/main/output/nist_csf2_taxonomy.ttl [R=303,L]
+
+# NIST CSF Function, Category, and Subcategory URIs
+RewriteRule ^concept/(.*)$ https://raw.githubusercontent.com/georgeturca/nistcsf2.0-skos-taxonomy/main/output/nist_csf2_taxonomy.ttl [R=303,L]
+
+# Local Informative Reference URIs
+RewriteRule ^reference/(.*)$ https://raw.githubusercontent.com/georgeturca/nistcsf2.0-skos-taxonomy/main/output/nist_csf2_taxonomy.ttl [R=303,L]

--- a/nist-csf2-skos/README.md
+++ b/nist-csf2-skos/README.md
@@ -1,0 +1,59 @@
+# NIST CSF 2.0 SKOS Taxonomy Persistent Identifiers
+
+This W3ID namespace provides persistent identifiers for the NIST CSF 2.0 SKOS taxonomy created as part of the research project:
+
+**Creating a Machine-Readable SKOS Taxonomy of the NIST Cybersecurity Framework 2.0**
+
+## Namespace
+
+```text
+https://w3id.org/nist-csf2-skos/
+```
+
+## Maintainer
+
+Gheorghe Turca
+University of Twente
+Student number: s3197999
+
+## Project repository
+
+```text
+https://github.com/georgeturca/nistcsf2.0-skos-taxonomy
+```
+
+## Main resources
+
+```text
+https://w3id.org/nist-csf2-skos/
+https://w3id.org/nist-csf2-skos/taxonomy
+https://w3id.org/nist-csf2-skos/scheme/core
+https://w3id.org/nist-csf2-skos/scheme/informative-references
+https://w3id.org/nist-csf2-skos/concept/
+https://w3id.org/nist-csf2-skos/reference/
+```
+
+## Description
+
+The namespace is used for RDF/SKOS identifiers representing NIST CSF 2.0 Functions, Categories, Subcategories, and local Informative Reference concepts.
+
+The generated taxonomy is serialized in Turtle and is available from the project repository. The identifiers are intended to provide stable Linked Data identifiers for the generated taxonomy.
+
+## Redirect behavior
+
+* `/` redirects to the project repository.
+* `/taxonomy` redirects to the generated Turtle file.
+* `/scheme/*` redirects to the generated Turtle file.
+* `/concept/*` redirects to the generated Turtle file.
+* `/reference/*` redirects to the generated Turtle file.
+
+## Example identifiers
+
+```text
+https://w3id.org/nist-csf2-skos/concept/GV
+https://w3id.org/nist-csf2-skos/concept/GV-OC
+https://w3id.org/nist-csf2-skos/concept/GV-OC-01
+```
+
+These identifiers are used in the generated RDF/SKOS taxonomy instead of temporary `example.org` identifiers.
+

--- a/nist-csf2-skos/README.md
+++ b/nist-csf2-skos/README.md
@@ -13,6 +13,7 @@ https://w3id.org/nist-csf2-skos/
 ## Maintainer
 
 Gheorghe Turca
+GitHub: [@georgeturca](https://github.com/georgeturca)  
 University of Twente
 Student number: s3197999
 


### PR DESCRIPTION
This pull request adds a persistent W3ID namespace for a research project that represents the NIST Cybersecurity Framework 2.0 as an RDF/SKOS taxonomy.

The namespace redirects to the project repository, the generated Turtle taxonomy, and RDF resources for NIST CSF concepts, concept schemes, and local Informative Reference concepts.

Namespace:
https://w3id.org/nist-csf2-skos/

Maintainer:
Gheorghe Turca
s3197999
University of Twente