### PR TITLE
Serve FiCR version paths as Turtle snapshots

### DIFF
--- a/ficr/.htaccess
+++ b/ficr/.htaccess
@@ -12,26 +12,8 @@ RewriteEngine On
 
 # -----------------------------
 # Version paths: /ficr/{version}, e.g. /ficr/1.1.0 or /ficr/v1.1.0-beta
+# Version snapshots retain Turtle only.
 # -----------------------------
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^([A-Za-z0-9][A-Za-z0-9._-]*)/?$ https://raingo111.github.io/FiCR-ontology/$1/ontology.jsonld [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
-RewriteCond %{HTTP_ACCEPT} text/\* [OR]
-RewriteCond %{HTTP_ACCEPT} \*/turtle
-RewriteRule ^([A-Za-z0-9][A-Za-z0-9._-]*)/?$ https://raingo111.github.io/FiCR-ontology/$1/ontology.ttl [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^([A-Za-z0-9][A-Za-z0-9._-]*)/?$ https://raingo111.github.io/FiCR-ontology/$1/ontology.nt [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^([A-Za-z0-9][A-Za-z0-9._-]*)/?$ https://raingo111.github.io/FiCR-ontology/$1/ontology.owl [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
-RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^([A-Za-z0-9][A-Za-z0-9._-]*)/?$ https://raingo111.github.io/FiCR-ontology/$1/index-en.html [R=303,L]
-
 RewriteRule ^([A-Za-z0-9][A-Za-z0-9._-]*)/?$ https://raingo111.github.io/FiCR-ontology/$1/ontology.ttl [R=303,L]
 
 # -----------------------------


### PR DESCRIPTION
## Summary

Simplify versioned FiCR ontology snapshots to retain Turtle serializations only.

Version paths under `https://w3id.org/ficr/<version>` now redirect to:

`https://raingo111.github.io/FiCR-ontology/<version>/ontology.ttl`

This applies to browser and RDF clients alike.

## Rationale

The latest FiCR release continues to provide the full WIDOCO documentation site and multiple serializations. Historical version snapshots are retained as immutable Turtle ontology artifacts only, reducing duplicated generated documentation and WebVOWL assets.

## Examples

- `https://w3id.org/ficr/1.0.0` -> `.../1.0.0/ontology.ttl`
- `https://w3id.org/ficr/1.1.0` -> `.../1.1.0/ontology.ttl`
- `https://w3id.org/ficr/1.1.1` -> `.../1.1.1/ontology.ttl`

The latest path `https://w3id.org/ficr` and its existing content negotiation behavior are unchanged.