### PR TITLE
[codex] Add BusesForSale W3ID namespace

### DIFF
--- a/busesforsale/.htaccess
+++ b/busesforsale/.htaccess
@@ -1,0 +1,14 @@
+# BusesForSale vocabulary
+#
+# This space is administered by:
+# David Riccitelli
+# GitHub username: ziodave
+# Email: david@wordlift.io
+
+Options +FollowSymLinks
+Options -MultiViews
+
+RewriteEngine on
+
+# Temporary namespace target until vocabulary artifacts are published.
+RewriteRule ^$ https://www.busesforsale.com/ [R=303,L]

--- a/busesforsale/.htaccess
+++ b/busesforsale/.htaccess
@@ -8,7 +8,45 @@
 Options +FollowSymLinks
 Options -MultiViews
 
+AddType text/turtle .ttl
+AddType application/ld+json .jsonld
+
 RewriteEngine on
 
-# Temporary namespace target until vocabulary artifacts are published.
-RewriteRule ^$ https://www.busesforsale.com/ [R=303,L]
+# Namespace content negotiation.
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^$ https://w3id.org/busesforsale/index.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/ttl [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ https://w3id.org/busesforsale/index.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://w3id.org/busesforsale/index.html [R=303,L]
+
+# Term IRIs resolve to the vocabulary document in the requested format.
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^([^./]+)$ https://w3id.org/busesforsale/index.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/ttl [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^([^./]+)$ https://w3id.org/busesforsale/index.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^([^./]+)$ https://w3id.org/busesforsale/index.html#$1 [R=303,NE,L]
+
+# Default to human-readable documentation.
+RewriteRule ^$ https://w3id.org/busesforsale/index.html [R=303,L]
+RewriteRule ^([^./]+)$ https://w3id.org/busesforsale/index.html#$1 [R=303,NE,L]

--- a/busesforsale/README.md
+++ b/busesforsale/README.md
@@ -1,16 +1,25 @@
 # BusesForSale vocabulary
 
-This permanent identifier is reserved for the BusesForSale vocabulary:
+This permanent identifier publishes the BusesForSale vocabulary:
 
-<https://w3id.org/busesforsale>
+<https://w3id.org/busesforsale/>
 
-At this stage, the namespace redirects to the BusesForSale website:
+The vocabulary defines denormalized first-level properties for BusesForSale
+`schema:BusOrCoach` entities. These terms are designed for bots, retrieval
+systems, and chunkset embedding pipelines that need flat literal values while
+canonical `schema.org` markup remains available in the graph.
 
-<https://www.busesforsale.com/>
+## Artifacts
 
-Format-specific vocabulary artifacts, such as HTML documentation, RDF/XML,
-Turtle, and JSON-LD, can be added later when the vocabulary files are
-published.
+- Human-readable documentation: <https://w3id.org/busesforsale/index.html>
+- Turtle: <https://w3id.org/busesforsale/index.ttl>
+- JSON-LD: <https://w3id.org/busesforsale/index.jsonld>
+
+Term IRIs use slash identifiers under the namespace, for example:
+
+- <https://w3id.org/busesforsale/brandName>
+- <https://w3id.org/busesforsale/mileageMiles>
+- <https://w3id.org/busesforsale/feature>
 
 ## Contact
 

--- a/busesforsale/README.md
+++ b/busesforsale/README.md
@@ -1,0 +1,23 @@
+# BusesForSale vocabulary
+
+This permanent identifier is reserved for the BusesForSale vocabulary:
+
+<https://w3id.org/busesforsale>
+
+At this stage, the namespace redirects to the BusesForSale website:
+
+<https://www.busesforsale.com/>
+
+Format-specific vocabulary artifacts, such as HTML documentation, RDF/XML,
+Turtle, and JSON-LD, can be added later when the vocabulary files are
+published.
+
+## Contact
+
+This space is administered by:
+
+**David Riccitelli**  
+*Cofounder and CTO*  
+[WordLift](https://wordlift.io)  
+<david@wordlift.io>  
+GitHub: [ziodave](https://github.com/ziodave)

--- a/busesforsale/index.html
+++ b/busesforsale/index.html
@@ -1,0 +1,343 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BusesForSale vocabulary</title>
+  <style>
+    body { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height: 1.55; max-width: 1040px; margin: 0 auto; padding: 2rem; color: #1f2933; }
+    header { border-bottom: 4px solid #3452db; margin-bottom: 2rem; }
+    code { background: #f3f4f6; padding: 0.1rem 0.25rem; border-radius: 0.25rem; }
+    .term { border: 1px solid #d8dee9; border-left: 4px solid #3452db; border-radius: 0.5rem; padding: 1rem; margin: 1rem 0; }
+    .bot { color: #374151; }
+    dt { font-weight: 700; }
+    dd { margin: 0 0 0.5rem 0; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>BusesForSale vocabulary</h1>
+    <p><code>https://w3id.org/busesforsale/</code></p>
+  </header>
+  <main>
+    <section>
+      <h2>Purpose</h2>
+      <p>This vocabulary defines denormalized first-level properties for BusesForSale <code>schema:BusOrCoach</code> entities. These properties make bus entities easier for bots, retrieval systems, and chunkset embedding pipelines to consume without traversing linked <code>schema.org</code> nodes.</p>
+      <p>The properties are additive metadata. They do not replace canonical <code>schema.org</code> markup such as <code>schema:offers</code>, <code>schema:vehicleEngine</code>, or <code>schema:additionalProperty</code>.</p>
+      <p>Machine-readable serializations: <a href="index.ttl">Turtle</a> and <a href="index.jsonld">JSON-LD</a>.</p>
+    </section>
+    <section>
+      <h2>Terms</h2>
+      
+      <section id="brandName" class="term">
+        <h3><a href="#brandName">bfs:brandName</a></h3>
+        <p><strong>Brand name</strong>. The display name of the brand associated with a bus listing.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from schema:brand/schema:name on a schema:BusOrCoach entity. Expected value: text, for example &quot;Blue Bird&quot;.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/brandName</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Text</code></dd>
+        </dl>
+      </section>
+      <section id="manufacturerName" class="term">
+        <h3><a href="#manufacturerName">bfs:manufacturerName</a></h3>
+        <p><strong>Manufacturer name</strong>. The display name of the manufacturer associated with a bus listing.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from schema:manufacturer/schema:name on a schema:BusOrCoach entity. Expected value: text, for example &quot;Thomas Built Buses&quot;.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/manufacturerName</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Text</code></dd>
+        </dl>
+      </section>
+      <section id="price" class="term">
+        <h3><a href="#price">bfs:price</a></h3>
+        <p><strong>Price</strong>. The advertised offer price for the bus listing.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from schema:offers/schema:price. Expected value: numeric amount in the currency identified by bfs:priceCurrency.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/price</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Number</code></dd>
+        </dl>
+      </section>
+      <section id="lowPrice" class="term">
+        <h3><a href="#lowPrice">bfs:lowPrice</a></h3>
+        <p><strong>Low price</strong>. The lowest advertised price when the listing is represented by an aggregate offer.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from schema:offers/schema:lowPrice. Expected value: numeric amount in the currency identified by bfs:priceCurrency.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/lowPrice</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Number</code></dd>
+        </dl>
+      </section>
+      <section id="offerCount" class="term">
+        <h3><a href="#offerCount">bfs:offerCount</a></h3>
+        <p><strong>Offer count</strong>. The number of offers represented for the bus listing.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from schema:offers/schema:offerCount. Expected value: integer count.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/offerCount</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Integer</code></dd>
+        </dl>
+      </section>
+      <section id="priceCurrency" class="term">
+        <h3><a href="#priceCurrency">bfs:priceCurrency</a></h3>
+        <p><strong>Price currency</strong>. The ISO 4217 currency code used for price values on the bus listing.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from schema:offers/schema:priceCurrency. Expected value: text such as &quot;USD&quot;.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/priceCurrency</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Text</code></dd>
+        </dl>
+      </section>
+      <section id="availability" class="term">
+        <h3><a href="#availability">bfs:availability</a></h3>
+        <p><strong>Availability</strong>. The current availability value for the bus offer.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from schema:offers/schema:availability. Expected value: text or URI string such as http://schema.org/InStock.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/availability</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Text</code></dd>
+        </dl>
+      </section>
+      <section id="itemCondition" class="term">
+        <h3><a href="#itemCondition">bfs:itemCondition</a></h3>
+        <p><strong>Item condition</strong>. The condition of the bus being offered.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from schema:offers/schema:itemCondition. Expected value: text or URI string such as http://schema.org/UsedCondition.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/itemCondition</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Text</code></dd>
+        </dl>
+      </section>
+      <section id="mileageMiles" class="term">
+        <h3><a href="#mileageMiles">bfs:mileageMiles</a></h3>
+        <p><strong>Mileage in miles</strong>. The odometer mileage of the bus expressed in miles.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from schema:mileageFromOdometer/schema:value where the source quantitative value uses miles. Expected value: number of miles.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/mileageMiles</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Number</code></dd>
+        </dl>
+      </section>
+      <section id="passengerCapacity" class="term">
+        <h3><a href="#passengerCapacity">bfs:passengerCapacity</a></h3>
+        <p><strong>Passenger capacity</strong>. The number of passengers the bus is configured to carry.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from schema:vehicleSeatingCapacity/schema:value, with schema:seatingCapacity as fallback. Expected value: integer or numeric passenger count.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/passengerCapacity</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Integer</code></dd>
+        </dl>
+      </section>
+      <section id="engineType" class="term">
+        <h3><a href="#engineType">bfs:engineType</a></h3>
+        <p><strong>Engine type</strong>. A normalized or source-derived text label for the bus engine.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from schema:vehicleEngine/schema:engineType. Expected value: text such as &quot;cummins&quot;.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/engineType</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Text</code></dd>
+        </dl>
+      </section>
+      <section id="engineDisplacementLiters" class="term">
+        <h3><a href="#engineDisplacementLiters">bfs:engineDisplacementLiters</a></h3>
+        <p><strong>Engine displacement in liters</strong>. The engine displacement of the bus expressed in liters.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from schema:vehicleEngine/schema:engineDisplacement/schema:value where the source unit is liters. Expected value: numeric liters.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/engineDisplacementLiters</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Number</code></dd>
+        </dl>
+      </section>
+      <section id="gvwrLbs" class="term">
+        <h3><a href="#gvwrLbs">bfs:gvwrLbs</a></h3>
+        <p><strong>Gross vehicle weight rating in pounds</strong>. The gross vehicle weight rating of the bus expressed in pounds.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from schema:weightTotal/schema:value where the source unit is pounds. Expected value: numeric pounds.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/gvwrLbs</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Number</code></dd>
+        </dl>
+      </section>
+      <section id="exteriorHeightFeet" class="term">
+        <h3><a href="#exteriorHeightFeet">bfs:exteriorHeightFeet</a></h3>
+        <p><strong>Exterior height in feet</strong>. The exterior height of the bus expressed in feet.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from schema:height/schema:value where the source quantitative value describes exterior height. Expected value: numeric feet.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/exteriorHeightFeet</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Number</code></dd>
+        </dl>
+      </section>
+      <section id="exteriorWidthFeet" class="term">
+        <h3><a href="#exteriorWidthFeet">bfs:exteriorWidthFeet</a></h3>
+        <p><strong>Exterior width in feet</strong>. The exterior width of the bus expressed in feet.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from schema:width/schema:value where the source quantitative value describes exterior width. Expected value: numeric feet.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/exteriorWidthFeet</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Number</code></dd>
+        </dl>
+      </section>
+      <section id="exteriorLengthFeet" class="term">
+        <h3><a href="#exteriorLengthFeet">bfs:exteriorLengthFeet</a></h3>
+        <p><strong>Exterior length in feet</strong>. The exterior length of the bus expressed in feet.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from schema:depth/schema:value where the source quantitative value describes exterior length. Expected value: numeric feet.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/exteriorLengthFeet</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Number</code></dd>
+        </dl>
+      </section>
+      <section id="interiorHeightFeet" class="term">
+        <h3><a href="#interiorHeightFeet">bfs:interiorHeightFeet</a></h3>
+        <p><strong>Interior height in feet</strong>. The interior height of the bus expressed in feet.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from a schema:additionalProperty PropertyValue whose propertyID is dimensions.height_ft.interior. Expected value: numeric feet.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/interiorHeightFeet</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Number</code></dd>
+        </dl>
+      </section>
+      <section id="interiorWidthFeet" class="term">
+        <h3><a href="#interiorWidthFeet">bfs:interiorWidthFeet</a></h3>
+        <p><strong>Interior width in feet</strong>. The interior width of the bus expressed in feet.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from a schema:additionalProperty PropertyValue whose propertyID is dimensions.width_ft.interior. Expected value: numeric feet.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/interiorWidthFeet</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Number</code></dd>
+        </dl>
+      </section>
+      <section id="interiorLengthFeet" class="term">
+        <h3><a href="#interiorLengthFeet">bfs:interiorLengthFeet</a></h3>
+        <p><strong>Interior length in feet</strong>. The interior length of the bus expressed in feet.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from a schema:additionalProperty PropertyValue whose propertyID is dimensions.length_ft.interior. Expected value: numeric feet.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/interiorLengthFeet</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Number</code></dd>
+        </dl>
+      </section>
+      <section id="adaAccessible" class="term">
+        <h3><a href="#adaAccessible">bfs:adaAccessible</a></h3>
+        <p><strong>ADA accessible</strong>. Indicates whether the bus listing is marked as ADA accessible.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from a schema:additionalProperty PropertyValue whose propertyID is accessibility.ada. Expected value: boolean true or false.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/adaAccessible</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Boolean</code></dd>
+        </dl>
+      </section>
+      <section id="wheelchairLift" class="term">
+        <h3><a href="#wheelchairLift">bfs:wheelchairLift</a></h3>
+        <p><strong>Wheelchair lift</strong>. Indicates whether the bus has a wheelchair lift.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from a schema:additionalProperty PropertyValue whose propertyID is accessibility.wheelchair_lift. Expected value: boolean true or false.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/wheelchairLift</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Boolean</code></dd>
+        </dl>
+      </section>
+      <section id="wheelchairPositions" class="term">
+        <h3><a href="#wheelchairPositions">bfs:wheelchairPositions</a></h3>
+        <p><strong>Wheelchair positions</strong>. The number of wheelchair positions configured in the bus.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from a schema:additionalProperty PropertyValue whose propertyID is capacity.wheelchair_positions. Expected value: numeric count.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/wheelchairPositions</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Number</code></dd>
+        </dl>
+      </section>
+      <section id="hasRestroom" class="term">
+        <h3><a href="#hasRestroom">bfs:hasRestroom</a></h3>
+        <p><strong>Has restroom</strong>. Indicates whether the bus has a restroom, toilet, or bathroom feature.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from a schema:additionalProperty PropertyValue whose propertyID is interior.restroom. Expected value: boolean true or false.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/hasRestroom</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Boolean</code></dd>
+        </dl>
+      </section>
+      <section id="hasUsbPower" class="term">
+        <h3><a href="#hasUsbPower">bfs:hasUsbPower</a></h3>
+        <p><strong>Has USB power</strong>. Indicates whether the bus has USB power or USB charging features.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from a schema:additionalProperty PropertyValue whose propertyID is infotainment.power.usb. Expected value: boolean true or false.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/hasUsbPower</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Boolean</code></dd>
+        </dl>
+      </section>
+      <section id="hasLedLighting" class="term">
+        <h3><a href="#hasLedLighting">bfs:hasLedLighting</a></h3>
+        <p><strong>Has LED lighting</strong>. Indicates whether the bus has LED lighting features.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from a schema:additionalProperty PropertyValue whose propertyID is lighting.led. Expected value: boolean true or false.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/hasLedLighting</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Boolean</code></dd>
+        </dl>
+      </section>
+      <section id="airConditioningBtu" class="term">
+        <h3><a href="#airConditioningBtu">bfs:airConditioningBtu</a></h3>
+        <p><strong>Air conditioning capacity in BTU</strong>. The air-conditioning capacity of the bus expressed in BTU.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from a schema:additionalProperty PropertyValue whose propertyID is climate.ac.btu. Expected value: numeric BTU.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/airConditioningBtu</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Number</code></dd>
+        </dl>
+      </section>
+      <section id="idealUse" class="term">
+        <h3><a href="#idealUse">bfs:idealUse</a></h3>
+        <p><strong>Ideal use</strong>. A repeated text value describing an inferred or source-derived use case for the bus.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from schema:additionalProperty PropertyValue nodes whose propertyID starts with ideal_use. Multiple values may be present. Expected value: text such as &quot;School Transportation&quot;.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/idealUse</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Text</code></dd>
+        </dl>
+      </section>
+      <section id="feature" class="term">
+        <h3><a href="#feature">bfs:feature</a></h3>
+        <p><strong>Feature</strong>. A repeated text value preserving a source feature not represented by a more specific BusesForSale property.</p>
+        <p class="bot"><strong>For bots:</strong> Denormalized from schema:additionalProperty PropertyValue nodes whose propertyID is feature. Multiple values may be present. Expected value: source feature text.</p>
+        <dl>
+          <dt>IRI</dt><dd><code>https://w3id.org/busesforsale/feature</code></dd>
+          <dt>Type</dt><dd><code>owl:DatatypeProperty</code></dd>
+          <dt>Domain</dt><dd><code>schema:BusOrCoach</code></dd>
+          <dt>Range</dt><dd><code>schema:Text</code></dd>
+        </dl>
+      </section>
+    </section>
+  </main>
+</body>
+</html>

--- a/busesforsale/index.jsonld
+++ b/busesforsale/index.jsonld
@@ -1,0 +1,577 @@
+{
+  "@context": {
+    "bfs": "https://w3id.org/busesforsale/",
+    "dcterms": "http://purl.org/dc/terms/",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "schema": "http://schema.org/",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "label": "rdfs:label",
+    "comment": "rdfs:comment",
+    "definition": "skos:definition",
+    "domainIncludes": {
+      "@id": "schema:domainIncludes",
+      "@type": "@id"
+    },
+    "rangeIncludes": {
+      "@id": "schema:rangeIncludes",
+      "@type": "@id"
+    },
+    "isDefinedBy": {
+      "@id": "rdfs:isDefinedBy",
+      "@type": "@id"
+    }
+  },
+  "@graph": [
+    {
+      "@id": "https://w3id.org/busesforsale/",
+      "@type": "owl:Ontology",
+      "dcterms:title": {
+        "@value": "BusesForSale vocabulary",
+        "@language": "en"
+      },
+      "dcterms:description": {
+        "@value": "A vocabulary of denormalized first-level properties used to describe BusesForSale schema:BusOrCoach entities for retrieval, chunkset embeddings, and bot consumption while preserving canonical schema.org modeling.",
+        "@language": "en"
+      },
+      "dcterms:creator": "WordLift",
+      "dcterms:publisher": {
+        "@id": "https://wordlift.io/"
+      },
+      "owl:versionInfo": "0.1.1"
+    },
+    {
+      "@id": "bfs:brandName",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Brand name",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "The display name of the brand associated with a bus listing.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from schema:brand/schema:name on a schema:BusOrCoach entity. Expected value: text, for example \"Blue Bird\".",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Text",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:manufacturerName",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Manufacturer name",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "The display name of the manufacturer associated with a bus listing.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from schema:manufacturer/schema:name on a schema:BusOrCoach entity. Expected value: text, for example \"Thomas Built Buses\".",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Text",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:price",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Price",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "The advertised offer price for the bus listing.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from schema:offers/schema:price. Expected value: numeric amount in the currency identified by bfs:priceCurrency.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Number",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:lowPrice",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Low price",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "The lowest advertised price when the listing is represented by an aggregate offer.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from schema:offers/schema:lowPrice. Expected value: numeric amount in the currency identified by bfs:priceCurrency.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Number",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:offerCount",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Offer count",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "The number of offers represented for the bus listing.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from schema:offers/schema:offerCount. Expected value: integer count.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Integer",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:priceCurrency",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Price currency",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "The ISO 4217 currency code used for price values on the bus listing.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from schema:offers/schema:priceCurrency. Expected value: text such as \"USD\".",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Text",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:availability",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Availability",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "The current availability value for the bus offer.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from schema:offers/schema:availability. Expected value: text or URI string such as http://schema.org/InStock.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Text",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:itemCondition",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Item condition",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "The condition of the bus being offered.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from schema:offers/schema:itemCondition. Expected value: text or URI string such as http://schema.org/UsedCondition.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Text",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:mileageMiles",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Mileage in miles",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "The odometer mileage of the bus expressed in miles.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from schema:mileageFromOdometer/schema:value where the source quantitative value uses miles. Expected value: number of miles.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Number",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:passengerCapacity",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Passenger capacity",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "The number of passengers the bus is configured to carry.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from schema:vehicleSeatingCapacity/schema:value, with schema:seatingCapacity as fallback. Expected value: integer or numeric passenger count.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Integer",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:engineType",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Engine type",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "A normalized or source-derived text label for the bus engine.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from schema:vehicleEngine/schema:engineType. Expected value: text such as \"cummins\".",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Text",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:engineDisplacementLiters",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Engine displacement in liters",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "The engine displacement of the bus expressed in liters.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from schema:vehicleEngine/schema:engineDisplacement/schema:value where the source unit is liters. Expected value: numeric liters.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Number",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:gvwrLbs",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Gross vehicle weight rating in pounds",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "The gross vehicle weight rating of the bus expressed in pounds.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from schema:weightTotal/schema:value where the source unit is pounds. Expected value: numeric pounds.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Number",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:exteriorHeightFeet",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Exterior height in feet",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "The exterior height of the bus expressed in feet.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from schema:height/schema:value where the source quantitative value describes exterior height. Expected value: numeric feet.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Number",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:exteriorWidthFeet",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Exterior width in feet",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "The exterior width of the bus expressed in feet.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from schema:width/schema:value where the source quantitative value describes exterior width. Expected value: numeric feet.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Number",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:exteriorLengthFeet",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Exterior length in feet",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "The exterior length of the bus expressed in feet.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from schema:depth/schema:value where the source quantitative value describes exterior length. Expected value: numeric feet.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Number",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:interiorHeightFeet",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Interior height in feet",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "The interior height of the bus expressed in feet.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from a schema:additionalProperty PropertyValue whose propertyID is dimensions.height_ft.interior. Expected value: numeric feet.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Number",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:interiorWidthFeet",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Interior width in feet",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "The interior width of the bus expressed in feet.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from a schema:additionalProperty PropertyValue whose propertyID is dimensions.width_ft.interior. Expected value: numeric feet.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Number",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:interiorLengthFeet",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Interior length in feet",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "The interior length of the bus expressed in feet.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from a schema:additionalProperty PropertyValue whose propertyID is dimensions.length_ft.interior. Expected value: numeric feet.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Number",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:adaAccessible",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "ADA accessible",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "Indicates whether the bus listing is marked as ADA accessible.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from a schema:additionalProperty PropertyValue whose propertyID is accessibility.ada. Expected value: boolean true or false.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Boolean",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:wheelchairLift",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Wheelchair lift",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "Indicates whether the bus has a wheelchair lift.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from a schema:additionalProperty PropertyValue whose propertyID is accessibility.wheelchair_lift. Expected value: boolean true or false.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Boolean",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:wheelchairPositions",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Wheelchair positions",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "The number of wheelchair positions configured in the bus.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from a schema:additionalProperty PropertyValue whose propertyID is capacity.wheelchair_positions. Expected value: numeric count.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Number",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:hasRestroom",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Has restroom",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "Indicates whether the bus has a restroom, toilet, or bathroom feature.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from a schema:additionalProperty PropertyValue whose propertyID is interior.restroom. Expected value: boolean true or false.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Boolean",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:hasUsbPower",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Has USB power",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "Indicates whether the bus has USB power or USB charging features.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from a schema:additionalProperty PropertyValue whose propertyID is infotainment.power.usb. Expected value: boolean true or false.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Boolean",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:hasLedLighting",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Has LED lighting",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "Indicates whether the bus has LED lighting features.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from a schema:additionalProperty PropertyValue whose propertyID is lighting.led. Expected value: boolean true or false.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Boolean",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:airConditioningBtu",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Air conditioning capacity in BTU",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "The air-conditioning capacity of the bus expressed in BTU.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from a schema:additionalProperty PropertyValue whose propertyID is climate.ac.btu. Expected value: numeric BTU.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Number",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:idealUse",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Ideal use",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "A repeated text value describing an inferred or source-derived use case for the bus.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from schema:additionalProperty PropertyValue nodes whose propertyID starts with ideal_use. Multiple values may be present. Expected value: text such as \"School Transportation\".",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Text",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    },
+    {
+      "@id": "bfs:feature",
+      "@type": "owl:DatatypeProperty",
+      "label": {
+        "@value": "Feature",
+        "@language": "en"
+      },
+      "comment": {
+        "@value": "A repeated text value preserving a source feature not represented by a more specific BusesForSale property.",
+        "@language": "en"
+      },
+      "definition": {
+        "@value": "Denormalized from schema:additionalProperty PropertyValue nodes whose propertyID is feature. Multiple values may be present. Expected value: source feature text.",
+        "@language": "en"
+      },
+      "domainIncludes": "schema:BusOrCoach",
+      "rangeIncludes": "schema:Text",
+      "isDefinedBy": "https://w3id.org/busesforsale/"
+    }
+  ]
+}

--- a/busesforsale/index.ttl
+++ b/busesforsale/index.ttl
@@ -1,0 +1,240 @@
+@prefix bfs: <https://w3id.org/busesforsale/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+bfs: a owl:Ontology ;
+  dcterms:title "BusesForSale vocabulary"@en ;
+  dcterms:description "A vocabulary of denormalized first-level properties used to describe BusesForSale schema:BusOrCoach entities for retrieval, chunkset embeddings, and bot consumption while preserving canonical schema.org modeling."@en ;
+  dcterms:creator "WordLift" ;
+  dcterms:publisher <https://wordlift.io/> ;
+  dcterms:issued "2026-07-06"^^xsd:date ;
+  dcterms:modified "2026-07-06"^^xsd:date ;
+  owl:versionInfo "0.1.1" .
+
+bfs:brandName a owl:DatatypeProperty ;
+  rdfs:label "Brand name"@en ;
+  rdfs:comment "The display name of the brand associated with a bus listing."@en ;
+  skos:definition "Denormalized from schema:brand/schema:name on a schema:BusOrCoach entity. Expected value: text, for example \"Blue Bird\"."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Text ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:manufacturerName a owl:DatatypeProperty ;
+  rdfs:label "Manufacturer name"@en ;
+  rdfs:comment "The display name of the manufacturer associated with a bus listing."@en ;
+  skos:definition "Denormalized from schema:manufacturer/schema:name on a schema:BusOrCoach entity. Expected value: text, for example \"Thomas Built Buses\"."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Text ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:price a owl:DatatypeProperty ;
+  rdfs:label "Price"@en ;
+  rdfs:comment "The advertised offer price for the bus listing."@en ;
+  skos:definition "Denormalized from schema:offers/schema:price. Expected value: numeric amount in the currency identified by bfs:priceCurrency."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Number ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:lowPrice a owl:DatatypeProperty ;
+  rdfs:label "Low price"@en ;
+  rdfs:comment "The lowest advertised price when the listing is represented by an aggregate offer."@en ;
+  skos:definition "Denormalized from schema:offers/schema:lowPrice. Expected value: numeric amount in the currency identified by bfs:priceCurrency."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Number ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:offerCount a owl:DatatypeProperty ;
+  rdfs:label "Offer count"@en ;
+  rdfs:comment "The number of offers represented for the bus listing."@en ;
+  skos:definition "Denormalized from schema:offers/schema:offerCount. Expected value: integer count."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Integer ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:priceCurrency a owl:DatatypeProperty ;
+  rdfs:label "Price currency"@en ;
+  rdfs:comment "The ISO 4217 currency code used for price values on the bus listing."@en ;
+  skos:definition "Denormalized from schema:offers/schema:priceCurrency. Expected value: text such as \"USD\"."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Text ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:availability a owl:DatatypeProperty ;
+  rdfs:label "Availability"@en ;
+  rdfs:comment "The current availability value for the bus offer."@en ;
+  skos:definition "Denormalized from schema:offers/schema:availability. Expected value: text or URI string such as http://schema.org/InStock."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Text ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:itemCondition a owl:DatatypeProperty ;
+  rdfs:label "Item condition"@en ;
+  rdfs:comment "The condition of the bus being offered."@en ;
+  skos:definition "Denormalized from schema:offers/schema:itemCondition. Expected value: text or URI string such as http://schema.org/UsedCondition."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Text ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:mileageMiles a owl:DatatypeProperty ;
+  rdfs:label "Mileage in miles"@en ;
+  rdfs:comment "The odometer mileage of the bus expressed in miles."@en ;
+  skos:definition "Denormalized from schema:mileageFromOdometer/schema:value where the source quantitative value uses miles. Expected value: number of miles."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Number ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:passengerCapacity a owl:DatatypeProperty ;
+  rdfs:label "Passenger capacity"@en ;
+  rdfs:comment "The number of passengers the bus is configured to carry."@en ;
+  skos:definition "Denormalized from schema:vehicleSeatingCapacity/schema:value, with schema:seatingCapacity as fallback. Expected value: integer or numeric passenger count."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Integer ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:engineType a owl:DatatypeProperty ;
+  rdfs:label "Engine type"@en ;
+  rdfs:comment "A normalized or source-derived text label for the bus engine."@en ;
+  skos:definition "Denormalized from schema:vehicleEngine/schema:engineType. Expected value: text such as \"cummins\"."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Text ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:engineDisplacementLiters a owl:DatatypeProperty ;
+  rdfs:label "Engine displacement in liters"@en ;
+  rdfs:comment "The engine displacement of the bus expressed in liters."@en ;
+  skos:definition "Denormalized from schema:vehicleEngine/schema:engineDisplacement/schema:value where the source unit is liters. Expected value: numeric liters."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Number ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:gvwrLbs a owl:DatatypeProperty ;
+  rdfs:label "Gross vehicle weight rating in pounds"@en ;
+  rdfs:comment "The gross vehicle weight rating of the bus expressed in pounds."@en ;
+  skos:definition "Denormalized from schema:weightTotal/schema:value where the source unit is pounds. Expected value: numeric pounds."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Number ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:exteriorHeightFeet a owl:DatatypeProperty ;
+  rdfs:label "Exterior height in feet"@en ;
+  rdfs:comment "The exterior height of the bus expressed in feet."@en ;
+  skos:definition "Denormalized from schema:height/schema:value where the source quantitative value describes exterior height. Expected value: numeric feet."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Number ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:exteriorWidthFeet a owl:DatatypeProperty ;
+  rdfs:label "Exterior width in feet"@en ;
+  rdfs:comment "The exterior width of the bus expressed in feet."@en ;
+  skos:definition "Denormalized from schema:width/schema:value where the source quantitative value describes exterior width. Expected value: numeric feet."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Number ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:exteriorLengthFeet a owl:DatatypeProperty ;
+  rdfs:label "Exterior length in feet"@en ;
+  rdfs:comment "The exterior length of the bus expressed in feet."@en ;
+  skos:definition "Denormalized from schema:depth/schema:value where the source quantitative value describes exterior length. Expected value: numeric feet."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Number ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:interiorHeightFeet a owl:DatatypeProperty ;
+  rdfs:label "Interior height in feet"@en ;
+  rdfs:comment "The interior height of the bus expressed in feet."@en ;
+  skos:definition "Denormalized from a schema:additionalProperty PropertyValue whose propertyID is dimensions.height_ft.interior. Expected value: numeric feet."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Number ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:interiorWidthFeet a owl:DatatypeProperty ;
+  rdfs:label "Interior width in feet"@en ;
+  rdfs:comment "The interior width of the bus expressed in feet."@en ;
+  skos:definition "Denormalized from a schema:additionalProperty PropertyValue whose propertyID is dimensions.width_ft.interior. Expected value: numeric feet."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Number ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:interiorLengthFeet a owl:DatatypeProperty ;
+  rdfs:label "Interior length in feet"@en ;
+  rdfs:comment "The interior length of the bus expressed in feet."@en ;
+  skos:definition "Denormalized from a schema:additionalProperty PropertyValue whose propertyID is dimensions.length_ft.interior. Expected value: numeric feet."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Number ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:adaAccessible a owl:DatatypeProperty ;
+  rdfs:label "ADA accessible"@en ;
+  rdfs:comment "Indicates whether the bus listing is marked as ADA accessible."@en ;
+  skos:definition "Denormalized from a schema:additionalProperty PropertyValue whose propertyID is accessibility.ada. Expected value: boolean true or false."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Boolean ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:wheelchairLift a owl:DatatypeProperty ;
+  rdfs:label "Wheelchair lift"@en ;
+  rdfs:comment "Indicates whether the bus has a wheelchair lift."@en ;
+  skos:definition "Denormalized from a schema:additionalProperty PropertyValue whose propertyID is accessibility.wheelchair_lift. Expected value: boolean true or false."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Boolean ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:wheelchairPositions a owl:DatatypeProperty ;
+  rdfs:label "Wheelchair positions"@en ;
+  rdfs:comment "The number of wheelchair positions configured in the bus."@en ;
+  skos:definition "Denormalized from a schema:additionalProperty PropertyValue whose propertyID is capacity.wheelchair_positions. Expected value: numeric count."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Number ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:hasRestroom a owl:DatatypeProperty ;
+  rdfs:label "Has restroom"@en ;
+  rdfs:comment "Indicates whether the bus has a restroom, toilet, or bathroom feature."@en ;
+  skos:definition "Denormalized from a schema:additionalProperty PropertyValue whose propertyID is interior.restroom. Expected value: boolean true or false."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Boolean ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:hasUsbPower a owl:DatatypeProperty ;
+  rdfs:label "Has USB power"@en ;
+  rdfs:comment "Indicates whether the bus has USB power or USB charging features."@en ;
+  skos:definition "Denormalized from a schema:additionalProperty PropertyValue whose propertyID is infotainment.power.usb. Expected value: boolean true or false."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Boolean ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:hasLedLighting a owl:DatatypeProperty ;
+  rdfs:label "Has LED lighting"@en ;
+  rdfs:comment "Indicates whether the bus has LED lighting features."@en ;
+  skos:definition "Denormalized from a schema:additionalProperty PropertyValue whose propertyID is lighting.led. Expected value: boolean true or false."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Boolean ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:airConditioningBtu a owl:DatatypeProperty ;
+  rdfs:label "Air conditioning capacity in BTU"@en ;
+  rdfs:comment "The air-conditioning capacity of the bus expressed in BTU."@en ;
+  skos:definition "Denormalized from a schema:additionalProperty PropertyValue whose propertyID is climate.ac.btu. Expected value: numeric BTU."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Number ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:idealUse a owl:DatatypeProperty ;
+  rdfs:label "Ideal use"@en ;
+  rdfs:comment "A repeated text value describing an inferred or source-derived use case for the bus."@en ;
+  skos:definition "Denormalized from schema:additionalProperty PropertyValue nodes whose propertyID starts with ideal_use. Multiple values may be present. Expected value: text such as \"School Transportation\"."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Text ;
+  rdfs:isDefinedBy bfs: .
+
+bfs:feature a owl:DatatypeProperty ;
+  rdfs:label "Feature"@en ;
+  rdfs:comment "A repeated text value preserving a source feature not represented by a more specific BusesForSale property."@en ;
+  skos:definition "Denormalized from schema:additionalProperty PropertyValue nodes whose propertyID is feature. Multiple values may be present. Expected value: source feature text."@en ;
+  schema:domainIncludes schema:BusOrCoach ;
+  schema:rangeIncludes schema:Text ;
+  rdfs:isDefinedBy bfs: .


### PR DESCRIPTION
## Brief Description

Adds the `https://w3id.org/busesforsale/` namespace for the BusesForSale vocabulary.

This PR currently includes:

- maintainer/contact details in `busesforsale/.htaccess` and `busesforsale/README.md`
- W3ID rewrite rules for namespace and term IRIs such as `https://w3id.org/busesforsale/brandName`
- content negotiation for HTML, Turtle, and JSON-LD
- vocabulary artifacts for the first set of BusesForSale flat `schema:BusOrCoach` properties:
  - `busesforsale/index.html`
  - `busesforsale/index.ttl`
  - `busesforsale/index.jsonld`

The vocabulary terms describe denormalized first-level properties for BusesForSale bus listings, intended for bots, retrieval systems, and chunkset embedding workflows while preserving canonical `schema.org` modeling.

## Validation

- Turtle parses successfully with `rdflib`.
- JSON-LD parses successfully with `rdflib`.
- The ontology defines 28 `owl:DatatypeProperty` terms.
- The branch has been rebased onto upstream `perma-id/w3id.org:master`.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [ ] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
