### PR TITLE
Add qubiten/ namespace redirects

### DIFF
--- a/qubiten/.htaccess
+++ b/qubiten/.htaccess
@@ -1,6 +1,6 @@
 # Permanent-identifier redirects for https://w3id.org/qubiten/
 # Namespace: metadata registry (ISO/IEC 11179) of Qubiten
-# Maintainer: Wilbye (Qubiten) <wilbye@qubiten.com>
+# Maintainer: @wilbyembabu (Wilbye, Qubiten) <wilbye@qubiten.com>
 # Source of record: https://github.com/Qubiten/metadata-registry
 # Interim target: repository documentation (superseded when the LDP
 # containers provide dereferenceable resources).

--- a/qubiten/.htaccess
+++ b/qubiten/.htaccess
@@ -1,0 +1,18 @@
+# Permanent-identifier redirects for https://w3id.org/qubiten/
+# Namespace: metadata registry (ISO/IEC 11179) of Qubiten
+# Maintainer: Wilbye (Qubiten) <wilbye@qubiten.com>
+# Source of record: https://github.com/Qubiten/metadata-registry
+# Interim target: repository documentation (superseded when the LDP
+# containers provide dereferenceable resources).
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# Registration authority identifier
+RewriteRule ^mr/ra/qubiten$ https://github.com/Qubiten/metadata-registry/blob/main/docs/01-designation-register.md [R=302,L]
+
+# Namespace root -> documentation index
+RewriteRule ^mr/?$ https://github.com/Qubiten/metadata-registry/blob/main/docs/README.md [R=302,L]
+
+# All other IRIs under the namespace -> repository (interim)
+RewriteRule ^mr/(.*)$ https://github.com/Qubiten/metadata-registry [R=302,L]

--- a/qubiten/README.md
+++ b/qubiten/README.md
@@ -10,11 +10,11 @@ Permanent identifiers for the Qubiten metadata registry (ISO/IEC 11179).
   repository, <https://github.com/Qubiten/metadata-registry>, until the registry's HTTP
   containers are publicly deployed.
 
-## Contact
+## Maintainer
 
-This space is administered by:
+This namespace is maintained by **[@wilbyembabu](https://github.com/wilbyembabu)** (Wilbye, Qubiten),
+acting as the registration authority (`https://w3id.org/qubiten/mr/ra/qubiten`).
 
-**Wilbye (Qubiten)**
-
-Email: [wilbye@qubiten.com](mailto:wilbye@qubiten.com)
-GitHub: [Qubiten](https://github.com/Qubiten)
+* Maintainer: [@wilbyembabu](https://github.com/wilbyembabu)
+* Email: [wilbye@qubiten.com](mailto:wilbye@qubiten.com)
+* Organization: [Qubiten](https://github.com/Qubiten)

--- a/qubiten/README.md
+++ b/qubiten/README.md
@@ -1,0 +1,20 @@
+# /qubiten/
+
+Permanent identifiers for the Qubiten metadata registry (ISO/IEC 11179).
+
+* [`https://w3id.org/qubiten/mr/`](https://w3id.org/qubiten/mr/) — namespace root; redirects to
+  the registry's documentation index.
+* [`https://w3id.org/qubiten/mr/ra/qubiten`](https://w3id.org/qubiten/mr/ra/qubiten) — the
+  registration authority identifier.
+* All other IRIs under `https://w3id.org/qubiten/mr/` redirect (interim) to the source
+  repository, <https://github.com/Qubiten/metadata-registry>, until the registry's HTTP
+  containers are publicly deployed.
+
+## Contact
+
+This space is administered by:
+
+**Wilbye (Qubiten)**
+
+Email: [wilbye@qubiten.com](mailto:wilbye@qubiten.com)
+GitHub: [Qubiten](https://github.com/Qubiten)


### PR DESCRIPTION
Registers https://w3id.org/qubiten/ for the Qubiten metadata registry (ISO/IEC 11179). Redirect targets are the source repository's documentation until the registry's HTTP containers are publicly deployed.

Contact: wilbye@qubiten.com


Claude-Session: https://claude.ai/code/session_01KZBbzQvoqSyrYzKQrE2fvn

<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [ ] Changes have been tested.
- [ ] The number of commits is minimal. Squash if needed.
- [ ] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
