### PR TITLE
Add OpenVerifiable namespace (w3id.org/openverifiable/v1 context)

### DIFF
--- a/openverifiable/.htaccess
+++ b/openverifiable/.htaccess
@@ -1,3 +1,4 @@
+# Maintainer: lnispel (https://github.com/lnispel) - OpenVerifiable (https://github.com/OpenVerifiable)
 Header set Access-Control-Allow-Origin *
 Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Accept
 Options +FollowSymLinks

--- a/openverifiable/.htaccess
+++ b/openverifiable/.htaccess
@@ -1,0 +1,9 @@
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Accept
+Options +FollowSymLinks
+RewriteEngine on
+
+RewriteRule ^$ https://openverifiable.ai/ [R=302,L]
+RewriteRule ^v1$ https://raw.githubusercontent.com/decentralized-identity/credential-schemas/main/community-schemas/WordPress/schemas/wpai-monitor-record/context.json [R=302,L]
+RewriteRule ^v1\.jsonld$ https://raw.githubusercontent.com/decentralized-identity/credential-schemas/main/community-schemas/WordPress/schemas/wpai-monitor-record/context.json [R=302,L]
+RewriteRule ^(.*)$ https://openverifiable.ai/$1 [R=302,L]

--- a/openverifiable/README.md
+++ b/openverifiable/README.md
@@ -1,6 +1,6 @@
 # /openverifiable/
 
-This [W3ID](https://w3id.org) namespace provides **stable URLs** for [OpenVerifiable](https://openverifiable.ai/) JSON-LD context documents used in subject-only provenance records (e.g. the WordPress AI [C2PA Monitor](https://github.com/WordPress/ai) experiment’s `_wpai_monitor_record` postmeta).
+This [W3ID](https://w3id.org) namespace provides **stable URLs** for [OpenVerifiable](https://openverifiable.ai/) JSON-LD context documents used in subject-only provenance records (e.g. the WordPress AI [C2PA Monitor](https://github.com/WordPress/ai) experiment's `_wpai_monitor_record` postmeta).
 
 ## Identifiers
 
@@ -14,12 +14,20 @@ The v1 context is the **editorial** JSON-LD mapping for the WordPress monitor re
 
 **Note:** Future versions may add redirects for a dedicated `openverifiable/contexts` host or a CMS-agnostic context only; v1 remains a stable redirect target once published per OpenVerifiable governance (immutability policy TBD in the `contexts` repository).
 
+## Maintainers
+
+This namespace is maintained by:
+
+- [@lnispel](https://github.com/lnispel) — OpenVerifiable
+
+GitHub organization: [OpenVerifiable](https://github.com/OpenVerifiable)
+
 ## Contact
 
 **OpenVerifiable**
 
 - Website: [https://openverifiable.ai/](https://openverifiable.ai/)
 - GitHub: [https://github.com/OpenVerifiable](https://github.com/OpenVerifiable)
-- Source of truth for context bytes (until a separate contexts repo is published): [DIF credential-schemas — `WordPress/schemas/wpai-monitor-record/`](https://github.com/decentralized-identity/credential-schemas/tree/main/community-schemas/WordPress/schemas/wpai-monitor-record)
+- Source of truth for context bytes (until a separate contexts repo is published): [DIF credential-schemas - `WordPress/schemas/wpai-monitor-record/`](https://github.com/decentralized-identity/credential-schemas/tree/main/community-schemas/WordPress/schemas/wpai-monitor-record)
 
 For w3id.org namespace administration, open an issue on [perma-id/w3id.org](https://github.com/perma-id/w3id.org) and tag the maintainers listed in the parent repository [README](https://github.com/perma-id/w3id.org#management).

--- a/openverifiable/README.md
+++ b/openverifiable/README.md
@@ -1,0 +1,25 @@
+# /openverifiable/
+
+This [W3ID](https://w3id.org) namespace provides **stable URLs** for [OpenVerifiable](https://openverifiable.ai/) JSON-LD context documents used in subject-only provenance records (e.g. the WordPress AI [C2PA Monitor](https://github.com/WordPress/ai) experiment’s `_wpai_monitor_record` postmeta).
+
+## Identifiers
+
+| W3ID | Target (302) |
+|------|----------------|
+| [https://w3id.org/openverifiable/](https://w3id.org/openverifiable/) | [https://openverifiable.ai/](https://openverifiable.ai/) (project home) |
+| [https://w3id.org/openverifiable/v1](https://w3id.org/openverifiable/v1) | [wpai-monitor-record `context.json`](https://raw.githubusercontent.com/decentralized-identity/credential-schemas/main/community-schemas/WordPress/schemas/wpai-monitor-record/context.json) on the DIF [credential-schemas](https://github.com/decentralized-identity/credential-schemas) `main` branch |
+| [https://w3id.org/openverifiable/v1.jsonld](https://w3id.org/openverifiable/v1.jsonld) | same as `v1` |
+
+The v1 context is the **editorial** JSON-LD mapping for the WordPress monitor record; it extends the OpenVerifiable `ove:` vocabulary and Schema.org. Machine-readable JSON Schema for the same shape lives alongside it in the DIF repo (`schema.json`).
+
+**Note:** Future versions may add redirects for a dedicated `openverifiable/contexts` host or a CMS-agnostic context only; v1 remains a stable redirect target once published per OpenVerifiable governance (immutability policy TBD in the `contexts` repository).
+
+## Contact
+
+**OpenVerifiable**
+
+- Website: [https://openverifiable.ai/](https://openverifiable.ai/)
+- GitHub: [https://github.com/OpenVerifiable](https://github.com/OpenVerifiable)
+- Source of truth for context bytes (until a separate contexts repo is published): [DIF credential-schemas — `WordPress/schemas/wpai-monitor-record/`](https://github.com/decentralized-identity/credential-schemas/tree/main/community-schemas/WordPress/schemas/wpai-monitor-record)
+
+For w3id.org namespace administration, open an issue on [perma-id/w3id.org](https://github.com/perma-id/w3id.org) and tag the maintainers listed in the parent repository [README](https://github.com/perma-id/w3id.org#management).


### PR DESCRIPTION
Re-files #6007, which was closed for inactivity. This adds permanent redirects for the OpenVerifiable JSON-LD context `v1` used as the `@context` value in WordPress AI [C2PA Monitor](https://github.com/WordPress/ai/pull/459) provenance records (`_wpai_monitor_record` postmeta).

## Review fix from #6007

@dgarijo flagged that the submitter was not listed as a maintainer in the README. Addressed:

- Added a **Maintainers** section to `openverifiable/README.md` listing the GitHub username [@lnispel](https://github.com/lnispel).
- Added a maintainer comment line to `openverifiable/.htaccess`.

## Brief Description

New namespace `openverifiable/` providing stable W3IDs for the OpenVerifiable JSON-LD context vocabulary. `v1` and `v1.jsonld` 302-redirect to the DIF credential-schemas `wpai-monitor-record/context.json` on `main`; the namespace root redirects to openverifiable.ai; a catch-all passes unknown subpaths to the project site. Contact, maintainer, and resolution table are in the README.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details ([@lnispel](https://github.com/lnispel); GitHub org: https://github.com/OpenVerifiable).

## Optional Requests for W3ID Maintainers

- Please squash commits on merge if preferred.