### PR TITLE
Retarget xwkont HTML redirects to GitHub Pages

### DIFF
--- a/xwkont/.htaccess
+++ b/xwkont/.htaccess
@@ -5,17 +5,17 @@ RewriteEngine on
 
 # === Rewrite Rules ===========================================================
 
-# Temporary (302) redirect while the project is pre-release.
-# e.g. https://w3id.org/xwkont => https://github.com/xwkont
-RewriteRule ^$ https://github.com/xwkont [R=302,L]
+# Project entry point: public documentation site.
+# e.g. https://w3id.org/xwkont => https://xwkont.github.io/xwkont/
+RewriteRule ^$ https://xwkont.github.io/xwkont/ [R=302,L]
 
 # Current core namespace document: Turtle representation.
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
 RewriteRule ^core$ https://raw.githubusercontent.com/xwkont/xwkont/main/data/ontology/core.ttl [R=302,L]
 
-# Current core namespace document: human-readable representation.
-RewriteRule ^core$ https://github.com/xwkont/xwkont/blob/main/docs/ontology/core-ontology.md [R=302,L]
+# Current core namespace document: human-readable representation (GitHub Pages).
+RewriteRule ^core$ https://xwkont.github.io/xwkont/ontology/core-ontology/ [R=302,L]
 
 # === Contact ==================================================================
 #


### PR DESCRIPTION
## Summary
- Point `https://w3id.org/xwkont/` at the public docs site `https://xwkont.github.io/xwkont/`
- Point HTML (default) negotiation for `https://w3id.org/xwkont/core` at `https://xwkont.github.io/xwkont/ontology/core-ontology/`
- Leave Turtle / `application/x-turtle` negotiation unchanged on `raw.githubusercontent.com/.../core.ttl`

## Why
XwkOnt now publishes a Material for MkDocs site on GitHub Pages. HTML consumers should land on that site rather than the GitHub blob view / org page.

## Test plan
- [ ] `curl -I https://w3id.org/xwkont/` → 302 → `https://xwkont.github.io/xwkont/`
- [ ] `curl -I -H 'Accept: text/html' https://w3id.org/xwkont/core` → 302 → `https://xwkont.github.io/xwkont/ontology/core-ontology/`
- [ ] `curl -I -H 'Accept: text/turtle' https://w3id.org/xwkont/core` → 302 → raw `core.ttl` (unchanged)

Contact: @reneyap

Made with [Cursor](https://cursor.com)