### PR TITLE
Add w3id.org/oap (OntoAgenticPerformance ontology)

### DIFF
--- a/oap/.htaccess
+++ b/oap/.htaccess
@@ -1,0 +1,16 @@
+# w3id.org/oap — OntoAgenticPerformance (OAP) ontology
+Options +FollowSymLinks
+RewriteEngine on
+
+# Version IRI -> the ontology document
+RewriteRule ^1\.0\.0$ https://raw.githubusercontent.com/erKikeGM/OntoAgenticPerformance/main/ontology/oap.ttl [R=303,L]
+
+# Content negotiation: RDF serialisations -> raw Turtle
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/x-turtle|application/rdf\+xml|application/ld\+json|application/n-triples) [NC]
+RewriteRule ^$ https://raw.githubusercontent.com/erKikeGM/OntoAgenticPerformance/main/ontology/oap.ttl [R=303,L]
+
+# Humans -> repository documentation
+RewriteRule ^$ https://github.com/erKikeGM/OntoAgenticPerformance [R=303,L]
+
+# Sub-paths (e.g. /oap/traces) -> repository
+RewriteRule ^(.+)$ https://github.com/erKikeGM/OntoAgenticPerformance [R=303,L]

--- a/oap/README.md
+++ b/oap/README.md
@@ -1,0 +1,21 @@
+# w3id.org/oap
+
+Permanent identifiers for **OntoAgenticPerformance (OAP)** — an OWL 2
+ontology for attributing the performance of LLM agentic systems
+(knowledge, skills, tasks/trajectories, context/memory, tools, governance,
+evaluation, performance attribution).
+
+- `https://w3id.org/oap` → ontology repository (HTML) or `ontology/oap.ttl`
+  (RDF content negotiation)
+- `https://w3id.org/oap#<Term>` → hash-namespace terms
+- `https://w3id.org/oap/1.0.0` → version IRI
+- `https://w3id.org/oap/traces#` → instance namespace for trace experiments
+
+Target repository: <https://github.com/erKikeGM/OntoAgenticPerformance>
+License: CC BY 4.0
+
+## Contact
+
+| Name | Email | GitHub |
+|---|---|---|
+| Enrique Gomicia (HUMAIN) | egomicia@humain.com | @erKikeGM |


### PR DESCRIPTION
Requesting the `oap` namespace for **OntoAgenticPerformance (OAP)** — an OWL 2 ontology for attributing the performance of LLM agentic systems (CC BY 4.0).

- Target: https://github.com/erKikeGM/OntoAgenticPerformance
- `https://w3id.org/oap` redirects to the repository (HTML) or to `ontology/oap.ttl` for RDF content-negotiation (`text/turtle`, `application/rdf+xml`, `application/ld+json`, `application/n-triples`)
- `https://w3id.org/oap/1.0.0` → version IRI → the ontology document
- Hash namespace for terms (`https://w3id.org/oap#Claim`, …) and `https://w3id.org/oap/traces#` for experiment instance data

Contact: Enrique Gomicia (HUMAIN), egomicia@humain.com, GitHub @erKikeGM — listed in `oap/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)