### PR TITLE
Add FiCR ontology namespace

### DIFF
--- a/ficr/.htaccess
+++ b/ficr/.htaccess
@@ -1,0 +1,61 @@
+# FiCR ontology w3id redirect
+# Namespace: https://w3id.org/ficr#
+# Ontology IRI: https://w3id.org/ficr
+
+# Maintainer:
+# GitHub: RainGo111
+# Project: FiCR Ontology
+
+Options +FollowSymLinks
+Options -MultiViews
+RewriteEngine On
+
+SetEnv FICR_BASE https://raingo111.github.io/FiCR-ontology
+
+# -----------------------------
+# Version path: /ficr/1.0.0
+# -----------------------------
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^1\.0\.0/?$ %{ENV:FICR_BASE}/1.0.0/ontology.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^1\.0\.0/?$ %{ENV:FICR_BASE}/1.0.0/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^1\.0\.0/?$ %{ENV:FICR_BASE}/1.0.0/ontology.nt [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^1\.0\.0/?$ %{ENV:FICR_BASE}/1.0.0/ontology.owl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^1\.0\.0/?$ %{ENV:FICR_BASE}/1.0.0/index-en.html [R=303,L]
+
+RewriteRule ^1\.0\.0/?$ %{ENV:FICR_BASE}/1.0.0/ontology.ttl [R=303,L]
+
+# -----------------------------
+# Latest path: /ficr
+# -----------------------------
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ %{ENV:FICR_BASE}/ontology.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ %{ENV:FICR_BASE}/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ %{ENV:FICR_BASE}/ontology.nt [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ %{ENV:FICR_BASE}/ontology.owl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ %{ENV:FICR_BASE}/index-en.html [R=303,L]
+
+RewriteRule ^$ %{ENV:FICR_BASE}/ontology.ttl [R=303,L]

--- a/ficr/README.md
+++ b/ficr/README.md
@@ -1,0 +1,13 @@
+# FiCR Ontology
+
+This directory contains the w3id redirects for the FiCR ontology.
+
+- Ontology IRI: <https://w3id.org/ficr>
+- Namespace: <https://w3id.org/ficr#>
+- Version IRI: <https://w3id.org/ficr/1.0.0>
+- Documentation: <https://raingo111.github.io/FiCR-ontology/>
+- Repository: <https://github.com/RainGo111/FiCR-ontology>
+
+Maintainer:
+
+- GitHub: [RainGo111](https://github.com/RainGo111)


### PR DESCRIPTION
This PR adds a new w3id namespace for the FiCR ontology.

Ontology IRI: https://w3id.org/ficr
Namespace: https://w3id.org/ficr#
Version IRI: https://w3id.org/ficr/1.0.0

The redirects point to the GitHub Pages deployment:
https://raingo111.github.io/FiCR-ontology/