### PR TITLE
sstim: add /sstim/void route and JSON-LD/RDF-XML content negotiation

### DIFF
--- a/sstim/.htaccess
+++ b/sstim/.htaccess
@@ -20,7 +20,7 @@ RewriteEngine On
 # -------------------------------------------------------------------------
 # Versioned immutable snapshots. These routes back owl:versionIRI values such
 # as /sstim/0.1.0 and direct frozen-file URLs such as
-# /sstim/0.1.0/sstim-core.ttl.
+# /sstim/0.1.0/sstim-core.ttl. (Turtle only — snapshots are not multi-format.)
 # -------------------------------------------------------------------------
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/([A-Za-z0-9._-]+\.ttl)$ https://labiosyncare.github.io/ontology/$1/$2 [R=302,L]
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://labiosyncare.github.io/ontology/$1/sstim-core.ttl [R=302,L]
@@ -31,6 +31,12 @@ RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://labiosyncare.github.io/ontology
 RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
 RewriteRule ^vocab$ https://labiosyncare.github.io/ [R=303,L]
 
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^vocab$ https://labiosyncare.github.io/ontology/sstim-vocab.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^vocab$ https://labiosyncare.github.io/ontology/sstim-vocab.rdf [R=303,L]
+
 RewriteRule ^vocab$ https://labiosyncare.github.io/ontology/sstim-vocab.ttl [R=303,L]
 
 # -------------------------------------------------------------------------
@@ -38,6 +44,12 @@ RewriteRule ^vocab$ https://labiosyncare.github.io/ontology/sstim-vocab.ttl [R=3
 # -------------------------------------------------------------------------
 RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
 RewriteRule ^shapes$ https://labiosyncare.github.io/ [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^shapes$ https://labiosyncare.github.io/ontology/sstim-shapes.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^shapes$ https://labiosyncare.github.io/ontology/sstim-shapes.rdf [R=303,L]
 
 RewriteRule ^shapes$ https://labiosyncare.github.io/ontology/sstim-shapes.ttl [R=303,L]
 
@@ -47,6 +59,12 @@ RewriteRule ^shapes$ https://labiosyncare.github.io/ontology/sstim-shapes.ttl [R
 RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
 RewriteRule ^alignments$ https://labiosyncare.github.io/ [R=303,L]
 
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^alignments$ https://labiosyncare.github.io/ontology/sstim-alignments.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^alignments$ https://labiosyncare.github.io/ontology/sstim-alignments.rdf [R=303,L]
+
 RewriteRule ^alignments$ https://labiosyncare.github.io/ontology/sstim-alignments.ttl [R=303,L]
 
 # -------------------------------------------------------------------------
@@ -55,7 +73,35 @@ RewriteRule ^alignments$ https://labiosyncare.github.io/ontology/sstim-alignment
 RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
 RewriteRule ^patch-studio$ https://labiosyncare.github.io/ [R=303,L]
 
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^patch-studio$ https://labiosyncare.github.io/ontology/sstim-patch-studio.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^patch-studio$ https://labiosyncare.github.io/ontology/sstim-patch-studio.rdf [R=303,L]
+
 RewriteRule ^patch-studio$ https://labiosyncare.github.io/ontology/sstim-patch-studio.ttl [R=303,L]
+
+# -------------------------------------------------------------------------
+# /sstim/exposure — exposure, delivery, modality, and experiment vocabulary
+# -------------------------------------------------------------------------
+RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
+RewriteRule ^exposure$ https://labiosyncare.github.io/ [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^exposure$ https://labiosyncare.github.io/ontology/sstim-exposure.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^exposure$ https://labiosyncare.github.io/ontology/sstim-exposure.rdf [R=303,L]
+
+RewriteRule ^exposure$ https://labiosyncare.github.io/ontology/sstim-exposure.ttl [R=303,L]
+
+# -------------------------------------------------------------------------
+# /sstim/void — VoID + DCAT dataset description (Turtle only; not exported)
+# -------------------------------------------------------------------------
+RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
+RewriteRule ^void$ https://labiosyncare.github.io/ [R=303,L]
+
+RewriteRule ^void$ https://labiosyncare.github.io/ontology/void.ttl [R=303,L]
 
 # -------------------------------------------------------------------------
 # /sstim — core ontology (OWL classes and properties). Fragment IRIs such
@@ -65,6 +111,12 @@ RewriteRule ^patch-studio$ https://labiosyncare.github.io/ontology/sstim-patch-s
 # target in Phase 1 once they are generated).
 RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
 RewriteRule ^$ https://labiosyncare.github.io/ [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://labiosyncare.github.io/ontology/sstim-core.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://labiosyncare.github.io/ontology/sstim-core.rdf [R=303,L]
 
 # Turtle or unspecified → core ontology file
 RewriteRule ^$ https://labiosyncare.github.io/ontology/sstim-core.ttl [R=303,L]

--- a/sstim/README.md
+++ b/sstim/README.md
@@ -1,66 +1,40 @@
 # sstim — Sensory Stimulation Ontology
 
-Persistent identifier (PID) home for the **SSTIM** (Sensory Stimulation)
-ontology, developed and maintained as part of the open-source
-[**BSC Lab**](https://github.com/laBioSynCare/laBioSynCare.github.io)
-project.
+Persistent identifiers for **SSTIM**, an OWL ontology with a companion
+SKOS vocabulary and SHACL validation shapes describing sensory
+stimulation protocols (auditory, visual, haptic), their parameters, and
+evidence chains. Developed in the open-source
+[BSC Lab](https://github.com/laBioSynCare/laBioSynCare.github.io) project.
 
 - **Base PID:** <https://w3id.org/sstim>
-- **Target (GitHub Pages):** <https://labiosyncare.github.io/ontology/>
-- **Maintainer:** Renato Fabbri — GitHub [@ttm](https://github.com/ttm) —
-  `renato@junto.space` —
-  ORCID [0000-0002-9699-629X](https://orcid.org/0000-0002-9699-629X)
+- **Target:** <https://labiosyncare.github.io/ontology/>
 
-SSTIM is an OWL ontology with a companion SKOS vocabulary and SHACL
-validation shapes, describing stimulation protocols (auditory,
-visual, haptic), their parameters (frequency bands, voice types,
-breathing models), evidence chains, and session instances. It is
-designed to be reusable by any sensory-stimulation research or
-application project — not specific to BSC Lab or BioSynCare.
+## Maintainer
 
-## Resolvable resources
+**Renato Fabbri** — GitHub [@ttm](https://github.com/ttm) —
+renato.fabbri@gmail.com —
+ORCID [0000-0002-9699-629X](https://orcid.org/0000-0002-9699-629X)
 
-| PID                                   | Content                                           | Format |
-|---------------------------------------|---------------------------------------------------|--------|
-| `https://w3id.org/sstim`              | Core ontology — OWL classes and properties        | Turtle |
-| `https://w3id.org/sstim/vocab`        | SKOS vocabulary — frequency bands, groups, tiers  | Turtle |
-| `https://w3id.org/sstim/shapes`       | SHACL validation shapes                           | Turtle |
-| `https://w3id.org/sstim/alignments`   | External alignments (BFO, OBI, IAO, Wikidata, …)  | Turtle |
+Future PRs touching `sstim/` will be authored or approved by
+[@ttm](https://github.com/ttm).
 
-Fragment IRIs such as `https://w3id.org/sstim#Preset` or
-`https://w3id.org/sstim/vocab#alpha` resolve to the same base
-document; the fragment is resolved client-side by the RDF tool.
+## Routes
 
-## Content negotiation
+| PID                        | Content                                          |
+|----------------------------|--------------------------------------------------|
+| `/sstim`                   | Core OWL ontology                                |
+| `/sstim/vocab`             | SKOS vocabulary                                  |
+| `/sstim/shapes`            | SHACL validation shapes                          |
+| `/sstim/alignments`        | External alignments (BFO, OBI, IAO, Wikidata, …) |
+| `/sstim/patch-studio`      | Patch Studio authoring-model vocabulary          |
+| `/sstim/exposure`          | Exposure, delivery, and modality vocabulary      |
+| `/sstim/void`              | VoID + DCAT dataset description (Turtle only)    |
+| `/sstim/{major.minor.patch}` | Versioned immutable snapshots (Turtle only)    |
 
-The `.htaccess` dispatches on the `Accept` header:
+Content negotiation on each route: Turtle (default), JSON-LD
+(`application/ld+json`), RDF/XML (`application/rdf+xml`); HTML requests
+redirect to the project landing page. Fragment IRIs such as
+`/sstim#Preset` resolve to the base document.
 
-| `Accept` header                      | Response                                           |
-|--------------------------------------|----------------------------------------------------|
-| `text/turtle` (and unspecified)      | The corresponding `.ttl` file                      |
-| `text/html`, `application/xhtml+xml` | BSC Lab landing page (<https://labiosyncare.github.io/>) |
-
-**Planned (Phase 1):** HTML requests will redirect to WIDOCO-generated
-ontology documentation, which will allow anchor navigation to
-individual terms.
-
-## Project
-
-- **Source repository:** <https://github.com/laBioSynCare/laBioSynCare.github.io>
-  (open-source — ontology and documentation under CC BY 4.0; application
-  code under a permissive OSI-approved license, both being finalized in Phase 1)
-- **Scope:** BSC Lab is the open scientific infrastructure for sensory
-  stimulation: ontology, evidence framework, and a planned multi-engine
-  audiovisual stimulation application (Web Audio, AudioWorklets, PixiJS).
-  The SSTIM ontology is designed to be reusable beyond BSC Lab by any
-  project in this domain.
-- **Related commercial project:** BioSynCare (React Native app, separate
-  closed-source repository) will consume BSC Lab's exported preset catalog
-  as JSON; it does not use or import the ontology namespace directly.
-
-## Contact
-
-- PID redirection issues → open an issue at
-  <https://github.com/laBioSynCare/laBioSynCare.github.io/issues>
-- Upstream `w3id.org` configuration issues →
-  <https://github.com/perma-id/w3id.org/issues>
+Redirect issues: open an issue at
+<https://github.com/laBioSynCare/laBioSynCare.github.io/issues>.


### PR DESCRIPTION
Scoped strictly to the existing `sstim/` directory. **Additive** — no existing rule is removed or changed (only one comment line reworded); this extends the already-live routes for the SSTIM ontology (an OWL 2 / SKOS vocabulary, CC BY 4.0, https://w3id.org/sstim).

### What this adds

1. **`/sstim/void`** → the VoID + DCAT dataset description:
   - `https://w3id.org/sstim/void` → `https://labiosyncare.github.io/ontology/void.ttl`

2. **JSON-LD and RDF/XML content negotiation** for core and every module, alongside the existing Turtle/HTML branches:
   - `Accept: application/ld+json` → `…/ontology/<module>.jsonld`
   - `Accept: application/rdf+xml` → `…/ontology/<module>.rdf`
   - anything else → the Turtle master (unchanged)

   Applies to `^$` (core), `vocab`, `shapes`, `alignments`, `patch-studio`, `exposure`.

### Redirect targets are already live on GitHub Pages

All new targets return `200`:
- `https://labiosyncare.github.io/ontology/void.ttl`
- `https://labiosyncare.github.io/ontology/sstim-core.jsonld` / `.rdf`
- …and the same `.jsonld`/`.rdf` for `vocab`, `shapes`, `alignments`, `patch-studio`, `exposure`.

Source of this file: https://github.com/laBioSynCare/laBioSynCare.github.io/blob/main/docs/ecosystem/w3id/sstim/.htaccess