### PR TITLE
Add /sven namespace (SVEN ontology, ISWC 2026)

### DIFF
--- a/sven/.htaccess
+++ b/sven/.htaccess
@@ -1,0 +1,8 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Permanent alias -> canonical LISN namespace (which content-negotiates).
+RewriteRule ^ontology/?$ https://sven.lisn.upsaclay.fr/ontology [R=302,L]
+
+# Bare prefix -> same canonical resource.
+RewriteRule ^$ https://sven.lisn.upsaclay.fr/ontology [R=302,L]

--- a/sven/.htaccess
+++ b/sven/.htaccess
@@ -1,3 +1,10 @@
+# SVEN ontology namespace
+# Maintainer: Swordsouler (https://github.com/Swordsouler)
+# Contact: swordsouler.nsl@gmail.com
+# Permanent identifier for the SVEN ontology (Semanticize Virtual ENvironments),
+# ISWC 2026 Resource Track. Redirects to the canonical namespace on the
+# project's institutional host, which performs content negotiation.
+
 Options +FollowSymLinks
 RewriteEngine on
 


### PR DESCRIPTION
### New namespace: /sven/

This PR registers `https://w3id.org/sven/` as a permanent identifier for the
**SVEN** ontology (*Semanticize Virtual ENvironments*), a resource published at
the ISWC 2026 Resource Track.

**Target resource:** https://sven.lisn.upsaclay.fr/ontology#
**Documentation (WIDOCO):** https://sven.lisn.upsaclay.fr/doc/ontology/
**Source code:** https://github.com/Swordsouler/SVENUnity
**Archived DOIs:** 10.5281/zenodo.15408983 (ontology), 10.5281/zenodo.15403733 (Unity library)

`/sven/ontology` redirects to the canonical namespace on the project's
institutional host, which performs content negotiation (Turtle sources vs
human-readable documentation) on the `Accept` header.

I am the maintainer of this resource and control the target host. The `sven`
namespace matches the ontology's established prefix and project name. If a
shorter top-level name is a concern, I am happy to move it under a longer
prefix at the maintainers' discretion.