### PR TITLE
Add /aget namespace (AGET Framework Vocabulary)

### DIFF
--- a/aget/.htaccess
+++ b/aget/.htaccess
@@ -1,0 +1,16 @@
+# w3id.org/aget — AGET Framework Vocabulary
+# Content negotiation per W3C swbp-vocab-pub Recipe 3 (hash namespace).
+# Default (incl. */* and empty Accept) is RDF Turtle, deterministically.
+Options +FollowSymLinks
+RewriteEngine on
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^vocab$ https://aget-framework.github.io/vocab/vocab.ttl [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^vocab$ https://aget-framework.github.io/vocab/vocab.jsonld [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} text/html [NC]
+RewriteRule ^vocab$ https://aget-framework.github.io/vocab/index.html [R=302,L]
+
+RewriteRule ^vocab$ https://aget-framework.github.io/vocab/vocab.ttl [R=302,L]

--- a/aget/README.md
+++ b/aget/README.md
@@ -1,0 +1,13 @@
+# /aget — AGET Framework Vocabulary
+
+Persistent identifiers for the [AGET framework](https://github.com/aget-framework/aget) published SKOS vocabulary.
+
+- `https://w3id.org/aget/vocab` — the vocabulary (SKOS ConceptScheme); concepts are hash URIs (`#ConceptName`)
+- Content negotiation: Turtle / JSON-LD / HTML per Accept header; default is Turtle
+- Redirect target: https://aget-framework.github.io/vocab/ (GitHub Pages; target may change, URIs will not)
+
+## Contact
+
+| Name | GitHub | Email |
+|------|--------|-------|
+| Gabor Melli | [@gmelli](https://github.com/gmelli) | gabormelli@gmail.com |


### PR DESCRIPTION
Registers `w3id.org/aget` for the AGET framework's published SKOS vocabulary.

- `https://w3id.org/aget/vocab` → content-negotiated redirect (Turtle / JSON-LD / HTML per Accept; default Turtle) to https://aget-framework.github.io/vocab/
- Hash-namespace concept URIs (`#ConceptName`) per W3C swbp-vocab-pub Recipe 3
- Vocabulary is Apache-2.0, published from https://github.com/aget-framework/vocab
- Contact: @gmelli (listed in aget/README.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)