### PR TITLE
Add w3id.org/portauth namespace (PortAuth — Portable Authorization for AI Agents)

### DIFF
--- a/portauth/.htaccess
+++ b/portauth/.htaccess
@@ -1,0 +1,16 @@
+# PortAuth — Portable Authorization for AI Agents
+# Permanent identifier namespace for the PortAuth A2A extension.
+# Contact: Partha Madhira <partha.madhira@kyndryl.com>
+# Project: https://github.com/kyndryl-open-source/aiagent-portable-authorization
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# Versioned A2A extension identifier -> normative spec
+RewriteRule ^a2a/v1/?$ https://github.com/kyndryl-open-source/aiagent-portable-authorization/blob/main/extensions/a2a/SPEC.md [R=302,L]
+
+# Namespace root -> project repository
+RewriteRule ^$ https://github.com/kyndryl-open-source/aiagent-portable-authorization [R=302,L]
+
+# Fallback -> project repository
+RewriteRule ^(.*)$ https://github.com/kyndryl-open-source/aiagent-portable-authorization [R=302,L]

--- a/portauth/README.md
+++ b/portauth/README.md
@@ -1,0 +1,9 @@
+# PortAuth namespace (w3id.org/portauth)
+
+Permanent identifiers for **PortAuth — Portable Authorization for AI Agents**,
+the reference implementation of arXiv:2605.11487.
+
+- `https://w3id.org/portauth/a2a/v1` — PortAuth A2A extension (v1); resolves to the normative spec.
+
+Project: https://github.com/kyndryl-open-source/aiagent-portable-authorization
+Maintainer / contact: Partha Madhira <partha.madhira@kyndryl.com>

--- a/portauth/README.md
+++ b/portauth/README.md
@@ -6,4 +6,4 @@ the reference implementation of arXiv:2605.11487.
 - `https://w3id.org/portauth/a2a/v1` — PortAuth A2A extension (v1); resolves to the normative spec.
 
 Project: https://github.com/kyndryl-open-source/aiagent-portable-authorization
-Maintainer / contact: Partha Madhira <partha.madhira@kyndryl.com>
+Maintainer / contact: Partha Madhira <partha.madhira@kyndryl.com> ([@partha-kyndryl](https://github.com/partha-kyndryl))


### PR DESCRIPTION
Adds a permanent identifier namespace for the PortAuth A2A extension. https://w3id.org/portauth/a2a/v1 resolves to the extension spec. Project: https://github.com/kyndryl-open-source/aiagent-portable-authorization. Contact: Partha Madhira <partha.madhira@kyndryl.com>.