### PR TITLE
ogc: add /bblocks/meta-register-orgs.json redirect to OGC Building Blocks meta-registry org metadata

### DIFF
--- a/ogc/.htaccess
+++ b/ogc/.htaccess
@@ -28,3 +28,4 @@ RewriteRule ^ladm/(.+)$ https://defs-dev.opengis.net/prez-b/object?uri=https://w
 
 ## bblocks
 RewriteRule ^bblocks/meta-register\.json$ https://ogcincubator.github.io/bblocks-meta-register-data/index.json [R=302,L]
+RewriteRule ^bblocks/meta-register-orgs\.json$ https://ogcincubator.github.io/bblocks-meta-register-data/orgs.json [R=302,L]

--- a/ogc/README.md
+++ b/ogc/README.md
@@ -6,6 +6,7 @@ The following sub-namespaces are defined:
 * OGC
   * `/bblocks` — OGC Building Blocks resources
     * `/bblocks/meta-register.json` — OGC Building Blocks meta-registry index ([source](https://github.com/ogcincubator/bblocks-meta-register-data))
+    * `/bblocks/meta-register-orgs.json` — OGC Building Blocks meta-registry organisation metadata
   * `/geopose`
   * `/ladm`
   * `/stac`


### PR DESCRIPTION
## Brief Description

Adds a redirect from `/ogc/bblocks/meta-register-orgs.json` to the OGC Building Blocks meta-registry organisation metadata at `https://ogcincubator.github.io/bblocks-meta-register-data/orgs.json`, providing a stable persistent URI for the org metadata resource.

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- N/A — updating an existing directory -->

## Update ID Directory Checklist
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.