### PR TITLE
Add tre namespaces

### DIFF
--- a/tre/.htaccess
+++ b/tre/.htaccess
@@ -1,0 +1,36 @@
+# Trusted Research Environment (TRE) vocabuary
+# including Five Safes Licence
+#
+# Contact
+#
+# This space is administered by:
+# Freek Dijkstra <freek.dijkstra@surf.nl>, Github @freekdijkstra
+# Slawa Loev <slawa.loev@surf.nl>, Github @slawa-loev
+#
+# Secondary administrators:
+# All members of https://github.com/orgs/odissei-data/people
+
+RewriteEngine On
+
+# Namespace root redirects to project repository home
+RewriteRule ^$ https://github.com/odissei-data/ODISSEI-Five-Safes-license/ [R=302,L]
+
+# Passthrough if explicit extension is given
+RewriteRule ^(.*)\.md$ https://github.com/odissei-data/ODISSEI-Five-Safes-license/blob/main/$1.md [R=302,L]
+RewriteRule ^(.*)\.html$ https://github.com/odissei-data/ODISSEI-Five-Safes-license/blob/main/$1.md [R=302,L]
+RewriteRule ^(.*)\.ttl$ https://raw.githubusercontent.com/odissei-data/ODISSEI-Five-Safes-license/refs/heads/main/$1.ttl [R=302,L]
+RewriteRule ^(.*)\.jsonld$ https://raw.githubusercontent.com/odissei-data/ODISSEI-Five-Safes-license/refs/heads/main/$1.jsonld [R=302,L]
+RewriteRule ^(.*)\.rdf$ https://raw.githubusercontent.com/odissei-data/ODISSEI-Five-Safes-license/refs/heads/main/$1.rdf [R=302,L]
+
+# Without extension, use HTTP Accept header to determine extension.
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^(.*?)/?$ https://raw.githubusercontent.com/odissei-data/ODISSEI-Five-Safes-license/refs/heads/main/$1.ttl [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^(.*?)/?$ https://raw.githubusercontent.com/odissei-data/ODISSEI-Five-Safes-license/refs/heads/main/$1.jsonld [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^(.*?)/?$ https://raw.githubusercontent.com/odissei-data/ODISSEI-Five-Safes-license/refs/heads/main/$1.rdf [R=302,L]
+
+# default (text/html and everything else)
+RewriteRule ^(.*?)/?$ https://github.com/odissei-data/ODISSEI-Five-Safes-license/blob/main/$1.md [R=302,L]

--- a/tre/README.md
+++ b/tre/README.md
@@ -1,0 +1,31 @@
+# Trusted Research Environment (TRE)
+
+This is the persistent URI namespace `https://w3id.org/tre/`, providing stable
+identifiers for the TRE vocabulary and ODISSEI Five Safes License.
+
+Trusted Research Environments (sometimes also called Secure Processing Environments) provide a means to analyse data without the data leaking the environment. More information at the home page.
+
+## Homepage
+
+For the vocabulary:
+
+- https://github.com/odissei-data/ODISSEI-Five-Safes-license
+
+Latest version of the Five Safes License:
+
+- https://doi.org/10.5281/zenodo.18456774
+
+Content is negotiated by `Accept` header (Turtle, JSON-LD, RDF/XML) with a
+human-readable Markdown rendering as the default; explicit file extensions
+(`.ttl`, `.jsonld`, `.rdf`, `.md`, `.html`) bypass negotiation. See `.htaccess`.
+
+## Contact
+
+This namespace is administered by:
+
+- Freek Dijkstra <freek.dijkstra@surf.nl>, [@freekdijkstra](https://github.com/freekdijkstra)
+- Slawa Loev <slawa.loev@surf.nl>, [@slawa-loev](https://github.com/slawa-loev)
+
+Secondary administrators:
+
+- All members of https://github.com/orgs/odissei-data/people


### PR DESCRIPTION
For Trusted Research Environments (TRE) vocabulary and ODISSEI Five Safes License.

## Brief Description
This registers the persistent URI namespace `https://w3id.org/tre/`, providing stable
identifiers for the TRE vocabulary and ODISSEI Five Safes License.

Trusted Research Environments (TRE; sometimes also called Secure Processing Environments) provide a means to analyse data without the data leaking the environment.

## General Checklist
- [X] Changes have been tested.
- [X] The number of commits is minimal. Squash if needed.
- [X] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [X] Maintainer details are in `.htaccess` or `README.md`.
- [X] GitHub username ids are listed in the maintainer details.
