### PR TITLE
midas-catalog: add root and schema/ path redirects

### DIFF
--- a/midas-catalog/.htaccess
+++ b/midas-catalog/.htaccess
@@ -1,4 +1,7 @@
 RewriteEngine on
 AddDefaultCharset UTF-8 
+
 RewriteRule ^([0-9]+)$ https://catalog.midasnetwork.us/?object_id=$1 [R=302,L,NE]
+RewriteRule ^schema/(.+)$ https://catalog.midasnetwork.us/schema/$1 [R=302,L,NE]
+RewriteRule ^$ https://catalog.midasnetwork.us/ [R=302,L,NE]
 


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
Adds two redirect rules to the existing midas-catalog namespace so that the schema $id IRI and the namespace root resolve.
Currently only numeric record IDs redirect (e.g. /midas-catalog/46 → catalog record). The schema $id (https://w3id.org/midas-catalog/schema/midas-catalog-jsonld.schema.json), which is published in our JSON-LD output, returns 404 because no rule matches the schema/ path. The namespace root returns an Apache directory listing.
This PR adds:

^schema/(.+)$ → https://catalog.midasnetwork.us/schema/$1 — makes the published schema $id dereferenceable
^$ → https://catalog.midasnetwork.us/ — points the namespace root at the catalog home

The existing numeric-ID rule is unchanged.

## General Checklist
<!-- For all ID related PRs. -->
- [ x] Changes have been tested.
- [ x] The number of commits is minimal. Squash if needed.
- [ x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [x ] GitHub username ids are listed in the changed maintainer details.
- [ x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
