### PR TITLE
sanskrit-lexicon: add /repwg/, keep /pwg-ru/ as a permanent 301

### DIFF
--- a/sanskrit-lexicon/.htaccess
+++ b/sanskrit-lexicon/.htaccess
@@ -4,10 +4,17 @@
 # Cologne Digital Sanskrit Dictionaries (https://www.sanskrit-lexicon.uni-koeln.de/).
 #
 # https://w3id.org/sanskrit-lexicon/          -> namespace index
-# https://w3id.org/sanskrit-lexicon/pwg-ru/*  -> PWG->RU LOD graph
-#                                                (Petersburg Dictionary with
-#                                                 Russian sense definitions;
-#                                                 OntoLex-Lemon + PROV-O)
+# https://w3id.org/sanskrit-lexicon/repwg/*   -> rePWG: the re-edition graph of
+#                                                the Petersburg Dictionary
+#                                                (Boehtlingk-Roth PWG and its PW,
+#                                                 SCH, PWKVN, NWS supplements),
+#                                                with the German edition layers
+#                                                and Russian sense definitions;
+#                                                OntoLex-Lemon + TEI Lex-0 + PROV-O
+# https://w3id.org/sanskrit-lexicon/pwg-ru/*  -> 301 to the repwg equivalent
+#                                                (former name of the same graph;
+#                                                 kept permanently so identifiers
+#                                                 minted before 27-07-2026 resolve)
 #
 # Instances use slash IRIs and are resolved with 303 See Other under content
 # negotiation: an RDF media type is served Turtle, anything else HTML.
@@ -35,16 +42,26 @@ RewriteEngine on
 # Namespace index.
 RewriteRule ^$ https://gasyoun.github.io/pwg-ru-lod/ [R=302,L]
 
-# ---- /pwg-ru/ --------------------------------------------------------------
+# ---- /pwg-ru/ -> /repwg/ ---------------------------------------------------
+#
+# The sub-namespace was renamed to `repwg` on 27-07-2026: four of the five
+# graphs it carries are not Russian (the German edition layers are public-domain
+# Boehtlingk-Roth), so `pwg-ru` named a property the namespace does not have.
+# These 301s are permanent -- an identifier is never withdrawn, only redirected.
+
+RewriteRule ^pwg-ru/?$ https://w3id.org/sanskrit-lexicon/repwg/ [R=301,L]
+RewriteRule ^pwg-ru/(.+)$ https://w3id.org/sanskrit-lexicon/repwg/$1 [R=301,L]
+
+# ---- /repwg/ ---------------------------------------------------------------
 
 # Sub-namespace root.
-RewriteRule ^pwg-ru/?$ https://gasyoun.github.io/pwg-ru-lod/ [R=302,L]
+RewriteRule ^repwg/?$ https://gasyoun.github.io/pwg-ru-lod/ [R=302,L]
 
 # An RDF media type was requested -> serve Turtle.
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^pwg-ru/(.+)$ https://gasyoun.github.io/pwg-ru-lod/$1.ttl [R=303,L]
+RewriteRule ^repwg/(.+)$ https://gasyoun.github.io/pwg-ru-lod/$1.ttl [R=303,L]
 
 # Anything else -> serve HTML.
-RewriteRule ^pwg-ru/(.+)$ https://gasyoun.github.io/pwg-ru-lod/$1.html [R=303,L]
+RewriteRule ^repwg/(.+)$ https://gasyoun.github.io/pwg-ru-lod/$1.html [R=303,L]


### PR DESCRIPTION
Follow-up to #6386, which registered `/sanskrit-lexicon/` with a `pwg-ru` sub-namespace.

## What changes

The sub-namespace is renamed `pwg-ru` → `repwg` ("rePWG"), and **no identifier is withdrawn**: every `^pwg-ru/...` now 301s to its `repwg` equivalent, permanently, so anything minted under the old name still resolves.

The `repwg` rules are a straight copy of the existing ones — 302 on the sub-namespace root, 303 content-negotiated for instances (Turtle for an RDF `Accept`, HTML otherwise). The redirect target is unchanged.

## Why

`pwg-ru` named a property the namespace does not have. It was minted when the only graph was a PWG→Russian lexicon, but the namespace now carries five graphs and four of them are not Russian:

| graph | language |
|---|---|
| PWG→RU lexical | Russian |
| German enrichment (PWG++) | German, public domain |
| German edition graph (PWG/PW/SCH/PWKVN/NWS) | German, public domain |
| DCS corpus frequency | language-neutral |
| Grammar layer (Whitney / Zaliznyak) | language-neutral |

So public-domain 19th-century German lexicography was being served from a namespace that reads as a Russian translation project. `repwg` = "rePWG", a *re-edition* of the Petersburg Dictionary — which is also the honest label, since the graphs carry derived structure rather than the Cologne source text verbatim.

Lowercase in the path deliberately: IRI paths are case-sensitive, so `rePWG` there would invite `repwg`/`REPWG`/`rePwg` indefinitely. The mixed-case form is used only in labels and prose.

## Contact

Same administrator as #6386 — Marcis Gasuns, rusamskrtam@gmail.com, ORCID [0000-0003-4513-884X](https://orcid.org/0000-0003-4513-884X), GitHub @gasyoun.
