### PR TITLE
ontodisinfo: add /2.9.0/* routes and point unversioned IRIs to v2.9.0

### DIFF
--- a/ontodisinfo/.htaccess
+++ b/ontodisinfo/.htaccess
@@ -37,9 +37,9 @@ RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/  [R=302,L]
 # RDF tools -> consolidated Turtle pinned to the latest release tag
 RewriteCond %{HTTP_ACCEPT} (text/turtle|application/(rdf\+xml|x-turtle|ld\+json|n-triples|n-quads))
-RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.7.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.9.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 # Default (no Accept header, curl, etc.) -> Turtle, Linked Data convention
-RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.7.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.9.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 
 # =============================================================================
 # 2. Individual modules with content negotiation
@@ -49,38 +49,38 @@ RewriteRule ^$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.7
 # --- core ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^core/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/core/  [R=302,L]
-RewriteRule ^core/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.7.0/ontology/domain/core/ontodis-core.ttl  [R=302,L]
+RewriteRule ^core/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.9.0/ontology/domain/core/ontodis-core.ttl  [R=302,L]
 
 # --- ml ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^ml/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/ml/  [R=302,L]
-RewriteRule ^ml/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.7.0/ontology/domain/ml/ontodis-ml.ttl  [R=302,L]
+RewriteRule ^ml/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.9.0/ontology/domain/ml/ontodis-ml.ttl  [R=302,L]
 
 # --- electoral ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^electoral/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/electoral/  [R=302,L]
-RewriteRule ^electoral/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.7.0/ontology/domain/electoral/ontodis-elec.ttl  [R=302,L]
+RewriteRule ^electoral/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.9.0/ontology/domain/electoral/ontodis-elec.ttl  [R=302,L]
 
 # --- legal ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^legal/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/legal/  [R=302,L]
-RewriteRule ^legal/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.7.0/ontology/domain/legal/ontodis-legal.ttl  [R=302,L]
+RewriteRule ^legal/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.9.0/ontology/domain/legal/ontodis-legal.ttl  [R=302,L]
 
 # --- inference ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^inference/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/modules/inference/  [R=302,L]
-RewriteRule ^inference/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.7.0/ontology/application/ontodis-inference.ttl  [R=302,L]
+RewriteRule ^inference/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.9.0/ontology/application/ontodis-inference.ttl  [R=302,L]
 
 # --- alignments (external) ---
 RewriteCond %{HTTP_ACCEPT} text/html
 RewriteRule ^alignments/?$  https://gustavosouto.gitlab.io/ontodisinfo-electoral/reference/alignments/  [R=302,L]
-RewriteRule ^alignments/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.7.0/ontology/adapter/ontodis-alignments.ttl  [R=302,L]
+RewriteRule ^alignments/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.9.0/ontology/adapter/ontodis-alignments.ttl  [R=302,L]
 
 # --- gufo-alignment (no dedicated doc page; always Turtle) ---
-RewriteRule ^gufo-alignment/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.7.0/ontology/adapter/ontodis-gufo-alignment.ttl  [R=302,L]
+RewriteRule ^gufo-alignment/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.9.0/ontology/adapter/ontodis-gufo-alignment.ttl  [R=302,L]
 
 # --- full integrated (entry point for Protege/reasoners) ---
-RewriteRule ^full/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.7.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^full/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.9.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 
 # =============================================================================
 # 3. Versioned IRIs (owl:versionIRI)
@@ -316,6 +316,21 @@ RewriteRule ^2\.7\.0/gufo-alignment$  https://gitlab.com/gustavosouto/ontodisinf
 RewriteRule ^2\.7\.0/full$            https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.7.0/ontology/composition/ontodis-full.ttl          [R=302,L]
 
 
+# --- 2.9.0 ---
+# Minor: semantic alignment fixes (SIOC num_replies now aligns numComentarios;
+# PROV-O explicaResultado subPropertyOf wasDerivedFrom replaces the inverted
+# temExplicacao mapping) and updated Disseminador annotations (RoleMixin).
+# Additive: no IRI removed or renamed. (2.8.x was a software-only series;
+# OWL modules skip from 2.7.0 to 2.9.0.)
+RewriteRule ^2\.9\.0/core$              https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.9.0/ontology/domain/core/ontodis-core.ttl  [R=302,L]
+RewriteRule ^2\.9\.0/ml$                https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.9.0/ontology/domain/ml/ontodis-ml.ttl  [R=302,L]
+RewriteRule ^2\.9\.0/electoral$         https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.9.0/ontology/domain/electoral/ontodis-elec.ttl  [R=302,L]
+RewriteRule ^2\.9\.0/legal$             https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.9.0/ontology/domain/legal/ontodis-legal.ttl  [R=302,L]
+RewriteRule ^2\.9\.0/inference$         https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.9.0/ontology/application/ontodis-inference.ttl  [R=302,L]
+RewriteRule ^2\.9\.0/alignments$        https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.9.0/ontology/adapter/ontodis-alignments.ttl  [R=302,L]
+RewriteRule ^2\.9\.0/gufo-alignment$    https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.9.0/ontology/adapter/ontodis-gufo-alignment.ttl  [R=302,L]
+RewriteRule ^2\.9\.0/full$              https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.9.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+
 # =============================================================================
 # 4. Documentation shortcuts (HTML site sections)
 #    Citable URLs for specific parts of the public documentation.
@@ -331,5 +346,5 @@ RewriteRule ^metrics/?$          https://gustavosouto.gitlab.io/ontodisinfo-elec
 # =============================================================================
 # 5. Convenience redirects
 # =============================================================================
-RewriteRule ^latest/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.7.0/ontology/composition/ontodis-full.ttl  [R=302,L]
+RewriteRule ^latest/?$  https://gitlab.com/gustavosouto/ontodisinfo-electoral/-/raw/v2.9.0/ontology/composition/ontodis-full.ttl  [R=302,L]
 RewriteRule ^repo/?$    https://gitlab.com/gustavosouto/ontodisinfo-electoral                                                      [R=302,L]


### PR DESCRIPTION
Adds versioned routes for release 2.9.0 of OntoDisinfo-Electoral and repoints the unversioned IRIs (namespace root, module IRIs and /latest) from v2.7.0 to v2.9.0. Additive only: all previously published versioned IRIs keep resolving unchanged. Same maintainer as in ontodisinfo/README.md.