### PR TITLE
Add heritagegraph (HeritageGraph Ontology, CAIR-Nepal)

### DIFF
--- a/heritagegraph/.htaccess
+++ b/heritagegraph/.htaccess
@@ -1,0 +1,30 @@
+# HeritageGraph Ontology — https://w3id.org/heritagegraph/
+# Redirects to the versioned artifacts published from
+# https://github.com/CAIRNepal/heritagegraphontology (GitHub Pages).
+# Maintainers: see README.md in this directory.
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# --- content negotiation (applies to the namespace root, /ontology,
+#     versioned IRIs such as /ontology/0.1.0-alpha.5, the legacy
+#     /schema.owl.ttl identifier, and every term IRI in the namespace;
+#     all resolve to the current ontology document per LOD practice) ---
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^.*$ https://cairnepal.github.io/heritagegraphontology/ontology.nt [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/n3
+RewriteRule ^.*$ https://cairnepal.github.io/heritagegraphontology/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/owl\+xml
+RewriteRule ^.*$ https://cairnepal.github.io/heritagegraphontology/ontology.owl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^.*$ https://cairnepal.github.io/heritagegraphontology/ontology.jsonld [R=303,L]
+
+# --- default: human-readable documentation ---
+RewriteRule ^.*$ https://cairnepal.github.io/heritagegraphontology/ [R=303,L]

--- a/heritagegraph/README.md
+++ b/heritagegraph/README.md
@@ -1,0 +1,22 @@
+# HeritageGraph Ontology
+
+Permanent identifiers for the HeritageGraph ontology — an event-centric
+cultural-heritage ontology (CIDOC-CRM / PROV-O aligned) for Kathmandu Valley
+living heritage, developed by CAIR-Nepal.
+
+| IRI | Resolves to |
+|---|---|
+| `https://w3id.org/heritagegraph/` (namespace) | ontology document (content-negotiated) |
+| `https://w3id.org/heritagegraph/ontology` (ontology IRI) | ontology document (content-negotiated) |
+| `https://w3id.org/heritagegraph/ontology/<version>` (version IRIs) | ontology document (content-negotiated) |
+| any term IRI in the namespace | ontology document (content-negotiated) |
+
+Content negotiation: `text/turtle`, `application/rdf+xml`, `application/n-triples`,
+`application/ld+json`; default is the HTML documentation at
+<https://cairnepal.github.io/heritagegraphontology/>.
+
+- Source repository: <https://github.com/CAIRNepal/heritagegraphontology>
+- Organization: CAIR-Nepal — <https://cair-nepal.org>
+- Contacts: [@nirajkark](https://github.com/nirajkark) (Niraj Karki),
+  [CAIRNepal](https://github.com/CAIRNepal) organization
+- License of the ontology: CC BY 4.0


### PR DESCRIPTION
This PR registers permanent identifiers for the **HeritageGraph Ontology**, an event-centric cultural-heritage ontology (CIDOC-CRM / PROV-O aligned) for Kathmandu Valley living heritage, developed by [CAIR-Nepal](https://cair-nepal.org).

**Namespace:** `https://w3id.org/heritagegraph/`

**Redirect target:** GitHub Pages of the source repository <https://github.com/CAIRNepal/heritagegraphontology> (live: <https://cairnepal.github.io/heritagegraphontology/>), with 303 content negotiation for `text/turtle`, `application/rdf+xml`, `application/n-triples`, and `application/ld+json`; HTML documentation as default. The ontology already declares this namespace (`vann:preferredNamespaceUri`), ontology IRI `https://w3id.org/heritagegraph/ontology`, and version IRIs beneath it.

**Contacts / maintainers:** @nirajkark (Niraj Karki, CAIR-Nepal) and the [CAIRNepal](https://github.com/CAIRNepal) GitHub organization.

The redirect targets are already live and serving the correct media types.