### PR TITLE
Add /tlaf/ namespace for The Landscape Archive Foundation

### DIFF
--- a/tlaf/.htaccess
+++ b/tlaf/.htaccess
@@ -1,0 +1,25 @@
+# /tlaf/ — The Landscape Archive Foundation
+#
+# Permanent identifiers for Foundation-stewarded vocabularies, starting with
+# TLA-185 (federated landscape metadata dictionary).
+#
+# ## Contact
+# The Landscape Archive Foundation
+# admin@landscapearchive.com.au
+# https://github.com/marknorlanlaririt-ai/landscape-archive-foundation
+# Maintainer GitHub: @marknorlanlaririt-ai
+
+RewriteEngine On
+Options +FollowSymLinks
+
+# Foundation site root
+RewriteRule ^/?$ https://landscapearchive.org/ [R=302,L]
+
+# TLA-185 scheme root → dictionary
+RewriteRule ^185/?$ https://schema.landscapearchive.org/dictionary/ [R=302,L]
+
+# Module concepts → dictionary (anchors TBD)
+RewriteRule ^185/module/(.*)$ https://schema.landscapearchive.org/dictionary/#$1 [R=302,L]
+
+# Term concepts → term detail pages
+RewriteRule ^185/term/(.*)$ https://schema.landscapearchive.org/term/$1 [R=302,L]

--- a/tlaf/README.md
+++ b/tlaf/README.md
@@ -1,0 +1,23 @@
+# /tlaf/ — The Landscape Archive Foundation
+
+Permanent identifiers for vocabularies stewarded by
+[The Landscape Archive Foundation](https://landscapearchive.org/).
+
+This is a **dedicated Foundation namespace**. It does **not** extend `/tla/`,
+which is owned by the Total Learning Architecture (TLA Toolbox) project.
+
+## TLA-185 (Landscape Data Dictionary)
+
+| URI pattern | Redirect target |
+| --- | --- |
+| `https://w3id.org/tlaf` | `https://landscapearchive.org/` |
+| `https://w3id.org/tlaf/185` | `https://schema.landscapearchive.org/dictionary/` |
+| `https://w3id.org/tlaf/185/module/{key}` | `https://schema.landscapearchive.org/dictionary/#{key}` |
+| `https://w3id.org/tlaf/185/term/{key}` | `https://schema.landscapearchive.org/term/{key}` |
+
+## Contact / maintainers
+
+- **Organisation:** The Landscape Archive Foundation
+- **Email:** admin@landscapearchive.com.au
+- **GitHub (PRs / maintainers):** [@marknorlanlaririt-ai](https://github.com/marknorlanlaririt-ai)
+- **Foundation repo:** [landscape-archive-foundation](https://github.com/marknorlanlaririt-ai/landscape-archive-foundation)


### PR DESCRIPTION
## Summary

Register a **dedicated** permanent-identifier namespace `https://w3id.org/tlaf/` for **The Landscape Archive Foundation**.

This replaces closed PR #6338, which incorrectly proposed nesting under `/tla/185/`. Per @nphoenix feedback, `/tla/` is governed for Total Learning Architecture (TLA Toolbox); Foundation identifiers now use `/tlaf/` instead.

Redirects (HTTP 302):

| w3id.org URI | Target |
| --- | --- |
| `/tlaf` | `https://landscapearchive.org/` |
| `/tlaf/185` | `https://schema.landscapearchive.org/dictionary/` |
| `/tlaf/185/module/{key}` | `https://schema.landscapearchive.org/dictionary/#{key}` |
| `/tlaf/185/term/{key}` | `https://schema.landscapearchive.org/term/{key}` |

## Contact / maintainers

- **Organisation:** The Landscape Archive Foundation
- **Email:** admin@landscapearchive.com.au
- **GitHub maintainer:** @marknorlanlaririt-ai
- **Repo:** https://github.com/marknorlanlaririt-ai/landscape-archive-foundation

## Test plan

After merge, verify:

- [ ] `https://w3id.org/tlaf` → 302 → landscapearchive.org
- [ ] `https://w3id.org/tlaf/185` → 302 → schema dictionary
- [ ] `https://w3id.org/tlaf/185/term/speciesKey` → 302 → `https://schema.landscapearchive.org/term/speciesKey`
- [ ] `https://w3id.org/tlaf/185/module/taxonomy` → 302 → dictionary with anchor
- [ ] Existing `/tla/` (TLA Toolbox) URIs unchanged
