### PR TITLE
Add /sanskrit-lexicon/ namespace for Cologne Digital Sanskrit Dictionaries LOD

### DIFF
--- a/sanskrit-lexicon/.htaccess
+++ b/sanskrit-lexicon/.htaccess
@@ -1,0 +1,50 @@
+# # /sanskrit-lexicon/
+#
+# Permanent identifier namespace for Linked Open Data derived from the
+# Cologne Digital Sanskrit Dictionaries (https://www.sanskrit-lexicon.uni-koeln.de/).
+#
+# https://w3id.org/sanskrit-lexicon/          -> namespace index
+# https://w3id.org/sanskrit-lexicon/pwg-ru/*  -> PWG->RU LOD graph
+#                                                (Petersburg Dictionary with
+#                                                 Russian sense definitions;
+#                                                 OntoLex-Lemon + PROV-O)
+#
+# Instances use slash IRIs and are resolved with 303 See Other under content
+# negotiation: an RDF media type is served Turtle, anything else HTML.
+# The hash form (vocab#term) is reserved for the project vocabulary document.
+#
+# The redirect target is GitHub Pages so that the identifiers stay independent
+# of any project domain or hosting arrangement.
+#
+# ## Contact
+# This space is administered by:
+#
+# Marcis Gasuns
+# rusamskrtam@gmail.com
+# ORCID: 0000-0003-4513-884X
+# GitHub username: gasyoun
+
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/rdf+xml .rdf
+AddType application/n-triples .nt
+
+RewriteEngine on
+
+# Namespace index.
+RewriteRule ^$ https://gasyoun.github.io/pwg-ru-lod/ [R=302,L]
+
+# ---- /pwg-ru/ --------------------------------------------------------------
+
+# Sub-namespace root.
+RewriteRule ^pwg-ru/?$ https://gasyoun.github.io/pwg-ru-lod/ [R=302,L]
+
+# An RDF media type was requested -> serve Turtle.
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^pwg-ru/(.+)$ https://gasyoun.github.io/pwg-ru-lod/$1.ttl [R=303,L]
+
+# Anything else -> serve HTML.
+RewriteRule ^pwg-ru/(.+)$ https://gasyoun.github.io/pwg-ru-lod/$1.html [R=303,L]

--- a/sanskrit-lexicon/README.md
+++ b/sanskrit-lexicon/README.md
@@ -1,0 +1,45 @@
+# /sanskrit-lexicon/
+
+Permanent identifier namespace for Linked Open Data derived from the
+[Cologne Digital Sanskrit Dictionaries](https://www.sanskrit-lexicon.uni-koeln.de/)
+(CDSL), a long-running digitisation of the major printed Sanskrit lexica.
+
+Namespace index: <https://w3id.org/sanskrit-lexicon/>
+
+## Sub-namespaces
+
+| IRI | Dataset |
+|---|---|
+| `https://w3id.org/sanskrit-lexicon/pwg-ru/` | **PWG→RU** — the Petersburg Dictionary (Böhtlingk–Roth, *Sanskrit-Wörterbuch*) with Russian sense definitions. Modelled in OntoLex-Lemon with a LiLa-style lemma bank, PROV-O evidence grades, first-class source citations, Renou stratum dating, `vartrans` sense relations, and Digital Corpus of Sanskrit frequency data. |
+
+Further sub-namespaces (other CDSL dictionaries) will be added to this same
+directory as they are published.
+
+## Resolution
+
+Instances use slash IRIs and resolve with **303 See Other** under content
+negotiation — an RDF media type (`text/turtle`, `application/rdf+xml`,
+`application/n-triples`) is served Turtle, anything else HTML. The hash form
+(`vocab#term`) is reserved for the project vocabulary document.
+
+Redirects point at GitHub Pages
+([gasyoun.github.io/pwg-ru-lod](https://gasyoun.github.io/pwg-ru-lod/)) so that
+the identifiers remain independent of any project domain or hosting arrangement.
+The target is expected to move to an institutional endpoint in future; that
+change will not affect any IRI.
+
+## Current publication state
+
+The namespace and its IRI scheme are stable and already in use by the graph
+generator and its test fixtures. At the time of registration the published
+target carries the namespace index and the SHACL profile; instance data is
+withheld pending an editorial approval pass, and is documented as such on the
+index page. The namespace is being registered ahead of the data precisely so
+that the identifiers minted from here never have to change.
+
+## Maintainer
+
+Dr. Mārcis Gasūns
+rusamskrtam@gmail.com
+[ORCID 0000-0003-4513-884X](https://orcid.org/0000-0003-4513-884X)
+GitHub: [@gasyoun](https://github.com/gasyoun)


### PR DESCRIPTION
@
Requesting `https://w3id.org/sanskrit-lexicon/` for Linked Open Data derived from the [Cologne Digital Sanskrit Dictionaries](https://www.sanskrit-lexicon.uni-koeln.de/) (CDSL), a long-running digitisation of the major printed Sanskrit lexica.

The first sub-namespace is `/sanskrit-lexicon/pwg-ru/` — the Petersburg Dictionary (Böhtlingk–Roth, *Sanskrit-Wörterbuch*) with Russian sense definitions, modelled in OntoLex-Lemon with a LiLa-style lemma bank, PROV-O evidence grades, first-class source citations, stratum dating, `vartrans` sense relations, and Digital Corpus of Sanskrit frequency data. Further CDSL dictionaries will be added to the same directory as they are published.

### Files

- `sanskrit-lexicon/.htaccess` — namespace index at `^$`; 303 content negotiation under `/pwg-ru/` (RDF media type → `.ttl`, otherwise `.html`), per the pattern in `/examples/`.
- `sanskrit-lexicon/README.md` — namespace description, resolution rules, maintainer contact.

### Testing

Both redirect targets were verified to return HTTP 200 before opening this PR:

- `https://gasyoun.github.io/pwg-ru-lod/` → 200 (namespace index)
- `https://gasyoun.github.io/pwg-ru-lod/shapes.ttl` → 200 (SHACL profile, i.e. the `text/turtle` branch)

### A note on publication state

I am registering the namespace **ahead of the bulk graph data**, deliberately. The IRI scheme is already stable and baked into the generator and its fixtures, and the point of a w3id PURL is that those identifiers never have to churn. The target currently serves the namespace index and the SHACL profile; instance data is withheld pending an editorial approval pass and is documented as withheld on the index page, rather than left to look like an outage. Redirects point at GitHub Pages so the identifiers stay independent of any project domain; an eventual move to an institutional endpoint will not affect any IRI.

### Contact

Dr. Mārcis Gasūns · rusamskrtam@gmail.com · [ORCID 0000-0003-4513-884X](https://orcid.org/0000-0003-4513-884X) · GitHub [@gasyoun](https://github.com/gasyoun)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@