### PR TITLE
Add biodivrisK-onto namespace redirect

### DIFF
--- a/biodivrisK-onto/.htaccess
+++ b/biodivrisK-onto/.htaccess
@@ -1,0 +1,13 @@
+Options -MultiViews
+AddType text/turtle .ttl
+AddType application/rdf+xml .owl
+
+RewriteEngine on
+
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^$ https://raw.githubusercontent.com/marcosdzarate/biorisk-ai/main/ontology/biodivrisK-onto.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://raw.githubusercontent.com/marcosdzarate/biorisk-ai/main/ontology/biodivrisK-onto.owl [R=303,L]
+
+RewriteRule ^$ https://github.com/marcosdzarate/biorisk-ai/tree/main/ontology [R=303,L]

--- a/biodivrisK-onto/README.md
+++ b/biodivrisK-onto/README.md
@@ -2,5 +2,7 @@
 
 Persistent URI namespace for BiodivRisk-Onto, an OWL 2 ontology for semantic alignment of biodiversity risk disclosure frameworks (TNFD, CSRD/ESRS E4, SBTN and GRI 101) for Latin America and the Caribbean.
 
-**Maintainer:** Marcos Daniel Zárate (marcosdzarate@gmail.com)
+**Maintainer:** Marcos Daniel Zárate  
+**GitHub:** https://github.com/marcosdzarate  
+**Email:** marcosdzarate@gmail.com  
 **Repository:** https://github.com/marcosdzarate/biorisk-ai/tree/main/ontology

--- a/biodivrisK-onto/README.md
+++ b/biodivrisK-onto/README.md
@@ -1,0 +1,6 @@
+# biodivrisK-onto
+
+Persistent URI namespace for BiodivRisk-Onto, an OWL 2 ontology for semantic alignment of biodiversity risk disclosure frameworks (TNFD, CSRD/ESRS E4, SBTN and GRI 101) for Latin America and the Caribbean.
+
+**Maintainer:** Marcos Daniel Zárate (marcosdzarate@gmail.com)
+**Repository:** https://github.com/marcosdzarate/biorisk-ai/tree/main/ontology


### PR DESCRIPTION
## Brief Description
Adding persistent URI redirect for BiodivRisk-Onto, an OWL 2 ontology 
for semantic alignment of biodiversity risk disclosure frameworks 
(TNFD, CSRD/ESRS E4, SBTN and GRI 101) for Latin America and the Caribbean.

## General Checklist
- Namespace: https://w3id.org/biodivrisK-onto
- Default (HTML): https://github.com/marcosdzarate/biorisk-ai/tree/main/ontology
- text/turtle → biodivrisK-onto.ttl (raw GitHub)
- application/rdf+xml → biodivrisK-onto.owl (raw GitHub)
- Contact: marcosdzarate@gmail.com