### PR TITLE
Update bsdd LCA and IFC redirects

### DIFF
--- a/lcabim/.htaccess
+++ b/lcabim/.htaccess
@@ -10,7 +10,8 @@ RewriteRule ^obd/?$           https://design-computation-rwth.github.io/lcabim-o
 RewriteRule ^concreteclass/?$ https://design-computation-rwth.github.io/lcabim-ontology/concreteclass/index-en.html [R=302,L]
 RewriteRule ^ilcd/?$          https://design-computation-rwth.github.io/lcabim-ontology/ilcd/index-en.html [R=302,L]
 RewriteRule ^ilcdind/?$       https://design-computation-rwth.github.io/lcabim-ontology/ilcdind/index-en.html [R=302,L]
-RewriteRule ^bsdd/?$          https://design-computation-rwth.github.io/lcabim-ontology/bsdd/index-en.html [R=302,L]
+RewriteRule ^bsddlca/?$       https://design-computation-rwth.github.io/lcabim-ontology/bsddlca/index-en.html [R=302,L]
+RewriteRule ^bsddifc/?$       https://design-computation-rwth.github.io/lcabim-ontology/bsddifc/index-en.html [R=302,L]
 RewriteRule ^lcabimcore/?$    https://design-computation-rwth.github.io/lcabim-ontology/lcabimcore/index-en.html [R=302,L]
 
 # Everything else


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->

## Brief Description

This PR updates the existing `lcabim` namespace redirects under `https://w3id.org/lcabim/`.

It replaces the `bsdd` redirect with separate redirects for the `bsddlca` and `bsddifc` ontology modules, both pointing to their respective pages under:

`https://design-computation-rwth.github.io/lcabim-ontology/`.

## General Checklist

<!-- For all ID related PRs. -->

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

<!-- For new ID PRs. -->

- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist

<!-- For updated ID PRs. -->

- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers

<!-- Optional requests for any PR. -->

- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.