### PR TITLE
 Redirects for the FAIR Assessment components of the OSTrails project

### DIFF
--- a/FAIR-Assessment/.htaccess
+++ b/FAIR-Assessment/.htaccess
@@ -1,0 +1,3 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^(.*) https://tests.ostrails.eu/$1 [R=307,L]

--- a/FAIR-Assessment/README.md
+++ b/FAIR-Assessment/README.md
@@ -1,0 +1,7 @@
+## Redirect for FAIR Testing Services
+
+see more at:  http://fairmetrics.org
+
+The FAIR Tests are hosted on a server operated by FAIR Data Systems S.L., Madrid.
+
+Contact: info@fairdata.systems  or mark.moby.wilkinson@gmail.com  

--- a/FAIR-Assessment/README.md
+++ b/FAIR-Assessment/README.md
@@ -2,4 +2,4 @@
 
 Endpoints for FAIRness tests written and maintained by the FAIR Champion team
 
-Contact: info@fairdata.systems  or mark.moby.wilkinson@gmail.com  
+Contact: info@fairdata.systems  or mark.moby.wilkinson@gmail.com  (github:  markwilkinson)

--- a/FAIR-Assessment/README.md
+++ b/FAIR-Assessment/README.md
@@ -1,7 +1,5 @@
-## Redirect for FAIR Testing Services
+## Redirect for FAIR Testing Service Endpoints
 
-see more at:  http://fairmetrics.org
-
-The FAIR Tests are hosted on a server operated by FAIR Data Systems S.L., Madrid.
+Endpoints for FAIRness tests written and maintained by the FAIR Champion team
 
 Contact: info@fairdata.systems  or mark.moby.wilkinson@gmail.com  

--- a/FAIR-Test-Registry/.htaccess
+++ b/FAIR-Test-Registry/.htaccess
@@ -1,0 +1,4 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^(.*)$ https://tools.ostrails.eu/fdp-index/$1 [R=302,L,QSA]
+

--- a/FAIR-Test-Registry/README.md
+++ b/FAIR-Test-Registry/README.md
@@ -1,0 +1,7 @@
+## Redirect for the OSTrails Registry of FAIR Tests and Algorithms
+
+Tools for excuting assessments of the FAIRness of a digital object
+
+
+maintainers of this w3id:  
+     Mark D Wilkinson:  mark.wilkinson@upm.es  (github:  markwilkinson)


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->
All public resources for the FAIR assessment components of the OSTrails project need to utilize perma-ids.  This PR includes a redirect for all FAIR tests, and a redirect for the registry of FAIR Tests.


## General Checklist
<!-- For all ID related PRs. -->
- [ ] Changes have been tested.
- [X] The number of commits is minimal. Squash if needed.
- [X] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [X] Maintainer details are in `.htaccess` or `README.md`.
- [X] GitHub username ids are listed in the maintainer details.

