### PR TITLE
Add teka-vocab namespace

### DIFF
--- a/teka-vocab/.htaccess
+++ b/teka-vocab/.htaccess
@@ -1,8 +1,22 @@
-# w3id.org redirect for the teka-vocab namespace
-# Placeholder stage: temporary 302 redirect to the "under construction" page.
-# When the real SKOS vocabularies are hosted, change the target URL and switch 302 -> 301.
-RewriteEngine On
-RewriteBase /teka-vocab/
+# # /teka-vocab/
+#
+# Namespace for controlled vocabularies (SKOS) used by the Archivarious/EERA
+# project — metadata standards for archival records from Eastern European and
+# post-Soviet historical collections.
+#
+# https://w3id.org/teka-vocab/ redirects to
+# https://ravve.github.io/teka-vocab-placeholder/
+#
+# Placeholder stage: temporary 302 (Found) redirect to an "under construction"
+# page. When the real vocabularies are hosted, the target will be updated and
+# the redirect switched to 301 (permanent) via a follow-up PR.
+#
+# ## Contact
+# This space is administered by:
+#
+# Roman Ravve
+# GitHub username: ravve
+# Email: roman.ravve@gmail.com
 
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteRule ^$ https://ravve.github.io/teka-vocab-placeholder/ [R=302,L]
+RewriteEngine on
+RewriteRule ^ https://ravve.github.io/teka-vocab-placeholder/ [R=302,L]

--- a/teka-vocab/.htaccess
+++ b/teka-vocab/.htaccess
@@ -1,0 +1,8 @@
+# w3id.org redirect for the teka-vocab namespace
+# Placeholder stage: temporary 302 redirect to the "under construction" page.
+# When the real SKOS vocabularies are hosted, change the target URL and switch 302 -> 301.
+RewriteEngine On
+RewriteBase /teka-vocab/
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteRule ^$ https://ravve.github.io/teka-vocab-placeholder/ [R=302,L]

--- a/teka-vocab/README.md
+++ b/teka-vocab/README.md
@@ -1,0 +1,8 @@
+# teka-vocab
+
+Namespace for controlled vocabularies (SKOS) used by the Archivarious/EERA project —
+metadata standards for archival records from Eastern European and post-Soviet historical collections.
+
+Status: placeholder, real content in development.
+
+Contact: roman.ravve@gmail.com


### PR DESCRIPTION
Register the `teka-vocab` namespace for the Archivarious/EERA project â€” controlled SKOS vocabularies for archival metadata from Eastern European and post-Soviet historical collections. Temporary 302 redirect to an under-construction placeholder while the vocabularies are in development; will be updated to the real data (and switched to 301) via a follow-up PR. Placeholder page: https://ravve.github.io/teka-vocab-placeholder/