### PR TITLE
aio: resolve base/full release products (owl, obo, json)

### DIFF
--- a/aio/.htaccess
+++ b/aio/.htaccess
@@ -5,6 +5,15 @@ RewriteRule ^$ https://github.com/berkeleybop/artificial-intelligence-ontology [
 
 RewriteRule ^aio.owl$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio.owl [R=302,L]
 
+RewriteRule ^aio-base.owl$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio-base.owl [R=302,L]
+RewriteRule ^aio-full.owl$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio-full.owl [R=302,L]
+RewriteRule ^aio.obo$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio.obo [R=302,L]
+RewriteRule ^aio-base.obo$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio-base.obo [R=302,L]
+RewriteRule ^aio-full.obo$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio-full.obo [R=302,L]
+RewriteRule ^aio.json$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio.json [R=302,L]
+RewriteRule ^aio-base.json$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio-base.json [R=302,L]
+RewriteRule ^aio-full.json$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio-full.json [R=302,L]
+
 RewriteRule ^aio-src.csv$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/refs/heads/main/src/ontology/aio-src.csv [R=302,L]
 
 RewriteRule ^bridge/aio-bridge-to-upper.owl$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/src/ontology/bridge/aio-bridge-to-upper.owl [R=302,L]

--- a/aio/.htaccess
+++ b/aio/.htaccess
@@ -3,16 +3,16 @@ RewriteEngine on
 
 RewriteRule ^$ https://github.com/berkeleybop/artificial-intelligence-ontology [R=302,L]
 
-RewriteRule ^aio.owl$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio.owl [R=302,L]
+RewriteRule ^aio\.owl$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio.owl [R=302,L]
 
-RewriteRule ^aio-base.owl$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio-base.owl [R=302,L]
-RewriteRule ^aio-full.owl$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio-full.owl [R=302,L]
-RewriteRule ^aio.obo$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio.obo [R=302,L]
-RewriteRule ^aio-base.obo$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio-base.obo [R=302,L]
-RewriteRule ^aio-full.obo$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio-full.obo [R=302,L]
-RewriteRule ^aio.json$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio.json [R=302,L]
-RewriteRule ^aio-base.json$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio-base.json [R=302,L]
-RewriteRule ^aio-full.json$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio-full.json [R=302,L]
+RewriteRule ^aio-base\.owl$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio-base.owl [R=302,L]
+RewriteRule ^aio-full\.owl$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio-full.owl [R=302,L]
+RewriteRule ^aio\.obo$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio.obo [R=302,L]
+RewriteRule ^aio-base\.obo$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio-base.obo [R=302,L]
+RewriteRule ^aio-full\.obo$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio-full.obo [R=302,L]
+RewriteRule ^aio\.json$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio.json [R=302,L]
+RewriteRule ^aio-base\.json$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio-base.json [R=302,L]
+RewriteRule ^aio-full\.json$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/main/aio-full.json [R=302,L]
 
 RewriteRule ^aio-src.csv$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/refs/heads/main/src/ontology/aio-src.csv [R=302,L]
 


### PR DESCRIPTION
Adds redirect rules to the existing `aio/` namespace so the AIO release products resolve, the same way `aio.owl` already does.

Today only `aio.owl` resolves. The registered ontology product `aio-full.owl` (and `aio-base.owl`, plus the `.obo` and `.json` serializations) fall through to the catch-all and do not resolve to the ontology. This PR adds one rule per product, each identical in form to the existing `aio.owl` rule, pointing at the raw file on `main`. All redirect targets return 200.

No existing rule is changed; the diff is purely additive.
