### PR TITLE
add redirect for icer

### DIFF
--- a/icer/.htaccess
+++ b/icer/.htaccess
@@ -1,0 +1,5 @@
+RewriteEngine on
+
+RewriteRule ^profile-registry https://raw.githubusercontent.com/icer-unibe-ch/voc-profile-registry/main/registry.csv [R=302,L]
+RewriteRule ^p([0-9]+)/([a-zA-Z]+) https://raw.githubusercontent.com/icer-unibe-ch/voc-p$1/main/$2.json [R=302,L]
+RewriteRule ^v([0-9]+)/(.*) https://icer-unibe-ch.github.io/voc-v$1/icer-unibe-ch.github.io/voc-v$1/$2 [R=302,L]

--- a/icer/README.md
+++ b/icer/README.md
@@ -1,0 +1,8 @@
+# ICER 
+
+The Interfaculty Centre for Educational Research (ICER) at the University of Bern is an academic institute conducting empirical research in education across all educational levels in Switzerland.
+
+# Contacts
+
+Maintainer: Nathanael Jost (github: nathanaeljost)
+Email: nathanael.jost2@unibe.ch, info.icer@unibe.ch


### PR DESCRIPTION
## Brief Description
PR adds w3id permalinks for skohub vocabularies for Swiss national assessments. 
All resources can be found at [icer-unibe-ch](https://github.com/icer-unibe-ch)
Contact: nathanael.jost2@unibe.ch

