### PR TITLE
Add HdZ Mission Ontology permanent identifiers

### DIFF
--- a/HdZ/.htaccess
+++ b/HdZ/.htaccess
@@ -1,0 +1,37 @@
+# Handwerk der Zukunft (HdZ) Mission Ontology
+# https://w3id.org/HdZ
+#
+# Maintainer: Essam Fadel
+# GitHub: https://github.com/EssamFadel
+
+Options +FollowSymLinks
+RewriteEngine On
+
+# Version 2.0.0 content negotiation
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^2\.0\.0/?$ https://cdn.jsdelivr.net/gh/EssamFadel/HdZ-Ontology@v2.0.0/HdZ.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^2\.0\.0/?$ https://cdn.jsdelivr.net/gh/EssamFadel/HdZ-Ontology@v2.0.0/HdZ.rdf [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/html [NC]
+RewriteRule ^2\.0\.0/?$ https://github.com/EssamFadel/HdZ-Ontology/tree/v2.0.0 [R=303,L]
+
+RewriteRule ^2\.0\.0/?$ https://cdn.jsdelivr.net/gh/EssamFadel/HdZ-Ontology@v2.0.0/HdZ.rdf [R=303,L]
+
+# Explicit serialization paths for the current release
+RewriteRule ^HdZ\.rdf$ https://cdn.jsdelivr.net/gh/EssamFadel/HdZ-Ontology@main/HdZ.rdf [R=303,L]
+RewriteRule ^HdZ\.ttl$ https://cdn.jsdelivr.net/gh/EssamFadel/HdZ-Ontology@main/HdZ.ttl [R=303,L]
+
+# Current ontology content negotiation
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^$ https://cdn.jsdelivr.net/gh/EssamFadel/HdZ-Ontology@main/HdZ.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^$ https://cdn.jsdelivr.net/gh/EssamFadel/HdZ-Ontology@main/HdZ.rdf [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/html [NC]
+RewriteRule ^$ https://github.com/EssamFadel/HdZ-Ontology [R=303,L]
+
+# Serve RDF/XML to clients that do not request a specific representation
+RewriteRule ^$ https://cdn.jsdelivr.net/gh/EssamFadel/HdZ-Ontology@main/HdZ.rdf [R=303,L]

--- a/HdZ/README.md
+++ b/HdZ/README.md
@@ -1,0 +1,24 @@
+# Handwerk der Zukunft (HdZ) Mission Ontology
+
+This directory provides permanent identifiers for the Handwerk der Zukunft (HdZ) Mission Ontology.
+
+## Identifiers
+
+- Ontology: <https://w3id.org/HdZ>
+- Namespace: `https://w3id.org/HdZ#`
+- Version 2.0.0: <https://w3id.org/HdZ/2.0.0>
+- RDF/XML: <https://w3id.org/HdZ/HdZ.rdf>
+- Turtle: <https://w3id.org/HdZ/HdZ.ttl>
+
+The current ontology identifier uses HTTP content negotiation:
+
+- `text/html` redirects to the [ontology repository](https://github.com/EssamFadel/HdZ-Ontology).
+- `application/rdf+xml` redirects to the RDF/XML serialization.
+- `text/turtle` redirects to the Turtle serialization.
+- Requests without a recognized representation preference default to RDF/XML.
+
+The versioned identifier resolves to the immutable `v2.0.0` release.
+
+## Maintainer
+
+Essam Fadel ([@EssamFadel](https://github.com/EssamFadel))


### PR DESCRIPTION
## Brief Description

Adds permanent identifiers for the Handwerk der Zukunft (HdZ) Mission Ontology at `https://w3id.org/HdZ`.

The redirect rules provide:

- HTML, RDF/XML, and Turtle content negotiation for the current ontology
- explicit RDF/XML and Turtle serialization paths
- an immutable, content-negotiated `2.0.0` version identifier
- maintainer and project information

Ontology source: https://github.com/EssamFadel/HdZ-Ontology

## Validation

- Apache 2.4 configuration syntax: OK
- Local Apache redirect tests: all tested routes return HTTP 303 with the expected target
- RDF/XML and Turtle destinations: HTTP 200 with `application/rdf+xml` and `text/turtle`
- RDF graph validation: both serializations parse to 518 triples and are isomorphic

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Optional Requests for W3ID Maintainers

- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
