### PR TITLE
Add w3id namespace for Design Uncertainty Taxonomy

### DIFF
--- a/design-uncertainty/.htaccess
+++ b/design-uncertainty/.htaccess
@@ -1,0 +1,24 @@
+Options +FollowSymLinks
+RewriteEngine On
+
+# Contact: uncertaintyinaeco@gmail.com
+# Project: Design Uncertainty Taxonomy
+
+# HTML documentation
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml+xml [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\*
+RewriteRule ^$ https://uncertaintyinaeco.github.io/DesignUncertainty_taxonomy/pylode/index.html [R=303,L]
+
+# Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^$ https://raw.githubusercontent.com/UncertaintyInAECO/DesignUncertainty_taxonomy/main/taxonomy/extensions/design-uncertainty-annotations.ttl [R=303,L]
+
+# RDF/XML
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://raw.githubusercontent.com/UncertaintyInAECO/DesignUncertainty_taxonomy/main/taxonomy/exports/design-uncertainty.rdf [R=303,L]
+
+# JSON-LD
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://raw.githubusercontent.com/UncertaintyInAECO/DesignUncertainty_taxonomy/main/taxonomy/exports/design-uncertainty.jsonld [R=303,L]

--- a/design-uncertainty/README.md
+++ b/design-uncertainty/README.md
@@ -23,6 +23,7 @@ This namespace resolves to the public documentation and RDF serializations of th
 
 - Name: Uncertainty in AECO Research Group
 - Contact: uncertaintyinaeco@gmail.com
+- github: https://github.com/UncertaintyInAECO
 - Repository: https://github.com/UncertaintyInAECO/DesignUncertainty_taxonomy
 
 ## Notes

--- a/design-uncertainty/README.md
+++ b/design-uncertainty/README.md
@@ -1,0 +1,31 @@
+# design-uncertainty
+
+Persistent identifier namespace for the Design Uncertainty Taxonomy.
+
+## Namespace
+
+```text
+https://w3id.org/design-uncertainty/
+```
+
+## Purpose
+
+This namespace resolves to the public documentation and RDF serializations of the Design Uncertainty Taxonomy.
+
+## Resolution targets
+
+- HTML documentation: GitHub Pages - https://uncertaintyinaeco.github.io/DesignUncertainty_taxonomy/pylode/index.html
+- Turtle source: repository raw file - https://github.com/UncertaintyInAECO/DesignUncertainty_taxonomy/blob/main/taxonomy/extensions/design-uncertainty-annotations.ttl
+- RDF/XML export: repository raw file - https://github.com/UncertaintyInAECO/DesignUncertainty_taxonomy/blob/main/taxonomy/exports/design-uncertainty.rdf
+- JSON-LD export: repository raw file - https://github.com/UncertaintyInAECO/DesignUncertainty_taxonomy/blob/main/taxonomy/exports/design-uncertainty.jsonld
+
+## Maintainer
+
+- Name: Uncertainty in AECO Research Group
+- Contact: uncertaintyinaeco@gmail.com
+- Repository: https://github.com/UncertaintyInAECO/DesignUncertainty_taxonomy
+
+## Notes
+
+The default browser resolution points to the HTML documentation page.
+Machine-readable RDF serializations are available through content negotiation.


### PR DESCRIPTION
This pull request adds the `https://w3id.org/design-uncertainty/` namespace.

It redirects:
- browser requests to the GitHub Pages HTML documentation,
- Turtle requests to the annotation TTL file,
- RDF/XML requests to the RDF export,
- JSON-LD requests to the JSON-LD export.

Project repository:
https://github.com/UncertaintyInAECO/DesignUncertainty_taxonomy

Maintainer contact:
uncertaintyinaeco@gmail.com

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
