### PR TITLE
OSO: add text/n3 and application/json content negotiation (follow-up to #6408)

### DIFF
--- a/earthsemantics/OSO/.htaccess
+++ b/earthsemantics/OSO/.htaccess
@@ -43,6 +43,13 @@ RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://virtuoso.ifremer.fr/oso-version
 RewriteCond %{HTTP_ACCEPT} application/n-triples
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.nt [R=302,L]
 
+RewriteCond %{HTTP_ACCEPT} text/n3
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.n3 [R=302,L]
+
+# application/json -> OSO.json (twin of OSO.jsonld served as application/json)
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.json [R=302,L]
+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://emso-eric.github.io/oso-ontology/ [R=302,L]
@@ -98,6 +105,10 @@ RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.owl [R=302,L]
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
 RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.jsonld [R=302,L]
 
+# JSON (twin of JSON-LD served as application/json for EarthPortal checker)
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.json [R=302,L]
+
 # N-Triples
 RewriteCond %{HTTP_ACCEPT} application/n-triples
 RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.nt [R=302,L]
@@ -124,6 +135,7 @@ RewriteRule ^OSO\.ttl/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.ttl 
 RewriteRule ^OSO\.owl/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.owl [R=303,L]
 RewriteRule ^OSO\.rdf/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.owl [R=303,L]
 RewriteRule ^OSO\.jsonld/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.jsonld [R=303,L]
+RewriteRule ^OSO\.json/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.json [R=303,L]
 RewriteRule ^OSO\.nt/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.nt [R=303,L]
 RewriteRule ^OSO\.n3/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.n3 [R=303,L]
 RewriteRule ^OSO\.trig/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.trig [R=303,L]
@@ -131,6 +143,7 @@ RewriteRule ^ttl/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.ttl [R=30
 RewriteRule ^owl/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.owl [R=303,L]
 RewriteRule ^rdf/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.owl [R=303,L]
 RewriteRule ^jsonld/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.jsonld [R=303,L]
+RewriteRule ^json/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.json [R=303,L]
 RewriteRule ^nt/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.nt [R=303,L]
 RewriteRule ^n3/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.n3 [R=303,L]
 RewriteRule ^trig/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.trig [R=303,L]


### PR DESCRIPTION
## Summary

Follow-up to #6408 (merged). Adds two missing content-negotiation formats for the OSO ontology so the [EarthPortal resolvability checker](https://earthportal.eu/check_resolvability) reports them as resolvable.

## Context

The EarthPortal checker **follows redirects** and validates the **final** `Content-Type` against the `Accept` header (unlike O'FAIRe, which does not follow redirects). On the versioned IRI `https://w3id.org/earthsemantics/OSO/1.1.0/`, two formats returned **406** because they fell through to the default `OSO.ttl` (served as `text/turtle`):

| Accept | Before | After |
|--------|--------|-------|
| `text/n3` | 302 → OSO.ttl → **406** | 302 → OSO.n3 → **200 text/n3** |
| `application/json` | 302 → OSO.ttl → **406** | 302 → OSO.json → **200 application/json** |

## Changes

- `text/n3` → `OSO.n3` for the versioned IRI (already handled on the main IRI in #6408).
- `application/json` → `OSO.json` for both the versioned and main IRIs. JSON-LD's `application/ld+json` is treated as a distinct type by the checker, so a JSON twin resource is served literally as `application/json`.
- Explicit `OSO.json` / `json` serialization URLs.

## Note

The `OSO.json` twin resource is provisioned server-side on the Virtuoso DAV store (EMSO infrastructure); this PR only adds the w3id redirect rules. Existing formats from #6408 are unaffected.