### PR TITLE
Update SSTIM catalog and ecosystem routes

### DIFF
--- a/sstim/.htaccess
+++ b/sstim/.htaccess
@@ -26,6 +26,68 @@ RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/([A-Za-z0-9._-]+\.ttl)$ https://labiosynca
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://labiosyncare.github.io/ontology/$1/sstim-core.ttl [R=302,L]
 
 # -------------------------------------------------------------------------
+# Stable BSC catalog identities. Framework, application, and component IRIs
+# resolve to their owning static RDF documents; the Patch Studio component is
+# intentionally distinct from the /sstim/patch-studio ontology module.
+# -------------------------------------------------------------------------
+# BEGIN audited BSC catalog routes
+RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
+RewriteRule ^(framework/bsc|implementation/bsclab|implementation/biosyncare|implementation/bsclab/component/patch-studio)/?$ https://labiosyncare.github.io/ [R=303,L]
+
+RewriteRule ^(framework/bsc)/?$ https://labiosyncare.github.io/ontology/instances/frameworks/bsc.ttl [R=303,L]
+RewriteRule ^(implementation/bsclab|implementation/biosyncare|implementation/bsclab/component/patch-studio)/?$ https://labiosyncare.github.io/ontology/instances/implementations/implementations.ttl [R=303,L]
+# END audited BSC catalog routes
+
+# -------------------------------------------------------------------------
+# Synthetic ecosystem instance identifiers. Keep these rules exact: real
+# people and organizations get their own reviewed route when F4 data lands,
+# and must never resolve accidentally to the synthetic contract fixture.
+# -------------------------------------------------------------------------
+# BEGIN audited synthetic ecosystem fixture routes
+RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
+RewriteRule ^(specialist/synthetic-alex-rivera|organization/synthetic-aurora-lab|organization/synthetic-resonance-coop)/?$ https://labiosyncare.github.io/ [R=303,L]
+
+RewriteRule ^(specialist/synthetic-alex-rivera|organization/synthetic-aurora-lab|organization/synthetic-resonance-coop)/?$ https://labiosyncare.github.io/ontology/instances/ecosystem/fixtures/synthetic-ecosystem.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
+RewriteRule ^(ecosystem-record/relationship/alex-membership-aurora|ecosystem-record/relationship/alex-membership-resonance|ecosystem-record/relationship/alex-attribution-player|ecosystem-record/relationship/alex-outreach-resonance|ecosystem-record/relationship/aurora-develops-player|ecosystem-record/relationship/resonance-provides-player)/?$ https://labiosyncare.github.io/ [R=303,L]
+
+RewriteRule ^(ecosystem-record/relationship/alex-membership-aurora|ecosystem-record/relationship/alex-membership-resonance|ecosystem-record/relationship/alex-attribution-player|ecosystem-record/relationship/alex-outreach-resonance|ecosystem-record/relationship/aurora-develops-player|ecosystem-record/relationship/resonance-provides-player)/?$ https://labiosyncare.github.io/ontology/instances/ecosystem/fixtures/synthetic-ecosystem.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
+RewriteRule ^(ecosystem-record/activity/aurora-membership-consent|ecosystem-record/activity/aurora-membership-publication|ecosystem-record/activity/resonance-membership-consent|ecosystem-record/activity/resonance-membership-publication)/?$ https://labiosyncare.github.io/ [R=303,L]
+
+RewriteRule ^(ecosystem-record/activity/aurora-membership-consent|ecosystem-record/activity/aurora-membership-publication|ecosystem-record/activity/resonance-membership-consent|ecosystem-record/activity/resonance-membership-publication)/?$ https://labiosyncare.github.io/ontology/instances/ecosystem/fixtures/synthetic-ecosystem.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
+RewriteRule ^(ecosystem-record/activity/player-attribution-notification|ecosystem-record/activity/player-attribution-response|ecosystem-record/activity/player-attribution-consent|ecosystem-record/activity/player-attribution-publication|ecosystem-record/activity/resonance-outreach-notification|ecosystem-record/activity/resonance-outreach-response|ecosystem-record/activity/resonance-outreach-consent|ecosystem-record/activity/resonance-outreach-publication)/?$ https://labiosyncare.github.io/ [R=303,L]
+
+RewriteRule ^(ecosystem-record/activity/player-attribution-notification|ecosystem-record/activity/player-attribution-response|ecosystem-record/activity/player-attribution-consent|ecosystem-record/activity/player-attribution-publication|ecosystem-record/activity/resonance-outreach-notification|ecosystem-record/activity/resonance-outreach-response|ecosystem-record/activity/resonance-outreach-consent|ecosystem-record/activity/resonance-outreach-publication)/?$ https://labiosyncare.github.io/ontology/instances/ecosystem/fixtures/synthetic-ecosystem.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
+RewriteRule ^(ecosystem-record/activity/aurora-player-publication|ecosystem-record/activity/resonance-player-publication)/?$ https://labiosyncare.github.io/ [R=303,L]
+
+RewriteRule ^(ecosystem-record/activity/aurora-player-publication|ecosystem-record/activity/resonance-player-publication)/?$ https://labiosyncare.github.io/ontology/instances/ecosystem/fixtures/synthetic-ecosystem.ttl [R=303,L]
+# END audited synthetic ecosystem fixture routes
+
+# BEGIN audited real ecosystem routes
+RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
+RewriteRule ^(specialist/renato-fabbri|organization/biosyncare|organization/junto-innovation-hub|organization/aeterni-anima|ecosystem-record/role/head-of-applied-science|ecosystem-record/role/chief-executive-officer|ecosystem-record/role/chief-technology-officer)/?$ https://labiosyncare.github.io/ [R=303,L]
+
+RewriteRule ^(specialist/renato-fabbri|organization/biosyncare|organization/junto-innovation-hub|organization/aeterni-anima|ecosystem-record/role/head-of-applied-science|ecosystem-record/role/chief-executive-officer|ecosystem-record/role/chief-technology-officer)/?$ https://biosyncare-lab.web.app/current.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
+RewriteRule ^(ecosystem-record/relationship/renato-develops-bsclab|ecosystem-record/relationship/renato-develops-biosyncare|ecosystem-record/relationship/renato-develops-patch-studio|ecosystem-record/relationship/renato-created-sstim|ecosystem-record/relationship/renato-created-bsc-framework|ecosystem-record/relationship/renato-member-of-junto|ecosystem-record/relationship/renato-created-aeterni-anima|ecosystem-record/relationship/renato-leads-aeterni-anima|ecosystem-record/relationship/biosyncare-offers-sensory-stimulation-tools|ecosystem-record/relationship/junto-supports-biosyncare|ecosystem-record/relationship/aeterni-provides-sensory-stimulation-tools)/?$ https://labiosyncare.github.io/ [R=303,L]
+
+RewriteRule ^(ecosystem-record/relationship/renato-develops-bsclab|ecosystem-record/relationship/renato-develops-biosyncare|ecosystem-record/relationship/renato-develops-patch-studio|ecosystem-record/relationship/renato-created-sstim|ecosystem-record/relationship/renato-created-bsc-framework|ecosystem-record/relationship/renato-member-of-junto|ecosystem-record/relationship/renato-created-aeterni-anima|ecosystem-record/relationship/renato-leads-aeterni-anima|ecosystem-record/relationship/biosyncare-offers-sensory-stimulation-tools|ecosystem-record/relationship/junto-supports-biosyncare|ecosystem-record/relationship/aeterni-provides-sensory-stimulation-tools)/?$ https://biosyncare-lab.web.app/current.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
+RewriteRule ^(ecosystem-record/activity/renato-bsclab-self-publication|ecosystem-record/activity/renato-biosyncare-self-publication|ecosystem-record/activity/renato-patch-studio-self-publication|ecosystem-record/activity/renato-sstim-self-publication|ecosystem-record/activity/renato-bsc-framework-self-publication|ecosystem-record/activity/renato-junto-self-publication|ecosystem-record/activity/renato-aeterni-creator-self-publication|ecosystem-record/activity/renato-aeterni-leadership-self-publication|ecosystem-record/activity/biosyncare-tools-publication|ecosystem-record/activity/junto-biosyncare-publication|ecosystem-record/activity/aeterni-tools-publication)/?$ https://labiosyncare.github.io/ [R=303,L]
+
+RewriteRule ^(ecosystem-record/activity/renato-bsclab-self-publication|ecosystem-record/activity/renato-biosyncare-self-publication|ecosystem-record/activity/renato-patch-studio-self-publication|ecosystem-record/activity/renato-sstim-self-publication|ecosystem-record/activity/renato-bsc-framework-self-publication|ecosystem-record/activity/renato-junto-self-publication|ecosystem-record/activity/renato-aeterni-creator-self-publication|ecosystem-record/activity/renato-aeterni-leadership-self-publication|ecosystem-record/activity/biosyncare-tools-publication|ecosystem-record/activity/junto-biosyncare-publication|ecosystem-record/activity/aeterni-tools-publication)/?$ https://biosyncare-lab.web.app/current.ttl [R=303,L]
+# END audited real ecosystem routes
+
+# -------------------------------------------------------------------------
 # /sstim/vocab — SKOS vocabulary (frequency bands, groups, sub-bands, …)
 # -------------------------------------------------------------------------
 RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
@@ -94,6 +156,20 @@ RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
 RewriteRule ^exposure$ https://labiosyncare.github.io/ontology/sstim-exposure.rdf [R=303,L]
 
 RewriteRule ^exposure$ https://labiosyncare.github.io/ontology/sstim-exposure.ttl [R=303,L]
+
+# -------------------------------------------------------------------------
+# /sstim/ecosystem — ecosystem relationships and consent lifecycle
+# -------------------------------------------------------------------------
+RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
+RewriteRule ^ecosystem$ https://labiosyncare.github.io/ [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^ecosystem$ https://labiosyncare.github.io/ontology/sstim-ecosystem.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^ecosystem$ https://labiosyncare.github.io/ontology/sstim-ecosystem.rdf [R=303,L]
+
+RewriteRule ^ecosystem$ https://labiosyncare.github.io/ontology/sstim-ecosystem.ttl [R=303,L]
 
 # -------------------------------------------------------------------------
 # /sstim/void — VoID + DCAT dataset description (Turtle only; not exported)

--- a/sstim/.htaccess
+++ b/sstim/.htaccess
@@ -70,22 +70,21 @@ RewriteRule ^(ecosystem-record/activity/aurora-player-publication|ecosystem-reco
 RewriteRule ^(ecosystem-record/activity/aurora-player-publication|ecosystem-record/activity/resonance-player-publication)/?$ https://labiosyncare.github.io/ontology/instances/ecosystem/fixtures/synthetic-ecosystem.ttl [R=303,L]
 # END audited synthetic ecosystem fixture routes
 
-# BEGIN audited real ecosystem routes
+# -------------------------------------------------------------------------
+# Live ecosystem identifier namespaces. Dataset membership belongs to the
+# mutable RDF projection, not this registry configuration: new, corrected, or
+# retracted records therefore do not require a w3id.org rule change.
+# -------------------------------------------------------------------------
+# BEGIN audited live ecosystem namespace routes
 RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^(specialist/renato-fabbri|organization/biosyncare|organization/junto-innovation-hub|organization/aeterni-anima|ecosystem-record/role/head-of-applied-science|ecosystem-record/role/chief-executive-officer|ecosystem-record/role/chief-technology-officer)/?$ https://labiosyncare.github.io/ [R=303,L]
-
-RewriteRule ^(specialist/renato-fabbri|organization/biosyncare|organization/junto-innovation-hub|organization/aeterni-anima|ecosystem-record/role/head-of-applied-science|ecosystem-record/role/chief-executive-officer|ecosystem-record/role/chief-technology-officer)/?$ https://biosyncare-lab.web.app/current.ttl [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^(ecosystem-record/relationship/renato-develops-bsclab|ecosystem-record/relationship/renato-develops-biosyncare|ecosystem-record/relationship/renato-develops-patch-studio|ecosystem-record/relationship/renato-created-sstim|ecosystem-record/relationship/renato-created-bsc-framework|ecosystem-record/relationship/renato-member-of-junto|ecosystem-record/relationship/renato-created-aeterni-anima|ecosystem-record/relationship/renato-leads-aeterni-anima|ecosystem-record/relationship/biosyncare-offers-sensory-stimulation-tools|ecosystem-record/relationship/junto-supports-biosyncare|ecosystem-record/relationship/aeterni-provides-sensory-stimulation-tools)/?$ https://labiosyncare.github.io/ [R=303,L]
-
-RewriteRule ^(ecosystem-record/relationship/renato-develops-bsclab|ecosystem-record/relationship/renato-develops-biosyncare|ecosystem-record/relationship/renato-develops-patch-studio|ecosystem-record/relationship/renato-created-sstim|ecosystem-record/relationship/renato-created-bsc-framework|ecosystem-record/relationship/renato-member-of-junto|ecosystem-record/relationship/renato-created-aeterni-anima|ecosystem-record/relationship/renato-leads-aeterni-anima|ecosystem-record/relationship/biosyncare-offers-sensory-stimulation-tools|ecosystem-record/relationship/junto-supports-biosyncare|ecosystem-record/relationship/aeterni-provides-sensory-stimulation-tools)/?$ https://biosyncare-lab.web.app/current.ttl [R=303,L]
+RewriteRule ^(specialist|organization)/[A-Za-z0-9._~-]+/?$ https://labiosyncare.github.io/ [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^(ecosystem-record/activity/renato-bsclab-self-publication|ecosystem-record/activity/renato-biosyncare-self-publication|ecosystem-record/activity/renato-patch-studio-self-publication|ecosystem-record/activity/renato-sstim-self-publication|ecosystem-record/activity/renato-bsc-framework-self-publication|ecosystem-record/activity/renato-junto-self-publication|ecosystem-record/activity/renato-aeterni-creator-self-publication|ecosystem-record/activity/renato-aeterni-leadership-self-publication|ecosystem-record/activity/biosyncare-tools-publication|ecosystem-record/activity/junto-biosyncare-publication|ecosystem-record/activity/aeterni-tools-publication)/?$ https://labiosyncare.github.io/ [R=303,L]
+RewriteRule ^ecosystem-record/(relationship|activity|role)/[A-Za-z0-9._~-]+/?$ https://labiosyncare.github.io/ [R=303,L]
 
-RewriteRule ^(ecosystem-record/activity/renato-bsclab-self-publication|ecosystem-record/activity/renato-biosyncare-self-publication|ecosystem-record/activity/renato-patch-studio-self-publication|ecosystem-record/activity/renato-sstim-self-publication|ecosystem-record/activity/renato-bsc-framework-self-publication|ecosystem-record/activity/renato-junto-self-publication|ecosystem-record/activity/renato-aeterni-creator-self-publication|ecosystem-record/activity/renato-aeterni-leadership-self-publication|ecosystem-record/activity/biosyncare-tools-publication|ecosystem-record/activity/junto-biosyncare-publication|ecosystem-record/activity/aeterni-tools-publication)/?$ https://biosyncare-lab.web.app/current.ttl [R=303,L]
-# END audited real ecosystem routes
+RewriteRule ^(specialist|organization)/[A-Za-z0-9._~-]+/?$ https://biosyncare-lab.web.app/current.ttl [R=303,L]
+RewriteRule ^ecosystem-record/(relationship|activity|role)/[A-Za-z0-9._~-]+/?$ https://biosyncare-lab.web.app/current.ttl [R=303,L]
+# END audited live ecosystem namespace routes
 
 # -------------------------------------------------------------------------
 # /sstim/vocab — SKOS vocabulary (frequency bands, groups, sub-bands, …)

--- a/sstim/.htaccess
+++ b/sstim/.htaccess
@@ -39,9 +39,9 @@ RewriteRule ^(implementation/bsclab|implementation/biosyncare|implementation/bsc
 # END audited BSC catalog routes
 
 # -------------------------------------------------------------------------
-# Synthetic ecosystem instance identifiers. Keep these rules exact: real
-# people and organizations get their own reviewed route when F4 data lands,
-# and must never resolve accidentally to the synthetic contract fixture.
+# Synthetic ecosystem instance identifiers. Keep these exact rules before the
+# general live namespaces so fixture subjects never resolve accidentally to the
+# mutable real-agent projection.
 # -------------------------------------------------------------------------
 # BEGIN audited synthetic ecosystem fixture routes
 RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)

--- a/sstim/.htaccess
+++ b/sstim/.htaccess
@@ -39,51 +39,20 @@ RewriteRule ^(implementation/bsclab|implementation/biosyncare|implementation/bsc
 # END audited BSC catalog routes
 
 # -------------------------------------------------------------------------
-# Synthetic ecosystem instance identifiers. Keep these exact rules before the
-# general live namespaces so fixture subjects never resolve accidentally to the
-# mutable real-agent projection.
-# -------------------------------------------------------------------------
-# BEGIN audited synthetic ecosystem fixture routes
-RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^(specialist/synthetic-alex-rivera|organization/synthetic-aurora-lab|organization/synthetic-resonance-coop)/?$ https://labiosyncare.github.io/ [R=303,L]
-
-RewriteRule ^(specialist/synthetic-alex-rivera|organization/synthetic-aurora-lab|organization/synthetic-resonance-coop)/?$ https://labiosyncare.github.io/ontology/instances/ecosystem/fixtures/synthetic-ecosystem.ttl [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^(ecosystem-record/relationship/alex-membership-aurora|ecosystem-record/relationship/alex-membership-resonance|ecosystem-record/relationship/alex-attribution-player|ecosystem-record/relationship/alex-outreach-resonance|ecosystem-record/relationship/aurora-develops-player|ecosystem-record/relationship/resonance-provides-player)/?$ https://labiosyncare.github.io/ [R=303,L]
-
-RewriteRule ^(ecosystem-record/relationship/alex-membership-aurora|ecosystem-record/relationship/alex-membership-resonance|ecosystem-record/relationship/alex-attribution-player|ecosystem-record/relationship/alex-outreach-resonance|ecosystem-record/relationship/aurora-develops-player|ecosystem-record/relationship/resonance-provides-player)/?$ https://labiosyncare.github.io/ontology/instances/ecosystem/fixtures/synthetic-ecosystem.ttl [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^(ecosystem-record/activity/aurora-membership-consent|ecosystem-record/activity/aurora-membership-publication|ecosystem-record/activity/resonance-membership-consent|ecosystem-record/activity/resonance-membership-publication)/?$ https://labiosyncare.github.io/ [R=303,L]
-
-RewriteRule ^(ecosystem-record/activity/aurora-membership-consent|ecosystem-record/activity/aurora-membership-publication|ecosystem-record/activity/resonance-membership-consent|ecosystem-record/activity/resonance-membership-publication)/?$ https://labiosyncare.github.io/ontology/instances/ecosystem/fixtures/synthetic-ecosystem.ttl [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^(ecosystem-record/activity/player-attribution-notification|ecosystem-record/activity/player-attribution-response|ecosystem-record/activity/player-attribution-consent|ecosystem-record/activity/player-attribution-publication|ecosystem-record/activity/resonance-outreach-notification|ecosystem-record/activity/resonance-outreach-response|ecosystem-record/activity/resonance-outreach-consent|ecosystem-record/activity/resonance-outreach-publication)/?$ https://labiosyncare.github.io/ [R=303,L]
-
-RewriteRule ^(ecosystem-record/activity/player-attribution-notification|ecosystem-record/activity/player-attribution-response|ecosystem-record/activity/player-attribution-consent|ecosystem-record/activity/player-attribution-publication|ecosystem-record/activity/resonance-outreach-notification|ecosystem-record/activity/resonance-outreach-response|ecosystem-record/activity/resonance-outreach-consent|ecosystem-record/activity/resonance-outreach-publication)/?$ https://labiosyncare.github.io/ontology/instances/ecosystem/fixtures/synthetic-ecosystem.ttl [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^(ecosystem-record/activity/aurora-player-publication|ecosystem-record/activity/resonance-player-publication)/?$ https://labiosyncare.github.io/ [R=303,L]
-
-RewriteRule ^(ecosystem-record/activity/aurora-player-publication|ecosystem-record/activity/resonance-player-publication)/?$ https://labiosyncare.github.io/ontology/instances/ecosystem/fixtures/synthetic-ecosystem.ttl [R=303,L]
-# END audited synthetic ecosystem fixture routes
-
-# -------------------------------------------------------------------------
 # Live ecosystem identifier namespaces. Dataset membership belongs to the
 # mutable RDF projection, not this registry configuration: new, corrected, or
-# retracted records therefore do not require a w3id.org rule change.
+# retracted records therefore do not require a w3id.org rule change. The
+# reserved synthetic-* fixture prefix is deliberately outside these routes.
 # -------------------------------------------------------------------------
 # BEGIN audited live ecosystem namespace routes
 RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^(specialist|organization)/[A-Za-z0-9._~-]+/?$ https://labiosyncare.github.io/ [R=303,L]
+RewriteRule ^(specialist|organization)/(?!synthetic-)[A-Za-z0-9._~-]+/?$ https://labiosyncare.github.io/ [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^ecosystem-record/(relationship|activity|role)/[A-Za-z0-9._~-]+/?$ https://labiosyncare.github.io/ [R=303,L]
+RewriteRule ^ecosystem-record/(relationship|activity|role)/(?!synthetic-)[A-Za-z0-9._~-]+/?$ https://labiosyncare.github.io/ [R=303,L]
 
-RewriteRule ^(specialist|organization)/[A-Za-z0-9._~-]+/?$ https://biosyncare-lab.web.app/current.ttl [R=303,L]
-RewriteRule ^ecosystem-record/(relationship|activity|role)/[A-Za-z0-9._~-]+/?$ https://biosyncare-lab.web.app/current.ttl [R=303,L]
+RewriteRule ^(specialist|organization)/(?!synthetic-)[A-Za-z0-9._~-]+/?$ https://biosyncare-lab.web.app/current.ttl [R=303,L]
+RewriteRule ^ecosystem-record/(relationship|activity|role)/(?!synthetic-)[A-Za-z0-9._~-]+/?$ https://biosyncare-lab.web.app/current.ttl [R=303,L]
 # END audited live ecosystem namespace routes
 
 # -------------------------------------------------------------------------

--- a/sstim/README.md
+++ b/sstim/README.md
@@ -28,13 +28,37 @@ Future PRs touching `sstim/` will be authored or approved by
 | `/sstim/alignments`        | External alignments (BFO, OBI, IAO, Wikidata, …) |
 | `/sstim/patch-studio`      | Patch Studio authoring-model vocabulary          |
 | `/sstim/exposure`          | Exposure, delivery, and modality vocabulary      |
+| `/sstim/ecosystem`         | Ecosystem relationships and consent lifecycle    |
+| `/sstim/framework/bsc`     | BSC framework catalog record                     |
+| `/sstim/implementation/bsclab` | BSC Lab implementation catalog record        |
+| `/sstim/implementation/biosyncare` | BioSynCare application catalog record    |
+| `/sstim/implementation/bsclab/component/patch-studio` | Patch Studio software-component catalog record |
+| `/sstim/specialist/synthetic-alex-rivera` | Synthetic ecosystem person fixture |
+| `/sstim/organization/synthetic-aurora-lab` | Synthetic ecosystem organization fixture |
+| `/sstim/organization/synthetic-resonance-coop` | Synthetic ecosystem organization fixture |
+| Six exact `/sstim/ecosystem-record/relationship/{id}` routes | Synthetic qualified relationships |
+| Fourteen exact `/sstim/ecosystem-record/activity/{id}` routes | Synthetic engagement activities |
+| Exact reviewed `/sstim/specialist`, `/organization`, and `/ecosystem-record/{relationship,activity,role}` routes | Mutable live-only ecosystem projection |
 | `/sstim/void`              | VoID + DCAT dataset description (Turtle only)    |
 | `/sstim/{major.minor.patch}` | Versioned immutable snapshots (Turtle only)    |
 
-Content negotiation on each route: Turtle (default), JSON-LD
-(`application/ld+json`), RDF/XML (`application/rdf+xml`); HTML requests
-redirect to the project landing page. Fragment IRIs such as
+The base and ontology-module routes negotiate Turtle (default), JSON-LD
+(`application/ld+json`), and RDF/XML (`application/rdf+xml`); HTML requests
+redirect to the project landing page. VoID, versioned snapshots, and the
+instance routes below are Turtle resources. Fragment IRIs such as
 `/sstim#Preset` resolve to the base document.
+
+Audited static catalog routes send RDF clients to the owning Turtle instance
+file. Synthetic ecosystem routes remain isolated in the fixture graph. Exact
+reviewed real-subject routes instead send RDF clients to the mutable,
+live-only `current.ttl` projection; they never reuse the synthetic graph. HTML
+requests reach the project landing page in all three cases.
+
+Real-subject paths are identifying configuration metadata recorded in Git and
+registry review history. Removing a live record therefore requires removing
+its active rules, but cannot erase historical path traces, third-party caches,
+or previously downloaded copies. The mutable projection is not part of a
+Zenodo ontology snapshot and carries no archival-consent implication.
 
 Redirect issues: open an issue at
 <https://github.com/laBioSynCare/laBioSynCare.github.io/issues>.

--- a/sstim/README.md
+++ b/sstim/README.md
@@ -38,7 +38,8 @@ Future PRs touching `sstim/` will be authored or approved by
 | `/sstim/organization/synthetic-resonance-coop` | Synthetic ecosystem organization fixture |
 | Six exact `/sstim/ecosystem-record/relationship/{id}` routes | Synthetic qualified relationships |
 | Fourteen exact `/sstim/ecosystem-record/activity/{id}` routes | Synthetic engagement activities |
-| Exact reviewed `/sstim/specialist`, `/organization`, and `/ecosystem-record/{relationship,activity,role}` routes | Mutable live-only ecosystem projection |
+| `/sstim/specialist/{id}` and `/sstim/organization/{id}` namespaces | Mutable live-only ecosystem projection |
+| `/sstim/ecosystem-record/{relationship,activity,role}/{id}` namespaces | Mutable live-only ecosystem projection |
 | `/sstim/void`              | VoID + DCAT dataset description (Turtle only)    |
 | `/sstim/{major.minor.patch}` | Versioned immutable snapshots (Turtle only)    |
 
@@ -49,16 +50,19 @@ instance routes below are Turtle resources. Fragment IRIs such as
 `/sstim#Preset` resolve to the base document.
 
 Audited static catalog routes send RDF clients to the owning Turtle instance
-file. Synthetic ecosystem routes remain isolated in the fixture graph. Exact
-reviewed real-subject routes instead send RDF clients to the mutable,
+file. Synthetic ecosystem routes remain isolated in the fixture graph. General
+live ecosystem namespace rules instead send RDF clients to the mutable,
 live-only `current.ttl` projection; they never reuse the synthetic graph. HTML
 requests reach the project landing page in all three cases.
 
-Real-subject paths are identifying configuration metadata recorded in Git and
-registry review history. Removing a live record therefore requires removing
-its active rules, but cannot erase historical path traces, third-party caches,
-or previously downloaded copies. The mutable projection is not part of a
-Zenodo ontology snapshot and carries no archival-consent implication.
+Dataset membership belongs to the live RDF projection, not the registry
+configuration. Adding, correcting, or retracting a record therefore does not
+require a person-specific w3id.org rule change. A syntactically valid but
+unknown path may reach the aggregate, but it describes no resource unless the
+requested IRI occurs as a subject in the current projection. Retraction removes
+that subject and its approved public statements; it cannot erase third-party
+caches or previously downloaded copies. The mutable projection is not part of
+a Zenodo ontology snapshot and carries no archival-consent implication.
 
 Redirect issues: open an issue at
 <https://github.com/laBioSynCare/laBioSynCare.github.io/issues>.

--- a/sstim/README.md
+++ b/sstim/README.md
@@ -33,13 +33,8 @@ Future PRs touching `sstim/` will be authored or approved by
 | `/sstim/implementation/bsclab` | BSC Lab implementation catalog record        |
 | `/sstim/implementation/biosyncare` | BioSynCare application catalog record    |
 | `/sstim/implementation/bsclab/component/patch-studio` | Patch Studio software-component catalog record |
-| `/sstim/specialist/synthetic-alex-rivera` | Synthetic ecosystem person fixture |
-| `/sstim/organization/synthetic-aurora-lab` | Synthetic ecosystem organization fixture |
-| `/sstim/organization/synthetic-resonance-coop` | Synthetic ecosystem organization fixture |
-| Six exact `/sstim/ecosystem-record/relationship/{id}` routes | Synthetic qualified relationships |
-| Fourteen exact `/sstim/ecosystem-record/activity/{id}` routes | Synthetic engagement activities |
-| `/sstim/specialist/{id}` and `/sstim/organization/{id}` namespaces | Mutable live-only ecosystem projection |
-| `/sstim/ecosystem-record/{relationship,activity,role}/{id}` namespaces | Mutable live-only ecosystem projection |
+| `/sstim/specialist/{id}` and `/sstim/organization/{id}` namespaces (`synthetic-*` excluded) | Mutable live-only ecosystem projection |
+| `/sstim/ecosystem-record/{relationship,activity,role}/{id}` namespaces (`synthetic-*` excluded) | Mutable live-only ecosystem projection |
 | `/sstim/void`              | VoID + DCAT dataset description (Turtle only)    |
 | `/sstim/{major.minor.patch}` | Versioned immutable snapshots (Turtle only)    |
 
@@ -50,10 +45,12 @@ instance routes below are Turtle resources. Fragment IRIs such as
 `/sstim#Preset` resolve to the base document.
 
 Audited static catalog routes send RDF clients to the owning Turtle instance
-file. Synthetic ecosystem routes remain isolated in the fixture graph. General
-live ecosystem namespace rules instead send RDF clients to the mutable,
-live-only `current.ttl` projection; they never reuse the synthetic graph. HTML
-requests reach the project landing page in all three cases.
+file. General live ecosystem namespace rules send RDF clients to the mutable,
+live-only `current.ttl` projection. Current synthetic contract subjects reserve
+a `synthetic-*` slug rejected by those rules and are available only through the
+direct fixture artifact; there are no fixture-specific routes. The frozen
+SSTIM 0.7.0 snapshot remains unchanged. HTML requests reach the project landing
+page for static catalog and live ecosystem identifiers.
 
 Dataset membership belongs to the live RDF projection, not the registry
 configuration. Adding, correcting, or retracting a record therefore does not


### PR DESCRIPTION
## What changed

All changes are scoped to the existing `sstim/` namespace directory.

- add content-negotiated routes for the `/sstim/ecosystem` ontology module
  (Turtle default, JSON-LD, RDF/XML; HTML requests go to the project landing
  page, matching every other module route);
- add exact Turtle routes for the stable BSC catalog identities — the BSC
  framework, the BSC Lab and BioSynCare implementations, and the Patch Studio
  software component (intentionally distinct from the `/sstim/patch-studio`
  ontology module); and
- add four compact live namespace rules for `/sstim/specialist/{id}`,
  `/sstim/organization/{id}`, and
  `/sstim/ecosystem-record/{relationship,activity,role}/{id}`: RDF requests
  resolve to the mutable live-only projection, HTML requests to the landing
  page, and the reserved `synthetic-*` fixture slug prefix is rejected by the
  rules themselves.

## Why

SSTIM 0.7.0 released the qualified ecosystem relationship contract, and the
project has deployed the corresponding static catalog resources and the
separately hosted mutable live-only projection. Exact rules avoid conflating
the Patch Studio software component with its ontology module.

The registry configuration stays generic on purpose: dataset membership
belongs to the live RDF projection, so adding, correcting, or retracting an
ecosystem record never requires a w3id.org rule change. No person,
organization, or fixture is named in `.htaccess`; synthetic contract fixtures
use the reserved `synthetic-*` slug and remain reachable only through their
direct test artifact. The privacy and removal boundary is documented in
`sstim/README.md`.

The namespace continues to serve the SSTIM OWL/SKOS ontology, published under
CC BY 4.0.

## Impact

RDF clients can dereference each catalog subject to its owning Turtle resource
and any live ecosystem identifier to the mutable projection. Browser requests
continue to reach the project landing page. Existing SSTIM routes, content
negotiation, and the frozen version snapshots (including 0.7.0) are unchanged.

## Verification

- Every static redirect target returns HTTP 200 with the expected Turtle,
  JSON-LD, or RDF/XML media type and wildcard CORS (re-verified 2026-07-17).
- The mutable `current.ttl` endpoint returns HTTP 200, `text/turtle`, wildcard
  CORS, and `Cache-Control: no-store`; its deployed SHA-256 is
  `1e8a96eb4ecf0fa55516dbb862086027d0d47f80aa05189aaff3cfda477a15a5`.
- The source repository's pinned `make validate` gate passes: SHACL shapes,
  the ecosystem contract (34 SHACL negative fixtures, 11 browser contract
  tests), quality audit, ROBOT/HermiT consistency across 7 modules, SPARQL
  sanity checks, and JSON-LD/RDF-XML round-trip serialization.
- The two route files in this PR are byte-for-byte identical to the audited
  staging copies at laBioSynCare/laBioSynCare.github.io@ad7c916
  (`docs/ecosystem/w3id/sstim/`).
