### PR TITLE
metpo: resolve base/full release products (owl, obo, json)

### DIFF
--- a/metpo/.htaccess
+++ b/metpo/.htaccess
@@ -3,15 +3,15 @@ RewriteEngine on
 
 RewriteRule ^$ https://github.com/berkeleybop/metpo [R=302,L]
 
-RewriteRule ^metpo.owl$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo.owl [R=302,L]
+RewriteRule ^metpo\.owl$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo.owl [R=302,L]
 
-RewriteRule ^metpo-base.owl$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo-base.owl [R=302,L]
-RewriteRule ^metpo-full.owl$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo-full.owl [R=302,L]
-RewriteRule ^metpo.obo$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo.obo [R=302,L]
-RewriteRule ^metpo-base.obo$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo-base.obo [R=302,L]
-RewriteRule ^metpo-full.obo$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo-full.obo [R=302,L]
-RewriteRule ^metpo.json$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo.json [R=302,L]
-RewriteRule ^metpo-base.json$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo-base.json [R=302,L]
-RewriteRule ^metpo-full.json$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo-full.json [R=302,L]
+RewriteRule ^metpo-base\.owl$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo-base.owl [R=302,L]
+RewriteRule ^metpo-full\.owl$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo-full.owl [R=302,L]
+RewriteRule ^metpo\.obo$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo.obo [R=302,L]
+RewriteRule ^metpo-base\.obo$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo-base.obo [R=302,L]
+RewriteRule ^metpo-full\.obo$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo-full.obo [R=302,L]
+RewriteRule ^metpo\.json$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo.json [R=302,L]
+RewriteRule ^metpo-base\.json$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo-base.json [R=302,L]
+RewriteRule ^metpo-full\.json$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo-full.json [R=302,L]
 
 RewriteRule ^(.*)$ https://bioportal.bioontology.org/ontologies/METPO/?p=classes&conceptid=https://w3id.org/metpo/$1 [R=302,L,NE]

--- a/metpo/.htaccess
+++ b/metpo/.htaccess
@@ -5,4 +5,13 @@ RewriteRule ^$ https://github.com/berkeleybop/metpo [R=302,L]
 
 RewriteRule ^metpo.owl$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo.owl [R=302,L]
 
+RewriteRule ^metpo-base.owl$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo-base.owl [R=302,L]
+RewriteRule ^metpo-full.owl$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo-full.owl [R=302,L]
+RewriteRule ^metpo.obo$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo.obo [R=302,L]
+RewriteRule ^metpo-base.obo$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo-base.obo [R=302,L]
+RewriteRule ^metpo-full.obo$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo-full.obo [R=302,L]
+RewriteRule ^metpo.json$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo.json [R=302,L]
+RewriteRule ^metpo-base.json$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo-base.json [R=302,L]
+RewriteRule ^metpo-full.json$ https://raw.githubusercontent.com/berkeleybop/metpo/main/metpo-full.json [R=302,L]
+
 RewriteRule ^(.*)$ https://bioportal.bioontology.org/ontologies/METPO/?p=classes&conceptid=https://w3id.org/metpo/$1 [R=302,L,NE]


### PR DESCRIPTION
Adds redirect rules to the existing `metpo/` namespace so the METPO release products resolve, the same way `metpo.owl` already does.

Today only `metpo.owl` resolves. The base and full sub-artifacts, plus the `.obo` and `.json` serializations, fall through to the catch-all and do not resolve to the ontology. This PR adds one rule per product, each identical in form to the existing `metpo.owl` rule, pointing at the raw file on `main`. All redirect targets return 200.

No existing rule is changed; the diff is purely additive.

Contact: Mark A. Miller <MAM@lbl.gov>, maintainer of the METPO namespace.
