### PR TITLE
Add HCMO (Home Cage Monitoring Ontology) namespace

### DIFF
--- a/HCMO/.htaccess
+++ b/HCMO/.htaccess
@@ -14,10 +14,10 @@
 # Modules:         https://w3id.org/hcmo/ontology/hcm/bio#
 #                  https://w3id.org/hcmo/ontology/hcm/env#
 #                  https://w3id.org/hcmo/ontology/hcm/obs#
-# Version IRI:     https://w3id.org/hcmo/ontology/hcm/0.0.1
+# Version IRI:     https://w3id.org/hcmo/ontology/hcm/<version>  (e.g. /0.9)
 #
-# The merged distributions in the repository's dist/ directory contain all
-# modules, so every module/version IRI resolves to the same merged graph.
+# RDF distributions are served from GitHub Release assets. The merged
+# distributions contain all modules, so module IRIs resolve to the same graph.
 #
 # ## Contact
 # This space is administered by:
@@ -30,42 +30,69 @@ Options -MultiViews
 
 RewriteEngine on
 
-# ---------------------------------------------------------------------------
-# Ontology IRI resolution (ontology root, modules bio/env/obs, version IRIs)
-#
-# Content negotiation:
-#   * browsers (HTML)            -> WIDOCO documentation on GitHub Pages
-#   * application/rdf+xml (OWL)  -> dist/hcmo.owl
-#   * text/turtle                -> dist/hcmo.ttl
-#   * application/ld+json        -> dist/hcmo.json
-# ---------------------------------------------------------------------------
+# ===========================================================================
+# Version-aware resolution: https://w3id.org/hcmo/ontology/hcm/<version>
+# <version> is any segment beginning with a digit (e.g. 0.9). It is mapped to
+# the matching GitHub release tag (v<version>), so /hcm/0.9 -> release v0.9.
+# (Module names such as bio/env/obs begin with a letter and fall through to
+#  the "latest" block below.)
+# ===========================================================================
 
 # Turtle
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
-RewriteRule ^ontology/hcm(/.*)?$ https://raw.githubusercontent.com/dhuzard/HCMO/main/dist/hcmo.ttl [R=303,L]
+RewriteRule ^ontology/hcm/([0-9][^/]*)$ https://github.com/dhuzard/HCMO/releases/download/v$1/hcmo.ttl [R=303,L]
 
 # RDF/XML (OWL)
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} application/xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/xml
-RewriteRule ^ontology/hcm(/.*)?$ https://raw.githubusercontent.com/dhuzard/HCMO/main/dist/hcmo.owl [R=303,L]
+RewriteRule ^ontology/hcm/([0-9][^/]*)$ https://github.com/dhuzard/HCMO/releases/download/v$1/hcmo.owl [R=303,L]
 
 # JSON-LD
 RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
 RewriteCond %{HTTP_ACCEPT} application/json
-RewriteRule ^ontology/hcm(/.*)?$ https://raw.githubusercontent.com/dhuzard/HCMO/main/dist/hcmo.json [R=303,L]
+RewriteRule ^ontology/hcm/([0-9][^/]*)$ https://github.com/dhuzard/HCMO/releases/download/v$1/hcmo.json [R=303,L]
 
-# HTML documentation (browsers and Mozilla-like user agents)
+# HTML documentation (browsers) -> the GitHub release page for that version
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^ontology/hcm(/.*)?$ https://dhuzard.github.io/HCMO/ [R=303,L]
+RewriteRule ^ontology/hcm/([0-9][^/]*)$ https://github.com/dhuzard/HCMO/releases/tag/v$1 [R=303,L]
+
+# Default for a version IRI: serve the canonical Turtle graph
+RewriteRule ^ontology/hcm/([0-9][^/]*)$ https://github.com/dhuzard/HCMO/releases/download/v$1/hcmo.ttl [R=303,L]
+
+# ===========================================================================
+# Latest resolution: https://w3id.org/hcmo/ontology/hcm (+ bio/env/obs modules)
+# ===========================================================================
+
+# Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^ontology/hcm(/(bio|env|obs))?$ https://github.com/dhuzard/HCMO/releases/latest/download/hcmo.ttl [R=303,L]
+
+# RDF/XML (OWL)
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/xml
+RewriteRule ^ontology/hcm(/(bio|env|obs))?$ https://github.com/dhuzard/HCMO/releases/latest/download/hcmo.owl [R=303,L]
+
+# JSON-LD
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^ontology/hcm(/(bio|env|obs))?$ https://github.com/dhuzard/HCMO/releases/latest/download/hcmo.json [R=303,L]
+
+# HTML documentation (browsers) -> WIDOCO documentation on GitHub Pages
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^ontology/hcm(/(bio|env|obs))?$ https://dhuzard.github.io/HCMO/ [R=303,L]
 
 # Default response for the ontology IRI: serve the canonical Turtle graph
-RewriteRule ^ontology/hcm(/.*)?$ https://raw.githubusercontent.com/dhuzard/HCMO/main/dist/hcmo.ttl [R=303,L]
+RewriteRule ^ontology/hcm(/(bio|env|obs))?$ https://github.com/dhuzard/HCMO/releases/latest/download/hcmo.ttl [R=303,L]
 
-# ---------------------------------------------------------------------------
-# Landing: https://w3id.org/hcmo/ (and any unmatched path) -> source repository
-# ---------------------------------------------------------------------------
+# ===========================================================================
+# Landing: https://w3id.org/HCMO/ (and any unmatched path) -> source repo
+# ===========================================================================
 RewriteRule ^ https://github.com/dhuzard/HCMO [R=302,L]

--- a/HCMO/.htaccess
+++ b/HCMO/.htaccess
@@ -1,0 +1,71 @@
+# HCMO — Home Cage Monitoring Ontology
+#
+# Canonical permanent W3ID directory providing stable, content-negotiated
+# resolution for the HCMO ontology, developed at
+# https://github.com/dhuzard/HCMO
+#
+# W3ID paths are case-sensitive. The ontology declares lowercase IRIs; both
+# cases resolve, because the lowercase /hcmo/ directory aliases to this one:
+#   https://w3id.org/HCMO/ontology/hcm   (canonical directory)
+#   https://w3id.org/hcmo/ontology/hcm   (alias -> redirects here)
+#
+# Ontology IRI:    https://w3id.org/hcmo/ontology/hcm
+# Base namespace:  https://w3id.org/hcmo/ontology/hcm#
+# Modules:         https://w3id.org/hcmo/ontology/hcm/bio#
+#                  https://w3id.org/hcmo/ontology/hcm/env#
+#                  https://w3id.org/hcmo/ontology/hcm/obs#
+# Version IRI:     https://w3id.org/hcmo/ontology/hcm/0.0.1
+#
+# The merged distributions in the repository's dist/ directory contain all
+# modules, so every module/version IRI resolves to the same merged graph.
+#
+# ## Contact
+# This space is administered by:
+#
+# Damien Huzard
+# damien@metadatapp.net
+# GitHub username: dhuzard
+
+Options -MultiViews
+
+RewriteEngine on
+
+# ---------------------------------------------------------------------------
+# Ontology IRI resolution (ontology root, modules bio/env/obs, version IRIs)
+#
+# Content negotiation:
+#   * browsers (HTML)            -> WIDOCO documentation on GitHub Pages
+#   * application/rdf+xml (OWL)  -> dist/hcmo.owl
+#   * text/turtle                -> dist/hcmo.ttl
+#   * application/ld+json        -> dist/hcmo.json
+# ---------------------------------------------------------------------------
+
+# Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^ontology/hcm(/.*)?$ https://raw.githubusercontent.com/dhuzard/HCMO/main/dist/hcmo.ttl [R=303,L]
+
+# RDF/XML (OWL)
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/xml
+RewriteRule ^ontology/hcm(/.*)?$ https://raw.githubusercontent.com/dhuzard/HCMO/main/dist/hcmo.owl [R=303,L]
+
+# JSON-LD
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^ontology/hcm(/.*)?$ https://raw.githubusercontent.com/dhuzard/HCMO/main/dist/hcmo.json [R=303,L]
+
+# HTML documentation (browsers and Mozilla-like user agents)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^ontology/hcm(/.*)?$ https://dhuzard.github.io/HCMO/ [R=303,L]
+
+# Default response for the ontology IRI: serve the canonical Turtle graph
+RewriteRule ^ontology/hcm(/.*)?$ https://raw.githubusercontent.com/dhuzard/HCMO/main/dist/hcmo.ttl [R=303,L]
+
+# ---------------------------------------------------------------------------
+# Landing: https://w3id.org/hcmo/ (and any unmatched path) -> source repository
+# ---------------------------------------------------------------------------
+RewriteRule ^ https://github.com/dhuzard/HCMO [R=302,L]

--- a/HCMO/README.md
+++ b/HCMO/README.md
@@ -25,17 +25,26 @@ resolve.
 ## Content negotiation
 
 Requests to the ontology IRI are redirected (HTTP `303`) according to the
-`Accept` header:
+`Accept` header. RDF is served from **GitHub Release assets**:
 
-| `Accept` | Target |
-| --- | --- |
-| `text/html` (browsers) | WIDOCO documentation on GitHub Pages |
-| `application/rdf+xml` | `dist/hcmo.owl` |
-| `text/turtle` (default) | `dist/hcmo.ttl` |
-| `application/ld+json` | `dist/hcmo.json` |
+| `Accept` | Latest (`…/hcm`) | Versioned (`…/hcm/<version>`) |
+| --- | --- | --- |
+| `text/html` (browsers) | WIDOCO docs on GitHub Pages | release page `releases/tag/v<version>` |
+| `application/rdf+xml` | `releases/latest/download/hcmo.owl` | `releases/download/v<version>/hcmo.owl` |
+| `text/turtle` (default) | `releases/latest/download/hcmo.ttl` | `releases/download/v<version>/hcmo.ttl` |
+| `application/ld+json` | `releases/latest/download/hcmo.json` | `releases/download/v<version>/hcmo.json` |
 
-The merged distributions contain all modules, so the module and version IRIs
-resolve to the same merged graph.
+The merged distributions contain all modules, so the `bio`/`env`/`obs` module
+IRIs resolve to the same merged graph. A version segment is any path segment
+beginning with a digit (e.g. `…/hcm/0.9`) and is mapped to the GitHub release
+tag `v<version>`.
+
+> **Note — version tag vs. manifest:** the ontology manifest (`hcmo.yaml`)
+> currently declares `version: 0.0.1`, but the latest published release is
+> `v0.9`. Consequently `…/hcm/0.9` resolves, while the declared version IRI
+> `…/hcm/0.0.1` will 303 to a `v0.0.1` release that does not exist. Reconcile
+> by bumping the manifest to the release tag scheme, or by cutting a matching
+> release.
 
 ## Contact
 

--- a/HCMO/README.md
+++ b/HCMO/README.md
@@ -1,0 +1,44 @@
+# /HCMO/
+
+Permanent identifier namespace for the **HCMO — Home Cage Monitoring Ontology**.
+
+The ontology is developed and maintained at
+<https://github.com/dhuzard/HCMO>.
+
+`HCMO/` is the canonical directory. W3ID paths are case-sensitive, and the
+ontology declares lowercase IRIs, so a lowercase [`hcmo/`](../hcmo/) alias
+redirects here — both `https://w3id.org/HCMO/…` and `https://w3id.org/hcmo/…`
+resolve.
+
+## Identifiers
+
+| IRI | Resolves to |
+| --- | --- |
+| `https://w3id.org/HCMO/` | Source repository (landing page) |
+| `https://w3id.org/hcmo/ontology/hcm` | Ontology (content negotiated) |
+| `https://w3id.org/hcmo/ontology/hcm#` | Base namespace |
+| `https://w3id.org/hcmo/ontology/hcm/bio#` | Biological module |
+| `https://w3id.org/hcmo/ontology/hcm/env#` | Environmental module |
+| `https://w3id.org/hcmo/ontology/hcm/obs#` | Observational module |
+| `https://w3id.org/hcmo/ontology/hcm/0.0.1` | Version IRI |
+
+## Content negotiation
+
+Requests to the ontology IRI are redirected (HTTP `303`) according to the
+`Accept` header:
+
+| `Accept` | Target |
+| --- | --- |
+| `text/html` (browsers) | WIDOCO documentation on GitHub Pages |
+| `application/rdf+xml` | `dist/hcmo.owl` |
+| `text/turtle` (default) | `dist/hcmo.ttl` |
+| `application/ld+json` | `dist/hcmo.json` |
+
+The merged distributions contain all modules, so the module and version IRIs
+resolve to the same merged graph.
+
+## Contact
+
+This space is administered by:
+
+- **Damien Huzard** — <damien@metadatapp.net> — GitHub: [@dhuzard](https://github.com/dhuzard)

--- a/hcmo/.htaccess
+++ b/hcmo/.htaccess
@@ -1,17 +1,9 @@
-# HCMO — MAPP Ontology
+# hcmo — lowercase alias for HCMO (Home Cage Monitoring Ontology)
 #
-# This permanent W3ID provides stable, content-negotiated resolution for the
-# HCMO ontology, developed at https://github.com/dhuzard/HCMO
-#
-# Ontology IRI:    https://w3id.org/hcmo/ontology/hcm
-# Base namespace:  https://w3id.org/hcmo/ontology/hcm#
-# Modules:         https://w3id.org/hcmo/ontology/hcm/bio#
-#                  https://w3id.org/hcmo/ontology/hcm/env#
-#                  https://w3id.org/hcmo/ontology/hcm/obs#
-# Version IRI:     https://w3id.org/hcmo/ontology/hcm/0.0.1
-#
-# The merged distributions in the repository's dist/ directory contain all
-# modules, so every module/version IRI resolves to the same merged graph.
+# The HCMO ontology (https://github.com/dhuzard/HCMO) declares lowercase IRIs
+# such as https://w3id.org/hcmo/ontology/hcm . W3ID paths are case-sensitive,
+# so this alias redirects every lowercase request to the canonical /HCMO/
+# directory, which performs the content negotiation.
 #
 # ## Contact
 # This space is administered by:
@@ -20,46 +12,5 @@
 # damien@metadatapp.net
 # GitHub username: dhuzard
 
-Options -MultiViews
-
 RewriteEngine on
-
-# ---------------------------------------------------------------------------
-# Ontology IRI resolution (ontology root, modules bio/env/obs, version IRIs)
-#
-# Content negotiation:
-#   * browsers (HTML)            -> WIDOCO documentation on GitHub Pages
-#   * application/rdf+xml (OWL)  -> dist/hcmo.owl
-#   * text/turtle                -> dist/hcmo.ttl
-#   * application/ld+json        -> dist/hcmo.json
-# ---------------------------------------------------------------------------
-
-# Turtle
-RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
-RewriteCond %{HTTP_ACCEPT} application/x-turtle
-RewriteRule ^ontology/hcm(/.*)?$ https://raw.githubusercontent.com/dhuzard/HCMO/main/dist/hcmo.ttl [R=303,L]
-
-# RDF/XML (OWL)
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
-RewriteCond %{HTTP_ACCEPT} application/xml [OR]
-RewriteCond %{HTTP_ACCEPT} text/xml
-RewriteRule ^ontology/hcm(/.*)?$ https://raw.githubusercontent.com/dhuzard/HCMO/main/dist/hcmo.owl [R=303,L]
-
-# JSON-LD
-RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
-RewriteCond %{HTTP_ACCEPT} application/json
-RewriteRule ^ontology/hcm(/.*)?$ https://raw.githubusercontent.com/dhuzard/HCMO/main/dist/hcmo.json [R=303,L]
-
-# HTML documentation (browsers and Mozilla-like user agents)
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
-RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^ontology/hcm(/.*)?$ https://dhuzard.github.io/HCMO/ [R=303,L]
-
-# Default response for the ontology IRI: serve the canonical Turtle graph
-RewriteRule ^ontology/hcm(/.*)?$ https://raw.githubusercontent.com/dhuzard/HCMO/main/dist/hcmo.ttl [R=303,L]
-
-# ---------------------------------------------------------------------------
-# Landing: https://w3id.org/hcmo/ (and any unmatched path) -> source repository
-# ---------------------------------------------------------------------------
-RewriteRule ^ https://github.com/dhuzard/HCMO [R=302,L]
+RewriteRule ^(.*)$ https://w3id.org/HCMO/$1 [R=302,L,NE]

--- a/hcmo/.htaccess
+++ b/hcmo/.htaccess
@@ -1,0 +1,65 @@
+# HCMO — MAPP Ontology
+#
+# This permanent W3ID provides stable, content-negotiated resolution for the
+# HCMO ontology, developed at https://github.com/dhuzard/HCMO
+#
+# Ontology IRI:    https://w3id.org/hcmo/ontology/hcm
+# Base namespace:  https://w3id.org/hcmo/ontology/hcm#
+# Modules:         https://w3id.org/hcmo/ontology/hcm/bio#
+#                  https://w3id.org/hcmo/ontology/hcm/env#
+#                  https://w3id.org/hcmo/ontology/hcm/obs#
+# Version IRI:     https://w3id.org/hcmo/ontology/hcm/0.0.1
+#
+# The merged distributions in the repository's dist/ directory contain all
+# modules, so every module/version IRI resolves to the same merged graph.
+#
+# ## Contact
+# This space is administered by:
+#
+# Damien Huzard
+# damien@metadatapp.net
+# GitHub username: dhuzard
+
+Options -MultiViews
+
+RewriteEngine on
+
+# ---------------------------------------------------------------------------
+# Ontology IRI resolution (ontology root, modules bio/env/obs, version IRIs)
+#
+# Content negotiation:
+#   * browsers (HTML)            -> WIDOCO documentation on GitHub Pages
+#   * application/rdf+xml (OWL)  -> dist/hcmo.owl
+#   * text/turtle                -> dist/hcmo.ttl
+#   * application/ld+json        -> dist/hcmo.json
+# ---------------------------------------------------------------------------
+
+# Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^ontology/hcm(/.*)?$ https://raw.githubusercontent.com/dhuzard/HCMO/main/dist/hcmo.ttl [R=303,L]
+
+# RDF/XML (OWL)
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/xml
+RewriteRule ^ontology/hcm(/.*)?$ https://raw.githubusercontent.com/dhuzard/HCMO/main/dist/hcmo.owl [R=303,L]
+
+# JSON-LD
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^ontology/hcm(/.*)?$ https://raw.githubusercontent.com/dhuzard/HCMO/main/dist/hcmo.json [R=303,L]
+
+# HTML documentation (browsers and Mozilla-like user agents)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^ontology/hcm(/.*)?$ https://dhuzard.github.io/HCMO/ [R=303,L]
+
+# Default response for the ontology IRI: serve the canonical Turtle graph
+RewriteRule ^ontology/hcm(/.*)?$ https://raw.githubusercontent.com/dhuzard/HCMO/main/dist/hcmo.ttl [R=303,L]
+
+# ---------------------------------------------------------------------------
+# Landing: https://w3id.org/hcmo/ (and any unmatched path) -> source repository
+# ---------------------------------------------------------------------------
+RewriteRule ^ https://github.com/dhuzard/HCMO [R=302,L]

--- a/hcmo/README.md
+++ b/hcmo/README.md
@@ -1,0 +1,39 @@
+# /hcmo/
+
+Permanent identifier namespace for the **HCMO — MAPP Ontology**.
+
+The ontology is developed and maintained at
+<https://github.com/dhuzard/HCMO>.
+
+## Identifiers
+
+| IRI | Resolves to |
+| --- | --- |
+| `https://w3id.org/hcmo/` | Source repository (landing page) |
+| `https://w3id.org/hcmo/ontology/hcm` | Ontology (content negotiated) |
+| `https://w3id.org/hcmo/ontology/hcm#` | Base namespace |
+| `https://w3id.org/hcmo/ontology/hcm/bio#` | Biological module |
+| `https://w3id.org/hcmo/ontology/hcm/env#` | Environmental module |
+| `https://w3id.org/hcmo/ontology/hcm/obs#` | Observational module |
+| `https://w3id.org/hcmo/ontology/hcm/0.0.1` | Version IRI |
+
+## Content negotiation
+
+Requests to the ontology IRI are redirected (HTTP `303`) according to the
+`Accept` header:
+
+| `Accept` | Target |
+| --- | --- |
+| `text/html` (browsers) | WIDOCO documentation on GitHub Pages |
+| `application/rdf+xml` | `dist/hcmo.owl` |
+| `text/turtle` (default) | `dist/hcmo.ttl` |
+| `application/ld+json` | `dist/hcmo.json` |
+
+The merged distributions contain all modules, so the module and version IRIs
+resolve to the same merged graph.
+
+## Contact
+
+This space is administered by:
+
+- **Damien Huzard** — <damien@metadatapp.net> — GitHub: [@dhuzard](https://github.com/dhuzard)

--- a/hcmo/README.md
+++ b/hcmo/README.md
@@ -1,36 +1,12 @@
 # /hcmo/
 
-Permanent identifier namespace for the **HCMO — MAPP Ontology**.
+Lowercase alias for the **HCMO — Home Cage Monitoring Ontology** namespace.
 
-The ontology is developed and maintained at
-<https://github.com/dhuzard/HCMO>.
-
-## Identifiers
-
-| IRI | Resolves to |
-| --- | --- |
-| `https://w3id.org/hcmo/` | Source repository (landing page) |
-| `https://w3id.org/hcmo/ontology/hcm` | Ontology (content negotiated) |
-| `https://w3id.org/hcmo/ontology/hcm#` | Base namespace |
-| `https://w3id.org/hcmo/ontology/hcm/bio#` | Biological module |
-| `https://w3id.org/hcmo/ontology/hcm/env#` | Environmental module |
-| `https://w3id.org/hcmo/ontology/hcm/obs#` | Observational module |
-| `https://w3id.org/hcmo/ontology/hcm/0.0.1` | Version IRI |
-
-## Content negotiation
-
-Requests to the ontology IRI are redirected (HTTP `303`) according to the
-`Accept` header:
-
-| `Accept` | Target |
-| --- | --- |
-| `text/html` (browsers) | WIDOCO documentation on GitHub Pages |
-| `application/rdf+xml` | `dist/hcmo.owl` |
-| `text/turtle` (default) | `dist/hcmo.ttl` |
-| `application/ld+json` | `dist/hcmo.json` |
-
-The merged distributions contain all modules, so the module and version IRIs
-resolve to the same merged graph.
+W3ID paths are case-sensitive. The HCMO ontology
+(<https://github.com/dhuzard/HCMO>) declares lowercase IRIs such as
+`https://w3id.org/hcmo/ontology/hcm`, so this directory redirects every
+lowercase request to the canonical [`HCMO/`](../HCMO/) directory, which
+performs content negotiation.
 
 ## Contact
 


### PR DESCRIPTION
## Brief Description

Adds a new permanent identifier namespace for **HCMO — the Home Cage Monitoring
Ontology** (https://github.com/dhuzard/HCMO).

`HCMO/` is the canonical directory; it performs redirect-only, content-negotiated
resolution of the ontology IRI (`https://w3id.org/hcmo/ontology/hcm`), its module
IRIs (`bio`/`env`/`obs`) and its version IRIs (`…/hcm/<version>`) to the project's
GitHub release assets, with browsers sent to the WIDOCO documentation. A lowercase
`hcmo/` directory aliases (302) to `HCMO/` so the ontology's declared lowercase
IRIs keep resolving on case-sensitive paths.

Maintainer: Damien Huzard (@dhuzard).

## General Checklist
- [x] Changes have been tested.
- [ ] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.