### PR TITLE
Update DEC viewer redirect

### DIFF
--- a/conjectures/.htaccess
+++ b/conjectures/.htaccess
@@ -1,8 +1,8 @@
 RewriteEngine On
 
 # DEC live viewer.
-RewriteRule   "^dec/?$" https://dec.fabiovitali.it/ [R=302,L,QSA]
-RewriteRule   "^dec/viewer/?$" https://dec.fabiovitali.it/ [R=302,L,QSA]
+RewriteRule   "^dec/?$" http://site252625.tw.cs.unibo.it/ [R=302,L,QSA]
+RewriteRule   "^dec/viewer/?$" http://site252625.tw.cs.unibo.it/ [R=302,L,QSA]
 
 # DEC source code.
 RewriteRule "^dec/code/?$" https://github.com/fvitali/dec-reasoner [R=302,L,QSA]


### PR DESCRIPTION
Updates the DEC live viewer redirects under /conjectures/dec and /conjectures/dec/viewer to point to the current University of Bologna deployment.

The source-code redirects are unchanged.