### PR TITLE
Add /sunstone for Sunstone Institute

### DIFF
--- a/sunstone/.htaccess
+++ b/sunstone/.htaccess
@@ -1,0 +1,27 @@
+# Sunstone Institute RDF registry
+# Redirects https://w3id.org/sunstone/* to https://sunstone.institute/rdf/*
+RewriteEngine on
+
+# Paths with an explicit format extension: redirect as-is
+RewriteRule ^(.*\.(ttl|jsonld|rdf|html|md))$ https://sunstone.institute/rdf/$1 [R=302,NE,L]
+
+## Content negotiation for extension-less resource IRIs
+# RDF 1.2 Turtle (opt-in via profile parameter)
+RewriteCond %{HTTP_ACCEPT} text/turtle.*profile="?https://sunstone\.institute/ns/rdf-1\.2"? [NC]
+RewriteRule ^(.*[^/])$ https://sunstone.institute/rdf/$1.1-2.ttl [R=302,NE,L]
+
+# Turtle (RDF 1.1)
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^(.*[^/])$ https://sunstone.institute/rdf/$1.ttl [R=302,NE,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^(.*[^/])$ https://sunstone.institute/rdf/$1.jsonld [R=302,NE,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^(.*[^/])$ https://sunstone.institute/rdf/$1.rdf [R=302,NE,L]
+
+RewriteCond %{HTTP_ACCEPT} text/markdown [NC]
+RewriteRule ^(.*[^/])$ https://sunstone.institute/rdf/$1.md [R=302,NE,L]
+
+# Everything else (browsers, HTML, no Accept): origin negotiates
+RewriteRule ^(.*)$ https://sunstone.institute/rdf/$1 [R=302,NE,L]

--- a/sunstone/README.md
+++ b/sunstone/README.md
@@ -1,0 +1,12 @@
+# Sunstone Institute RDF Registry
+
+Ontologies, concept schemes, and mappings published by Sunstone Institute.
+
+* https://w3id.org/sunstone/ redirects to https://sunstone.institute/rdf/
+
+Supported formats via content negotiation: HTML, Turtle (RDF 1.1 default,
+RDF 1.2 via `Accept: text/turtle; version="1.2"`),
+RDF/XML, JSON-LD, Markdown.
+
+## Contacts:
+* Stig Bakken <stig@sunstoneinstitute.ai> @stigsb


### PR DESCRIPTION
Redirects https://w3id.org/sunstone/ to https://sunstone.institute/rdf/ which contains ontologies, concepts and mappings for categorizing scientific, media and policy documents.

<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
