### PR TITLE
Update MAO redirect from DomesticBeethoven to mss2221

### DIFF
--- a/music-annotation/.htaccess
+++ b/music-annotation/.htaccess
@@ -16,48 +16,48 @@ RewriteEngine on
 
 # Rewrite rule to serve RDF/XML content if requested
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/1.0/music-annotation-ontology.rdf [R=303,L]
+RewriteRule ^(latest)?/?$ https://mss2221.github.io/ontology/mao/1.0/music-annotation-ontology.rdf [R=303,L]
 
 # Rewrite rule to serve JSON-LD content if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/1.0/music-annotation-ontology.jsonld [R=303,L]
+RewriteRule ^(latest)?/?$ https://mss2221.github.io/ontology/mao/1.0/music-annotation-ontology.jsonld [R=303,L]
 
 # Rewrite rule to serve N-Quads content if requested
 RewriteCond %{HTTP_ACCEPT} application/n-quads
-RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/1.0/music-annotation-ontology.nq [R=303,L]
+RewriteRule ^(latest)?/?$ https://mss2221.github.io/ontology/mao/1.0/music-annotation-ontology.nq [R=303,L]
 
 # Rewrite rule to serve N-Triples content if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/1.0/music-annotation-ontology.nt [R=303,L]
+RewriteRule ^(latest)?/?$ https://mss2221.github.io/ontology/mao/1.0/music-annotation-ontology.nt [R=303,L]
 
 # Rewrite rule to serve Turtle content if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/1.0/music-annotation-ontology.ttl [R=303,L]
+RewriteRule ^(latest)?/?$ https://mss2221.github.io/ontology/mao/1.0/music-annotation-ontology.ttl [R=303,L]
 
 # Fallback: serve HTML if no recognised format is requested
-RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/1.0/music-annotation-ontology.html [R=303,L]
+RewriteRule ^(latest)?/?$ https://mss2221.github.io/ontology/mao/1.0/music-annotation-ontology.html [R=303,L]
 
 ## We assume that a path of the form [0-9]+.[0-9]+ is a version number and should be persisted
 
 # Rewrite rule to serve RDF/XML content if requested
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^([0-9]+[.][0-9]+)/?$ https://domestic-beethoven.eu/ontology/$1/music-annotation-ontology.rdf [R=303,L]
+RewriteRule ^([0-9]+[.][0-9]+)/?$ https://mss2221.github.io/ontology/mao/$1/music-annotation-ontology.rdf [R=303,L]
 
 # Rewrite rule to serve JSON-LD content if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^([0-9]+[.][0-9]+)/?$ https://domestic-beethoven.eu/ontology/$1/music-annotation-ontology.jsonld [R=303,L]
+RewriteRule ^([0-9]+[.][0-9]+)/?$ https://mss2221.github.io/ontology/mao/$1/music-annotation-ontology.jsonld [R=303,L]
 
 # Rewrite rule to serve N-Quads content if requested
 RewriteCond %{HTTP_ACCEPT} application/n-quads
-RewriteRule ^([0-9]+[.][0-9]+)/?$ https://domestic-beethoven.eu/ontology/$1/music-annotation-ontology.nq [R=303,L]
+RewriteRule ^([0-9]+[.][0-9]+)/?$ https://mss2221.github.io/ontology/mao/$1/music-annotation-ontology.nq [R=303,L]
 
 # Rewrite rule to serve N-Triples content if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^([0-9]+[.][0-9]+)/?$ https://domestic-beethoven.eu/ontology/$1/music-annotation-ontology.nt [R=303,L]
+RewriteRule ^([0-9]+[.][0-9]+)/?$ https://mss2221.github.io/ontology/mao/$1/music-annotation-ontology.nt [R=303,L]
 
 # Rewrite rule to serve Turtle content if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^([0-9]+[.][0-9]+)/?$ https://domestic-beethoven.eu/ontology/$1/music-annotation-ontology.ttl [R=303,L]
+RewriteRule ^([0-9]+[.][0-9]+)/?$ https://mss2221.github.io/ontology/mao/$1/music-annotation-ontology.ttl [R=303,L]
 
 # Fallback: serve HTML if no recognised format is requested
-RewriteRule ^([0-9]+[.][0-9]+)/?$ https://domestic-beethoven.eu/ontology/$1/music-annotation-ontology.html [R=303,L]
+RewriteRule ^([0-9]+[.][0-9]+)/?$ https://mss2221.github.io/ontology/mao/$1/music-annotation-ontology.html [R=303,L]


### PR DESCRIPTION
## Brief Description
Repoints the w3id.org/mao redirect from the now-inactive DomesticBeethoven 
repository to mss2221/ontology, where the Music Annotation Ontology is 
currently maintained and served via GitHub Pages.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
