### PR TITLE
ontodisinfo: add /2.3.0/* routes and point unversioned IRIs to v2.3.0

### DIFF
--- a/ontodisinfo/.htaccess
+++ b/ontodisinfo/.htaccess
@@ -37,9 +37,9 @@ RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/  [R=302,L]
 # RDF tools -> consolidated Turtle pinned to the latest release tag
 RewriteCond %{HTTP_ACCEPT} (text/turtle|application/(rdf\+xml|x-turtle|ld\+json|n-triples|n-quads))
-RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.2.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.3.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 # Default (no Accept header, curl, etc.) -> Turtle, Linked Data convention
-RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.2.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.3.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 
 # =============================================================================
 # 2. Individual modules with content negotiation
@@ -49,38 +49,38 @@ RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.2
 # --- core ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^core/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/core/  [R=302,L]
-RewriteRule ^core/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.2.0/ontology/domain/core/ontodis-core.ttl  [R=302,L]
+RewriteRule ^core/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.3.0/ontology/domain/core/ontodis-core.ttl  [R=302,L]
 
 # --- ml ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^ml/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/ml/  [R=302,L]
-RewriteRule ^ml/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.2.0/ontology/domain/ml/ontodis-ml.ttl  [R=302,L]
+RewriteRule ^ml/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.3.0/ontology/domain/ml/ontodis-ml.ttl  [R=302,L]
 
 # --- electoral ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^electoral/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/electoral/  [R=302,L]
-RewriteRule ^electoral/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.2.0/ontology/domain/electoral/ontodis-elec.ttl  [R=302,L]
+RewriteRule ^electoral/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.3.0/ontology/domain/electoral/ontodis-elec.ttl  [R=302,L]
 
 # --- legal ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^legal/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/legal/  [R=302,L]
-RewriteRule ^legal/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.2.0/ontology/domain/legal/ontodis-legal.ttl  [R=302,L]
+RewriteRule ^legal/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.3.0/ontology/domain/legal/ontodis-legal.ttl  [R=302,L]
 
 # --- inference ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^inference/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/inference/  [R=302,L]
-RewriteRule ^inference/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.2.0/ontology/application/ontodis-inference.ttl  [R=302,L]
+RewriteRule ^inference/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.3.0/ontology/application/ontodis-inference.ttl  [R=302,L]
 
 # --- alignments (external) ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^alignments/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/reference/alignments/  [R=302,L]
-RewriteRule ^alignments/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.2.0/ontology/adapter/ontodis-alignments.ttl  [R=302,L]
+RewriteRule ^alignments/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.3.0/ontology/adapter/ontodis-alignments.ttl  [R=302,L]
 
 # --- gufo-alignment (no dedicated doc page; always Turtle) ---
-RewriteRule ^gufo-alignment/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.2.0/ontology/adapter/ontodis-gufo-alignment.ttl  [R=302,L]
+RewriteRule ^gufo-alignment/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.3.0/ontology/adapter/ontodis-gufo-alignment.ttl  [R=302,L]
 
 # --- full integrated (entry point for Protege/reasoners) ---
-RewriteRule ^full/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.2.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^full/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.3.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 
 # =============================================================================
 # 3. Versioned IRIs (owl:versionIRI)
@@ -252,6 +252,22 @@ RewriteRule ^2\.2\.0/gufo-alignment$  https://gitlab.com/gustavosouto/ontodisinf
 RewriteRule ^2\.2\.0/full$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.2.0/ontology/composition/ontodis-full.ttl          [R=302,L]
 
 
+# --- 2.3.0 ---
+# Minor: documentação SKOS bilíngue completa (skos:prefLabel e skos:definition
+# em pt e en nos 13 vocabulários controlados), seis conceitos jurídicos novos
+# em SancaoAplicavel e DireitoFundamental, 14 shapes SHACL de ancoragem de
+# vocabulário e o shape de fechamento da união Pessoa/Organização do Operador.
+# Aditivo: nenhuma IRI removida ou renomeada.
+RewriteRule ^2\.3\.0/core$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.3.0/ontology/domain/core/ontodis-core.ttl          [R=302,L]
+RewriteRule ^2\.3\.0/ml$              https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.3.0/ontology/domain/ml/ontodis-ml.ttl              [R=302,L]
+RewriteRule ^2\.3\.0/electoral$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.3.0/ontology/domain/electoral/ontodis-elec.ttl     [R=302,L]
+RewriteRule ^2\.3\.0/legal$           https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.3.0/ontology/domain/legal/ontodis-legal.ttl        [R=302,L]
+RewriteRule ^2\.3\.0/inference$       https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.3.0/ontology/application/ontodis-inference.ttl     [R=302,L]
+RewriteRule ^2\.3\.0/alignments$      https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.3.0/ontology/adapter/ontodis-alignments.ttl        [R=302,L]
+RewriteRule ^2\.3\.0/gufo-alignment$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.3.0/ontology/adapter/ontodis-gufo-alignment.ttl    [R=302,L]
+RewriteRule ^2\.3\.0/full$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.3.0/ontology/composition/ontodis-full.ttl          [R=302,L]
+
+
 # =============================================================================
 # 4. Documentation shortcuts (HTML site sections)
 #    Citable URLs for specific parts of the public documentation.
@@ -267,5 +283,5 @@ RewriteRule ^metrics/?$          https://gustavosouto.gitlab.io/ontodisinfo-elec
 # =============================================================================
 # 5. Convenience redirects
 # =============================================================================
-RewriteRule ^latest/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.2.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^latest/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.3.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 RewriteRule ^repo/?$    https://gitlab.com/gustavosouto/ontodisinfo-electoral                                                      [R=302,L]


### PR DESCRIPTION
Updates the `/ontodisinfo/` namespace for OntoDisinfo-Electoral v2.3.0.

- Adds the `/ontodisinfo/2.3.0/*` versioned redirects (core, ml, electoral, legal, inference, alignments, gufo-alignment, full), pinned to the `v2.3.0` Git tag.
- Repoints the unversioned IRIs (namespace root, per-module pages and `/latest`) from `v2.2.0` to `v2.3.0`.
- Leaves all previous versioned blocks (including `/2.2.0/*`) untouched, so already-published IRIs keep resolving to their original tags.

Release 2.3.0 is additive: complete bilingual SKOS documentation (`skos:prefLabel`/`skos:definition` across the 13 controlled vocabularies), six new legal concepts, 14 SHACL vocabulary-anchoring shapes and the operator union-closure shape. No IRI is removed or renamed.

All redirect targets return HTTP 200 against the `v2.3.0` tag. Only `ontodisinfo/.htaccess` is modified.