### PR TITLE
ontodisinfo: add /2.0.0/* and /2.1.0/* routes and point unversioned IRIs to v2.1.0

### DIFF
--- a/ontodisinfo/.htaccess
+++ b/ontodisinfo/.htaccess
@@ -37,9 +37,9 @@ RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/  [R=302,L]
 # RDF tools -> consolidated Turtle pinned to the latest release tag
 RewriteCond %{HTTP_ACCEPT} (text/turtle|application/(rdf\+xml|x-turtle|ld\+json|n-triples|n-quads))
-RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 # Default (no Accept header, curl, etc.) -> Turtle, Linked Data convention
-RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 
 # =============================================================================
 # 2. Individual modules with content negotiation
@@ -49,38 +49,38 @@ RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7
 # --- core ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^core/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/core/  [R=302,L]
-RewriteRule ^core/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/domain/core/ontodis-core.ttl  [R=302,L]
+RewriteRule ^core/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/domain/core/ontodis-core.ttl  [R=302,L]
 
 # --- ml ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^ml/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/ml/  [R=302,L]
-RewriteRule ^ml/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/domain/ml/ontodis-ml.ttl  [R=302,L]
+RewriteRule ^ml/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/domain/ml/ontodis-ml.ttl  [R=302,L]
 
 # --- electoral ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^electoral/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/electoral/  [R=302,L]
-RewriteRule ^electoral/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/domain/electoral/ontodis-elec.ttl  [R=302,L]
+RewriteRule ^electoral/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/domain/electoral/ontodis-elec.ttl  [R=302,L]
 
 # --- legal ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^legal/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/legal/  [R=302,L]
-RewriteRule ^legal/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/domain/legal/ontodis-legal.ttl  [R=302,L]
+RewriteRule ^legal/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/domain/legal/ontodis-legal.ttl  [R=302,L]
 
 # --- inference ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^inference/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/inference/  [R=302,L]
-RewriteRule ^inference/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/application/ontodis-inference.ttl  [R=302,L]
+RewriteRule ^inference/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/application/ontodis-inference.ttl  [R=302,L]
 
 # --- alignments (external) ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^alignments/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/reference/alignments/  [R=302,L]
-RewriteRule ^alignments/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/adapter/ontodis-alignments.ttl  [R=302,L]
+RewriteRule ^alignments/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/adapter/ontodis-alignments.ttl  [R=302,L]
 
 # --- gufo-alignment (no dedicated doc page; always Turtle) ---
-RewriteRule ^gufo-alignment/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/adapter/ontodis-gufo-alignment.ttl  [R=302,L]
+RewriteRule ^gufo-alignment/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/adapter/ontodis-gufo-alignment.ttl  [R=302,L]
 
 # --- full integrated (entry point for Protege/reasoners) ---
-RewriteRule ^full/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^full/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 
 # =============================================================================
 # 3. Versioned IRIs (owl:versionIRI)
@@ -200,6 +200,22 @@ RewriteRule ^1\.7\.0/alignments$      https://gitlab.com/gustavosouto/ontodisinf
 RewriteRule ^1\.7\.0/gufo-alignment$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/adapter/ontodis-gufo-alignment.ttl    [R=302,L]
 RewriteRule ^1\.7\.0/full$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/composition/ontodis-full.ttl          [R=302,L]
 
+# --- 2.0.0 ---
+# Major: renomeia core:Agente para core:ContaDeRedeSocial (subtipos ContaPessoaFisica/
+# ContaInstitucional/ContaBotAutomatizada, propriedades temContaOperadora/eventoPorConta/
+# contaDisparouEvento, inference:ContaDeAltoRiscoEleitoral), mantendo os nomes antigos como
+# owl:deprecated (owl:equivalentClass/equivalentProperty) ate a v3.0.0. Remove os deprecated
+# da v1.5.0 (core:TipoConteudo, temTipoConteudo/tipoConteudoDe, 5 TC_*). legal:temAgenteImputado
+# preservado: designa o principal responsavel, nao a conta.
+RewriteRule ^2\.0\.0/core$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/domain/core/ontodis-core.ttl          [R=302,L]
+RewriteRule ^2\.0\.0/ml$              https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/domain/ml/ontodis-ml.ttl              [R=302,L]
+RewriteRule ^2\.0\.0/electoral$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/domain/electoral/ontodis-elec.ttl     [R=302,L]
+RewriteRule ^2\.0\.0/legal$           https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/domain/legal/ontodis-legal.ttl        [R=302,L]
+RewriteRule ^2\.0\.0/inference$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/application/ontodis-inference.ttl     [R=302,L]
+RewriteRule ^2\.0\.0/alignments$      https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/adapter/ontodis-alignments.ttl        [R=302,L]
+RewriteRule ^2\.0\.0/gufo-alignment$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/adapter/ontodis-gufo-alignment.ttl    [R=302,L]
+RewriteRule ^2\.0\.0/full$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/composition/ontodis-full.ttl          [R=302,L]
+
 
 
 
@@ -218,5 +234,5 @@ RewriteRule ^metrics/?$          https://gustavosouto.gitlab.io/ontodisinfo-elec
 # =============================================================================
 # 5. Convenience redirects
 # =============================================================================
-RewriteRule ^latest/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v1.7.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^latest/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 RewriteRule ^repo/?$    https://gitlab.com/gustavosouto/ontodisinfo-electoral                                                      [R=302,L]

--- a/ontodisinfo/.htaccess
+++ b/ontodisinfo/.htaccess
@@ -37,9 +37,9 @@ RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/  [R=302,L]
 # RDF tools -> consolidated Turtle pinned to the latest release tag
 RewriteCond %{HTTP_ACCEPT} (text/turtle|application/(rdf\+xml|x-turtle|ld\+json|n-triples|n-quads))
-RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.1.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 # Default (no Accept header, curl, etc.) -> Turtle, Linked Data convention
-RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.1.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 
 # =============================================================================
 # 2. Individual modules with content negotiation
@@ -49,38 +49,38 @@ RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0
 # --- core ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^core/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/core/  [R=302,L]
-RewriteRule ^core/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/domain/core/ontodis-core.ttl  [R=302,L]
+RewriteRule ^core/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.1.0/ontology/domain/core/ontodis-core.ttl  [R=302,L]
 
 # --- ml ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^ml/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/ml/  [R=302,L]
-RewriteRule ^ml/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/domain/ml/ontodis-ml.ttl  [R=302,L]
+RewriteRule ^ml/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.1.0/ontology/domain/ml/ontodis-ml.ttl  [R=302,L]
 
 # --- electoral ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^electoral/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/electoral/  [R=302,L]
-RewriteRule ^electoral/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/domain/electoral/ontodis-elec.ttl  [R=302,L]
+RewriteRule ^electoral/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.1.0/ontology/domain/electoral/ontodis-elec.ttl  [R=302,L]
 
 # --- legal ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^legal/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/legal/  [R=302,L]
-RewriteRule ^legal/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/domain/legal/ontodis-legal.ttl  [R=302,L]
+RewriteRule ^legal/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.1.0/ontology/domain/legal/ontodis-legal.ttl  [R=302,L]
 
 # --- inference ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^inference/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/inference/  [R=302,L]
-RewriteRule ^inference/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/application/ontodis-inference.ttl  [R=302,L]
+RewriteRule ^inference/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.1.0/ontology/application/ontodis-inference.ttl  [R=302,L]
 
 # --- alignments (external) ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^alignments/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/reference/alignments/  [R=302,L]
-RewriteRule ^alignments/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/adapter/ontodis-alignments.ttl  [R=302,L]
+RewriteRule ^alignments/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.1.0/ontology/adapter/ontodis-alignments.ttl  [R=302,L]
 
 # --- gufo-alignment (no dedicated doc page; always Turtle) ---
-RewriteRule ^gufo-alignment/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/adapter/ontodis-gufo-alignment.ttl  [R=302,L]
+RewriteRule ^gufo-alignment/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.1.0/ontology/adapter/ontodis-gufo-alignment.ttl  [R=302,L]
 
 # --- full integrated (entry point for Protege/reasoners) ---
-RewriteRule ^full/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^full/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.1.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 
 # =============================================================================
 # 3. Versioned IRIs (owl:versionIRI)
@@ -219,6 +219,23 @@ RewriteRule ^2\.0\.0/full$            https://gitlab.com/gustavosouto/ontodisinf
 
 
 
+# --- 2.1.0 ---
+# Minor: auditoria de estereótipos gUFO/UFO (OntoClean). Category corrigida para
+# rígida; papéis multi-kind como RoleMixin; eventos como EventType; subtipos de
+# operação da conta por critério misto (operador define Role; modo bot define
+# Phase); 13 tipologias qualitativas migradas de gufo:Category para vocabulários
+# SKOS (skos:ConceptScheme/skos:Concept, IRIs preservados); classes derivadas da
+# inferência como Role. Aditivo: nenhuma IRI removida ou renomeada.
+RewriteRule ^2\.1\.0/core$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.1.0/ontology/domain/core/ontodis-core.ttl          [R=302,L]
+RewriteRule ^2\.1\.0/ml$              https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.1.0/ontology/domain/ml/ontodis-ml.ttl              [R=302,L]
+RewriteRule ^2\.1\.0/electoral$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.1.0/ontology/domain/electoral/ontodis-elec.ttl     [R=302,L]
+RewriteRule ^2\.1\.0/legal$           https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.1.0/ontology/domain/legal/ontodis-legal.ttl        [R=302,L]
+RewriteRule ^2\.1\.0/inference$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.1.0/ontology/application/ontodis-inference.ttl     [R=302,L]
+RewriteRule ^2\.1\.0/alignments$      https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.1.0/ontology/adapter/ontodis-alignments.ttl        [R=302,L]
+RewriteRule ^2\.1\.0/gufo-alignment$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.1.0/ontology/adapter/ontodis-gufo-alignment.ttl    [R=302,L]
+RewriteRule ^2\.1\.0/full$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.1.0/ontology/composition/ontodis-full.ttl          [R=302,L]
+
+
 # =============================================================================
 # 4. Documentation shortcuts (HTML site sections)
 #    Citable URLs for specific parts of the public documentation.
@@ -234,5 +251,5 @@ RewriteRule ^metrics/?$          https://gustavosouto.gitlab.io/ontodisinfo-elec
 # =============================================================================
 # 5. Convenience redirects
 # =============================================================================
-RewriteRule ^latest/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.0.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^latest/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.1.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 RewriteRule ^repo/?$    https://gitlab.com/gustavosouto/ontodisinfo-electoral                                                      [R=302,L]


### PR DESCRIPTION
#### Purpose of this update

Same release pattern as the previous version PRs for the `/ontodisinfo/` namespace, now for releases **v2.0.0** and **v2.1.0** of OntoDisinfo-Electoral:

1. **New fixed redirects `/2.0.0/*` and `/2.1.0/*`** for the eight module IRIs (core, ml, electoral, legal, inference, alignments, gufo-alignment, full), pinned to the Git tags `v2.0.0` and `v2.1.0` of the source repository.

2. **Repoint of the unversioned IRIs** (namespace root, the eight modules and `/latest`) from tag `v1.7.0` to tag `v2.1.0`, keeping the policy that unversioned IRIs always serve the latest release while versioned IRIs stay immutable.

Release v2.0.0 renamed `core:Agente` to `core:ContaDeRedeSocial` (old names kept as `owl:deprecated` until v3.0.0). Release v2.1.0 is the gUFO/UFO stereotype audit (OntoClean): `Category` corrected to rigid, multi-kind roles as RoleMixin, events as EventType, account-operation subtypes by a mixed criterion (operator defines Role, automated mode defines Phase), 13 qualitative typologies migrated from `gufo:Category` to SKOS controlled vocabularies (`skos:ConceptScheme` / `skos:Concept`), and derived inference classes as Role. Minor, additive release: no IRI removed or renamed; data and corpus unchanged.

#### What is preserved

- All versioned IRIs `/1.0.0/*` through `/2.0.0/*` remain pinned to their original tags.
- Documentation shortcuts (`/docs`, `/about`, `/cite`, `/scenarios`, `/pipeline`, `/reproducibility`, `/metrics`) unchanged.
- Content negotiation rules unchanged.
- License (CC BY 4.0), serialization (Turtle), OWL 2 DL profile and maintainer remain the same.

#### Backwards compatibility

Zero breaking changes: every IRI that resolved before continues to resolve. Unversioned IRIs now serve the v2.1.0 artifacts, consistent with the namespace policy established in PR #5978.

#### Maintainer

- **Name:** Gustavo Souto Silva de Barros Santos
- **Affiliation:** Center for Informatics (CIn), Federal University of Pernambuco (UFPE), Brazil
- **Email:** gssbs@cin.ufpe.br
- **GitHub:** [@gustavosouto](https://github.com/gustavosouto)
