### PR TITLE
Add parliamentrag namespace

### DIFF
--- a/parliamentrag/.htaccess
+++ b/parliamentrag/.htaccess
@@ -1,0 +1,11 @@
+# ParliamentRAG — knowledge graph of the Italian Chamber of Deputies
+RewriteEngine on
+
+# Ontology terms (https://w3id.org/parliamentrag/ontology#...)
+RewriteRule ^ontology(.*)$ https://github.com/Emeierkeio/ParliamentRAG [R=302,L]
+
+# Minted resource URIs (https://w3id.org/parliamentrag/resource/...)
+RewriteRule ^resource/(.*)$ https://www.parliamentrag.it/data [R=302,L]
+
+# Everything else
+RewriteRule ^(.*)$ https://www.parliamentrag.it/ [R=302,L]

--- a/parliamentrag/README.md
+++ b/parliamentrag/README.md
@@ -13,7 +13,7 @@ generation system over the proceedings of the Italian Chamber of Deputies
 
 This space is administered by:
 
-Mirko Tritella
-University of Milano-Bicocca
-GitHub username: Emeierkeio
+Mirko Tritella<br>
+University of Milano-Bicocca<br>
+GitHub username: Emeierkeio<br>
 Email: mirkotritella1999@gmail.com

--- a/parliamentrag/README.md
+++ b/parliamentrag/README.md
@@ -1,0 +1,19 @@
+# /parliamentrag/
+
+Namespace for ParliamentRAG, a knowledge graph and retrieval-augmented
+generation system over the proceedings of the Italian Chamber of Deputies
+(19th legislature). The namespace is used in the published RDF export
+(ontology terms under `ontology#`, minted entity URIs under `resource/`).
+
+- `https://w3id.org/parliamentrag/ontology#…` → project repository (ontology documentation)
+- `https://w3id.org/parliamentrag/resource/…` → https://www.parliamentrag.it/data
+- anything else → https://www.parliamentrag.it/
+
+## Contact
+
+This space is administered by:
+
+Mirko Tritella
+University of Milano-Bicocca
+GitHub username: Emeierkeio
+Email: mirkotritella1999@gmail.com


### PR DESCRIPTION
New namespace for **ParliamentRAG**, a knowledge graph and RAG system over the proceedings of the Italian Chamber of Deputies (19th legislature), developed at the University of Milano-Bicocca.

The namespace is used in the published RDF export of the knowledge graph (ontology terms under `ontology#`, minted entity URIs under `resource/`), described in an ISWC 2026 submission.

Redirects:
- `ontology#…` → project repository https://github.com/Emeierkeio/ParliamentRAG
- `resource/…` → https://www.parliamentrag.it/data
- default → https://www.parliamentrag.it/

Contact: GitHub @Emeierkeio (see README.md in the folder).