### PR TITLE
OSO: fix trailing-slash redirect, disable directory listings, add Content-Type overrides

### DIFF
--- a/earthsemantics/OSO/.htaccess
+++ b/earthsemantics/OSO/.htaccess
@@ -18,11 +18,15 @@ SetEnvIf Accept "application/json" CT_JSON
 SetEnvIf Accept "application/xml" CT_XML
 SetEnvIf Accept "text/plain" CT_PLAIN
 SetEnvIf Accept "application/rdf\+xml" CT_RDFXML
+SetEnvIf Accept "text/turtle" CT_TURTLE
+SetEnvIf Accept "text/n3" CT_N3
 
 Header always set Content-Type "application/json" env=CT_JSON
 Header always set Content-Type "application/xml" env=CT_XML
 Header always set Content-Type "text/plain" env=CT_PLAIN
 Header always set Content-Type "application/rdf+xml" env=CT_RDFXML
+Header always set Content-Type "text/turtle" env=CT_TURTLE
+Header always set Content-Type "text/n3" env=CT_N3
 
 # ====================================================================
 # Versioned ontology IRI content negotiation

--- a/earthsemantics/OSO/.htaccess
+++ b/earthsemantics/OSO/.htaccess
@@ -1,4 +1,4 @@
-Options +FollowSymLinks
+Options +FollowSymLinks -Indexes
 RewriteEngine On
 DirectorySlash Off
 
@@ -27,6 +27,14 @@ Header always set Content-Type "text/plain" env=CT_PLAIN
 Header always set Content-Type "application/rdf+xml" env=CT_RDFXML
 Header always set Content-Type "text/turtle" env=CT_TURTLE
 Header always set Content-Type "text/n3" env=CT_N3
+
+# ====================================================================
+# Redirect directory root without trailing slash to trailing slash
+# ====================================================================
+
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteCond %{REQUEST_URI} !/$
+RewriteRule ^.*$ %{REQUEST_URI}/ [R=302,L]
 
 # ====================================================================
 # Versioned ontology IRI content negotiation


### PR DESCRIPTION
## Summary

Fixes the XML parsing error visible in browsers when accessing `https://w3id.org/earthsemantics/OSO` (without trailing slash).

### Changes to `earthsemantics/OSO/.htaccess`

1. **`Options -Indexes`** — Disable Apache directory autoindex to prevent malformed XML responses when directory listing is served with a forced `application/xml` Content-Type.

2. **Redirect `/OSO` → `/OSO/` (302)** — When the ontology IRI is requested without a trailing slash, Apache was returning a directory listing (HTTP 200) instead of redirecting. The `Header always set Content-Type` directives (needed for O'FAIRe A1Q3 content negotiation compatibility) were overriding the Content-Type on this 200 response, causing browsers to interpret the HTML autoindex as XML and fail with:
   > `error on line 1 at column 55: Space required after the Public Identifier`

   The fix adds a `RewriteRule` that redirects directory requests without trailing slash to the trailing-slash URL with `R=302,L` (302 for O'FAIRe compatibility, which only accepts 200/302).

3. **Content-Type override for `text/turtle` and `text/n3`** — Adds `SetEnvIf` + `Header always set` rules for `text/turtle` and `text/n3` Accept headers, ensuring O'FAIRe's `ResolvableURLTest` (which does not follow redirects and requires exact Content-Type match on 302 responses) passes for these formats.

### Context

These changes were developed while running the [O'FAIRe](https://services.earthportal.eu/ofaire/) FAIRness assessment on the OSO ontology. The existing `.htaccess` rules (merged in #6408) were close but missing the trailing-slash redirect and the turtle/n3 Content-Type overrides.