### PR TITLE
Route SSTIM BSC framework technique IRIs

### DIFF
--- a/sstim/.htaccess
+++ b/sstim/.htaccess
@@ -39,6 +39,24 @@ RewriteRule ^(implementation/bsclab|implementation/biosyncare|implementation/bsc
 # END audited BSC catalog routes
 
 # -------------------------------------------------------------------------
+# BSC framework technique identities. Every rule is exact — no prefix wildcard
+# — so a retired slug can never fall through to the framework document and
+# appear current. The three techniques BSC originated resolve to the framework
+# file that defines them; the four retired in ADR 0033 resolve to the SKOS
+# vocabulary that now carries their vendor-neutral replacements
+# (techBinauralBeats, techPhoticDriving, techAudiovisualEntrainment,
+# techVibrotactileEntrainment). Before this block every path under
+# framework/bsc/technique/ returned 404.
+# -------------------------------------------------------------------------
+# BEGIN audited BSC technique routes
+RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
+RewriteRule ^(framework/bsc/technique/martigli-breathing-oscillation|framework/bsc/technique/martigli-binaural-hybrid|framework/bsc/technique/symmetry-permutation-entrainment|framework/bsc/technique/binaural-beat-stimulation|framework/bsc/technique/photic-rhythm-stimulation|framework/bsc/technique/audiovisual-rhythm-coordination|framework/bsc/technique/vibrotactile-rhythm-stimulation)/?$ https://labiosyncare.github.io/ [R=303,L]
+
+RewriteRule ^(framework/bsc/technique/martigli-breathing-oscillation|framework/bsc/technique/martigli-binaural-hybrid|framework/bsc/technique/symmetry-permutation-entrainment)/?$ https://labiosyncare.github.io/ontology/instances/frameworks/bsc.ttl [R=303,L]
+RewriteRule ^(framework/bsc/technique/binaural-beat-stimulation|framework/bsc/technique/photic-rhythm-stimulation|framework/bsc/technique/audiovisual-rhythm-coordination|framework/bsc/technique/vibrotactile-rhythm-stimulation)/?$ https://labiosyncare.github.io/ontology/sstim-vocab.ttl [R=303,L]
+# END audited BSC technique routes
+
+# -------------------------------------------------------------------------
 # Live ecosystem identifier namespaces. Dataset membership belongs to the
 # mutable RDF projection, not this registry configuration: new, corrected, or
 # retracted records therefore do not require a w3id.org rule change. The


### PR DESCRIPTION
## Brief Description

Adds exact w3id routes for the seven SSTIM BSC framework technique IRIs under `sstim/framework/bsc/technique/`. None of them currently resolve: the existing audited catalog block in `sstim/.htaccess` matches `^framework/bsc/?$` exactly, so every technique path 404s (verified against live w3id 2026-07-19). This is a pure addition — no existing route is changed.

Three techniques the BSC framework originated (Martigli breathing oscillation, the Martigli-Binaural hybrid, Symmetry permutation entrainment) resolve to the framework document that defines them. Four retired as framework-scoped duplicates of vendor-neutral SSTIM vocabulary concepts (binaural beats, photic driving, audiovisual entrainment, vibrotactile entrainment — see [ADR 0033](https://github.com/laBioSynCare/laBioSynCare.github.io/blob/main/docs/decisions/0033-framework-scope-and-generic-technique-deduplication.md)) resolve instead to `sstim-vocab.ttl`, where their replacements now live.

Every rule is an exact match, not a `technique/` prefix wildcard, so a retired slug can never fall through to the framework file and read as current. This follows the same audited/fail-closed pattern as the existing catalog block, enforced by this project's `scripts/sstim-quality-audit.py`.

Provenance: staged and committed at [laBioSynCare.github.io@8f71e61](https://github.com/laBioSynCare/laBioSynCare.github.io/commit/8f71e61), part of the SSTIM 0.8.0 release ([CHANGELOG](https://github.com/laBioSynCare/laBioSynCare.github.io/blob/main/CHANGELOG.md#080---2026-07-20)).

## General Checklist

- [x] Changes have been tested. All three redirect targets return 200 with correct Content-Type (text/turtle or text/html) and CORS; the local `make validate` route-block audit was negative-tested against a swapped target and a prefix wildcard to confirm it actually rejects malformed rules, not just accepts good ones.
- [x] The number of commits is minimal (one).
- [x] Commits only include redirects and basic information.

## Update ID Directory Checklist

- [x] GitHub username ids are listed in the changed maintainer details — unchanged from the existing `sstim` directory (ttm), which already maintains this namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
