### PR TITLE
Amend /atlas namespace: add root + version-IRI redirects, point at public ontology pages

### DIFF
--- a/atlas/.htaccess
+++ b/atlas/.htaccess
@@ -3,9 +3,14 @@
 Options +FollowSymLinks
 RewriteEngine on
 
-# Concept IRIs → live concept detail pages
-# e.g. https://w3id.org/atlas/tribology/concept/wear-rate
-RewriteRule ^tribology/concept/(.+)$ https://atlas-web-production-a3c8.up.railway.app/knowledge/ontology/concept/$1/ [R=302,L]
+# Concept IRIs → public concept pages (303; client re-sends Accept, Django negotiates)
+RewriteRule ^tribology/concept/(.+)$ https://atlas-web-production-a3c8.up.railway.app/ontology/concept/$1/ [R=303,L]
 
-# Namespace root → project
+# Version IRIs (CalVer: YYYY.MM.DD.N) → frozen release pages
+RewriteRule ^tribology/(\d{4}\.\d{2}\.\d{2}\.\d+)/?$ https://atlas-web-production-a3c8.up.railway.app/ontology/$1/ [R=303,L]
+
+# Namespace root (also covers hash-namespace class IRIs — fragments never reach the server)
+RewriteRule ^tribology/?$ https://atlas-web-production-a3c8.up.railway.app/ontology/ [R=303,L]
+
+# Bare /atlas/ root → project homepage
 RewriteRule ^$ https://atlas-web-production-a3c8.up.railway.app/ [R=302,L]


### PR DESCRIPTION
Amendment to the already-registered `/atlas` namespace (#6301, merged 2026-07-04).

**What was broken:** the registered `.htaccess` had no rule for the namespace root, so `https://w3id.org/atlas/tribology/` returned 404, and concept IRIs redirected to a login-gated application page — neither resolvable for FAIR tooling.

**This PR (redirect targets only — no IRI changes):**
- `tribology/` root → public, content-negotiated ontology landing page (303)
- `tribology/concept/<slug>` → public concept pages, previously login-gated (302 → 303 per httpRange-14)
- new rule: version IRIs (CalVer `YYYY.MM.DD.N`) → frozen release pages (303)
- bare `/atlas/` root → project homepage (unchanged, 302)

All persistent IRIs stay under `w3id.org/atlas/`; the target endpoints are live and serve Turtle/RDF-XML/JSON-LD/HTML via Accept-header negotiation:
- https://atlas-web-production-a3c8.up.railway.app/ontology/
- https://atlas-web-production-a3c8.up.railway.app/ontology/concept/wear-rate/
- https://atlas-web-production-a3c8.up.railway.app/ontology/2026.07.15.1/