### PR TITLE
Add tvdberg namespace (stego-agentic redirect)

### DIFF
--- a/tvdberg/.htaccess
+++ b/tvdberg/.htaccess
@@ -1,0 +1,9 @@
+# Timo van den Berg — research identifiers
+# Administered by: Timo van den Berg
+# Contact: tvdberg@timosberg.nl
+# GitHub: SuperTiem
+Options +FollowSymLinks
+RewriteEngine on
+
+# Steganography in agentic coding
+RewriteRule ^stego-agentic(/.*)?$ https://github.com/SuperTiem/Steganography-agentic-coding$1 [R=302,L]

--- a/tvdberg/README.md
+++ b/tvdberg/README.md
@@ -1,0 +1,12 @@
+# Timo van den Berg — research identifiers
+
+Permanent identifiers for research projects by Timo van den Berg.
+
+This space is administered by:
+Timo van den Berg
+tvdberg@timosberg.nl
+GitHub username: SuperTiem
+
+## Projects
+- /stego-agentic → Steganography in agentic coding systems research repo
+  (https://github.com/SuperTiem/Steganography-agentic-coding)


### PR DESCRIPTION
## Brief Description
Add new `tvdberg` namespace with a redirect from /tvdberg/stego-agentic to the
"Steganography in agentic coding" GitHub repository. Maintained by Timo van den Berg.

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
