### PR TITLE
Add Certi OpenBadge v3 vocabulary redirects

### DIFF
--- a/certi/.htaccess
+++ b/certi/.htaccess
@@ -4,4 +4,6 @@ Options +FollowSymLinks
 RewriteEngine on
 RewriteRule ^$ https://www.certi.world [R=302,L]
 RewriteRule ^v1$ https://api.certi.world/jsonld/v1/schema/context.json [R=302,L]
+RewriteRule ^v3/contexts/merkle-proof-v1\.json$ https://nftime24.github.io/certi-vocabulary/v3/contexts/merkle-proof-v1.jsonld [R=302,L]
+RewriteRule ^v3/?$ https://nftime24.github.io/certi-vocabulary/v3/ [R=302,L]
 RewriteRule ^(.*)$ https://api.certi.world/jsonld/$1 [R=302,L]

--- a/certi/README.md
+++ b/certi/README.md
@@ -10,6 +10,18 @@ JSON-LD contexts:
 
 https://w3id.org/certi/v1
 
+https://w3id.org/certi/v3/contexts/merkle-proof-v1.json
+
+
+Vocabulary documentation:
+
+https://w3id.org/certi/v3
+
+
+Source repository:
+
+https://github.com/NFTime24/certi-vocabulary
+
 Contacts:
 
 sircoon4@nftime.world


### PR DESCRIPTION
## Brief Description

Add permanent Certi OpenBadge 3.0 vocabulary and JSON-LD context redirects.

- `https://w3id.org/certi/v3` redirects to the bilingual vocabulary documentation hosted by NFTime24 GitHub Pages.
- `https://w3id.org/certi/v3/contexts/merkle-proof-v1.json` redirects to the immutable JSON-LD context.
- Existing Certi root, v1, and fallback redirects remain unchanged.

The target repository is <https://github.com/NFTime24/certi-vocabulary>. Its validation workflow and GitHub Pages deployment are passing.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal.
- [x] The commit only includes redirects and basic information.

## Update ID Directory Checklist

- [x] The GitHub username remains listed in the maintainer details.
- [x] The submitting GitHub account (`@sircoon4`) is listed as a maintainer.

## Verification

- The context target responds with HTTP 200, `Content-Type: application/ld+json`, and `Access-Control-Allow-Origin: *`.
- The documentation target responds with HTTP 200 and contains exact fragment anchors for every Certi v3 term.
