### PR TITLE
Add-UOGTO-namespace-redirects

### DIFF
--- a/uogto/.htaccess
+++ b/uogto/.htaccess
@@ -1,0 +1,9 @@
+RewriteEngine On
+
+# Universal Open Game Theory Ontology (UOGTO)
+# Maintainer: Edwin Chan <edithatogo@users.noreply.github.com>
+# Project: https://github.com/edithatogo/UOGTO
+
+RewriteRule ^$ https://edithatogo.github.io/UOGTO/ [R=303,L]
+RewriteRule ^core/?$ https://edithatogo.github.io/UOGTO/ [R=303,L]
+RewriteRule ^extensions/?$ https://edithatogo.github.io/UOGTO/ [R=303,L]

--- a/uogto/README.md
+++ b/uogto/README.md
@@ -1,0 +1,22 @@
+# UOGTO
+
+This directory contains W3ID redirects for the Universal Open Game Theory Ontology (UOGTO).
+
+## Redirects
+
+- `https://w3id.org/uogto/` redirects to the generated UOGTO documentation.
+- `https://w3id.org/uogto/core` supports the documented `https://w3id.org/uogto/core#` namespace IRI.
+- `https://w3id.org/uogto/extensions` supports the documented `https://w3id.org/uogto/extensions#` namespace IRI.
+
+URL fragments are not sent to HTTP servers, so the hash namespace IRIs are supported by redirecting the corresponding fragmentless paths.
+
+## Targets
+
+- Documentation: <https://edithatogo.github.io/UOGTO/>
+- Project repository: <https://github.com/edithatogo/UOGTO>
+- Canonical RDF release asset: <https://github.com/edithatogo/UOGTO/releases/download/v1.0.0/uogto.ttl>
+
+## Contact
+
+- Maintainer: Edwin Chan
+- GitHub: <https://github.com/edithatogo>


### PR DESCRIPTION
Adds W3ID redirects for the Universal Open Game Theory Ontology (UOGTO).

Redirects requested:

- `https://w3id.org/uogto/` redirects to `https://edithatogo.github.io/UOGTO/`
- `https://w3id.org/uogto/core` redirects to `https://edithatogo.github.io/UOGTO/`
- `https://w3id.org/uogto/extensions` redirects to `https://edithatogo.github.io/UOGTO/`

The `core` and `extensions` paths support the documented hash namespace IRIs `https://w3id.org/uogto/core#` and `https://w3id.org/uogto/extensions#`, since URL fragments are not sent to the server.

Project repository: <https://github.com/edithatogo/UOGTO>

Canonical RDF release asset: <https://github.com/edithatogo/UOGTO/releases/download/v1.0.0/uogto.ttl>

Verified before submission:

- GitHub Pages documentation target returns HTTP 200.
- v1.0.0 RDF release asset resolves through the GitHub release redirect to HTTP 200.
