### PR TITLE
add versions with 1.1.0 as the latest

### DIFF
--- a/PrOM/.htaccess
+++ b/PrOM/.htaccess
@@ -12,10 +12,13 @@ AddType application/ld+json .jsonld
 # Rewrite engine setup
 RewriteEngine On
 
+# Latest version
+# ---------------------------
+
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 # Placed before HTML to support serving JSON-LD from a browser (e.g., JSON Playground)
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^$ https://prom-o.codeberg.page/PrOM/widoco/ontology.jsonld [R=303,L]
+RewriteRule ^$ https://prom-o.codeberg.page/PrOM/1.1.0/ontology.jsonld [R=303,L]
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*|\*/\*)
@@ -24,25 +27,58 @@ RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://prom-o.codeberg.page/PrOM/widoco/index-en.html [R=303,NE,L]
+RewriteRule ^$ https://prom-o.codeberg.page/PrOM/1.1.0/index-en.html [R=303,NE,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} ^.*application/rdf+xml*
-RewriteRule ^$ https://prom-o.codeberg.page/PrOM/widoco/ontology.owl [R=303,NE,L]
+RewriteRule ^$ https://prom-o.codeberg.page/PrOM/1.1.0/ontology.owl [R=303,NE,L]
 
 # Rewrite rule to serve N-Triples content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} ^.*application/n-triples*
-RewriteRule ^$ https://prom-o.codeberg.page/PrOM/widoco/ontology.nt [R=303,NE,L]
+RewriteRule ^$ https://prom-o.codeberg.page/PrOM/1.1.0/ontology.nt [R=303,NE,L]
 
 # Rewrite rule to serve TTL content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.*
-RewriteRule ^$ https://prom-o.codeberg.page/PrOM/widoco/ontology.ttl [R=303,NE,L]
+RewriteRule ^$ https://prom-o.codeberg.page/PrOM/1.1.0/ontology.ttl [R=303,NE,L]
 
 RewriteCond %{HTTP_ACCEPT} .+
-RewriteRule ^$ https://prom-o.codeberg.page/PrOM/widoco/406.html [R=406,L]
+RewriteRule ^$ https://prom-o.codeberg.page/PrOM/1.1.0/406.html [R=406,L]
 
 # Default response : ttl
-RewriteRule ^$ https://prom-o.codeberg.page/PrOM/widoco/ontology.ttl [R=303,NE,L] 
+RewriteRule ^$ https://prom-o.codeberg.page/PrOM/1.1.0/ontology.ttl [R=303,NE,L] 
 
 
 
+# Default response
+# ---------------------------
+
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(.+)$ https://prom-o.codeberg.page/PrOM/$1/ontology.jsonld [R=303,L]
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*|\*/\*)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^(.+)$ https://prom-o.codeberg.page/PrOM/$1/index-en.html [R=303,NE,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} ^.*application/rdf+xml*
+RewriteRule ^(.+)$ https://prom-o.codeberg.page/PrOM/$1/ontology.owl [R=303,NE,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} ^.*application/n-triples*
+RewriteRule ^(.+)$ https://prom-o.codeberg.page/PrOM/$1/ontology.nt [R=303,NE,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.*
+RewriteRule ^(.+)$ https://prom-o.codeberg.page/PrOM/$1/ontology.ttl [R=303,NE,L]
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^(.+)$ https://prom-o.codeberg.page/PrOM/$1/406.html [R=406,L]
+
+# Default response : ttl
+RewriteRule ^(.+)$ https://prom-o.codeberg.page/PrOM/$1/ontology.ttl [R=303,NE,L] 


### PR DESCRIPTION
## Brief Description
Enable version-specific content negotiation for the PrOM ontology w3id.

Previously the `.htaccess` only redirected the base vocabulary URI (`w3id.org/PrOM/`) to the `widoco` folder on the Codeberg Pages site, with no way to resolve a specific version.

This pull request:
- Updates the default redirects to point at the current release folder `1.1.0` instead of `widoco`.
- Adds a second set of rewrite rules matching `^(.+)$`, so requests like `w3id.org/PrOM/1.0.0/` are redirected to `https://prom-o.codeberg.page/PrOM/1.0.0/...` with the same content negotiation (JSON-LD, HTML, RDF/XML, N-Triples, Turtle, 406 fallback) as the default route.



## General Checklist
- [ x] The number of commits is minimal. Squash if needed.
- [ x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## Update ID Directory Checklist
- [ x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.


