### PR TITLE
Add the collection DID kind to the dataerai namespace redirects

### DIFF
--- a/dataerai/.htaccess
+++ b/dataerai/.htaccess
@@ -2,7 +2,7 @@
 #
 # DID shape: did:dataerai:[<env>:]<kind>:<subject>
 #   <env>     dev | beta (absent in production)
-#   <kind>    asset | dataset | person | project
+#   <kind>    asset | dataset | person | project | collection
 #   <subject> 32 lowercase base32 chars [a-z2-7]
 #
 # w3id.org/dataerai/[<env>/]<kind>/<subject> 303-redirects to the public DID
@@ -13,17 +13,17 @@ Options +FollowSymLinks
 RewriteEngine On
 
 # ── Non-production: /dataerai/<env>/<kind>/<subj> ─────────────────────────────
-RewriteRule ^(dev|beta)/(asset|dataset|person|project)/([a-z2-7]{32})/?$ https://$1.dataerai.com/api/identity/resolve/did:dataerai:$1:$2:$3/ [R=303,L,NE]
+RewriteRule ^(dev|beta)/(asset|dataset|person|project|collection)/([a-z2-7]{32})/?$ https://$1.dataerai.com/api/identity/resolve/did:dataerai:$1:$2:$3/ [R=303,L,NE]
 
 # ── Production: /dataerai/<kind>/<subj> ───────────────────────────────────────
-RewriteRule ^(asset|dataset|person|project)/([a-z2-7]{32})/?$ https://app.dataerai.com/api/identity/resolve/did:dataerai:$1:$2/ [R=303,L,NE]
+RewriteRule ^(asset|dataset|person|project|collection)/([a-z2-7]{32})/?$ https://app.dataerai.com/api/identity/resolve/did:dataerai:$1:$2/ [R=303,L,NE]
 
 # ── Future (standards-conformant did:web) ─────────────────────────────────────
 # Once the id.<env>.dataerai.com resolver hosts serve did:web over public HTTPS,
 # swap the two rules above for these so w3id resolves to the W3C did:web
 # document instead of the resolve API:
-#   RewriteRule ^(dev|beta)/(asset|dataset|person|project)/([a-z2-7]{32})/?$ https://id.$1.dataerai.com/$2/$3/did.json [R=303,L,NE]
-#   RewriteRule ^(asset|dataset|person|project)/([a-z2-7]{32})/?$ https://id.dataerai.com/$1/$2/did.json [R=303,L,NE]
+#   RewriteRule ^(dev|beta)/(asset|dataset|person|project|collection)/([a-z2-7]{32})/?$ https://id.$1.dataerai.com/$2/$3/did.json [R=303,L,NE]
+#   RewriteRule ^(asset|dataset|person|project|collection)/([a-z2-7]{32})/?$ https://id.dataerai.com/$1/$2/did.json [R=303,L,NE]
 
 # Bare namespace → documentation
 RewriteRule ^/?$ https://docs.dataerai.com/identity/overview [R=302,L]

--- a/dataerai/README.md
+++ b/dataerai/README.md
@@ -2,8 +2,9 @@
 
 Persistent identifiers for Dataerai decentralized identifiers (DIDs) of the
 form `did:dataerai:[<env>:]<kind>:<subject>`, where `<env>` is `dev` or `beta`
-(absent in production), `<kind>` is one of `asset`, `dataset`, `person`, or
-`project`, and `<subject>` is 32 lowercase base32 characters (`[a-z2-7]`).
+(absent in production), `<kind>` is one of `asset`, `dataset`, `person`,
+`project`, or `collection`, and `<subject>` is 32 lowercase base32 characters
+(`[a-z2-7]`).
 
 `https://w3id.org/dataerai/[<env>/]<kind>/<subject>` 303-redirects to the
 public DID resolve API on the matching Dataerai environment:


### PR DESCRIPTION
Dataerai registered the `dataerai` namespace in #6254. Since then we added a fifth DID kind, **`collection`** (alongside `asset`, `dataset`, `person`, `project`), whose persistent citation URLs are the same shape as the existing four — `w3id.org/dataerai/[<env>/]collection/<subject>`. The redirect rules don't yet cover it, so those URLs currently 404.

This adds `collection` to both live rewrite rules (and the two commented `did:web` variants kept for a future standards-conformant upgrade), and to the README's kind list — nothing else changes. The `dataerai/` directory here is kept byte-identical to the `ops/w3id/dataerai/` source of truth in the Dataerai monorepo.

Maintainers: @jagar2, @kinor · contact identity@dataerai.com