### PR TITLE
Add /onsir for the OnSIR ontology (Ontology for Seed Irradiation Research)

### DIFF
--- a/onsir/.htaccess
+++ b/onsir/.htaccess
@@ -1,0 +1,81 @@
+# # /onsir/
+#
+# OnSIR -- Ontology for Seed Irradiation Research.
+#
+# An OWL 2 DL ontology for gamma and X-ray irradiation of plant seeds: treatments,
+# doses, dose rates, endpoints, taxon-specific dose windows expressed as OWL 2
+# datatype facets, and an ABox curated from a systematic review.
+#
+# Canonical location: https://github.com/lfmalves/OnSIR
+# Documentation:      https://lfmalves.github.io/OnSIR/
+#
+# https://w3id.org/onsir           -> HTML documentation, or the ontology under
+#                                     content negotiation (Turtle / RDF+XML)
+# https://w3id.org/onsir/<Term>    -> the term in the documentation, or the ontology
+# https://w3id.org/onsir/abox      -> the curated ABox
+# https://w3id.org/onsir/1.3.0     -> that version, from the matching git tag
+#
+# ## Contact
+# This space is administered by:
+#
+# Luis Felipe Medeiro Alves
+# GitHub username: lfmalves
+# ORCID: https://orcid.org/0009-0005-4227-5568
+
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+
+# Turn off MultiViews so that content negotiation is decided by the rules below
+Options -MultiViews
+
+# Serve the ontology serializations with the right media type
+AddType application/rdf+xml .owl
+AddType application/rdf+xml .rdf
+AddType text/turtle .ttl
+
+RewriteEngine on
+
+# ---------------------------------------------------------------- versioned IRIs
+# owl:versionIRI values have the form https://w3id.org/onsir/<major>.<minor>.<patch>
+# and resolve to the matching annotated git tag, so a version IRI keeps meaning the
+# release it was minted for.
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raw.githubusercontent.com/lfmalves/OnSIR/v$1/OnSIR.owl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raw.githubusercontent.com/lfmalves/OnSIR/v$1/OnSIR.ttl [R=303,L]
+
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://github.com/lfmalves/OnSIR/tree/v$1 [R=303,L]
+
+# ---------------------------------------------------------------- the ABox
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^abox/?$ https://raw.githubusercontent.com/lfmalves/OnSIR/main/OnSIR_abox.owl [R=303,L]
+
+RewriteRule ^abox/?$ https://raw.githubusercontent.com/lfmalves/OnSIR/main/OnSIR_abox.ttl [R=303,L]
+
+# ---------------------------------------------------------------- the ontology IRI
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://raw.githubusercontent.com/lfmalves/OnSIR/main/OnSIR.owl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ https://raw.githubusercontent.com/lfmalves/OnSIR/main/OnSIR.ttl [R=303,L]
+
+RewriteRule ^$ https://lfmalves.github.io/OnSIR/ [R=303,L]
+
+# ---------------------------------------------------------------- term IRIs
+# Terms are slash IRIs (https://w3id.org/onsir/HormeticDose). An RDF client is sent
+# the ontology that defines the term; a browser is sent to the term's entry in the
+# generated documentation.
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(.+)$ https://raw.githubusercontent.com/lfmalves/OnSIR/main/OnSIR.owl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^(.+)$ https://raw.githubusercontent.com/lfmalves/OnSIR/main/OnSIR.ttl [R=303,L]
+
+RewriteRule ^(.+)$ https://lfmalves.github.io/OnSIR/#$1 [R=303,L]

--- a/onsir/README.md
+++ b/onsir/README.md
@@ -1,0 +1,37 @@
+# OnSIR — Ontology for Seed Irradiation Research
+
+`https://w3id.org/onsir`
+
+An OWL 2 DL ontology for gamma and X-ray irradiation of plant seeds. It covers irradiation
+treatments, absorbed dose and dose rate as typed QUDT quantities, measured endpoints and endpoint
+categories, dose–response models, and taxon-specific dose windows expressed as OWL 2 datatype
+facets so that a reasoner derives where a numeric dose falls relative to the statistics reported
+for a given taxon. It ships with an ABox curated from a 28-study systematic review, SPARQL
+competency questions, and external alignments to BFO, PO, NCBITaxon, ChEBI, PATO, ENVO and QUDT.
+
+- **Canonical repository:** <https://github.com/lfmalves/OnSIR>
+- **Documentation:** <https://lfmalves.github.io/OnSIR/>
+- **Licence:** CC BY 4.0
+
+## Redirects
+
+| Request | Accept | Resolves to |
+| --- | --- | --- |
+| `/onsir` | `text/html` | the generated documentation |
+| `/onsir` | `text/turtle` | `OnSIR.ttl` |
+| `/onsir` | `application/rdf+xml` | `OnSIR.owl` |
+| `/onsir/<Term>` | `text/html` | that term in the documentation |
+| `/onsir/<Term>` | RDF | the ontology defining the term |
+| `/onsir/abox` | any | the curated ABox, Turtle or RDF/XML |
+| `/onsir/<x.y.z>` | any | that release, from the matching git tag `v<x.y.z>` |
+
+Term IRIs are slash IRIs. Version IRIs (`owl:versionIRI`) resolve to an annotated git tag, so a
+version IRI keeps denoting the release it was minted for while the unversioned IRI tracks the
+current one.
+
+All redirects are 303 See Other.
+
+## Contact
+
+Luis Felipe Medeiro Alves — GitHub [@lfmalves](https://github.com/lfmalves),
+ORCID [0009-0005-4227-5568](https://orcid.org/0009-0005-4227-5568)


### PR DESCRIPTION
This registers `/onsir` for **OnSIR**, an OWL 2 DL ontology for gamma and X-ray irradiation of plant seeds — treatments, absorbed dose and dose rate as typed QUDT quantities, endpoints, and taxon-specific dose windows expressed as OWL 2 datatype facets. It ships with an ABox curated from a 28-study systematic review and alignments to BFO, PO, NCBITaxon, ChEBI, PATO, ENVO and QUDT.

- Canonical repository: https://github.com/lfmalves/OnSIR (public, CC BY 4.0)
- Documentation: https://lfmalves.github.io/OnSIR/
- The ontology already declares `https://w3id.org/onsir/` as its term namespace and `https://w3id.org/onsir/<x.y.z>` as its `owl:versionIRI`, so this is the identifier it was minted against.

### What the rules do

| Request | `Accept` | Resolves to |
| --- | --- | --- |
| `/onsir` | `text/html` | the generated documentation |
| `/onsir` | `text/turtle` | `OnSIR.ttl` |
| `/onsir` | `application/rdf+xml` | `OnSIR.owl` |
| `/onsir/<Term>` | `text/html` | that term in the documentation |
| `/onsir/<Term>` | RDF | the defining ontology |
| `/onsir/abox` | any | the curated ABox |
| `/onsir/<x.y.z>` | any | that release, from git tag `v<x.y.z>` |

Term IRIs are slash IRIs. Version IRIs resolve to an annotated tag, so an `owl:versionIRI` keeps denoting the release it was minted for while the unversioned IRI tracks the current one. All redirects are 303.

### Testing

All eight redirect targets were requested and return 200: `OnSIR.ttl`, `OnSIR.owl`, `OnSIR_abox.ttl`, `OnSIR_abox.owl`, the two tagged serializations at `v1.3.0`, the tag tree page, and the documentation site. The rule patterns were checked against the nine request/`Accept` combinations in the table above.

`/onsir` is currently unused (404), and the entry claims one top-level directory only.

### Contact

Luis Felipe Medeiro Alves — GitHub @lfmalves, ORCID [0009-0005-4227-5568](https://orcid.org/0009-0005-4227-5568)