### PR TITLE
Add dating-profile: Dating Profile Vocabulary

### DIFF
--- a/dating-profile/.htaccess
+++ b/dating-profile/.htaccess
@@ -1,0 +1,24 @@
+# https://w3id.org/dating-profile
+#
+# Dating Profile Vocabulary — an open vocabulary for publishing
+# machine-readable dating profiles on personal websites.
+#
+# ## Contact
+# This space is administered by:
+#
+# Aaron Bailey
+# GitHub username: aaronbailey
+# Email: aaron@aaronbailey.com
+
+RewriteEngine on
+
+# JSON-LD context via content negotiation
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^$ https://aaronbailey.github.io/dating-profile/context.jsonld [R=303,L]
+
+# Explicit context path
+RewriteRule ^context(\.jsonld)?$ https://aaronbailey.github.io/dating-profile/context.jsonld [R=303,L]
+
+# Default: human-readable specification
+RewriteRule ^(.*)$ https://aaronbailey.github.io/dating-profile/$1 [R=303,L]

--- a/dating-profile/README.md
+++ b/dating-profile/README.md
@@ -1,0 +1,16 @@
+# Dating Profile Vocabulary
+
+An open vocabulary for publishing machine-readable dating profiles on
+personal websites, extending Schema.org with dating-specific fields
+(identity, lifestyle, family intent, and partner preferences) so that
+profiles on independent sites can be discovered and matched without a
+centralized platform.
+
+- https://w3id.org/dating-profile redirects to
+  https://aaronbailey.github.io/dating-profile/ (specification)
+- Requests with `Accept: application/ld+json` (and the `/context` path)
+  redirect to the JSON-LD context:
+  https://aaronbailey.github.io/dating-profile/context.jsonld
+- Source repository: https://github.com/aaronbailey/dating-profile
+
+Maintainer: Aaron Bailey (GitHub: [@aaronbailey](https://github.com/aaronbailey), aaron@aaronbailey.com)


### PR DESCRIPTION
Adds a new permanent identifier for the **Dating Profile Vocabulary** — an open vocabulary for publishing machine-readable dating profiles on personal websites, extending Schema.org with dating-specific fields so profiles on independent sites can be discovered and matched without a centralized platform.

**Redirects:**
- `https://w3id.org/dating-profile` → https://aaronbailey.github.io/dating-profile/ (specification, 303)
- `Accept: application/ld+json` requests and `/dating-profile/context` → https://aaronbailey.github.io/dating-profile/context.jsonld (303)

Both targets are live. Source repository: https://github.com/aaronbailey/dating-profile

**Contact:** Aaron Bailey (GitHub: @aaronbailey, aaron@aaronbailey.com) — contact info is included in both the `.htaccess` comment and the directory `README.md`.