### PR TITLE
cdif: add NE flag on xas/{concept} fragment redirect

### DIFF
--- a/cdif/.htaccess
+++ b/cdif/.htaccess
@@ -206,7 +206,10 @@ RewriteCond %{HTTP_ACCEPT} application/json
 RewriteRule ^xas/([a-z][a-z0-9-]*)/?$ %{ENV:XAS_PAGES}/concepts/$1.jsonld [R=303,L]
 
 # --- xas/{concept} → single-page HTML fragment (default) ---
-RewriteRule ^xas/([a-z][a-z0-9-]*)/?$ %{ENV:XAS_PAGES}/#$1 [R=303,L]
+# NE (noescape) prevents Apache from percent-encoding the fragment '#',
+# so the browser receives a real fragment identifier and scrolls to the
+# right section instead of requesting /XAS-CDIF/%23{concept}.
+RewriteRule ^xas/([a-z][a-z0-9-]*)/?$ %{ENV:XAS_PAGES}/#$1 [R=303,L,NE]
 
 # --- xas/ → master SKOS document (Accept: JSON-LD) ---
 RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]


### PR DESCRIPTION
Apache mod_rewrite was percent-encoding the '#' in the substitution URL, so https://w3id.org/cdif/xas/pointgroup was redirecting to https://smrgeoinfo.github.io/XAS-CDIF/%23pointgroup — 404 because there is no file named '%23pointgroup'. NE (noescape) leaves the '#' intact so the browser receives a real fragment identifier and scrolls to the right section of the single-page glossary.

fix the rewrite.