### PR TITLE
aio: resolve versioned release IRIs (releases/YYYY-MM-DD/)

### DIFF
--- a/aio/.htaccess
+++ b/aio/.htaccess
@@ -20,4 +20,7 @@ RewriteRule ^bridge/aio-bridge-to-upper.owl$ https://raw.githubusercontent.com/b
 
 RewriteRule ^mappings$ https://github.com/berkeleybop/artificial-intelligence-ontology/tree/main/src/mappings [R=302,L]
 
+# Versioned release IRIs resolve to the immutable bytes at the matching git tag (vYYYY-MM-DD)
+RewriteRule ^releases/([0-9]{4}-[0-9]{2}-[0-9]{2})/(aio(-base|-full)?\.(owl|obo|json))$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/v$1/$2 [R=302,L]
+
 RewriteRule ^(.*)$ https://bioportal.bioontology.org/ontologies/AIO/?p=classes&conceptid=https://w3id.org/aio/$1 [R=302,L,NE]


### PR DESCRIPTION
Adds a single rule so AIO versioned-release IRIs resolve.

`https://w3id.org/aio/releases/2026-07-22/aio.owl` is the version IRI minted in the released ontology, but it currently falls through to the BioPortal catch-all and 403s. This rule maps `releases/<date>/<product>` to the immutable bytes committed at the matching git tag `v<date>`:

```
RewriteRule ^releases/([0-9]{4}-[0-9]{2}-[0-9]{2})/(aio(-base|-full)?\.(owl|obo|json))$ https://raw.githubusercontent.com/berkeleybop/artificial-intelligence-ontology/v$1/$2 [R=302,L]
```

It targets the tag tree on `raw.githubusercontent.com`, so it works from the committed release snapshot and does not depend on GitHub release assets. Verified: all nine products (`aio`, `aio-base`, `aio-full` in `.owl`/`.obo`/`.json`) return 200 at `.../v2026-07-22/`.

Purely additive, placed before the BioPortal catch-all so it takes precedence. Follows #6399.