### PR TITLE
Add dataerai namespace for Dataerai DID persistent identifiers

### DIFF
--- a/dataerai/.htaccess
+++ b/dataerai/.htaccess
@@ -1,39 +1,29 @@
-# w3id.org/dataerai/… → Dataerai DID resolve API
-#
-# Submit this directory to https://github.com/perma-id/w3id.org (fork → add a
-# root-level `dataerai/` dir → PR). Once merged, w3id.org serves these
-# redirects from the permanent `https://w3id.org/dataerai/...` namespace.
+# w3id.org/dataerai — persistent identifiers for Dataerai DIDs
 #
 # DID shape: did:dataerai:[<env>:]<kind>:<subject>
-#   prod → https://w3id.org/dataerai/<kind>/<subj>
-#   dev  → https://w3id.org/dataerai/dev/<kind>/<subj>
-#   beta → https://w3id.org/dataerai/beta/<kind>/<subj>
-# Each redirects to that environment's app host, where the console serves the
-# public, host-agnostic resolve API GET /api/identity/resolve/<did>/ (AllowAny,
-# no resolver host required). The rule reconstructs the full DID from the path.
-# Confirm the app hosts below match the real per-environment domains.
+#   <env>     dev | beta (absent in production)
+#   <kind>    asset | dataset | person | project
+#   <subject> 32 lowercase base32 chars [a-z2-7]
+#
+# w3id.org/dataerai/[<env>/]<kind>/<subject> 303-redirects to the public DID
+# resolve API on that environment's host, reconstructing the full DID from the
+# path. NE keeps the literal ':' in the substitution.
 
 Options +FollowSymLinks
 RewriteEngine On
 
-# Clients are 303'd to the machine-readable resolve document (application/json).
-# A human landing page is a follow-up (add a content-negotiated 303→HTML rule
-# here once one exists). NE keeps the literal ':' in the reconstructed DID;
-# Django's <str:did> path converter matches it verbatim.
+# ── Non-production: /dataerai/<env>/<kind>/<subj> ─────────────────────────────
+RewriteRule ^(dev|beta)/(asset|dataset|person|project)/([a-z2-7]{32})/?$ https://$1.dataerai.com/api/identity/resolve/did:dataerai:$1:$2:$3/ [R=303,L,NE]
 
-# ── Non-production: /dataerai/<env>/<kind>/<subj> → env app-host resolve API ──
-RewriteRule ^(dev|beta)/(asset|dataset|person)/([a-z2-7]{32})/?$ https://$1.dataerai.com/api/identity/resolve/did:dataerai:$1:$2:$3/ [R=303,L,NE]
+# ── Production: /dataerai/<kind>/<subj> ───────────────────────────────────────
+RewriteRule ^(asset|dataset|person|project)/([a-z2-7]{32})/?$ https://app.dataerai.com/api/identity/resolve/did:dataerai:$1:$2/ [R=303,L,NE]
 
-# ── Production: /dataerai/<kind>/<subj> → prod app-host resolve API ───────────
-RewriteRule ^(asset|dataset|person)/([a-z2-7]{32})/?$ https://app.dataerai.com/api/identity/resolve/did:dataerai:$1:$2/ [R=303,L,NE]
-
-# ── FUTURE (standards-conformant did:web) ────────────────────────────────────
-# When each id.<env>.dataerai.com serves the console did:web routes over public
-# HTTPS (IDENTITY_RESOLVER_HOST set per env; Route53 + ACM + ALB :443 +
-# Host-preserving nginx), swap the two rules above for these so w3id resolves to
-# a W3C did:web document instead of the resolve API:
-#   RewriteRule ^(dev|beta)/(asset|dataset|person)/([a-z2-7]{32})/?$ https://id.$1.dataerai.com/$2/$3/did.json [R=303,L,NE]
-#   RewriteRule ^(asset|dataset|person)/([a-z2-7]{32})/?$ https://id.dataerai.com/$1/$2/did.json [R=303,L,NE]
+# ── Future (standards-conformant did:web) ─────────────────────────────────────
+# Once the id.<env>.dataerai.com resolver hosts serve did:web over public HTTPS,
+# swap the two rules above for these so w3id resolves to the W3C did:web
+# document instead of the resolve API:
+#   RewriteRule ^(dev|beta)/(asset|dataset|person|project)/([a-z2-7]{32})/?$ https://id.$1.dataerai.com/$2/$3/did.json [R=303,L,NE]
+#   RewriteRule ^(asset|dataset|person|project)/([a-z2-7]{32})/?$ https://id.dataerai.com/$1/$2/did.json [R=303,L,NE]
 
 # Bare namespace → documentation
 RewriteRule ^/?$ https://docs.dataerai.com/identity/overview [R=302,L]

--- a/dataerai/.htaccess
+++ b/dataerai/.htaccess
@@ -1,0 +1,39 @@
+# w3id.org/dataerai/… → Dataerai DID resolve API
+#
+# Submit this directory to https://github.com/perma-id/w3id.org (fork → add a
+# root-level `dataerai/` dir → PR). Once merged, w3id.org serves these
+# redirects from the permanent `https://w3id.org/dataerai/...` namespace.
+#
+# DID shape: did:dataerai:[<env>:]<kind>:<subject>
+#   prod → https://w3id.org/dataerai/<kind>/<subj>
+#   dev  → https://w3id.org/dataerai/dev/<kind>/<subj>
+#   beta → https://w3id.org/dataerai/beta/<kind>/<subj>
+# Each redirects to that environment's app host, where the console serves the
+# public, host-agnostic resolve API GET /api/identity/resolve/<did>/ (AllowAny,
+# no resolver host required). The rule reconstructs the full DID from the path.
+# Confirm the app hosts below match the real per-environment domains.
+
+Options +FollowSymLinks
+RewriteEngine On
+
+# Clients are 303'd to the machine-readable resolve document (application/json).
+# A human landing page is a follow-up (add a content-negotiated 303→HTML rule
+# here once one exists). NE keeps the literal ':' in the reconstructed DID;
+# Django's <str:did> path converter matches it verbatim.
+
+# ── Non-production: /dataerai/<env>/<kind>/<subj> → env app-host resolve API ──
+RewriteRule ^(dev|beta)/(asset|dataset|person)/([a-z2-7]{32})/?$ https://$1.dataerai.com/api/identity/resolve/did:dataerai:$1:$2:$3/ [R=303,L,NE]
+
+# ── Production: /dataerai/<kind>/<subj> → prod app-host resolve API ───────────
+RewriteRule ^(asset|dataset|person)/([a-z2-7]{32})/?$ https://app.dataerai.com/api/identity/resolve/did:dataerai:$1:$2/ [R=303,L,NE]
+
+# ── FUTURE (standards-conformant did:web) ────────────────────────────────────
+# When each id.<env>.dataerai.com serves the console did:web routes over public
+# HTTPS (IDENTITY_RESOLVER_HOST set per env; Route53 + ACM + ALB :443 +
+# Host-preserving nginx), swap the two rules above for these so w3id resolves to
+# a W3C did:web document instead of the resolve API:
+#   RewriteRule ^(dev|beta)/(asset|dataset|person)/([a-z2-7]{32})/?$ https://id.$1.dataerai.com/$2/$3/did.json [R=303,L,NE]
+#   RewriteRule ^(asset|dataset|person)/([a-z2-7]{32})/?$ https://id.dataerai.com/$1/$2/did.json [R=303,L,NE]
+
+# Bare namespace → documentation
+RewriteRule ^/?$ https://docs.dataerai.com/identity/overview [R=302,L]

--- a/dataerai/README.md
+++ b/dataerai/README.md
@@ -1,55 +1,29 @@
-# `dataerai` — w3id.org permanent-identifier namespace
+# dataerai
 
-Registers the **`dataerai`** namespace on [w3id.org](https://w3id.org) (the W3C
-Permanent Identifier Community Group's redirect service) so Dataerai DIDs have a
-stable, vendor-neutral citation URL that redirects to the environment's DID
-resolve API.
+Persistent identifiers for Dataerai decentralized identifiers (DIDs) of the
+form `did:dataerai:[<env>:]<kind>:<subject>`, where `<env>` is `dev` or `beta`
+(absent in production), `<kind>` is one of `asset`, `dataset`, `person`, or
+`project`, and `<subject>` is 32 lowercase base32 characters (`[a-z2-7]`).
 
-## What it does
+`https://w3id.org/dataerai/[<env>/]<kind>/<subject>` 303-redirects to the
+public DID resolve API on the matching Dataerai environment:
 
-`https://w3id.org/dataerai/[<env>/]<kind>/<subject>` → the public, host-agnostic
-resolve API on that environment's app host, with the full DID reconstructed from
-the path:
+| w3id URL | Redirects to |
+|----------|--------------|
+| `w3id.org/dataerai/<kind>/<subj>` | `https://app.dataerai.com/api/identity/resolve/did:dataerai:<kind>:<subj>/` |
+| `w3id.org/dataerai/dev/<kind>/<subj>` | `https://dev.dataerai.com/api/identity/resolve/did:dataerai:dev:<kind>:<subj>/` |
+| `w3id.org/dataerai/beta/<kind>/<subj>` | `https://beta.dataerai.com/api/identity/resolve/did:dataerai:beta:<kind>:<subj>/` |
 
-| DID | w3id citation URL | Resolves to |
-|-----|-------------------|-------------|
-| `did:dataerai:asset:<subj>` (prod) | `w3id.org/dataerai/asset/<subj>` | `https://app.dataerai.com/api/identity/resolve/did:dataerai:asset:<subj>/` |
-| `did:dataerai:dev:asset:<subj>` | `w3id.org/dataerai/dev/asset/<subj>` | `https://dev.dataerai.com/api/identity/resolve/did:dataerai:dev:asset:<subj>/` |
-| `did:dataerai:beta:asset:<subj>` | `w3id.org/dataerai/beta/asset/<subj>` | `https://beta.dataerai.com/api/identity/resolve/did:dataerai:beta:asset:<subj>/` |
+The bare namespace `https://w3id.org/dataerai/` redirects to the documentation
+at <https://docs.dataerai.com/identity/overview>.
 
-`<kind>` ∈ {asset, dataset, person}; `<subject>` is 32 base32 chars. The env tag
-mirrors `IDENTITY_ENV` (empty in production).
+## Maintainers
 
-## Prerequisite
+Maintained by [Dataerai](https://github.com/Dataerai). The source of truth is
+the `ops/w3id/dataerai/` directory of the `datatransfer-dataerai` repository;
+changes are re-submitted from there.
 
-Each environment's app host (`<env>.dataerai.com` / `app.dataerai.com`) must
-serve the console's public `GET /api/identity/resolve/<did>/` endpoint — it does
-by default (`AllowAny`, **no** resolver host required). `IDENTITY_ENV` must be set
-per environment (Helm `env.identityEnv` → `IDENTITY_ENV`, wired from the
-`.gitlab-ci.yml` workflow rules) so DIDs — and therefore their w3id paths — carry
-the correct env segment. w3id only redirects; the document lives on our host.
-Adjust the hosts in [`.htaccess`](./.htaccess) if the real domains differ.
+- Joshua C Agar — [@jagar2](https://github.com/jagar2)
+- Chad Peiper — [@kinor](https://github.com/kinor)
 
-> A standards-conformant `did:web` variant (w3id → `id.<env>.dataerai.com/.../did.json`)
-> is kept commented in [`.htaccess`](./.htaccess); enable it once the `id.<env>`
-> resolver hosts are stood up over public HTTPS.
-
-## How to register (one-time)
-
-1. Confirm the app hosts in `.htaccess` and the maintainer contact below.
-2. Fork <https://github.com/perma-id/w3id.org>.
-3. Copy this `dataerai/` directory to the **root** of your fork.
-4. Open a PR; a Community Group member reviews and merges it (w3id auto-deploys).
-5. Verify:
-   ```bash
-   curl -sIL https://w3id.org/dataerai/beta/asset/<subj>
-   # → 303 to https://beta.dataerai.com/api/identity/resolve/did:dataerai:beta:asset:<subj>/ → 200
-   ```
-
-## Maintainer
-
-- **Org**: Dataerai
-- **Contact**: `identity@dataerai.com` _(confirm or replace — w3id requires a
-  long-lived address in the PR)._
-- **Source of truth**: this directory in the `datatransfer-dataerai` monorepo
-  (`ops/w3id/dataerai/`). Edit here and re-PR upstream on change.
+Contact: <identity@dataerai.com>

--- a/dataerai/README.md
+++ b/dataerai/README.md
@@ -1,0 +1,55 @@
+# `dataerai` — w3id.org permanent-identifier namespace
+
+Registers the **`dataerai`** namespace on [w3id.org](https://w3id.org) (the W3C
+Permanent Identifier Community Group's redirect service) so Dataerai DIDs have a
+stable, vendor-neutral citation URL that redirects to the environment's DID
+resolve API.
+
+## What it does
+
+`https://w3id.org/dataerai/[<env>/]<kind>/<subject>` → the public, host-agnostic
+resolve API on that environment's app host, with the full DID reconstructed from
+the path:
+
+| DID | w3id citation URL | Resolves to |
+|-----|-------------------|-------------|
+| `did:dataerai:asset:<subj>` (prod) | `w3id.org/dataerai/asset/<subj>` | `https://app.dataerai.com/api/identity/resolve/did:dataerai:asset:<subj>/` |
+| `did:dataerai:dev:asset:<subj>` | `w3id.org/dataerai/dev/asset/<subj>` | `https://dev.dataerai.com/api/identity/resolve/did:dataerai:dev:asset:<subj>/` |
+| `did:dataerai:beta:asset:<subj>` | `w3id.org/dataerai/beta/asset/<subj>` | `https://beta.dataerai.com/api/identity/resolve/did:dataerai:beta:asset:<subj>/` |
+
+`<kind>` ∈ {asset, dataset, person}; `<subject>` is 32 base32 chars. The env tag
+mirrors `IDENTITY_ENV` (empty in production).
+
+## Prerequisite
+
+Each environment's app host (`<env>.dataerai.com` / `app.dataerai.com`) must
+serve the console's public `GET /api/identity/resolve/<did>/` endpoint — it does
+by default (`AllowAny`, **no** resolver host required). `IDENTITY_ENV` must be set
+per environment (Helm `env.identityEnv` → `IDENTITY_ENV`, wired from the
+`.gitlab-ci.yml` workflow rules) so DIDs — and therefore their w3id paths — carry
+the correct env segment. w3id only redirects; the document lives on our host.
+Adjust the hosts in [`.htaccess`](./.htaccess) if the real domains differ.
+
+> A standards-conformant `did:web` variant (w3id → `id.<env>.dataerai.com/.../did.json`)
+> is kept commented in [`.htaccess`](./.htaccess); enable it once the `id.<env>`
+> resolver hosts are stood up over public HTTPS.
+
+## How to register (one-time)
+
+1. Confirm the app hosts in `.htaccess` and the maintainer contact below.
+2. Fork <https://github.com/perma-id/w3id.org>.
+3. Copy this `dataerai/` directory to the **root** of your fork.
+4. Open a PR; a Community Group member reviews and merges it (w3id auto-deploys).
+5. Verify:
+   ```bash
+   curl -sIL https://w3id.org/dataerai/beta/asset/<subj>
+   # → 303 to https://beta.dataerai.com/api/identity/resolve/did:dataerai:beta:asset:<subj>/ → 200
+   ```
+
+## Maintainer
+
+- **Org**: Dataerai
+- **Contact**: `identity@dataerai.com` _(confirm or replace — w3id requires a
+  long-lived address in the PR)._
+- **Source of truth**: this directory in the `datatransfer-dataerai` monorepo
+  (`ops/w3id/dataerai/`). Edit here and re-PR upstream on change.


### PR DESCRIPTION
Registers the `dataerai` namespace so Dataerai decentralized identifiers (did:dataerai:[<env>:]<kind>:<subject>) have a stable, vendor-neutral citation URL. https://w3id.org/dataerai/[<env>/]<kind>/<subject> 303-redirects to the Dataerai DID resolve API for that environment.

Maintainer: Dataerai (contact: identity@dataerai.com).

<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [ ] Changes have been tested.
- [ ] The number of commits is minimal. Squash if needed.
- [ ] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
