### PR TITLE
Add w3id.org/provetrail for the Provetrail standard

### DIFF
--- a/provetrail/.htaccess
+++ b/provetrail/.htaccess
@@ -1,0 +1,15 @@
+# Provetrail: an open standard for verifiable execution provenance.
+# Project: https://github.com/ionalpha/provetrail
+# Maintainer: Ion Alpha (GitHub: @ion-alpha-dev) <contact@ionalpha.io>
+
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+# Versioned predicate-type definitions resolve to the predicate document in the spec.
+RewriteRule "^predicates/run-provenance/v0\.1/?$" "https://github.com/ionalpha/provetrail/blob/main/predicates/run-provenance.md" [R=302,L]
+
+# The namespace root and any other path resolve to the standard's repository.
+# This is a temporary target until provetrail.org serves the canonical documents;
+# the redirect can be repointed later without changing any identifier.
+RewriteRule "^(.*)$" "https://github.com/ionalpha/provetrail" [R=302,L]

--- a/provetrail/README.md
+++ b/provetrail/README.md
@@ -1,0 +1,19 @@
+# Provetrail
+
+Permanent identifier namespace for **Provetrail**, an open, vendor-neutral standard for verifiable execution provenance: a portable, third-party-verifiable record of what an agent did, in what order, and under what governance.
+
+The namespace is used as the stable `predicateType` identifier for Provetrail statements, so records that embed it keep resolving even if the project's hosting changes.
+
+- `https://w3id.org/provetrail/predicates/run-provenance/v0.1` redirects to the versioned predicate definition.
+- `https://w3id.org/provetrail` and any other path redirects to the standard's repository.
+
+The repository target is temporary until provetrail.org serves the canonical documents; only the redirect will change, never the identifier.
+
+Project: https://github.com/ionalpha/provetrail
+
+## Maintainer
+
+Ion Alpha
+
+- GitHub: [@ion-alpha-dev](https://github.com/ion-alpha-dev)
+- Email: contact@ionalpha.io


### PR DESCRIPTION
## Brief Description

Adds a permanent identifier namespace for **Provetrail**, an open, vendor-neutral standard for verifiable execution provenance (a portable, third-party-verifiable record of what an agent did, in what order, and under what governance). The namespace is used as the stable `predicateType` identifier for Provetrail statements, so records that embed it keep resolving even if the project's hosting changes.

`https://w3id.org/provetrail/predicates/run-provenance/v0.1` redirects to the versioned predicate definition. `https://w3id.org/provetrail` and any other path redirects to the standard's repository. Both targets resolve today (302). The repository target is temporary until the project's own domain serves the canonical documents; only the redirect will change, never the identifier.

Project: https://github.com/ionalpha/provetrail
Maintainer: Ion Alpha (GitHub: @ion-alpha-dev) <contact@ionalpha.io>

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.
