### PR TITLE
Update .htaccess - change default version from 1.1.0 to 0.2.0

### DIFF
--- a/PrOM/.htaccess
+++ b/PrOM/.htaccess
@@ -18,7 +18,7 @@ RewriteEngine On
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 # Placed before HTML to support serving JSON-LD from a browser (e.g., JSON Playground)
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^$ https://prom-o.codeberg.page/PrOM/1.1.0/ontology.jsonld [R=303,L]
+RewriteRule ^$ https://prom-o.codeberg.page/PrOM/0.2.0/ontology.jsonld [R=303,L]
 
 # Rewrite rule to serve HTML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml|text/\*|\*/\*)
@@ -27,25 +27,25 @@ RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://prom-o.codeberg.page/PrOM/1.1.0/index-en.html [R=303,NE,L]
+RewriteRule ^$ https://prom-o.codeberg.page/PrOM/0.2.0/index-en.html [R=303,NE,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} ^.*application/rdf+xml*
-RewriteRule ^$ https://prom-o.codeberg.page/PrOM/1.1.0/ontology.owl [R=303,NE,L]
+RewriteRule ^$ https://prom-o.codeberg.page/PrOM/0.2.0/ontology.owl [R=303,NE,L]
 
 # Rewrite rule to serve N-Triples content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} ^.*application/n-triples*
-RewriteRule ^$ https://prom-o.codeberg.page/PrOM/1.1.0/ontology.nt [R=303,NE,L]
+RewriteRule ^$ https://prom-o.codeberg.page/PrOM/0.2.0/ontology.nt [R=303,NE,L]
 
 # Rewrite rule to serve TTL content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.*
-RewriteRule ^$ https://prom-o.codeberg.page/PrOM/1.1.0/ontology.ttl [R=303,NE,L]
+RewriteRule ^$ https://prom-o.codeberg.page/PrOM/0.2.0/ontology.ttl [R=303,NE,L]
 
 RewriteCond %{HTTP_ACCEPT} .+
-RewriteRule ^$ https://prom-o.codeberg.page/PrOM/1.1.0/406.html [R=406,L]
+RewriteRule ^$ https://prom-o.codeberg.page/PrOM/0.2.0/406.html [R=406,L]
 
 # Default response : ttl
-RewriteRule ^$ https://prom-o.codeberg.page/PrOM/1.1.0/ontology.ttl [R=303,NE,L] 
+RewriteRule ^$ https://prom-o.codeberg.page/PrOM/0.2.0/ontology.ttl [R=303,NE,L] 
 
 
 


### PR DESCRIPTION
change default version from 1.1.0 to 0.2.0

Following a change in the project's versioning scheme (decided by the maintaining team), the current release of the PrOM ontology is now tagged 0.2.0 instead of 1.1.0.

## Brief Description
This pull request:
- Updates the default (unversioned) redirect rules for w3id.org/PrOM/ to point at 0.2.0 instead of 1.1.0, preserving the existing content negotiation (JSON-LD, HTML, RDF/XML, N-Triples, Turtle, 406 fallback).

## General Checklist
- [ x ] Changes have been tested.
- [ x ] The number of commits is minimal. Squash if needed.
- [ x ] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.