### PR TITLE
ogc: add /bblocks/meta-register.json redirect to OGC Building Blocks meta-registry

### DIFF
--- a/ogc/.htaccess
+++ b/ogc/.htaccess
@@ -25,3 +25,6 @@ RewriteRule ^stac/(.+)$ https://defs-dev.opengis.net/prez-b/object?uri=https://w
 
 ## ladm
 RewriteRule ^ladm/(.+)$ https://defs-dev.opengis.net/prez-b/object?uri=https://w3id.org/ogc/ladm/$1 [R=303,L]
+
+## bblocks
+RewriteRule ^bblocks/meta-register\.json$ https://ogcincubator.github.io/bblocks-meta-register-data/index.json [R=302,L]

--- a/ogc/README.md
+++ b/ogc/README.md
@@ -4,6 +4,8 @@ This [W3ID](https://w3id.org) provides a persistent URI namespace for the [Open 
 The following sub-namespaces are defined:
 
 * OGC
+  * `/bblocks` — OGC Building Blocks resources
+    * `/bblocks/meta-register.json` — OGC Building Blocks meta-registry index ([source](https://github.com/ogcincubator/bblocks-meta-register-data))
   * `/geopose`
   * `/ladm`
   * `/stac`


### PR DESCRIPTION
## Brief Description

Adds a redirect from `/ogc/bblocks/meta-register.json` to the OGC Building Blocks meta-registry index at `https://ogcincubator.github.io/bblocks-meta-register-data/index.json`, providing a stable persistent URI for the meta-registry.

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- N/A — updating an existing directory -->

## Update ID Directory Checklist
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.