### PR TITLE
Add AASP namespace

### DIFF
--- a/aasp/.htaccess
+++ b/aasp/.htaccess
@@ -7,21 +7,21 @@ Options +FollowSymLinks
 RewriteEngine On
 
 # Base documentation
-RewriteRule ^$ https://alperasinmaz.github.io/aasp/ [R=302,L]
+RewriteRule ^$ https://archaeodigit.github.io/aasp/ [R=302,L]
 
 # Versioned documentation and vocabulary
-RewriteRule ^0.4.2/?$ https://alperasinmaz.github.io/aasp/0.4.2/ [R=302,L]
-RewriteRule ^0.4.2/aasp.ttl$ https://alperasinmaz.github.io/aasp/0.4.2/aasp.ttl [R=302,L]
-RewriteRule ^0.4.2/aasp_shapes.ttl$ https://alperasinmaz.github.io/aasp/0.4.2/aasp_shapes.ttl [R=302,L]
+RewriteRule ^0.4.2/?$ https://archaeodigit.github.io/aasp/0.4.2/ [R=302,L]
+RewriteRule ^0.4.2/aasp.ttl$ https://archaeodigit.github.io/aasp/0.4.2/aasp.ttl [R=302,L]
+RewriteRule ^0.4.2/aasp_shapes.ttl$ https://archaeodigit.github.io/aasp/0.4.2/aasp_shapes.ttl [R=302,L]
 
 # Current vocabulary and supporting files
-RewriteRule ^aasp.ttl$ https://alperasinmaz.github.io/aasp/aasp.ttl [R=302,L]
-RewriteRule ^aasp_shapes.ttl$ https://alperasinmaz.github.io/aasp/aasp_shapes.ttl [R=302,L]
-RewriteRule ^examples/?$ https://alperasinmaz.github.io/aasp/examples/ [R=302,L]
-RewriteRule ^queries/?$ https://alperasinmaz.github.io/aasp/queries/ [R=302,L]
-RewriteRule ^figures/?$ https://alperasinmaz.github.io/aasp/figures/ [R=302,L]
+RewriteRule ^aasp.ttl$ https://archaeodigit.github.io/aasp/aasp.ttl [R=302,L]
+RewriteRule ^aasp_shapes.ttl$ https://archaeodigit.github.io/aasp/aasp_shapes.ttl [R=302,L]
+RewriteRule ^examples/?$ https://archaeodigit.github.io/aasp/examples/ [R=302,L]
+RewriteRule ^queries/?$ https://archaeodigit.github.io/aasp/queries/ [R=302,L]
+RewriteRule ^figures/?$ https://archaeodigit.github.io/aasp/figures/ [R=302,L]
 
 # Term IRIs resolve to the current documentation page.
 # Documentation should list and define each term.
-RewriteRule ^([A-Za-z][A-Za-z0-9_-]*)$ https://alperasinmaz.github.io/aasp/#$1 [R=302,L]
-RewriteRule ^([A-Za-z][A-Za-z0-9_-]*)/$ https://alperasinmaz.github.io/aasp/#$1 [R=302,L]
+RewriteRule ^([A-Za-z][A-Za-z0-9_-]*)$ https://archaeodigit.github.io/aasp/#$1 [R=302,L]
+RewriteRule ^([A-Za-z][A-Za-z0-9_-]*)/$ https://archaeodigit.github.io/aasp/#$1 [R=302,L]

--- a/aasp/.htaccess
+++ b/aasp/.htaccess
@@ -1,5 +1,5 @@
 # AASP: Archaeological Assertion and Synthesis Profile
-# Maintainer: Alper Aşınmaz <alperasinmaz@gmail.com>
+# Maintainer: Alper Asinmaz <alperasinmaz@gmail.com>
 # Preferred prefix: aasp
 # Namespace: https://w3id.org/aasp/
 

--- a/aasp/.htaccess
+++ b/aasp/.htaccess
@@ -1,0 +1,27 @@
+# AASP: Archaeological Assertion and Synthesis Profile
+# Maintainer: Alper Aşınmaz <alperasinmaz@gmail.com>
+# Preferred prefix: aasp
+# Namespace: https://w3id.org/aasp/
+
+Options +FollowSymLinks
+RewriteEngine On
+
+# Base documentation
+RewriteRule ^$ https://alperasinmaz.github.io/aasp/ [R=302,L]
+
+# Versioned documentation and vocabulary
+RewriteRule ^0.4.2/?$ https://alperasinmaz.github.io/aasp/0.4.2/ [R=302,L]
+RewriteRule ^0.4.2/aasp.ttl$ https://alperasinmaz.github.io/aasp/0.4.2/aasp.ttl [R=302,L]
+RewriteRule ^0.4.2/aasp_shapes.ttl$ https://alperasinmaz.github.io/aasp/0.4.2/aasp_shapes.ttl [R=302,L]
+
+# Current vocabulary and supporting files
+RewriteRule ^aasp.ttl$ https://alperasinmaz.github.io/aasp/aasp.ttl [R=302,L]
+RewriteRule ^aasp_shapes.ttl$ https://alperasinmaz.github.io/aasp/aasp_shapes.ttl [R=302,L]
+RewriteRule ^examples/?$ https://alperasinmaz.github.io/aasp/examples/ [R=302,L]
+RewriteRule ^queries/?$ https://alperasinmaz.github.io/aasp/queries/ [R=302,L]
+RewriteRule ^figures/?$ https://alperasinmaz.github.io/aasp/figures/ [R=302,L]
+
+# Term IRIs resolve to the current documentation page.
+# Documentation should list and define each term.
+RewriteRule ^([A-Za-z][A-Za-z0-9_-]*)$ https://alperasinmaz.github.io/aasp/#$1 [R=302,L]
+RewriteRule ^([A-Za-z][A-Za-z0-9_-]*)/$ https://alperasinmaz.github.io/aasp/#$1 [R=302,L]

--- a/aasp/README.md
+++ b/aasp/README.md
@@ -20,7 +20,7 @@ Current SHACL shapes: `https://w3id.org/aasp/aasp_shapes.ttl`
 
 The redirects currently point to:
 
-`https://alperasinmaz.github.io/aasp/`
+`https://archaeodigit.github.io/aasp/`
 
 ## Maintainer
 

--- a/aasp/README.md
+++ b/aasp/README.md
@@ -24,5 +24,5 @@ The redirects currently point to:
 
 ## Maintainer
 
-Alper Aşınmaz  
+Alper Asinmaz  
 Email: alperasinmaz@gmail.com

--- a/aasp/README.md
+++ b/aasp/README.md
@@ -25,5 +25,7 @@ The redirects currently point to:
 ## Maintainer
 
 Alper Asinmaz  
+
 GitHub ID: @archaeodigit
+
 Email: alperasinmaz@gmail.com

--- a/aasp/README.md
+++ b/aasp/README.md
@@ -1,0 +1,28 @@
+# AASP: Archaeological Assertion and Synthesis Profile
+
+This directory provides persistent redirects for the Archaeological Assertion and Synthesis Profile (AASP).
+
+AASP is a provisional, versioned Linked Data application profile for coordinating existing standards around the representation of revisable archaeological field-survey claims. It focuses on keeping evidence states, field procedures, analytical decisions, claims, claim relations, and dataset releases explicitly connected.
+
+## Namespace
+
+Preferred prefix: `aasp`
+
+Namespace URI: `https://w3id.org/aasp/`
+
+Current version URI: `https://w3id.org/aasp/0.4.2/`
+
+Current vocabulary: `https://w3id.org/aasp/aasp.ttl`
+
+Current SHACL shapes: `https://w3id.org/aasp/aasp_shapes.ttl`
+
+## Target documentation
+
+The redirects currently point to:
+
+`https://alperasinmaz.github.io/aasp/`
+
+## Maintainer
+
+Alper Aşınmaz  
+Email: alperasinmaz@gmail.com

--- a/aasp/README.md
+++ b/aasp/README.md
@@ -25,4 +25,5 @@ The redirects currently point to:
 ## Maintainer
 
 Alper Asinmaz  
+GitHub ID: @archaeodigit
 Email: alperasinmaz@gmail.com


### PR DESCRIPTION
This pull request adds redirects for the Archaeological Assertion and Synthesis Profile (AASP), a provisional Linked Data application profile for coordinating existing standards around revisable archaeological field-survey claims.

Requested namespace:
https://w3id.org/aasp/

Target documentation:
https://archaeodigit.github.io/aasp/

Maintainer:
Alper Aşınmaz
alperasinmaz@gmail.com