### PR TITLE
small fix, remove BOM from .htaccess and README.md

### DIFF
--- a/WiFi-CSI/.htaccess
+++ b/WiFi-CSI/.htaccess
@@ -1,4 +1,4 @@
-﻿Options +FollowSymLinks
+Options +FollowSymLinks
 RewriteEngine on
 
 # Turtle

--- a/WiFi-CSI/README.md
+++ b/WiFi-CSI/README.md
@@ -1,4 +1,4 @@
-﻿# WiFi-CSI
+# WiFi-CSI
 
 Permanent identifier for the EHUNAM WiFi CSI Activity Ontology.
 


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
The https://w3id.org/WiFi-CSI didn't work properly. The original files (.htaccess and README.md from WiFi-CSI) were saved as UTF-8 with BOM. With this new pull request the files are saved as UTF-8, with no other content changes. The namespace should work properly after merging.

## General Checklist
<!-- For all ID related PRs. -->
- [X] Changes have been tested.
- [X] The number of commits is minimal. Squash if needed.
- [X] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
Not applicable.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [X] GitHub username ids are listed in the changed maintainer details.
- [X] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
