### PR TITLE
New persistent-URI domain italia/PublicInvestment for the public investment

### DIFF
--- a/italia/PublicInvestment/README.md
+++ b/italia/PublicInvestment/README.md
@@ -1,0 +1,27 @@
+Repository (italia/PublicInvestment) for redirecting to the public investment ontology and controlled vocabularies of DIPE
+===================
+
+We intend to use **w3id.org/italia/PublicInvestment** for national persistent URIs of the
+**public investment** domain of the Italian public sector. The domain is modelled by
+**DIPE — Dipartimento per la programmazione e il coordinamento della politica economica**
+(Presidenza del Consiglio dei Ministri), in the context of **Commitment C6** of the
+**6th Italian OGP National Action Plan (2024–2026)**, starting from the semantic analysis of
+the *Codice Unico di Progetto (CUP)* and the information managed by the OpenCUP portal.
+
+We initially plan to create:
++ `w3id.org/italia/PublicInvestment/onto` for the public investment ontology (prefix `pi`)
++ `w3id.org/italia/PublicInvestment/controlled-vocabulary` for the related controlled vocabularies
++ `w3id.org/italia/PublicInvestment/data` for the linked open data produced in the above context
+
+Some redirect rules point to the
+[GitHub repository of DIPE](https://github.com/PCM-DIPE/public-investment) we are using as
+semantic assets repository, open to all. We commit to maintaining the persistence of these URIs.
+
+This work is carried out with the semantic stewardship of ISTAT and in coordination with the
+Department for Digital Transformation (DTD), within the National Catalogue of Semantic Assets
+([schema.gov.it](https://schema.gov.it)).
+
+Contacts:
+
++ Francesco De Stefanis (DIPE): github (https://github.com/PCM-DIPE) - email (f.destefanis@governo.it)
++ Leonardo Salvatori (DIPE): github (https://github.com/PCM-DIPE) - email (leo.salvatori@governo.it)

--- a/italia/PublicInvestment/README.md
+++ b/italia/PublicInvestment/README.md
@@ -21,7 +21,8 @@ This work is carried out with the semantic stewardship of ISTAT and in coordinat
 Department for Digital Transformation (DTD), within the National Catalogue of Semantic Assets
 ([schema.gov.it](https://schema.gov.it)).
 
-Contacts:
+Maintainers and contacts:
 
-+ Francesco De Stefanis (DIPE): github (https://github.com/PCM-DIPE) - email (f.destefanis@governo.it)
-+ Leonardo Salvatori (DIPE): github (https://github.com/PCM-DIPE) - email (leo.salvatori@governo.it)
++ **GitHub handle (maintainer):** [@PCM-DIPE](https://github.com/PCM-DIPE) — the DIPE organisation account; please mention `@PCM-DIPE` here for anything regarding these redirects.
++ Francesco De Stefanis (DIPE): email (f.destefanis@governo.it)
++ Leonardo Salvatori (DIPE): email (leo.salvatori@governo.it)

--- a/italia/PublicInvestment/controlled-vocabulary/.htaccess
+++ b/italia/PublicInvestment/controlled-vocabulary/.htaccess
@@ -1,0 +1,21 @@
+# Vocabolari controllati del dominio investimenti pubblici (PublicInvestment) - w3id namespace
+# Maintainer: DIPE - PCM. Contatto: f.destefanis@governo.it (Francesco De Stefanis), leo.salvatori@governo.it (Leonardo Salvatori) | GitHub: https://github.com/PCM-DIPE
+
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+SetEnvIf Accept ^.*text/turtle.* SYNTAX=ttl
+SetEnvIf Accept ^.*application/json.* SYNTAX=json
+SetEnvIf Accept ^.*application/csv.* SYNTAX=csv
+SetEnvIf Accept ^.*text/csv.* SYNTAX=csv
+SetEnvIf Accept ^.*text/html.* SYNTAX=html
+SetEnvIf Request_URI ^.*$ ROOT_URL=https://raw.githubusercontent.com/PCM-DIPE/public-investment/main/assets/controlled-vocabularies/
+
+RewriteCond %{ENV:SYNTAX} ^(ttl|json|csv)$
+RewriteRule ^([a-zA-Z-_0-9]+)(/?)$ %{ENV:ROOT_URL}$1/latest/$1.%{ENV:SYNTAX} [R=303,L]
+
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^(.+)$ https://schema.gov.it/lodview/PublicInvestment/controlled-vocabulary/$1 [R=303,L]
+
+RewriteRule ^(.+)/(.+)/(.+)$ https://schema.gov.it/lodview/PublicInvestment/controlled-vocabulary/$1/$2/$3 [R=303,L]

--- a/italia/PublicInvestment/data/.htaccess
+++ b/italia/PublicInvestment/data/.htaccess
@@ -1,0 +1,38 @@
+# Dati - schede progetto per Codice Unico di Progetto (CUP) - w3id namespace
+# Le URI  https://w3id.org/italia/PublicInvestment/data/CUP/{CUP}  sono gli
+# IDENTIFICATORI UFFICIALI E PERSISTENTI dei progetti CUP nei Linked Open Data:
+# ovunque, nei dati collegati, un progetto si riferisce con questa URI.
+#
+# Risoluzione:
+#   - HTML (e default): scheda pubblica del progetto su OpenCUP, per codice CUP.
+#   - JSON: rimandato. L'API OpenCUP per singolo CUP e' attualmente protetta da token
+#     (https://api.sogei.it/rgs/opencup/o/extServiceApi/v1/opendataes/cup/{CUP}, risponde 401),
+#     quindi non e' adatta a un'URI aperta. Verra' abilitata quando sara' disponibile un
+#     accesso aperto oppure una scheda statica (HTML+JS) ospitata dal DIPE. Vedi blocco
+#     commentato in fondo, gia' pronto da attivare.
+#
+# Maintainer: DIPE - PCM. Contatto: f.destefanis@governo.it (Francesco De Stefanis), leo.salvatori@governo.it (Leonardo Salvatori) | GitHub: https://github.com/PCM-DIPE
+
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+# Risoluzione del singolo CUP -> scheda pubblica OpenCUP (per codice CUP).
+# Esempio: /data/CUP/J59J21000640001 -> https://www.opencup.gov.it/portale/progetto/-/cup/J59J21000640001
+RewriteRule ^CUP/([A-Za-z0-9]+)/?$ https://www.opencup.gov.it/portale/progetto/-/cup/$1 [R=303,L]
+
+
+# ----------------------------------------------------------------------------
+# DA ATTIVARE IN FUTURO (content negotiation HTML/JSON), quando l'accesso al
+# dato sara' aperto. Sostituire la regola sopra con il blocco seguente:
+#
+# SetEnvIf Accept ^.*application/json.* SYNTAX=json
+# SetEnvIf Accept ^.*text/html.*        SYNTAX=html
+#
+# # JSON -> dato strutturato (API aperta o endpoint statico)
+# RewriteCond %{ENV:SYNTAX} ^json$
+# RewriteRule ^CUP/([A-Za-z0-9]+)/?$ https://api.sogei.it/rgs/opencup/o/extServiceApi/v1/opendataes/cup/$1 [R=303,L]
+#
+# # HTML (e default) -> scheda pubblica OpenCUP
+# RewriteRule ^CUP/([A-Za-z0-9]+)/?$ https://www.opencup.gov.it/portale/progetto/-/cup/$1 [R=303,L]
+# ----------------------------------------------------------------------------

--- a/italia/PublicInvestment/onto/.htaccess
+++ b/italia/PublicInvestment/onto/.htaccess
@@ -1,0 +1,25 @@
+# Ontologia del dominio degli investimenti pubblici (PublicInvestment) - w3id namespace
+# Maintainer: DIPE - Dipartimento per la programmazione e il coordinamento
+# della politica economica, Presidenza del Consiglio dei Ministri (PCM)
+# Impegno C6 - 6 Piano d'Azione Nazionale OGP (2024-2026)
+# Contatto: f.destefanis@governo.it (Francesco De Stefanis), leo.salvatori@governo.it (Leonardo Salvatori) | GitHub: https://github.com/PCM-DIPE
+
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+SetEnvIf Accept ^.*application/rdf\+xml.* SYNTAX=rdf
+SetEnvIf Accept ^.*application/n-triples.* SYNTAX=n3
+SetEnvIf Accept ^.*text/turtle.* SYNTAX=ttl
+SetEnvIf Accept ^.*text/html.* SYNTAX=html
+SetEnvIf Request_URI ^.*$ ROOT_URL=https://raw.githubusercontent.com/PCM-DIPE/public-investment/main/assets/ontologies/
+
+RewriteCond %{ENV:SYNTAX} ^(rdf|ttl|owl|n3)$
+RewriteRule ^([a-zA-Z-_0-9]+)(/?)$ %{ENV:ROOT_URL}$1/latest/$1.%{ENV:SYNTAX} [R=303,L]
+
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^(.+)(/.+)$ https://schema.gov.it/lodview/PublicInvestment/onto/$1$2 [R=303,L]
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^(.+)/$ https://schema.gov.it/lode/extract?url=https://w3id.org/italia/PublicInvestment/onto/$1 [R=303,L]
+RewriteCond %{ENV:SYNTAX} ^html$
+RewriteRule ^(.+)$ https://schema.gov.it/lode/extract?url=https://w3id.org/italia/PublicInvestment/onto/$1 [R=303,L]


### PR DESCRIPTION
**Brief Description**
New persistent-URI domain italia/PublicInvestment for the public investment ontology and controlled vocabularies maintained by DIPE — Presidenza del Consiglio dei Ministri (Commitment C6, 6th Italian OGP National Action Plan). Redirects point to the DIPE GitHub semantic-assets repository and to schema.gov.it visualizers (LODE/LodView). Work carried out with ISTAT semantic stewardship.

**General Checklist**

-  Changes have been tested.
-  The number of commits is minimal.
-  Commits only include redirects and basic information.


**New ID Directory Checklist**

-  Maintainer details are in .htaccess/README.md.
-  GitHub username ids are listed in the maintainer details.


Adding a new domain under the existing italia/ namespace. 
Tagging the italia/ maintainers for approval: @mfortini @giorgialodi @Clou-dia 
Could you please confirm the OK for this new public-sector domain? 
Thank you.