### PR TITLE
Add paper-anatomy: Paper Anatomy Vocabulary (PAX), University of Notre Dame

### DIFF
--- a/paper-anatomy/.htaccess
+++ b/paper-anatomy/.htaccess
@@ -2,7 +2,7 @@
 # A FAIR vocabulary for the structural anatomy of scientific papers,
 # built on SPAR (DoCO/DEO/FaBiO/PO) and W3C (Web Annotation/PROV/SKOS).
 # Source: https://github.com/ND-DAC-DOME/paper-anatomy
-# Maintainer: Priscila Saboia Moreira <pmoreira@nd.edu>
+# Maintainer: Priscila Saboia Moreira (GitHub: @psaboia) <pmoreira@nd.edu>
 #             DAC DOME, University of Notre Dame
 #             https://orcid.org/0009-0001-6047-385X
 Options +FollowSymLinks

--- a/paper-anatomy/.htaccess
+++ b/paper-anatomy/.htaccess
@@ -1,0 +1,35 @@
+# w3id.org/paper-anatomy — Paper Anatomy Vocabulary (PAX)
+# A FAIR vocabulary for the structural anatomy of scientific papers,
+# built on SPAR (DoCO/DEO/FaBiO/PO) and W3C (Web Annotation/PROV/SKOS).
+# Source: https://github.com/ND-DAC-DOME/paper-anatomy
+# Maintainer: Priscila Saboia Moreira <pmoreira@nd.edu>
+#             DAC DOME, University of Notre Dame
+#             https://orcid.org/0009-0001-6047-385X
+Options +FollowSymLinks
+RewriteEngine on
+
+# vocabulary: content negotiation (serializations under /vocab/)
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^vocab$ https://nd-dac-dome.github.io/paper-anatomy/vocab/ontology.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^vocab$ https://nd-dac-dome.github.io/paper-anatomy/vocab/ontology.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^vocab$ https://nd-dac-dome.github.io/paper-anatomy/vocab/ontology.owl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^vocab$ https://nd-dac-dome.github.io/paper-anatomy/vocab/ontology.nt [R=303,L]
+RewriteRule ^vocab$ https://nd-dac-dome.github.io/paper-anatomy/vocab/ [R=303,L]
+
+# shapes: aggregate index + per-profile documents
+RewriteRule ^shapes$ https://nd-dac-dome.github.io/paper-anatomy/shapes/ [R=303,L]
+RewriteRule ^shapes/(core|recommended|diagnostic)$ https://nd-dac-dome.github.io/paper-anatomy/shapes/$1.ttl [R=303,L]
+
+# versioned snapshots — the owl:versionIRI …/releases/<v>/vocab resolves to the
+# snapshot file; everything else under releases/ maps 1:1
+RewriteRule ^releases/([^/]+)/vocab$ https://nd-dac-dome.github.io/paper-anatomy/releases/$1/vocab.ttl [R=303,L]
+RewriteRule ^releases/(.+)$ https://nd-dac-dome.github.io/paper-anatomy/releases/$1 [R=303,L]
+
+# namespace root -> landing page
+RewriteRule ^$ https://nd-dac-dome.github.io/paper-anatomy/ [R=303,L]
+
+# everything else -> repository
+RewriteRule ^(.*)$ https://github.com/ND-DAC-DOME/paper-anatomy [R=303,L]

--- a/paper-anatomy/README.md
+++ b/paper-anatomy/README.md
@@ -1,0 +1,22 @@
+# /paper-anatomy/
+
+Namespace of the **Paper Anatomy Vocabulary (PAX)** — a FAIR, ontology-grounded
+vocabulary for the structural anatomy of scientific papers (section hierarchy,
+elements, captions, page-image regions, processing provenance), built on the SPAR
+suite (DoCO, DEO, FaBiO, PO) and W3C standards (Web Annotation, PROV-O, SKOS).
+
+| Identifier | Redirects to |
+|---|---|
+| `https://w3id.org/paper-anatomy/` | landing page (GitHub Pages) |
+| `https://w3id.org/paper-anatomy/vocab` | ontology spec, with content negotiation (HTML / Turtle / JSON-LD / RDF-XML / N-Triples) |
+| `https://w3id.org/paper-anatomy/vocab#<Term>` | term IRIs (namespace `…/vocab#`, prefix `pax`) |
+| `https://w3id.org/paper-anatomy/shapes` (+`/core`,`/recommended`,`/diagnostic`) | SHACL validation profiles |
+| `https://w3id.org/paper-anatomy/releases/<version>/vocab` | version snapshots (`owl:versionIRI` targets) |
+
+- **Source repository**: <https://github.com/ND-DAC-DOME/paper-anatomy>
+- **Published site**: <https://nd-dac-dome.github.io/paper-anatomy/>
+
+## Contact
+
+- Priscila Saboia Moreira — <pmoreira@nd.edu> — <https://orcid.org/0009-0001-6047-385X>
+- DAC DOME (Data, Operations, Modeling, and Engineering), University of Notre Dame

--- a/paper-anatomy/README.md
+++ b/paper-anatomy/README.md
@@ -16,7 +16,8 @@ suite (DoCO, DEO, FaBiO, PO) and W3C standards (Web Annotation, PROV-O, SKOS).
 - **Source repository**: <https://github.com/ND-DAC-DOME/paper-anatomy>
 - **Published site**: <https://nd-dac-dome.github.io/paper-anatomy/>
 
-## Contact
+## Contact / maintainer
 
+- Maintainer (GitHub): [@psaboia](https://github.com/psaboia)
 - Priscila Saboia Moreira — <pmoreira@nd.edu> — <https://orcid.org/0009-0001-6047-385X>
 - DAC DOME (Data, Operations, Modeling, and Engineering), University of Notre Dame


### PR DESCRIPTION
Registers the `paper-anatomy` namespace for the **Paper Anatomy Vocabulary (PAX)** — a FAIR vocabulary for the structural anatomy of scientific papers (section hierarchy, elements, captions, page-image regions, processing provenance), built on the SPAR suite (DoCO, DEO, FaBiO, PO) and W3C standards (Web Annotation, PROV-O, SKOS).

**Redirects** (all targets live and verified 200):
- `/paper-anatomy/` → landing page (GitHub Pages of [ND-DAC-DOME/paper-anatomy](https://github.com/ND-DAC-DOME/paper-anatomy))
- `/paper-anatomy/vocab` → ontology spec with content negotiation (HTML default; Turtle, JSON-LD, RDF/XML, N-Triples via Accept)
- `/paper-anatomy/shapes` (+ `/core|recommended|diagnostic`) → SHACL profiles
- `/paper-anatomy/releases/<v>/vocab` → version snapshots (`owl:versionIRI` targets)
- everything else → the source repository

**Contact**: Priscila Saboia Moreira <pmoreira@nd.edu> ([ORCID 0009-0001-6047-385X](https://orcid.org/0009-0001-6047-385X)), DAC DOME, University of Notre Dame.