### PR TITLE
Add TLA-185 redirects for Landscape Archive Foundation

### DIFF
--- a/tla/.htaccess
+++ b/tla/.htaccess
@@ -1,6 +1,11 @@
 RewriteEngine on
 Options +FollowSymLinks
 
+# Pass through to tla/185/ (Landscape Archive Foundation TLA-185 scheme).
+# Distinct from Total Learning Architecture / TLA Toolbox below.
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^185(/|$) - [L]
+
 # Turtle
 RewriteCond %{HTTP_ACCEPT} text/turtle
 RewriteRule ^(.*)$ https://tlatoolbox.com/$1.ttl [R=303,L]

--- a/tla/185/.htaccess
+++ b/tla/185/.htaccess
@@ -1,0 +1,21 @@
+# /tla/185/ — The Landscape Archive Federation scheme (TLA-185)
+#
+# Permanent term identifiers for the Landscape Archive Foundation federated
+# dictionary. Canonical human-readable pages live on the schema portal.
+#
+# ## Contact
+# The Landscape Archive Foundation
+# admin@landscapearchive.com.au
+# https://github.com/marknorlanlaririt-ai/landscape-archive-foundation
+
+RewriteEngine On
+Options +FollowSymLinks
+
+# Scheme root → dictionary
+RewriteRule ^?$ https://schema.landscapearchive.org/dictionary/ [R=302,L]
+
+# Module concepts → dictionary (anchors TBD)
+RewriteRule ^module/(.*)$ https://schema.landscapearchive.org/dictionary/#$1 [R=302,L]
+
+# Term concepts → term detail pages
+RewriteRule ^term/(.*)$ https://schema.landscapearchive.org/term/$1 [R=302,L]

--- a/tla/185/README.md
+++ b/tla/185/README.md
@@ -1,0 +1,20 @@
+# TLA-185 — The Landscape Archive Federation scheme
+
+Permanent identifiers for the **TLA-185** federated dictionary maintained by
+[The Landscape Archive Foundation](https://landscapearchive.org/).
+
+| URI pattern | Redirect target |
+| --- | --- |
+| `https://w3id.org/tla/185` | `https://schema.landscapearchive.org/dictionary/` |
+| `https://w3id.org/tla/185/module/{key}` | `https://schema.landscapearchive.org/dictionary/#{key}` |
+| `https://w3id.org/tla/185/term/{key}` | `https://schema.landscapearchive.org/term/{key}` |
+
+**Note:** The parent `tla/` namespace is also used by the Total Learning
+Architecture (TLA Toolbox) project. This `185/` sub-path is a distinct scheme
+under that shared prefix.
+
+## Contact
+
+- **Organisation:** The Landscape Archive Foundation
+- **Email:** admin@landscapearchive.com.au
+- **GitHub:** [landscape-archive-foundation](https://github.com/marknorlanlaririt-ai/landscape-archive-foundation)


### PR DESCRIPTION
## Summary

Register permanent identifiers under `https://w3id.org/tla/185/` for **TLA-185**, the federated dictionary scheme maintained by [The Landscape Archive Foundation](https://landscapearchive.org/).

Redirects (HTTP 302):

| w3id.org URI | Target |
| --- | --- |
| `/tla/185` | `https://schema.landscapearchive.org/dictionary/` |
| `/tla/185/module/{key}` | `https://schema.landscapearchive.org/dictionary/#{key}` |
| `/tla/185/term/{key}` | `https://schema.landscapearchive.org/term/{key}` |

## Namespace note

The parent `tla/` prefix is already used by the Total Learning Architecture (TLA Toolbox) project (inXsol LLC). This PR adds a **`185/` sub-namespace** with its own `.htaccess` and a pass-through rule in the parent `tla/.htaccess` so TLA-185 requests are not caught by the TLA Toolbox catch-all.

## Contact

- **Organisation:** The Landscape Archive Foundation
- **Email:** admin@landscapearchive.com.au
- **GitHub:** https://github.com/marknorlanlaririt-ai/landscape-archive-foundation

## Test plan

After merge, verify:

- [ ] `https://w3id.org/tla/185` → 302 → schema dictionary
- [ ] `https://w3id.org/tla/185/term/speciesKey` → 302 → `https://schema.landscapearchive.org/term/speciesKey`
- [ ] `https://w3id.org/tla/185/module/taxonomy` → 302 → dictionary with anchor
- [ ] Existing TLA Toolbox URIs (e.g. `https://w3id.org/tla/...` outside `185/`) still redirect to tlatoolbox.com

Made with [Cursor](https://cursor.com)