### PR TITLE
update namespace enabling nanopub redirect

### DIFF
--- a/peh/.htaccess
+++ b/peh/.htaccess
@@ -11,9 +11,16 @@ AddType application/ld+json .json
 
 RewriteEngine on
 
-# Rewrite rule for latest version.
-RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
-RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://github.com/eu-parc/parco-hbm/blob/main/README.md [R=303,L]
+# PEH namespace root
+RewriteRule ^$ https://w3id.org/spaces/peh-vocs [R=303,L]
+
+# Ontology
+RewriteRule ^terms/?$ https://eu-parc.github.io/parco-hbm/ [R=303,L]
+RewriteRule ^terms/([^/]+)$ https://eu-parc.github.io/parco-hbm/#$1 [R=303,NE,L]
+
+# Vocabulary nanopublications
+RewriteRule ^(biochementities|matrices|indicators|iadoptvariables)/([A-Za-z0-9_-]+)$ https://w3id.org/np/$2 [R=303,L]
+
+# Vocabulary landing pages
+RewriteRule ^matrices/?$ https://w3id.org/spaces/chemical-exposome-matrix/r/vocabulary [R=303,L]
+RewriteRule ^biochementities/?$ https://w3id.org/spaces/biochementity/r/vocabulary [R=303,L]

--- a/peh/README.md
+++ b/peh/README.md
@@ -11,4 +11,10 @@ The resources are core components for the next iteration of the HBM4EU project (
 *Data Architect* at [VITO](https://vito.be)  
 <dirk.devriendt.ext@vito.be>
 GitHub: [dirkdevriendt](https://github.com/dirkdevriendt)
-ORCID: [0000-0002-6514-0173](https://orcid.org/0000-0002-6514-0173)  
+ORCID: [0000-0002-6514-0173](https://orcid.org/0000-0002-6514-0173)
+
+**Gertjan Bisschop**  
+*Data Architect* at [VITO](https://vito.be)  
+<gertjan.bisschop@vito.be>
+GitHub: [GertjanBisschop](https://github.com/GertjanBisschop)
+ORCID: [0000-0001-8327-0142](https://orcid.org/0000-0001-8327-0142)


### PR DESCRIPTION
## Brief Description

Updates the existing `peh` W3ID namespace redirects to support the PEH vocabulary and ontology routes.

This PR changes `peh/.htaccess` so that:

- `https://w3id.org/peh` redirects to `https://w3id.org/spaces/peh-vocs`
- `https://w3id.org/peh/terms` redirects to `https://eu-parc.github.io/parco-hbm/`
- `https://w3id.org/peh/terms/<term-label>` redirects to `https://eu-parc.github.io/parco-hbm/#<term-label>`
- PEH vocabulary nanopublication hashes under `biochementities`, `matrices`, `indicators`, and `iadoptvariables` redirect to `https://w3id.org/np/<hash>`
- `https://w3id.org/peh/matrices` and `https://w3id.org/peh/biochementities` redirect to their vocabulary landing pages

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## Update ID Directory Checklist

- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.
