### PR TITLE
Add xwkont /core content-negotiation redirect

### DIFF
--- a/xwkont/.htaccess
+++ b/xwkont/.htaccess
@@ -9,6 +9,14 @@ RewriteEngine on
 # e.g. https://w3id.org/xwkont => https://github.com/xwkont
 RewriteRule ^$ https://github.com/xwkont [R=302,L]
 
+# Current core namespace document: Turtle representation.
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^core$ https://raw.githubusercontent.com/xwkont/xwkont/main/data/ontology/core.ttl [R=302,L]
+
+# Current core namespace document: human-readable representation.
+RewriteRule ^core$ https://github.com/xwkont/xwkont/blob/main/docs/ontology/core-ontology.md [R=302,L]
+
 # === Contact ==================================================================
 #
 # This space is administered by:


### PR DESCRIPTION
## Summary
- Adds the missing `/xwkont/core` redirect rules that were omitted from #6277
- Turtle (`Accept: text/turtle` or `application/x-turtle`) redirects to `data/ontology/core.ttl` on the `xwkont/xwkont` repository
- All other requests (HTML, no Accept header) redirect to the human-readable ontology spec
- Maintainer: Rene Yap (https://github.com/reneyap)

## Test plan
- [x] `.htaccess` follows the same per-namespace rewrite rule conventions as the existing `xwkont/` directory
- [ ] Confirm `https://w3id.org/xwkont/core` content-negotiates correctly once merged and once `xwkont/xwkont` is public