### PR TITLE
Add /iladub namespace root; migrate /etkl -> /iladub (301)

### DIFF
--- a/etkl/.htaccess
+++ b/etkl/.htaccess
@@ -1,15 +1,8 @@
 # # /etkl/
 #
-# Persistent namespace for the ET(K)L method (Extract, Transform-with-(K)nowledge,
-# Load) and its modules:
-#
-#   https://w3id.org/etkl         — ET(K)L method + umbrella vocabulary
-#   https://w3id.org/etkl/hol     — hol: holonic decision-context vocabulary
-#   https://w3id.org/etkl/iladub  — iladub: assertion/proposition vocabulary
-#
-# Content is negotiated: RDF clients receive Turtle from the source repository
-# (github.com/iladub/iladub), browsers are sent to the documentation site
-# (https://iladub.dev).
+# MIGRATED 2026-07-01 -> the iladub namespace root (https://w3id.org/iladub).
+# Every former /etkl/* path now 301-redirects to its new home under /iladub/.
+# See the /iladub/ entry for content negotiation.
 #
 # ## Contact
 # This space is administered by:
@@ -20,20 +13,15 @@
 Options +FollowSymLinks
 RewriteEngine on
 
-# ---- https://w3id.org/etkl/hol ------------------------------------------
-RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/n-triples|application/ld\+json|text/n3) [NC]
-RewriteRule ^hol/?$ https://raw.githubusercontent.com/iladub/iladub/main/vocab/ontology/hol.ttl [R=302,L]
-RewriteRule ^hol/?$ https://iladub.dev/hol/ [R=302,L]
-
-# ---- https://w3id.org/etkl/iladub ---------------------------------------
-RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/n-triples|application/ld\+json|text/n3) [NC]
-RewriteRule ^iladub/?$ https://raw.githubusercontent.com/iladub/iladub/main/vocab/ontology/iladub.ttl [R=302,L]
-RewriteRule ^iladub/?$ https://iladub.dev/assertion-proposition/ [R=302,L]
-
-# ---- https://w3id.org/etkl (umbrella) -----------------------------------
-RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/n-triples|application/ld\+json|text/n3) [NC]
-RewriteRule ^$ https://raw.githubusercontent.com/iladub/iladub/main/vocab/ontology/etkl.ttl [R=302,L]
-RewriteRule ^$ https://iladub.dev/etkl/ [R=302,L]
-
-# ---- fallback: any other /etkl/* path -> documentation site -------------
-RewriteRule ^(.*)$ https://iladub.dev/ [R=302,L]
+# 301 permanent redirects: old /etkl/* -> new /iladub/*  (most specific first)
+RewriteRule ^iladub/holons/?$        https://w3id.org/iladub/etkl/holons [R=301,L]
+RewriteRule ^iladub/hga-alignment/?$ https://w3id.org/iladub/hga-alignment [R=301,L]
+RewriteRule ^hol/hga-alignment/?$    https://w3id.org/iladub/dec/hga-alignment [R=301,L]
+RewriteRule ^risk/hga-alignment/?$   https://w3id.org/iladub/risk/hga-alignment [R=301,L]
+RewriteRule ^iladub/?$               https://w3id.org/iladub [R=301,L]
+RewriteRule ^hol/?$                  https://w3id.org/iladub/dec [R=301,L]
+RewriteRule ^risk/?$                 https://w3id.org/iladub/risk [R=301,L]
+RewriteRule ^governance-shapes/?$    https://w3id.org/iladub/governance-shapes [R=301,L]
+RewriteRule ^$                       https://w3id.org/iladub/etkl [R=301,L]
+# any other former /etkl/* subpath -> the new root
+RewriteRule ^(.*)$                   https://w3id.org/iladub/ [R=301,L]

--- a/etkl/README.md
+++ b/etkl/README.md
@@ -1,22 +1,27 @@
 # /etkl/
 
+> **Migrated 2026-07-01.** This namespace moved to the **iladub** root:
+> [`https://w3id.org/iladub`](https://w3id.org/iladub). Every former `/etkl/*` IRI now
+> 301-redirects to its new home under `/iladub/` (e.g. `/etkl/hol` → `/iladub/dec`,
+> `/etkl/iladub` → `/iladub`, `/etkl` → `/iladub/etkl`). See the `/iladub/` entry.
+
 Persistent namespace for the **ET(K)L** method — *Extract, Transform-with-(K)nowledge,
 Load* — and its ontology modules. Knowledge engineering is the first milestone of the
 pipeline: a semantic data contract declares the target semantics and a knowledge module
 is passed as an argument to the transform.
 
-| Persistent IRI | Resolves to |
+| Former IRI | Now redirects to |
 | --- | --- |
-| `https://w3id.org/etkl` | ET(K)L method + umbrella vocabulary |
-| `https://w3id.org/etkl/hol` | `hol` — holonic decision-context vocabulary |
-| `https://w3id.org/etkl/iladub` | `iladub` — assertion/proposition vocabulary |
+| `https://w3id.org/etkl` | `https://w3id.org/iladub/etkl` — ET(K)L method |
+| `https://w3id.org/etkl/hol` | `https://w3id.org/iladub/dec` — `dec` decision vocabulary |
+| `https://w3id.org/etkl/iladub` | `https://w3id.org/iladub` — iladub core (assertion/proposition) |
 
-Requests are **content-negotiated**: clients asking for RDF (`Accept: text/turtle`,
-`application/rdf+xml`, `application/ld+json`, …) are redirected to the Turtle ontology
-files in the source repository; browsers are redirected to the documentation site.
+Requests are **content-negotiated** at the new `/iladub/` root: clients asking for RDF
+(`Accept: text/turtle`, `application/rdf+xml`, `application/ld+json`, …) are redirected to the
+Turtle ontology files in the source repository; browsers are redirected to the documentation site.
 
 - **Documentation:** https://iladub.dev
-- **Source & ontologies:** https://github.com/iladub/iladub (under `vocab/ontology/`)
+- **Source & ontologies:** https://github.com/iladub/iladub (under `vocab/`)
 - **License:** ontologies are CC-BY-4.0; code is Apache-2.0.
 
 ## Maintainer

--- a/iladub/.htaccess
+++ b/iladub/.htaccess
@@ -1,0 +1,74 @@
+# # /iladub/
+#
+# Persistent namespace root for iladub and its modules:
+#
+#   https://w3id.org/iladub               — iladub core: assertion/proposition epistemics
+#   https://w3id.org/iladub/etkl          — ET(K)L method (knowledge-first transform)
+#   https://w3id.org/iladub/etkl/holons   — the doc-holon fabric (Raw/Clean/Portal/membrane)
+#   https://w3id.org/iladub/dec           — dec: decidability / decision-context vocabulary
+#   https://w3id.org/iladub/risk          — contextual-risk vocabulary
+#   https://w3id.org/iladub/hga-alignment      — iladub/etkl <-> W3C Holon CG (HGA) alignment
+#   https://w3id.org/iladub/dec/hga-alignment  — dec <-> HGA alignment
+#   https://w3id.org/iladub/risk/hga-alignment — risk <-> HGA alignment
+#   https://w3id.org/iladub/governance-shapes  — governance SHACL shapes
+#
+# Content is negotiated: RDF clients receive Turtle from the source repository
+# (github.com/iladub/iladub), browsers are sent to the documentation site
+# (https://iladub.dev). Supersedes the former /etkl entry (now 301 -> /iladub).
+#
+# ## Contact
+# This space is administered by:
+#
+# François Rosselet
+# GitHub username: Frosselet
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# ---- https://w3id.org/iladub/etkl/holons  (most specific first) ----------
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/n-triples|application/ld\+json|text/n3) [NC]
+RewriteRule ^etkl/holons/?$ https://raw.githubusercontent.com/iladub/iladub/main/vocab/ontology/etkl-holons.ttl [R=302,L]
+RewriteRule ^etkl/holons/?$ https://iladub.dev/holonic-interaction/ [R=302,L]
+
+# ---- https://w3id.org/iladub/dec/hga-alignment --------------------------
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/n-triples|application/ld\+json|text/n3) [NC]
+RewriteRule ^dec/hga-alignment/?$ https://raw.githubusercontent.com/iladub/iladub/main/vocab/ontology/dec-hga-align.ttl [R=302,L]
+RewriteRule ^dec/hga-alignment/?$ https://iladub.dev/holonic-interaction/ [R=302,L]
+
+# ---- https://w3id.org/iladub/risk/hga-alignment -------------------------
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/n-triples|application/ld\+json|text/n3) [NC]
+RewriteRule ^risk/hga-alignment/?$ https://raw.githubusercontent.com/iladub/iladub/main/vocab/ontology/risk-hga-align.ttl [R=302,L]
+RewriteRule ^risk/hga-alignment/?$ https://iladub.dev/holonic-interaction/ [R=302,L]
+
+# ---- https://w3id.org/iladub/hga-alignment ------------------------------
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/n-triples|application/ld\+json|text/n3) [NC]
+RewriteRule ^hga-alignment/?$ https://raw.githubusercontent.com/iladub/iladub/main/vocab/ontology/iladub-hga-align.ttl [R=302,L]
+RewriteRule ^hga-alignment/?$ https://iladub.dev/holonic-interaction/ [R=302,L]
+
+# ---- https://w3id.org/iladub/etkl ---------------------------------------
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/n-triples|application/ld\+json|text/n3) [NC]
+RewriteRule ^etkl/?$ https://raw.githubusercontent.com/iladub/iladub/main/vocab/ontology/etkl.ttl [R=302,L]
+RewriteRule ^etkl/?$ https://iladub.dev/etkl/ [R=302,L]
+
+# ---- https://w3id.org/iladub/dec ----------------------------------------
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/n-triples|application/ld\+json|text/n3) [NC]
+RewriteRule ^dec/?$ https://raw.githubusercontent.com/iladub/iladub/main/vocab/ontology/dec.ttl [R=302,L]
+RewriteRule ^dec/?$ https://iladub.dev/dec/ [R=302,L]
+
+# ---- https://w3id.org/iladub/risk ---------------------------------------
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/n-triples|application/ld\+json|text/n3) [NC]
+RewriteRule ^risk/?$ https://raw.githubusercontent.com/iladub/iladub/main/vocab/ontology/risk.ttl [R=302,L]
+RewriteRule ^risk/?$ https://iladub.dev/ [R=302,L]
+
+# ---- https://w3id.org/iladub/governance-shapes --------------------------
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/n-triples|application/ld\+json|text/n3) [NC]
+RewriteRule ^governance-shapes/?$ https://raw.githubusercontent.com/iladub/iladub/main/vocab/shapes/governance-shapes.ttl [R=302,L]
+RewriteRule ^governance-shapes/?$ https://iladub.dev/ [R=302,L]
+
+# ---- https://w3id.org/iladub (core) -------------------------------------
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/n-triples|application/ld\+json|text/n3) [NC]
+RewriteRule ^$ https://raw.githubusercontent.com/iladub/iladub/main/vocab/ontology/iladub.ttl [R=302,L]
+RewriteRule ^$ https://iladub.dev/assertion-proposition/ [R=302,L]
+
+# ---- fallback: any other /iladub/* path -> documentation site -----------
+RewriteRule ^(.*)$ https://iladub.dev/ [R=302,L]

--- a/iladub/README.md
+++ b/iladub/README.md
@@ -1,0 +1,33 @@
+# /iladub/
+
+Persistent namespace root for **iladub** — the document-carrier that compiles
+unstructured documents into FAIR, contract-defined semantic knowledge graphs.
+`iladub = a thin epistemic core + etkl (the K-transform) + dec (decidability)`, aligned
+to the W3C Holon CG substrate (HGA).
+
+| Persistent IRI | Resolves to |
+| --- | --- |
+| `https://w3id.org/iladub` | iladub core — assertion/proposition epistemics |
+| `https://w3id.org/iladub/etkl` | ET(K)L method (knowledge-first transform) |
+| `https://w3id.org/iladub/etkl/holons` | the doc-holon fabric |
+| `https://w3id.org/iladub/dec` | `dec` — decidability / decision-context vocabulary |
+| `https://w3id.org/iladub/risk` | contextual-risk vocabulary |
+| `https://w3id.org/iladub/hga-alignment` | iladub/etkl ↔ HGA alignment |
+| `https://w3id.org/iladub/dec/hga-alignment` | dec ↔ HGA alignment |
+| `https://w3id.org/iladub/risk/hga-alignment` | risk ↔ HGA alignment |
+| `https://w3id.org/iladub/governance-shapes` | governance SHACL shapes |
+
+Requests are **content-negotiated**: clients asking for RDF (`Accept: text/turtle`,
+`application/rdf+xml`, `application/ld+json`, …) are redirected to the Turtle files in the
+source repository; browsers are redirected to the documentation site.
+
+This supersedes the former `w3id.org/etkl` layout, whose paths now 301-redirect here.
+
+- **Documentation:** https://iladub.dev
+- **Source & ontologies:** https://github.com/iladub/iladub (under `vocab/`)
+- **License:** ontologies are CC-BY-4.0; code is Apache-2.0.
+
+## Maintainer
+
+- **François Rosselet**
+- GitHub: [@Frosselet](https://github.com/Frosselet)


### PR DESCRIPTION
Adds a new persistent namespace root **`https://w3id.org/iladub`** and migrates the existing
`/etkl` entry to it.

- **New `iladub/`** entry — content-negotiated (RDF `Accept:` → the Turtle files under
  `github.com/iladub/iladub/vocab/`, browsers → `https://iladub.dev`), covering the root plus
  `/etkl`, `/etkl/holons`, `/dec`, `/risk`, the three `*-hga-alignment` paths, and
  `/governance-shapes`. Follows the same style/convention as the existing `/etkl` entry.
- **`etkl/`** entry rewritten to **301-redirect** every former `/etkl/*` path to its new home
  under `/iladub/*` (e.g. `/etkl/hol` → `/iladub/dec`, `/etkl/iladub` → `/iladub`,
  `/etkl` → `/iladub/etkl`), preserving existing links.

Same administrator as the existing `/etkl` entry — **@Frosselet**. The redirect targets already
resolve on `github.com/iladub/iladub@main`.