### PR TITLE
security: repoint dead ns.did.ai suite redirects to jsld.org

### DIFF
--- a/security/.htaccess
+++ b/security/.htaccess
@@ -76,8 +76,8 @@ RewriteRule ^suites/merkle-disclosure-2021/v1$ https://w3c-ccg.github.io/Merkle-
 
 # http://w3id.org/security/suites/multikey-2021
 
-RewriteRule ^suites/multikey-2021$ https://ns.did.ai/suites/multikey-2021 [R=302,L]
-RewriteRule ^suites/multikey-2021/v1$ https://ns.did.ai/suites/multikey-2021/v1 [R=302,L]
+RewriteRule ^suites/multikey-2021$ https://jsld.org/suites/multikey-2021 [R=302,L]
+RewriteRule ^suites/multikey-2021/v1$ https://jsld.org/suites/multikey-2021/v1 [R=302,L]
 
 # http://w3id.org/security/suites/secp256k1recovery-2020
 
@@ -88,7 +88,7 @@ RewriteRule ^suites/secp256k1recovery-2020/v2$ https://identity.foundation/Ecdsa
 # http://w3id.org/security/suites/pgp-2021
 
 RewriteRule ^suites/pgp-2021$ https://or13.github.io/lds-pgp2021 [R=302,L]
-RewriteRule ^suites/pgp-2021/v1$ https://ns.did.ai/suites/pgp-2021/v1 [R=302,L]
+RewriteRule ^suites/pgp-2021/v1$ https://jsld.org/suites/pgp-2021/v1 [R=302,L]
 
 # http://w3id.org/security/suites/blockchain-2021
 
@@ -112,18 +112,18 @@ RewriteRule ^suites/eip712sig-2021/v1$ https://w3c-ccg.github.io/ethereum-eip712
 
 # http://w3id.org/security/suites/secp256k1-2020
 
-RewriteRule ^suites/secp256k1-2020$ https://ns.did.ai/suites/secp256k1-2020 [R=302,L]
-RewriteRule ^suites/secp256k1-2020/v1$ https://ns.did.ai/suites/secp256k1-2020/v1 [R=302,L]
+RewriteRule ^suites/secp256k1-2020$ https://jsld.org/suites/secp256k1-2020 [R=302,L]
+RewriteRule ^suites/secp256k1-2020/v1$ https://jsld.org/suites/secp256k1-2020/v1 [R=302,L]
 
 # http://w3id.org/security/suites/secp256k1-2019
 
-RewriteRule ^suites/secp256k1-2019$ https://ns.did.ai/suites/secp256k1-2019 [R=302,L]
-RewriteRule ^suites/secp256k1-2019/v1$ https://ns.did.ai/suites/secp256k1-2019/v1 [R=302,L]
+RewriteRule ^suites/secp256k1-2019$ https://jsld.org/suites/secp256k1-2019 [R=302,L]
+RewriteRule ^suites/secp256k1-2019/v1$ https://jsld.org/suites/secp256k1-2019/v1 [R=302,L]
 
 # http://w3id.org/security/suites/x25519-2019
 
-RewriteRule ^suites/x25519-2019$ https://ns.did.ai/suites/x25519-2019 [R=302,L]
-RewriteRule ^suites/x25519-2019/v1$ https://ns.did.ai/suites/x25519-2019/v1 [R=302,L]
+RewriteRule ^suites/x25519-2019$ https://jsld.org/suites/x25519-2019 [R=302,L]
+RewriteRule ^suites/x25519-2019/v1$ https://jsld.org/suites/x25519-2019/v1 [R=302,L]
 
 # http://w3id.org/security/suites/merkle-2019
 


### PR DESCRIPTION
## Problem

The `ns.did.ai` domain no longer resolves DNS. As a result, these `w3id.org/security/suites/*` redirects are broken — they 302 to a host that returns nothing, so JSON-LD expansion of any did:web / did:plc document referencing these suites fails:

- `secp256k1-2019` (+ /v1)
- `secp256k1-2020` (+ /v1)
- `multikey-2021` (+ /v1)
- `x25519-2019` (+ /v1)
- `pgp-2021/v1`

Reported here: transmute-industries/ns.did.ai#1

## Fix

Repoint those 9 rules from `https://ns.did.ai/suites/...` to `https://jsld.org/suites/...`. `jsld.org` (working DNS + GitHub Pages) now serves **byte-identical** copies of the same context documents at the same paths, so this is a pure host swap — paths and content are unchanged, and the suite contexts define their terms against `w3id.org/security#` so RDF semantics are preserved.

Verified the mirrored `/v1` contexts return `application/json` and diff-identical to the originals on `transmute-industries/ns.did.ai@master`.

**Contact:** Orie Steele — orie@or13.io (jsld.org maintainer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)