### PR TITLE
Update biodivrisK-onto redirect to WIDOCO documentation

### DIFF
--- a/biodivrisK-onto/.htaccess
+++ b/biodivrisK-onto/.htaccess
@@ -1,13 +1,9 @@
 Options -MultiViews
 AddType text/turtle .ttl
 AddType application/rdf+xml .owl
-
 RewriteEngine on
-
 RewriteCond %{HTTP_ACCEPT} text/turtle
 RewriteRule ^$ https://raw.githubusercontent.com/marcosdzarate/biorisk-ai/main/ontology/biodivrisK-onto.ttl [R=303,L]
-
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
 RewriteRule ^$ https://raw.githubusercontent.com/marcosdzarate/biorisk-ai/main/ontology/biodivrisK-onto.owl [R=303,L]
-
-RewriteRule ^$ https://github.com/marcosdzarate/biorisk-ai/tree/main/ontology [R=303,L]
+RewriteRule ^$ https://marcosdzarate.github.io/biorisk-ai/ontology/docs/ [R=303,L]

--- a/biodivrisK-onto/.htaccess
+++ b/biodivrisK-onto/.htaccess
@@ -6,4 +6,4 @@ RewriteCond %{HTTP_ACCEPT} text/turtle
 RewriteRule ^$ https://raw.githubusercontent.com/marcosdzarate/biorisk-ai/main/ontology/biodivrisK-onto.ttl [R=303,L]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
 RewriteRule ^$ https://raw.githubusercontent.com/marcosdzarate/biorisk-ai/main/ontology/biodivrisK-onto.owl [R=303,L]
-RewriteRule ^$ https://marcosdzarate.github.io/biorisk-ai/ontology/docs/ [R=303,L]
+RewriteRule ^$ https://marcosdzarate.github.io/biorisk-ai/ [R=303,L]


### PR DESCRIPTION
## Brief Description
Update redirect for https://w3id.org/biodivrisK-onto from GitHub tree 
to WIDOCO documentation at GitHub Pages.

- Previous target: https://github.com/marcosdzarate/biorisk-ai/tree/main/ontology
- New target: https://marcosdzarate.github.io/biorisk-ai/

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information.

## Update ID Directory Checklist
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR (marcosdzarate) is listed 
      as maintainer of the biodivrisK-onto directory.

## Optional Requests for W3ID Maintainers
- [x] Please squash commits for me.