### PR TITLE
Add w3id.org/holon redirect for W3C Holon Community Group

### DIFF
--- a/holon/.htaccess
+++ b/holon/.htaccess
@@ -1,0 +1,3 @@
+Options +FollowSymLinks
+RewriteEngine on
+RewriteRule ^$ https://w3c-cg.github.io/holon/ [R=302,L]

--- a/holon/README.md
+++ b/holon/README.md
@@ -1,0 +1,21 @@
+# Holon — Vocabulary and Architecture for Holonic Knowledge Graphs
+
+## Persistent URI
+https://w3id.org/holon
+
+## About
+The Holon vocabulary and Holon Graph Architecture (HGA) provide a framework
+for representing self-similar, nested knowledge structures ("holons") that
+can act simultaneously as whole entities and as components of larger wholes.
+Work is maintained under the auspices of the W3C Holon Community Group.
+
+## Community Group
+https://www.w3.org/community/holon/
+
+## Repository
+https://github.com/w3c-cg/holon
+
+## Contacts
+**Kurt Cagle** (Chair, W3C Holon Community Group)
+<kurt.cagle@gmail.com>
+https://github.com/kurtcagle


### PR DESCRIPTION
Registers `https://w3id.org/holon` as a permanent identifier redirecting to `https://w3c-cg.github.io/holon/`, the GitHub Pages site for the W3C Holon Community Group.

- **Group**: W3C Holon Community Group (https://www.w3.org/community/holon/)
- **Repository**: https://github.com/w3c-cg/holon
- **Contact**: Kurt Cagle (Chair) — kurt.cagle@gmail.com

This follows the standard `.htaccess` + `README.md` pattern documented in the repo's contribution guide.