### PR TITLE
Add WiFi-CSI identifier for EHUNAM WiFi CSI Activity Ontology

### DIFF
--- a/WiFi-CSI/.htaccess
+++ b/WiFi-CSI/.htaccess
@@ -1,0 +1,23 @@
+﻿Options +FollowSymLinks
+RewriteEngine on
+
+# Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^$ http://34.51.146.173:8090/ontology/wifi_activity.ttl [R=303,L]
+
+# RDF/XML
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/xml
+RewriteRule ^$ http://34.51.146.173:8090/ontology/wifi_activity.ttl [R=303,L]
+
+# HTML en espanol
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteCond %{HTTP_ACCEPT_LANGUAGE} ^es [NC]
+RewriteRule ^$ http://34.51.146.173:8090/ontology/docs/index-es.html [R=303,L]
+
+# default HTML
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^$ http://34.51.146.173:8090/ontology/docs/index-en.html [R=303,L]
+
+# Fallback
+RewriteRule ^$ http://34.51.146.173:8090/ontology/docs/index-en.html [R=303,L]

--- a/WiFi-CSI/.htaccess
+++ b/WiFi-CSI/.htaccess
@@ -3,21 +3,21 @@ RewriteEngine on
 
 # Turtle
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^$ http://34.51.146.173:8090/ontology/wifi_activity.ttl [R=303,L]
+RewriteRule ^$ https://mikelontxu.github.io/EHUNAM-WiFi-CSI-FAIR-data/ontology.ttl [R=303,L]
 
 # RDF/XML
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} application/xml
-RewriteRule ^$ http://34.51.146.173:8090/ontology/wifi_activity.ttl [R=303,L]
+RewriteRule ^$ https://mikelontxu.github.io/EHUNAM-WiFi-CSI-FAIR-data/ontology.owl [R=303,L]
 
-# HTML en espanol
+# HTML en español
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteCond %{HTTP_ACCEPT_LANGUAGE} ^es [NC]
-RewriteRule ^$ http://34.51.146.173:8090/ontology/docs/index-es.html [R=303,L]
+RewriteRule ^$ https://mikelontxu.github.io/EHUNAM-WiFi-CSI-FAIR-data/index-es.html [R=303,L]
 
 # default HTML
 RewriteCond %{HTTP_ACCEPT} text/html
-RewriteRule ^$ http://34.51.146.173:8090/ontology/docs/index-en.html [R=303,L]
+RewriteRule ^$ https://mikelontxu.github.io/EHUNAM-WiFi-CSI-FAIR-data/index-en.html [R=303,L]
 
 # Fallback
-RewriteRule ^$ http://34.51.146.173:8090/ontology/docs/index-en.html [R=303,L]
+RewriteRule ^$ https://mikelontxu.github.io/EHUNAM-WiFi-CSI-FAIR-data/index-en.html [R=303,L]

--- a/WiFi-CSI/README.md
+++ b/WiFi-CSI/README.md
@@ -1,0 +1,11 @@
+﻿# WiFi-CSI
+
+Permanent identifier for the EHUNAM WiFi CSI Activity Ontology.
+
+* Namespace: https://w3id.org/WiFi-CSI#
+* Documentation (EN): http://34.51.146.173:8090/ontology/docs/index-en.html
+* Documentation (ES): http://34.51.146.173:8090/ontology/docs/index-es.html
+* Source (Turtle): http://34.51.146.173:8090/ontology/wifi_activity.ttl
+* GitHub repo: https://github.com/mikelontxu/EHUNAM-WiFi-CSI-FAIR-data
+* Maintainer: Mikelontxu (https://github.com/Mikelontxu) mikel.aranburu.ehu@gmail.com
+* Zenodo DOI (versioned): https://doi.org/10.5281/zenodo.21089086

--- a/WiFi-CSI/README.md
+++ b/WiFi-CSI/README.md
@@ -3,9 +3,9 @@
 Permanent identifier for the EHUNAM WiFi CSI Activity Ontology.
 
 * Namespace: https://w3id.org/WiFi-CSI#
-* Documentation (EN): http://34.51.146.173:8090/ontology/docs/index-en.html
-* Documentation (ES): http://34.51.146.173:8090/ontology/docs/index-es.html
-* Source (Turtle): http://34.51.146.173:8090/ontology/wifi_activity.ttl
+* Documentation (EN): https://mikelontxu.github.io/EHUNAM-WiFi-CSI-FAIR-data/index-en.html
+* Documentation (ES): https://mikelontxu.github.io/EHUNAM-WiFi-CSI-FAIR-data/index-es.html
+* Source (Turtle): https://mikelontxu.github.io/EHUNAM-WiFi-CSI-FAIR-data/ontology.ttl
 * GitHub repo: https://github.com/mikelontxu/EHUNAM-WiFi-CSI-FAIR-data
 * Maintainer: Mikel Aranburu (https://github.com/Mikelontxu) mikel.aranburu.ehu@gmail.com
 * Zenodo DOI (versioned): https://doi.org/10.5281/zenodo.21089086

--- a/WiFi-CSI/README.md
+++ b/WiFi-CSI/README.md
@@ -7,5 +7,5 @@ Permanent identifier for the EHUNAM WiFi CSI Activity Ontology.
 * Documentation (ES): http://34.51.146.173:8090/ontology/docs/index-es.html
 * Source (Turtle): http://34.51.146.173:8090/ontology/wifi_activity.ttl
 * GitHub repo: https://github.com/mikelontxu/EHUNAM-WiFi-CSI-FAIR-data
-* Maintainer: Mikelontxu (https://github.com/Mikelontxu) mikel.aranburu.ehu@gmail.com
+* Maintainer: Mikel Aranburu (https://github.com/Mikelontxu) mikel.aranburu.ehu@gmail.com
 * Zenodo DOI (versioned): https://doi.org/10.5281/zenodo.21089086


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
Add a new permanent identifier WiFi-CSI for the EHUNAM WiFi CSI Activity Ontology.

## General Checklist
<!-- For all ID related PRs. -->
- [X] Changes have been tested.
- [X] The number of commits is minimal. Squash if needed.
- [X] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [X] Maintainer details are in `.htaccess` or `README.md`.
- [X] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
Not applicable, new namespace registration.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [X] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
