### PR TITLE
Repoint w3id.org/sda redirect to mss2221

### DIFF
--- a/sda/.htaccess
+++ b/sda/.htaccess
@@ -15,40 +15,40 @@ RewriteEngine on
 
 # Rewrite rule to serve RDF/XML content if requested
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/sda/1.0/sda-ontology.rdf [R=303,L]
+RewriteRule ^(latest)?/?$ https://mss2221.github.io/ontology/sda/1.0/sda-ontology.rdf [R=303,L]
 
 # Rewrite rule to serve N-Triples content if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/sda/1.0/sda-ontology.nt [R=303,L]
+RewriteRule ^(latest)?/?$ https://mss2221.github.io/ontology/sda/1.0/sda-ontology.nt [R=303,L]
 
 # Rewrite rule to serve JSON-LD content if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/sda/1.0/sda-ontology.jsonld [R=303,L]
+RewriteRule ^(latest)?/?$ https://mss2221.github.io/ontology/sda/1.0/sda-ontology.jsonld [R=303,L]
 
 # Rewrite rule to serve Turtle content if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/sda/1.0/sda-ontology.ttl [R=303,L]
+RewriteRule ^(latest)?/?$ https://mss2221.github.io/ontology/sda/1.0/sda-ontology.ttl [R=303,L]
 
 # Fallback to HTML landing page
-RewriteRule ^(latest)?/?$ https://domestic-beethoven.eu/ontology/sda/1.0/sda-ontology.html [R=303,L]
+RewriteRule ^(latest)?/?$ https://mss2221.github.io/ontology/sda/1.0/sda-ontology.html [R=303,L]
 
 ## We assume that a path of the form [0-9]+.[0-9]+ is a version number and should be persisted
 
 # Rewrite rule to serve RDF/XML content if requested
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^([0-9]+[.][0-9]+)/?$ https://domestic-beethoven.eu/ontology/sda/$1/sda-ontology.rdf [R=303,L]
+RewriteRule ^([0-9]+[.][0-9]+)/?$ https://mss2221.github.io/ontology/sda/$1/sda-ontology.rdf [R=303,L]
 
 # Rewrite rule to serve N-Triples content if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^([0-9]+[.][0-9]+)/?$ https://domestic-beethoven.eu/ontology/sda/$1/sda-ontology.nt [R=303,L]
+RewriteRule ^([0-9]+[.][0-9]+)/?$ https://mss2221.github.io/ontology/sda/$1/sda-ontology.nt [R=303,L]
 
 # Rewrite rule to serve JSON-LD content if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^([0-9]+[.][0-9]+)/?$ https://domestic-beethoven.eu/ontology/sda/$1/sda-ontology.jsonld [R=303,L]
+RewriteRule ^([0-9]+[.][0-9]+)/?$ https://mss2221.github.io/ontology/sda/$1/sda-ontology.jsonld [R=303,L]
 
 # Rewrite rule to serve Turtle content if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^([0-9]+[.][0-9]+)/?$ https://domestic-beethoven.eu/ontology/sda/$1/sda-ontology.ttl [R=303,L]
+RewriteRule ^([0-9]+[.][0-9]+)/?$ https://mss2221.github.io/ontology/sda/$1/sda-ontology.ttl [R=303,L]
 
 # Fallback to HTML for versioned requests
-RewriteRule ^([0-9]+[.][0-9]+)/?$ https://domestic-beethoven.eu/ontology/sda/$1/sda-ontology.html [R=303,L]
+RewriteRule ^([0-9]+[.][0-9]+)/?$ https://mss2221.github.io/ontology/sda/$1/sda-ontology.html [R=303,L]


### PR DESCRIPTION
## Brief Description
Repoints the w3id.org/sda redirect from the now-inactive DomesticBeethoven 
repository to mss2221/ontology, where the SDA (Scholarly Domain Activities) 
ontology is currently maintained and served via GitHub Pages.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
