### PR TITLE
Add /atlas namespace (ATLAS tribology ontology)

### DIFF
--- a/atlas/.htaccess
+++ b/atlas/.htaccess
@@ -1,0 +1,11 @@
+# ATLAS — tribology knowledge-extraction ontology
+# https://w3id.org/atlas/
+Options +FollowSymLinks
+RewriteEngine on
+
+# Concept IRIs → live concept detail pages
+# e.g. https://w3id.org/atlas/tribology/concept/wear-rate
+RewriteRule ^tribology/concept/(.+)$ https://atlas-web-production-a3c8.up.railway.app/knowledge/ontology/concept/$1/ [R=302,L]
+
+# Namespace root → project
+RewriteRule ^$ https://atlas-web-production-a3c8.up.railway.app/ [R=302,L]

--- a/atlas/README.md
+++ b/atlas/README.md
@@ -1,0 +1,19 @@
+# ATLAS tribology ontology namespace
+
+Permanent identifiers for the ATLAS tribology domain ontology — a
+human-curated thesaurus/ontology of tribology concepts (materials, test
+apparatus, operating conditions, measured properties) built by the ATLAS
+literature knowledge-extraction system at Northwestern University.
+
+Concept IRIs have the form:
+
+    https://w3id.org/atlas/tribology/concept/<slug>
+
+and redirect (302) to the live concept detail pages, so the redirect target
+can follow the hosting while the identifiers stay permanent.
+
+## Maintainers
+
+| Name | GitHub | Email |
+|------|--------|-------|
+| Brian D. | @bcd122200 | bcd122200@gmail.com |


### PR DESCRIPTION
Registers the /atlas namespace for the ATLAS tribology ontology — a curated domain ontology built by a literature knowledge-extraction system at Northwestern University.

IRIs of the form `https://w3id.org/atlas/tribology/concept/<slug>` are already embedded in our published concept data and redirect (302) to the live concept detail pages, e.g.:

https://atlas-web-production-a3c8.up.railway.app/knowledge/ontology/concept/wear-rate/

Maintainer contact is listed in the README.