### PR TITLE
Add xwkont namespace

### DIFF
--- a/xwkont/.htaccess
+++ b/xwkont/.htaccess
@@ -1,0 +1,19 @@
+# === Directory: /xwkont/ =====================================================
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# === Rewrite Rules ===========================================================
+
+# Temporary (302) redirect while the project is pre-release.
+# e.g. https://w3id.org/xwkont => https://github.com/xwkont
+RewriteRule ^$ https://github.com/xwkont [R=302,L]
+
+# === Contact ==================================================================
+#
+# This space is administered by:
+#
+# Rene Yap
+# GitHub username: reneyap
+
+# === END ======================================================================

--- a/xwkont/README.md
+++ b/xwkont/README.md
@@ -1,0 +1,16 @@
+# xwkont
+
+Persistent identifier namespace for the `xwkont` project.
+
+This project is currently under development. The public repository will be
+published at:
+
+https://github.com/xwkont/xwkont
+
+Until the project reaches its first public release, `https://w3id.org/xwkont`
+issues a temporary (302) redirect to https://github.com/xwkont. This will be
+updated to a permanent (301) redirect once the project stabilizes.
+
+## Maintainer
+
+Rene Yap ([https://github.com/reneyap](https://github.com/reneyap))


### PR DESCRIPTION
## Summary
- Adds the `xwkont/` namespace directory with a temporary (302) `.htaccess` redirect from `https://w3id.org/xwkont` to `https://github.com/xwkont`
- Project is still pre-release; redirect target will move to `https://github.com/xwkont/xwkont` once published, at which point this can be updated to a permanent (301) redirect
- Maintainer: Rene Yap (https://github.com/reneyap)

## Test plan
- [x] Verified `.htaccess` follows the repo's existing per-namespace rewrite rule conventions
- [ ] Confirm `https://w3id.org/xwkont` redirects to `https://github.com/xwkont` once merged