### PR TITLE
hcmo: update namespace for HCMO 0.2.0

### DIFF
--- a/hcmo/.htaccess
+++ b/hcmo/.htaccess
@@ -1,4 +1,4 @@
-# hcmo — Home Cage Monitoring Ontology (HCMO)
+# hcmo — Home-Cage Monitoring Ontology (HCMO)
 #
 # Permanent W3ID directory providing stable, content-negotiated resolution for
 # the HCMO ontology, developed at https://github.com/dhuzard/HCMO
@@ -8,7 +8,8 @@
 # Modules:         https://w3id.org/hcmo/ontology/hcm/bio#
 #                  https://w3id.org/hcmo/ontology/hcm/env#
 #                  https://w3id.org/hcmo/ontology/hcm/obs#
-# Version IRI:     https://w3id.org/hcmo/ontology/hcm/<version>  (e.g. /0.9)
+#                  https://w3id.org/hcmo/ontology/hcm/tech#
+# Version IRI:     https://w3id.org/hcmo/ontology/hcm/<version>  (e.g. /0.2.0)
 #
 # RDF distributions are served from GitHub Release assets. The merged
 # distributions contain all modules, so module IRIs resolve to the same graph.
@@ -26,9 +27,9 @@ RewriteEngine on
 
 # ===========================================================================
 # Version-aware resolution: https://w3id.org/hcmo/ontology/hcm/<version>
-# <version> is any segment beginning with a digit (e.g. 0.9). It is mapped to
-# the matching GitHub release tag (v<version>), so /hcm/0.9 -> release v0.9.
-# (Module names such as bio/env/obs begin with a letter and fall through to
+# <version> is any segment beginning with a digit (e.g. 0.2.0). It is mapped to
+# the matching GitHub release tag (v<version>), so /hcm/0.2.0 -> release v0.2.0.
+# (Module names such as bio/env/obs/tech begin with a letter and fall through to
 #  the "latest" block below.)
 # ===========================================================================
 
@@ -58,33 +59,33 @@ RewriteRule ^ontology/hcm/([0-9][^/]*)$ https://github.com/dhuzard/HCMO/releases
 RewriteRule ^ontology/hcm/([0-9][^/]*)$ https://github.com/dhuzard/HCMO/releases/download/v$1/hcmo.ttl [R=303,L]
 
 # ===========================================================================
-# Latest resolution: https://w3id.org/hcmo/ontology/hcm (+ bio/env/obs modules)
+# Latest resolution: https://w3id.org/hcmo/ontology/hcm (+ bio/env/obs/tech modules)
 # ===========================================================================
 
 # Turtle
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
-RewriteRule ^ontology/hcm(/(bio|env|obs))?$ https://github.com/dhuzard/HCMO/releases/latest/download/hcmo.ttl [R=303,L]
+RewriteRule ^ontology/hcm(/(bio|env|obs|tech))?$ https://github.com/dhuzard/HCMO/releases/latest/download/hcmo.ttl [R=303,L]
 
 # RDF/XML (OWL)
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} application/xml [OR]
 RewriteCond %{HTTP_ACCEPT} text/xml
-RewriteRule ^ontology/hcm(/(bio|env|obs))?$ https://github.com/dhuzard/HCMO/releases/latest/download/hcmo.owl [R=303,L]
+RewriteRule ^ontology/hcm(/(bio|env|obs|tech))?$ https://github.com/dhuzard/HCMO/releases/latest/download/hcmo.owl [R=303,L]
 
 # JSON-LD
 RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
 RewriteCond %{HTTP_ACCEPT} application/json
-RewriteRule ^ontology/hcm(/(bio|env|obs))?$ https://github.com/dhuzard/HCMO/releases/latest/download/hcmo.json [R=303,L]
+RewriteRule ^ontology/hcm(/(bio|env|obs|tech))?$ https://github.com/dhuzard/HCMO/releases/latest/download/hcmo.json [R=303,L]
 
 # HTML documentation (browsers) -> WIDOCO documentation on GitHub Pages
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^ontology/hcm(/(bio|env|obs))?$ https://dhuzard.github.io/HCMO/ [R=303,L]
+RewriteRule ^ontology/hcm(/(bio|env|obs|tech))?$ https://dhuzard.github.io/HCMO/ [R=303,L]
 
 # Default response for the ontology IRI: serve the canonical Turtle graph
-RewriteRule ^ontology/hcm(/(bio|env|obs))?$ https://github.com/dhuzard/HCMO/releases/latest/download/hcmo.ttl [R=303,L]
+RewriteRule ^ontology/hcm(/(bio|env|obs|tech))?$ https://github.com/dhuzard/HCMO/releases/latest/download/hcmo.ttl [R=303,L]
 
 # ===========================================================================
 # Landing: https://w3id.org/hcmo/ (and any unmatched path) -> source repo

--- a/hcmo/README.md
+++ b/hcmo/README.md
@@ -1,6 +1,6 @@
 # /hcmo/
 
-Permanent identifier namespace for the **HCMO — Home Cage Monitoring Ontology**.
+Permanent identifier namespace for the **HCMO — Home-Cage Monitoring Ontology**.
 
 The ontology is developed and maintained at
 <https://github.com/dhuzard/HCMO>.
@@ -15,7 +15,8 @@ The ontology is developed and maintained at
 | `https://w3id.org/hcmo/ontology/hcm/bio#` | Biological module |
 | `https://w3id.org/hcmo/ontology/hcm/env#` | Environmental module |
 | `https://w3id.org/hcmo/ontology/hcm/obs#` | Observational module |
-| `https://w3id.org/hcmo/ontology/hcm/<version>` | Version IRI (e.g. `/0.9`) |
+| `https://w3id.org/hcmo/ontology/hcm/tech#` | Technology module |
+| `https://w3id.org/hcmo/ontology/hcm/<version>` | Version IRI (e.g. `/0.2.0`) |
 
 ## Content negotiation
 
@@ -29,17 +30,17 @@ Requests to the ontology IRI are redirected (HTTP `303`) according to the
 | `text/turtle` (default) | `releases/latest/download/hcmo.ttl` | `releases/download/v<version>/hcmo.ttl` |
 | `application/ld+json` | `releases/latest/download/hcmo.json` | `releases/download/v<version>/hcmo.json` |
 
-The merged distributions contain all modules, so the `bio`/`env`/`obs` module
-IRIs resolve to the same merged graph. A version segment is any path segment
-beginning with a digit (e.g. `…/hcm/0.9`) and is mapped to the GitHub release
-tag `v<version>`.
+The merged distributions contain all modules, so the `bio`/`env`/`obs`/`tech`
+module IRIs resolve to the same merged graph. A version segment is any path
+segment beginning with a digit (e.g. `…/hcm/0.2.0`) and is mapped to the GitHub
+release tag `v<version>`.
 
-> **Note — version tag vs. manifest:** the ontology manifest (`hcmo.yaml`)
-> currently declares `version: 0.0.1`, but the latest published release is
-> `v0.9`. Consequently `…/hcm/0.9` resolves, while the declared version IRI
-> `…/hcm/0.0.1` will 303 to a `v0.0.1` release that does not exist. Reconcile
-> by bumping the manifest to the release tag scheme, or by cutting a matching
-> release.
+## Current release
+
+HCMO `0.2.0` is published as GitHub release `v0.2.0`. The version IRI
+`https://w3id.org/hcmo/ontology/hcm/0.2.0` resolves to the matching release
+artifacts, while the unversioned ontology and module IRIs resolve to the latest
+release.
 
 ## Contact
 


### PR DESCRIPTION
## Summary

- add the `hcm-tech` module namespace to every latest-release content-negotiation rule
- document HCMO `0.2.0` and its matching `v0.2.0` GitHub release
- remove the obsolete `0.0.1` versus `v0.9` mismatch note
- standardize the project name as Home-Cage Monitoring Ontology

## Why

HCMO 0.2.0 includes the technology module at `https://w3id.org/hcmo/ontology/hcm/tech#`. The version-aware rule already supports `0.2.0`, and the matching GitHub release now publishes all referenced RDF artifacts.

## Validation

- confirmed the diff is limited to `hcmo/.htaccess` and `hcmo/README.md`
- confirmed all five latest-release rewrite rules include `tech`
- confirmed every `v0.2.0` release asset returns HTTP 200
- confirmed `https://w3id.org/hcmo/ontology/hcm/0.2.0` returns HTTP 303 to the `v0.2.0` Turtle artifact
- `git diff --check` passes