### PR TITLE
Add /openevo/ namespace for OpenEvo ConceptBase (OECB)

### DIFF
--- a/openevo/.htaccess
+++ b/openevo/.htaccess
@@ -1,0 +1,49 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+# ============================================================================
+# OpenEvo ConceptBase (OECB) — https://www.w3id.org/openevo/
+# Source of truth: https://github.com/openevo-ccs/conceptbase
+#   docs/oecb_specifications.md §4 (Namespace and Identifier Architecture)
+# Contact: see readme.md in this directory.
+#
+# MVP scope note: this resolves every §4.2 sub-path to something real, but
+# only as flat JSON / raw YAML — no content negotiation, JSON-LD, RDF, or
+# SPARQL yet (that's Phase 4; see the spec). Rules below are written against
+# stable, predictable URL patterns (not one rule per identifier), so this
+# file should not need to change again as new concepts/vocabularies/LPMs are
+# added — only as new *sub-path types* are introduced.
+# ============================================================================
+
+# Namespace root — human landing page.
+RewriteRule ^$ https://github.com/openevo-ccs/conceptbase [R=302,L]
+
+# Ontology. Note: oe:ClassName expands to .../ontology#ClassName, and URL
+# fragments are never sent to the server — every class/property in the
+# ontology therefore resolves via this single rule.
+RewriteRule ^ontology$ https://raw.githubusercontent.com/openevo-ccs/conceptbase/main/ontologies/core_v1.yaml [R=302,L]
+RewriteRule ^ontology/$ https://raw.githubusercontent.com/openevo-ccs/conceptbase/main/ontologies/core_v1.yaml [R=302,L]
+
+# JSON Schemas (schemas/{name}.schema.yaml, authoring format).
+RewriteRule ^schemas/([A-Za-z]+)\.schema\.json$ https://raw.githubusercontent.com/openevo-ccs/conceptbase/main/schemas/$1.schema.yaml [R=302,L]
+
+# Controlled vocabularies — {name} includes the version suffix, e.g.
+# BIO-CORE-v1.0.0, matching the vocabRef pattern used throughout OECB.
+RewriteRule ^vocab/([A-Za-z0-9.\-]+)$ https://raw.githubusercontent.com/openevo-ccs/conceptbase/main/vocabularies/$1.yaml [R=302,L]
+
+# Concepts and cross-vocabulary alignment records — resolved against
+# conceptbase's generated flat-JSON registry (scripts/build_registry.py),
+# published via GitHub Pages alongside the ConceptBase Explorer app.
+RewriteRule ^concept/([A-Za-z0-9\-]+)$ https://openevo-ccs.github.io/conceptbase/registry/concept/$1.json [R=302,L]
+RewriteRule ^competency/([A-Za-z0-9\-]+)$ https://openevo-ccs.github.io/conceptbase/registry/competency/$1.json [R=302,L]
+RewriteRule ^alignment/([A-Za-z0-9\-]+)$ https://openevo-ccs.github.io/conceptbase/registry/alignment/$1.json [R=302,L]
+
+# LPMs and Strands live in independently governed dependent repositories,
+# not in conceptbase itself (see README, "What's In Scope (and What Isn't)").
+# Resolved via a small static lookup page that redirects on to the owning
+# repository — the identifier itself never reaches conceptbase's server
+# again after this single rule, so it never needs to change as new LPMs
+# are minted.
+RewriteRule ^lpm/([A-Za-z0-9\-]+)$ https://openevo-ccs.github.io/conceptbase/registry/resolve.html#lpm/$1 [R=302,L]
+RewriteRule ^strand/([A-Za-z0-9\-]+)$ https://openevo-ccs.github.io/conceptbase/registry/resolve.html#strand/$1 [R=302,L]

--- a/openevo/readme.md
+++ b/openevo/readme.md
@@ -1,0 +1,31 @@
+# OpenEvo ConceptBase (OECB)
+
+Permanent identifier namespace for the OpenEvo Computational Curriculum Studies (CCS) Lab's ConceptBase — the shared ontology, JSON Schemas, and controlled vocabularies that let independently governed curriculum-knowledge repositories (Learning Progression Models, Strands, Collections) interoperate.
+
+Homepage: https://w3id.org/openevo/
+Source / issue tracker: https://github.com/openevo-ccs/conceptbase
+Specification (source of truth): https://github.com/openevo-ccs/conceptbase/blob/main/docs/oecb_specifications.md
+
+## Resolved sub-paths
+
+| Path | Resolves to |
+|---|---|
+| `https://w3id.org/openevo/ontology` | The core ontology (raw YAML; `#ClassName` fragments select a class client-side) |
+| `https://w3id.org/openevo/vocab/{name-with-version}` | A controlled vocabulary file, e.g. `vocab/BIO-CORE-v1.0.0` |
+| `https://w3id.org/openevo/concept/{id}` | A single Concept instance as flat JSON, e.g. `concept/OE-CONCEPT-000102` |
+| `https://w3id.org/openevo/competency/{id}` | A single Competency instance as flat JSON, e.g. `competency/OE-COMPETENCY-000150` |
+| `https://w3id.org/openevo/alignment/{id}` | A cross-vocabulary alignment record as flat JSON |
+| `https://w3id.org/openevo/lpm/{id}` | The dependent repository that owns a given Learning Progression Model identifier |
+| `https://w3id.org/openevo/strand/{id}` | The dependent repository that owns a given Strand identifier |
+| `https://w3id.org/openevo/schemas/{name}.schema.json` | A JSON Schema document (raw YAML) |
+
+This is an intentional MVP: everything above resolves to something real today, but only as flat JSON / raw YAML — full content negotiation (JSON-LD, RDF, SPARQL) is planned (see the specification's phased roadmap) and will be added without changing any identifier or requiring a new PR to this repository, since redirect targets are keyed by stable URL patterns rather than per-identifier rules.
+
+## Contact
+
+This space is administered by:
+
+**Dustin Eirdosh**
+GitHub: [dustineirdosh](https://github.com/dustineirdosh)
+
+OpenEvo Computational Curriculum Studies (CCS) Lab — https://openevo.eva.mpg.de


### PR DESCRIPTION
Registers https://w3id.org/openevo/ as the permanent identifier namespace for the OpenEvo Computational Curriculum Studies (CCS) Lab's shared ontology, JSON Schemas, and controlled vocabularies.

Source of truth: https://github.com/openevo-ccs/conceptbase
Spec: https://github.com/openevo-ccs/conceptbase/blob/main/docs/oecb_specifications.md (§4)

This is an MVP resolution scheme: every sub-path resolves to real content today (flat JSON / raw YAML), with full content negotiation (JSON-LD, RDF, SPARQL) planned without requiring a new PR here, since redirects are keyed by stable URL patterns rather than per-identifier rules.

<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [ ] Changes have been tested.
- [ ] The number of commits is minimal. Squash if needed.
- [ ] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
