### PR TITLE
Add rewrite rules for DEC source code links

### DIFF
--- a/conjectures/.htaccess
+++ b/conjectures/.htaccess
@@ -3,3 +3,8 @@ RewriteEngine On
 # DEC live viewer.
 RewriteRule   "^dec/?$" https://dec.fabiovitali.it/ [R=302,L,QSA]
 RewriteRule   "^dec/viewer/?$" https://dec.fabiovitali.it/ [R=302,L,QSA]
+
+# DEC source code.
+RewriteRule "^dec/code/?$" https://github.com/fvitali/dec-reasoner [R=302,L,QSA]
+RewriteRule "^dec/code/reasoner/?$" https://github.com/fvitali/dec-reasoner [R=302,L,QSA]
+RewriteRule "^dec/code/viewer/?$" https://github.com/fvitali/dec-viewer [R=302,L,QSA]


### PR DESCRIPTION
This PR adds source-code redirects for the existing DEC W3ID namespace:

- https://w3id.org/conjectures/dec/code -> https://github.com/fvitali/dec-reasoner
- https://w3id.org/conjectures/dec/code/reasoner -> https://github.com/fvitali/dec-reasoner
- https://w3id.org/conjectures/dec/code/viewer -> https://github.com/fvitali/dec-viewer