### PR TITLE
Generalize FiCR version redirects

### DIFF
--- a/ficr/.htaccess
+++ b/ficr/.htaccess
@@ -11,28 +11,28 @@ Options -MultiViews
 RewriteEngine On
 
 # -----------------------------
-# Version paths: /ficr/{version}, e.g. /ficr/1.1.0
+# Version paths: /ficr/{version}, e.g. /ficr/1.1.0 or /ficr/v1.1.0-beta
 # -----------------------------
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raingo111.github.io/FiCR-ontology/$1/ontology.jsonld [R=303,L]
+RewriteRule ^([A-Za-z0-9][A-Za-z0-9._-]*)/?$ https://raingo111.github.io/FiCR-ontology/$1/ontology.jsonld [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle
-RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raingo111.github.io/FiCR-ontology/$1/ontology.ttl [R=303,L]
+RewriteRule ^([A-Za-z0-9][A-Za-z0-9._-]*)/?$ https://raingo111.github.io/FiCR-ontology/$1/ontology.ttl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raingo111.github.io/FiCR-ontology/$1/ontology.nt [R=303,L]
+RewriteRule ^([A-Za-z0-9][A-Za-z0-9._-]*)/?$ https://raingo111.github.io/FiCR-ontology/$1/ontology.nt [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raingo111.github.io/FiCR-ontology/$1/ontology.owl [R=303,L]
+RewriteRule ^([A-Za-z0-9][A-Za-z0-9._-]*)/?$ https://raingo111.github.io/FiCR-ontology/$1/ontology.owl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raingo111.github.io/FiCR-ontology/$1/index-en.html [R=303,L]
+RewriteRule ^([A-Za-z0-9][A-Za-z0-9._-]*)/?$ https://raingo111.github.io/FiCR-ontology/$1/index-en.html [R=303,L]
 
-RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raingo111.github.io/FiCR-ontology/$1/ontology.ttl [R=303,L]
+RewriteRule ^([A-Za-z0-9][A-Za-z0-9._-]*)/?$ https://raingo111.github.io/FiCR-ontology/$1/ontology.ttl [R=303,L]
 
 # -----------------------------
 # Latest path: /ficr

--- a/ficr/.htaccess
+++ b/ficr/.htaccess
@@ -11,28 +11,28 @@ Options -MultiViews
 RewriteEngine On
 
 # -----------------------------
-# Version path: /ficr/1.0.0
+# Version paths: /ficr/{version}, e.g. /ficr/1.1.0
 # -----------------------------
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^1\.0\.0/?$ https://raingo111.github.io/FiCR-ontology/1.0.0/ontology.jsonld [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raingo111.github.io/FiCR-ontology/$1/ontology.jsonld [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle
-RewriteRule ^1\.0\.0/?$ https://raingo111.github.io/FiCR-ontology/1.0.0/ontology.ttl [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raingo111.github.io/FiCR-ontology/$1/ontology.ttl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^1\.0\.0/?$ https://raingo111.github.io/FiCR-ontology/1.0.0/ontology.nt [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raingo111.github.io/FiCR-ontology/$1/ontology.nt [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^1\.0\.0/?$ https://raingo111.github.io/FiCR-ontology/1.0.0/ontology.owl [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raingo111.github.io/FiCR-ontology/$1/ontology.owl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^1\.0\.0/?$ https://raingo111.github.io/FiCR-ontology/1.0.0/index-en.html [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raingo111.github.io/FiCR-ontology/$1/index-en.html [R=303,L]
 
-RewriteRule ^1\.0\.0/?$ https://raingo111.github.io/FiCR-ontology/1.0.0/ontology.ttl [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raingo111.github.io/FiCR-ontology/$1/ontology.ttl [R=303,L]
 
 # -----------------------------
 # Latest path: /ficr


### PR DESCRIPTION
This PR updates the FiCR w3id redirect rules so versioned paths use a flexible single-segment version path pattern instead of being hard-coded to `1.0.0`.

Changes:
- Keeps the latest `/ficr` redirects unchanged.
- Changes `/ficr/1.0.0`-specific rules to `/ficr/{version}` rules.
- Allows version or snapshot paths such as `/ficr/1.1.0`, `/ficr/v1.2.0-beta`, and `/ficr/2026-07`.
- Redirects versioned paths to the corresponding GitHub Pages snapshot directory.
- Preserves content negotiation for HTML, Turtle, RDF/XML, JSON-LD, and N-Triples.

Target documentation base remains:
`https://raingo111.github.io/FiCR-ontology/`

The version path pattern is limited to a single path segment using letters, numbers, dots, underscores, and hyphens.