### PR TITLE
Add Automation Bias Ontology persistent identifier

### DIFF
--- a/abo/.htaccess
+++ b/abo/.htaccess
@@ -1,0 +1,54 @@
+# Automation Bias Ontology (ABO)
+#
+# https://w3id.org/abo identifies the latest release of ABO.
+# https://w3id.org/abo/1.0.0 identifies release 1.0.0.
+#
+# Maintainer:
+# Arpita Gado
+# GitHub username: arpitagado-dotcom
+
+Options -MultiViews
+
+Header always set Access-Control-Allow-Origin "*"
+Header always set Vary "Accept"
+
+AddType application/ld+json .jsonld
+AddType application/n-triples .nt
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+
+RewriteEngine On
+
+# Latest release
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^$ https://arpitagado-dotcom.github.io/ABO/release/1.0.0/ontology.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples [NC]
+RewriteRule ^$ https://arpitagado-dotcom.github.io/ABO/release/1.0.0/ontology.nt [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC,OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [NC]
+RewriteRule ^$ https://arpitagado-dotcom.github.io/ABO/release/1.0.0/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC,OR]
+RewriteCond %{HTTP_ACCEPT} application/owl\+xml [NC]
+RewriteRule ^$ https://arpitagado-dotcom.github.io/ABO/release/1.0.0/ontology.owl [R=303,L]
+
+RewriteRule ^$ https://arpitagado-dotcom.github.io/ABO/release/1.0.0/index-en.html [R=303,L]
+
+# Release 1.0.0
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^1\.0\.0/?$ https://arpitagado-dotcom.github.io/ABO/release/1.0.0/ontology.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples [NC]
+RewriteRule ^1\.0\.0/?$ https://arpitagado-dotcom.github.io/ABO/release/1.0.0/ontology.nt [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC,OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [NC]
+RewriteRule ^1\.0\.0/?$ https://arpitagado-dotcom.github.io/ABO/release/1.0.0/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC,OR]
+RewriteCond %{HTTP_ACCEPT} application/owl\+xml [NC]
+RewriteRule ^1\.0\.0/?$ https://arpitagado-dotcom.github.io/ABO/release/1.0.0/ontology.owl [R=303,L]
+
+RewriteRule ^1\.0\.0/?$ https://arpitagado-dotcom.github.io/ABO/release/1.0.0/index-en.html [R=303,L]

--- a/abo/README.md
+++ b/abo/README.md
@@ -1,0 +1,27 @@
+# Automation Bias Ontology (ABO)
+
+This W3ID provides persistent identifiers for the Automation Bias Ontology
+(ABO), an ontology for representing contextual information surrounding human
+oversight decisions in AI-assisted decision-making systems.
+
+## Identifiers
+
+- `https://w3id.org/abo` identifies the latest ABO release.
+- `https://w3id.org/abo/1.0.0` identifies ABO release 1.0.0.
+
+Both identifiers support HTTP content negotiation:
+
+| Accept media type | Representation |
+| --- | --- |
+| `text/html`, browser requests, or other media types | HTML documentation |
+| `text/turtle` or `application/x-turtle` | Turtle |
+| `application/rdf+xml` or `application/owl+xml` | RDF/XML |
+| `application/ld+json` | JSON-LD |
+| `application/n-triples` | N-Triples |
+
+Ontology source and documentation:
+<https://github.com/arpitagado-dotcom/ABO>
+
+## Maintainer
+
+- Arpita Gado ([@arpitagado-dotcom](https://github.com/arpitagado-dotcom))


### PR DESCRIPTION
## Brief Description

This PR adds the `https://w3id.org/abo` namespace for the Automation Bias
Ontology (ABO).

The namespace provides:

- `https://w3id.org/abo` for the latest release
- `https://w3id.org/abo/1.0.0` for the immutable 1.0.0 release
- content negotiation for HTML, Turtle, RDF/XML, JSON-LD, and N-Triples

Both identifiers redirect with HTTP 303 to the corresponding files hosted at
`https://arpitagado-dotcom.github.io/ABO/release/1.0.0/`.

The sole maintainer is @arpitagado-dotcom. Arpita, please confirm that you agree
to maintain this W3ID namespace.

## Validation

- Tested the rules using Apache HTTP Server 2.4 with the repository's root
  `.htaccess` active.
- Verified the latest and versioned identifiers with HTML, XHTML, JSON-LD,
  N-Triples, Turtle, RDF/XML, OWL/XML, wildcard, and mixed explicit/wildcard
  `Accept` headers.
- Verified both GET and HEAD requests.
- Verified CORS and `Vary: Accept` response headers.
- Verified all redirect destinations return HTTP 200 with the expected media
  types.
- Verified unknown versions are not redirected.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` and `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Optional Requests for W3ID Maintainers

- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
