### PR TITLE
Add OpenVerifiable namespace (w3id.org/openverifiable/v1 context)

### DIFF
--- a/openverifiable/.htaccess
+++ b/openverifiable/.htaccess
@@ -1,0 +1,21 @@
+# # /openverifiable/
+#
+# Stable URLs for OpenVerifiable JSON-LD context documents (v1 context used by
+# the WordPress AI C2PA Monitor _wpai_monitor_record postmeta).
+#
+# ## Contact
+# This namespace is administered by:
+#
+# Luke Nispel
+# GitHub username: lnispel
+# Organization: OpenVerifiable (GitHub org: OpenVerifiable)
+
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Accept
+Options +FollowSymLinks
+RewriteEngine on
+
+RewriteRule ^$ https://openverifiable.ai/ [R=302,L]
+RewriteRule ^v1$ https://raw.githubusercontent.com/decentralized-identity/credential-schemas/main/community-schemas/WordPress/schemas/wpai-monitor-record/context.json [R=302,L]
+RewriteRule ^v1\.jsonld$ https://raw.githubusercontent.com/decentralized-identity/credential-schemas/main/community-schemas/WordPress/schemas/wpai-monitor-record/context.json [R=302,L]
+RewriteRule ^(.*)$ https://openverifiable.ai/$1 [R=302,L]

--- a/openverifiable/README.md
+++ b/openverifiable/README.md
@@ -1,0 +1,33 @@
+# /openverifiable/
+
+This [W3ID](https://w3id.org) namespace provides **stable URLs** for [OpenVerifiable](https://openverifiable.ai/) JSON-LD context documents used in subject-only provenance records (e.g. the WordPress AI [C2PA Monitor](https://github.com/WordPress/ai) experiment's `_wpai_monitor_record` postmeta).
+
+## Identifiers
+
+| W3ID | Target (302) |
+|------|----------------|
+| [https://w3id.org/openverifiable/](https://w3id.org/openverifiable/) | [https://openverifiable.ai/](https://openverifiable.ai/) (project home) |
+| [https://w3id.org/openverifiable/v1](https://w3id.org/openverifiable/v1) | [wpai-monitor-record `context.json`](https://raw.githubusercontent.com/decentralized-identity/credential-schemas/main/community-schemas/WordPress/schemas/wpai-monitor-record/context.json) on the DIF [credential-schemas](https://github.com/decentralized-identity/credential-schemas) `main` branch |
+| [https://w3id.org/openverifiable/v1.jsonld](https://w3id.org/openverifiable/v1.jsonld) | same as `v1` |
+
+The v1 context is the **editorial** JSON-LD mapping for the WordPress monitor record; it extends the OpenVerifiable `ove:` vocabulary and Schema.org. Machine-readable JSON Schema for the same shape lives alongside it in the DIF repo (`schema.json`).
+
+**Note:** Future versions may add redirects for a dedicated `openverifiable/contexts` host or a CMS-agnostic context only; v1 remains a stable redirect target once published per OpenVerifiable governance (immutability policy TBD in the `contexts` repository).
+
+## Maintainers
+
+This namespace is administered by:
+
+**Luke Nispel**
+
+GitHub: [lnispel](https://github.com/lnispel)
+
+Organization: [OpenVerifiable](https://github.com/OpenVerifiable) (GitHub org: [OpenVerifiable](https://github.com/OpenVerifiable))
+
+## Contact
+
+- Website: [https://openverifiable.ai/](https://openverifiable.ai/)
+- GitHub organization: [https://github.com/OpenVerifiable](https://github.com/OpenVerifiable)
+- Source of truth for context bytes (until a separate contexts repo is published): [DIF credential-schemas - `WordPress/schemas/wpai-monitor-record/`](https://github.com/decentralized-identity/credential-schemas/tree/main/community-schemas/WordPress/schemas/wpai-monitor-record)
+
+For w3id.org namespace administration, open an issue on [perma-id/w3id.org](https://github.com/perma-id/w3id.org) and tag the maintainers listed in the parent repository [README](https://github.com/perma-id/w3id.org#management).


### PR DESCRIPTION
Adds permanent redirects for the OpenVerifiable JSON-LD context `v1`, used as the `@context` value in WordPress AI [C2PA Monitor](https://github.com/WordPress/ai/pull/459) provenance records (`_wpai_monitor_record` postmeta).

This is a clean re-file of #6007 (closed for inactivity) and supersedes #6375: single commit, branched off the current `master`, with the maintainer review fix applied.

## Brief Description

New namespace `openverifiable/` providing stable W3IDs for the OpenVerifiable JSON-LD context vocabulary. `v1` and `v1.jsonld` 302-redirect to the DIF credential-schemas `wpai-monitor-record/context.json` on `main`; the namespace root redirects to openverifiable.ai; a catch-all passes unknown subpaths to the project site.

## Review fix from #6007

@dgarijo flagged that the submitter was not listed as a maintainer in the README. Addressed:

- **Maintainers** section in `openverifiable/README.md` listing the GitHub username [@lnispel](https://github.com/lnispel).
- Maintainer comment line in `openverifiable/.htaccess`.

## Suitable PR content checklist

- [x] Contact info in `README.md` and `.htaccess` comment.
- [x] Single commit with a descriptive message including the project name.
- [x] Only adds redirects and basic information (no served content).

GitHub org: https://github.com/OpenVerifiable