### PR TITLE
Add namespace for the BEAST ontology

### DIFF
--- a/beast/.htaccess
+++ b/beast/.htaccess
@@ -1,0 +1,14 @@
+# 1. Enable Rewriting
+RewriteEngine On
+
+# 2. Redirect for the Ontology
+RewriteRule ^ontology$ https://hexwitches.github.io/beast/ontology/ontology.ttl [R=303,L]
+
+# 3. Redirect for the Knowledge Graph
+RewriteRule ^graph(/.*)?$ https://hexwitches.github.io/beast/graph/graph.ttl [R=303,L]
+
+# 4. Redirect for the Website Pages
+RewriteRule ^([^/.]+)$ https://hexwitches.github.io/beast/$1.html [R=303,L]
+
+# 5. Redirect for the Website Base
+RewriteRule ^$ https://hexwitches.github.io/beast/ [R=303,L]

--- a/beast/README.md
+++ b/beast/README.md
@@ -1,0 +1,17 @@
+README.md
+# BEAST (beast-ontology)
+
+- **Description**: Persistent identifiers for the BEAST, its ontology and knowledge graph.
+- **Project URL**: https://hexwitches.github.io/beast/
+- **Maintainers**:
+  - [hexWitches](https://github.com/hexWitches)
+- **Status**: Active
+
+This directory provides redirection for:
+- The main website: https://w3id.org/beast/
+- The Ontology: https://w3id.org/beast/ontology
+- The Knowledge Graph: https://w3id.org/beast/graph
+
+## Contact
+For issues or updates regarding these identifiers, please contact
+[mir-pin](https://github.com/mir-pin) or [sararoggi](https://github.com/sararoggi) via GitHub.


### PR DESCRIPTION
## Brief Description
Creating a permanent identifier for our semantic digital library hosted on Github Pages.