### PR TITLE
Add baseveda: permanent namespace for the BaseVeda Type/Function/Value ontology

### DIFF
--- a/baseveda/.htaccess
+++ b/baseveda/.htaccess
@@ -1,0 +1,35 @@
+# /baseveda/
+#
+# BaseVeda -- a Type / Function / Value ontology.
+#
+# This is the permanent, location-independent namespace for BaseVeda
+# vocabulary terms. It deliberately contains no hostname, so that every
+# independent deployment that speaks this vocabulary emits the identical
+# IRI for the same term.
+#
+# Terms are hash URIs, one document per ontology module:
+#
+#   https://w3id.org/baseveda/vocab#Person           -> core vocabulary document
+#   https://w3id.org/baseveda/planguage-core#File    -> a per-module document
+#
+# The fragment (#Person) is resolved by the client and never reaches the
+# server, so no per-term routes are required here. The rules below forward
+# the DOCUMENT path only; the client re-applies the fragment to the
+# retrieved document. New modules resolve without changing this file.
+#
+# ## Contact
+# This space is administered by:
+#
+# Kai Gilb
+# kaigilb@mac.com
+# GitHub username: KaiGilb
+
+RewriteEngine on
+
+# Bare namespace -> the core vocabulary document.
+RewriteRule ^$ https://veda.gilb.com/base/vocab [R=302,L]
+
+# Module documents -- path preserved, so additional modules need no change here.
+# 302 (temporary) is deliberate: the serve surface is expected to move to a
+# versioned release host, and a cached permanent redirect would outlive it.
+RewriteRule ^(.+)$ https://veda.gilb.com/base/$1 [R=302,L]

--- a/baseveda/README.md
+++ b/baseveda/README.md
@@ -1,0 +1,36 @@
+# /baseveda/
+
+Permanent namespace for **BaseVeda**, a Type / Function / Value ontology in
+which every type carries an explicit Function (what it is for) and an explicit
+Value (how it is measured on a real scale).
+
+## Why this identifier exists
+
+BaseVeda is consumed by many independent, self-hosted deployments. If the
+vocabulary namespace were derived from a deployment's own hostname, each
+deployment would emit a different IRI for the same term and no two datasets
+would join. A hostname-free `w3id.org` namespace gives every deployment the
+identical, permanent string for the same meaning, and lets the target be
+re-pointed by a one-line pull request if the serving host ever changes.
+
+## URI pattern
+
+Terms are hash URIs, one document per ontology module:
+
+| IRI | Resolves to |
+|---|---|
+| `https://w3id.org/baseveda/vocab#Person` | core vocabulary document |
+| `https://w3id.org/baseveda/planguage-core#File` | `planguage-core` module document |
+
+The fragment is resolved client-side and never reaches the server, so this
+identifier needs no per-term routes. Only module documents are redirected;
+the path is preserved, so new modules resolve without changing `.htaccess`.
+
+Documents are served as JSON-LD and describe their terms using these same
+canonical `w3id.org/baseveda/...` IRIs as subjects.
+
+## Maintainer
+
+| Name | Contact | GitHub |
+|---|---|---|
+| Kai Gilb | kaigilb@mac.com | [@KaiGilb](https://github.com/KaiGilb) |


### PR DESCRIPTION
Adds `/baseveda/`, the permanent namespace for **BaseVeda**, a Type/Function/Value ontology consumed by independent self-hosted deployments.

- Hash-URI vocabulary: `https://w3id.org/baseveda/vocab#Term`, one document per module; the path is preserved, so new modules need no `.htaccess` change.
- Redirects 302 to the serving host (`veda.gilb.com`); temporary by design — the serve surface will move to a versioned release host, and this indirection is exactly why we're registering.
- Served documents self-describe with these w3id IRIs as subjects.

Contact: Kai Gilb — kaigilb@mac.com (GitHub: KaiGilb)