### PR TITLE
Add persistent URI redirects for CWEO ontology

### DIFF
--- a/cweo/.htaccess
+++ b/cweo/.htaccess
@@ -1,0 +1,35 @@
+Options +FollowSymLinks
+RewriteEngine On
+
+# RDF/XML / OWL
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/owl\+xml
+RewriteRule ^$ https://xiaolisong1126.github.io/cweo/ontology.owl [R=303,L]
+
+# Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^$ https://xiaolisong1126.github.io/cweo/ontology.ttl [R=303,L]
+
+# JSON-LD
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://xiaolisong1126.github.io/cweo/ontology.jsonld [R=303,L]
+
+# N-Triples
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://xiaolisong1126.github.io/cweo/ontology.nt [R=303,L]
+
+# HTML for browsers
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://xiaolisong1126.github.io/cweo/ [R=303,L]
+
+# Direct file redirects
+RewriteRule ^ontology\.owl$ https://xiaolisong1126.github.io/cweo/ontology.owl [R=303,L]
+RewriteRule ^ontology\.ttl$ https://xiaolisong1126.github.io/cweo/ontology.ttl [R=303,L]
+RewriteRule ^ontology\.jsonld$ https://xiaolisong1126.github.io/cweo/ontology.jsonld [R=303,L]
+RewriteRule ^ontology\.nt$ https://xiaolisong1126.github.io/cweo/ontology.nt [R=303,L]
+
+# Fallback
+RewriteRule ^$ https://xiaolisong1126.github.io/cweo/ontology.ttl [R=303,L]

--- a/cweo/README.md
+++ b/cweo/README.md
@@ -1,0 +1,21 @@
+# CWEO: Crack Width Evolution Ontology
+
+This directory provides persistent URI redirection rules for the Crack Width Evolution Ontology (CWEO).
+
+## Ontology
+
+- Ontology IRI: `https://w3id.org/cweo`
+- Namespace URI: `https://w3id.org/cweo#`
+- Preferred prefix: `cweo`
+
+## Repository
+
+The ontology source files are maintained at:
+
+```text
+https://github.com/XiaoliSong1126/cweo
+```
+
+## Contact
+
+- Xiaoli Song: <xiaoli.song@tu-dresden.de>

--- a/cweo/README.md
+++ b/cweo/README.md
@@ -18,4 +18,6 @@ https://github.com/XiaoliSong1126/cweo
 
 ## Contact
 
-- Xiaoli Song: <xiaoli.song@tu-dresden.de>
+- **Name:** Xiaoli Song
+- **GitHub:** [@XiaoliSong1126](https://github.com/XiaoliSong1126)
+- **Email:** <xiaoli.song@tu-dresden.de>


### PR DESCRIPTION
This PR adds persistent URI redirects for the Crack Width Evolution Ontology (CWEO).

- Ontology IRI: https://w3id.org/cweo
- Namespace URI: https://w3id.org/cweo#
- Preferred prefix: cweo
- Documentation: https://xiaolisong1126.github.io/cweo/
- Repository: https://github.com/XiaoliSong1126/cweo

The redirect configuration supports content negotiation for:
- RDF/XML / OWL
- Turtle
- JSON-LD
- HTML documentation