### PR TITLE
Fix FiCR redirect targets

### DIFF
--- a/ficr/.htaccess
+++ b/ficr/.htaccess
@@ -10,52 +10,50 @@ Options +FollowSymLinks
 Options -MultiViews
 RewriteEngine On
 
-SetEnv FICR_BASE https://raingo111.github.io/FiCR-ontology
-
 # -----------------------------
 # Version path: /ficr/1.0.0
 # -----------------------------
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^1\.0\.0/?$ %{ENV:FICR_BASE}/1.0.0/ontology.jsonld [R=303,L]
+RewriteRule ^1\.0\.0/?$ https://raingo111.github.io/FiCR-ontology/1.0.0/ontology.jsonld [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle
-RewriteRule ^1\.0\.0/?$ %{ENV:FICR_BASE}/1.0.0/ontology.ttl [R=303,L]
+RewriteRule ^1\.0\.0/?$ https://raingo111.github.io/FiCR-ontology/1.0.0/ontology.ttl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^1\.0\.0/?$ %{ENV:FICR_BASE}/1.0.0/ontology.nt [R=303,L]
+RewriteRule ^1\.0\.0/?$ https://raingo111.github.io/FiCR-ontology/1.0.0/ontology.nt [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^1\.0\.0/?$ %{ENV:FICR_BASE}/1.0.0/ontology.owl [R=303,L]
+RewriteRule ^1\.0\.0/?$ https://raingo111.github.io/FiCR-ontology/1.0.0/ontology.owl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^1\.0\.0/?$ %{ENV:FICR_BASE}/1.0.0/index-en.html [R=303,L]
+RewriteRule ^1\.0\.0/?$ https://raingo111.github.io/FiCR-ontology/1.0.0/index-en.html [R=303,L]
 
-RewriteRule ^1\.0\.0/?$ %{ENV:FICR_BASE}/1.0.0/ontology.ttl [R=303,L]
+RewriteRule ^1\.0\.0/?$ https://raingo111.github.io/FiCR-ontology/1.0.0/ontology.ttl [R=303,L]
 
 # -----------------------------
 # Latest path: /ficr
 # -----------------------------
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^$ %{ENV:FICR_BASE}/ontology.jsonld [R=303,L]
+RewriteRule ^$ https://raingo111.github.io/FiCR-ontology/ontology.jsonld [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle
-RewriteRule ^$ %{ENV:FICR_BASE}/ontology.ttl [R=303,L]
+RewriteRule ^$ https://raingo111.github.io/FiCR-ontology/ontology.ttl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^$ %{ENV:FICR_BASE}/ontology.nt [R=303,L]
+RewriteRule ^$ https://raingo111.github.io/FiCR-ontology/ontology.nt [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^$ %{ENV:FICR_BASE}/ontology.owl [R=303,L]
+RewriteRule ^$ https://raingo111.github.io/FiCR-ontology/ontology.owl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ %{ENV:FICR_BASE}/index-en.html [R=303,L]
+RewriteRule ^$ https://raingo111.github.io/FiCR-ontology/index-en.html [R=303,L]
 
-RewriteRule ^$ %{ENV:FICR_BASE}/ontology.ttl [R=303,L]
+RewriteRule ^$ https://raingo111.github.io/FiCR-ontology/ontology.ttl [R=303,L]


### PR DESCRIPTION
This PR fixes the FiCR w3id redirects added in #6270.

The previously merged .htaccess used an environment variable for the GitHub Pages base URL. On w3id.org this expanded incorrectly, causing redirects such as:

https://w3id.org/ficr/ -> https://w3id.org/index-en.html

This update replaces the environment-variable based targets with explicit GitHub Pages URLs.

Expected redirects after merge:

- https://w3id.org/ficr -> https://raingo111.github.io/FiCR-ontology/index-en.html
- https://w3id.org/ficr/1.0.0 -> https://raingo111.github.io/FiCR-ontology/1.0.0/index-en.html