### PR TITLE
cdisc/usdm/v4: re-pin to v0.5.0, add instance context path

### DIFF
--- a/cdisc/usdm/v4/.htaccess
+++ b/cdisc/usdm/v4/.htaccess
@@ -5,7 +5,7 @@
 # source. Slash semantics (since v0.3): each minted IRI dereferences
 # individually — class IRIs to per-class HTML anchors, property IRIs
 # to property anchors on the rendered page; the canonical Turtle
-# (version-pinned at the v0.4.0 tag) is served for tools requesting
+# (version-pinned at the v0.5.0 tag) is served for tools requesting
 # RDF. Version IRIs (bare-numeric paths, e.g. /0.3.1) dereference to
 # their own tag-pinned Turtle via one generic rule.
 #
@@ -28,6 +28,13 @@ RewriteBase /cdisc/usdm/v4
 # (decision D3, docs/iri-and-governance.md).
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v$1/usdm_v4.ttl [R=303,L]
 
+# JSON-LD 1.1 instance context — fixed path, version-pinned like the
+# canonical Turtle. Must precede the Accept-based rules so the path
+# resolves regardless of Accept header (JSON-LD processors typically
+# send application/ld+json; browsers must not fall through to the
+# HTML anchor rule).
+RewriteRule ^context\.jsonld$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.5.0/usdm_v4.context.jsonld [R=303,L]
+
 # JSON-LD
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
 RewriteRule ^(.*)$ https://kerfors.github.io/usdm-rdf/ontology.jsonld [R=303,L]
@@ -40,9 +47,9 @@ RewriteRule ^(.*)$ https://kerfors.github.io/usdm-rdf/ontology.owl [R=303,L]
 RewriteCond %{HTTP_ACCEPT} application/n-triples
 RewriteRule ^(.*)$ https://kerfors.github.io/usdm-rdf/ontology.nt [R=303,L]
 
-# Turtle — canonical, version-pinned at the v0.4.0 tag
+# Turtle — canonical, version-pinned at the v0.5.0 tag
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^(.*)$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.4.0/usdm_v4.ttl [R=303,L]
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.5.0/usdm_v4.ttl [R=303,L]
 
 # HTML for browsers — namespace root and per-IRI variants
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
@@ -55,4 +62,4 @@ RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 RewriteRule ^(.+)$ https://kerfors.github.io/usdm-rdf/index.html#$1 [R=303,NE,L]
 
 # Default fallback (no Accept header, programmatic clients): canonical Turtle
-RewriteRule ^(.*)$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.4.0/usdm_v4.ttl [R=303,L]
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.5.0/usdm_v4.ttl [R=303,L]


### PR DESCRIPTION
Re-pins the canonical Turtle and fallback rules to the v0.5.0 tag. Adds one fixed-path rule serving the new JSON-LD 1.1 instance context (usdm_v4.context.jsonld) at /cdisc/usdm/v4/context.jsonld, version-pinned like the Turtle. No changes to the conneg or versionIRI rules. Previous PRs for this namespace: #6012, #6189, #6190.