### PR TITLE
Add legal-taxonomy (Open Legal Issue Taxonomy)

### DIFF
--- a/legal-taxonomy/.htaccess
+++ b/legal-taxonomy/.htaccess
@@ -1,0 +1,50 @@
+# https://w3id.org/legal-taxonomy
+# Open Legal Issue Taxonomy (OLIT) — a SKOS taxonomy of ~288,000 legal-issue concepts.
+#
+# ## Contact
+# This space is administered by:
+#
+# Arthur S. Rodrigues
+# arthursrodrigues@gmail.com
+# GitHub username: arthrod
+
+# Turn off MultiViews
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/ld+json .jsonld
+
+RewriteEngine on
+
+# --- Whole-vocabulary URI: https://w3id.org/legal-taxonomy/ ---
+# HTML for browsers / human agents
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://arthrod.github.io/legal-taxonomy/ [R=303,NE,L]
+
+# JSON-LD
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://arthrod.github.io/legal-taxonomy/legal-taxonomy.jsonld [R=303,NE,L]
+
+# Turtle (also the */* and text/* default for machine clients)
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\*
+RewriteRule ^$ https://arthrod.github.io/legal-taxonomy/legal-taxonomy.ttl [R=303,NE,L]
+
+# --- Per-concept dereferencing: /concept/000123 ---
+# Enable once per-concept files (or a Fuseki/Skosmos endpoint) are served.
+# RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+# RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+# RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+# RewriteRule ^concept/([0-9]+)$ https://arthrod.github.io/legal-taxonomy/concept/$1.ttl [R=303,NE,L]
+# RewriteRule ^concept/([0-9]+)$ https://arthrod.github.io/legal-taxonomy/concept/$1.html [R=303,NE,L]
+
+# --- Everything else (scheme.ttl, dumps/, downloads) ---
+RewriteRule ^(.*)$ https://arthrod.github.io/legal-taxonomy/$1 [R=302,L]
+
+# Default
+RewriteRule ^$ https://arthrod.github.io/legal-taxonomy/ [R=303,NE,L]

--- a/legal-taxonomy/README.md
+++ b/legal-taxonomy/README.md
@@ -9,4 +9,4 @@ SKOS controlled vocabulary of ~288,000 legal-issue concepts organised under
 - Published site & data: https://arthrod.github.io/legal-taxonomy/
 - Source: https://github.com/arthrod/legal-taxonomy
 
-**Maintainer:** Arthur S. Rodrigues — arthursrodrigues@gmail.com
+**Maintainer:** Arthur S. Rodrigues — arthursrodrigues@gmail.com — GitHub: [@arthrod](https://github.com/arthrod)

--- a/legal-taxonomy/README.md
+++ b/legal-taxonomy/README.md
@@ -1,0 +1,12 @@
+# legal-taxonomy
+
+Permanent identifier base for the **Open Legal Issue Taxonomy (OLIT)** — a
+SKOS controlled vocabulary of ~288,000 legal-issue concepts organised under
+13 top-level legal domains.
+
+- Concept URIs: `https://w3id.org/legal-taxonomy/concept/{notation}`
+- Concept scheme: `https://w3id.org/legal-taxonomy/scheme/olit`
+- Published site & data: https://arthrod.github.io/legal-taxonomy/
+- Source: https://github.com/arthrod/legal-taxonomy
+
+**Maintainer:** Arthur S. Rodrigues — arthursrodrigues@gmail.com


### PR DESCRIPTION
Adds the `/legal-taxonomy/` permanent identifier for the **Open Legal Issue Taxonomy (OLIT)** — a SKOS vocabulary of ~288,000 legal-issue concepts under 13 top-level legal domains.

- Concept URIs: `https://w3id.org/legal-taxonomy/concept/{notation}`
- Concept scheme: `https://w3id.org/legal-taxonomy/scheme/olit`
- Redirect target (GitHub Pages): https://arthrod.github.io/legal-taxonomy/
- Content negotiation on the base URI (HTML / Turtle / JSON-LD) via `303`, following `/example/`.

**Maintainer:** Arthur S. Rodrigues — arthursrodrigues@gmail.com — GitHub: @arthrod

Both `.htaccess` and `README.md` are included with contact info per the naming policy.