### PR TITLE
Updated optimar ontology to version 2.3

### DIFF
--- a/optimar/.htaccess
+++ b/optimar/.htaccess
@@ -30,15 +30,18 @@ RewriteRule ^$ https://bisite.github.io/OPTIMAR-Ontology/docs/index.html [R=303,
 # Rewrite rule to serve RDF/XML content if requested
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} application/owl\+xml
-RewriteRule ^$ https://bisite.github.io/OPTIMAR-Ontology/ontology/OPTiMAR-v2.2.ttl [R=303,L]
+RewriteRule ^$ https://bisite.github.io/OPTIMAR-Ontology/ontology/OPTiMAR-v2.3.ttl [R=303,L]
 
 # Default Rule
-RewriteRule ^$ https://bisite.github.io/OPTIMAR-Ontology/ontology/OPTiMAR-v2.2.ttl [R=303,L]
+RewriteRule ^$ https://bisite.github.io/OPTIMAR-Ontology/ontology/OPTiMAR-v2.3.ttl [R=303,L]
 
 
 # ---------------------------------------
 # SPECIFIC VERSION REDIRECTIONS
 # ---------------------------------------
+
+# Version 2.3
+RewriteRule ^2.2$ https://bisite.github.io/OPTIMAR-Ontology/ontology/OPTiMAR-v2.3.ttl [R=303,L]
 
 # Version 2.2
 RewriteRule ^2.2$ https://bisite.github.io/OPTIMAR-Ontology/ontology/OPTiMAR-v2.2.ttl [R=303,L]
@@ -62,4 +65,4 @@ RewriteRule ^0.2$ https://bisite.github.io/OPTIMAR-Ontology/ontology/OPTiMAR-v0.
 # ---------------------------------------
 
 # Any fragment identifiers (#ClassName) are ignored by the server, so we redirect to the RDF content for ontology term lookups
-RewriteRule ^(.*)$ https://bisite.github.io/OPTIMAR-Ontology/ontology/OPTiMAR-v2.2.ttl [R=303,L]
+RewriteRule ^(.*)$ https://bisite.github.io/OPTIMAR-Ontology/ontology/OPTiMAR-v2.3.ttl [R=303,L]

--- a/optimar/.htaccess
+++ b/optimar/.htaccess
@@ -41,7 +41,7 @@ RewriteRule ^$ https://bisite.github.io/OPTIMAR-Ontology/ontology/OPTiMAR-v2.3.t
 # ---------------------------------------
 
 # Version 2.3
-RewriteRule ^2.2$ https://bisite.github.io/OPTIMAR-Ontology/ontology/OPTiMAR-v2.3.ttl [R=303,L]
+RewriteRule ^2.3$ https://bisite.github.io/OPTIMAR-Ontology/ontology/OPTiMAR-v2.3.ttl [R=303,L]
 
 # Version 2.2
 RewriteRule ^2.2$ https://bisite.github.io/OPTIMAR-Ontology/ontology/OPTiMAR-v2.2.ttl [R=303,L]


### PR DESCRIPTION
Update optimar/.htaccess to version 2.3 of the OPTiMAR ontology: default and version-specific redirects to OPTiMAR-v2.3.ttl have been added, whilst retaining the redirects from previous versions (2.2, 2.1, 2.0, 1.0, 0.2)