### PR TITLE
Add Relive System Engine Core ontology identifier

### DIFF
--- a/relive/rse/core/.htaccess
+++ b/relive/rse/core/.htaccess
@@ -1,0 +1,20 @@
+﻿# Relive System Engine Core Ontology
+#
+# Permanent identifier:
+# https://w3id.org/relive/rse/core
+#
+# Canonical namespace:
+# https://w3id.org/relive/rse/core#
+#
+# Maintainer:
+# Hichem Kerkeni
+# GitHub: Hichemkerkeni
+
+RewriteEngine On
+
+# Turtle representation
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/x-turtle) [NC]
+RewriteRule ^$ https://hichemkerkeni.github.io/relive-rse-ontology/rse-core.ttl [R=303,L]
+
+# Default human-readable HTML documentation
+RewriteRule ^$ https://hichemkerkeni.github.io/relive-rse-ontology/ [R=303,L]

--- a/relive/rse/core/README.md
+++ b/relive/rse/core/README.md
@@ -1,0 +1,39 @@
+﻿# Relive System Engine Core Ontology
+
+This W3ID namespace provides persistent identifiers for the
+Relive System Engine Core Ontology.
+
+## Permanent identifier
+
+https://w3id.org/relive/rse/core
+
+## Canonical ontology namespace
+
+https://w3id.org/relive/rse/core#
+
+Examples:
+
+- https://w3id.org/relive/rse/core#System
+- https://w3id.org/relive/rse/core#Process
+- https://w3id.org/relive/rse/core#Observation
+- https://w3id.org/relive/rse/core#Decision
+
+## Public representations
+
+Human-readable documentation:
+
+https://hichemkerkeni.github.io/relive-rse-ontology/
+
+Turtle representation:
+
+https://hichemkerkeni.github.io/relive-rse-ontology/rse-core.ttl
+
+## Project
+
+Relive System Engine — System Intelligence for natural,
+industrial and enterprise systems.
+
+## Maintainer
+
+- Hichem Kerkeni
+- GitHub: https://github.com/Hichemkerkeni


### PR DESCRIPTION
## Requested W3ID

https://w3id.org/relive/rse/core

Canonical ontology namespace:

https://w3id.org/relive/rse/core#

## Purpose

This namespace provides persistent identifiers for the
Relive System Engine Core Ontology.

## Redirects

- Human-readable documentation:
  https://hichemkerkeni.github.io/relive-rse-ontology/

- Turtle representation:
  https://hichemkerkeni.github.io/relive-rse-ontology/rse-core.ttl

## HTTP behavior

- Requests accepting `text/turtle` or `application/x-turtle`
  are redirected with HTTP 303 to the Turtle representation.
- Other requests are redirected with HTTP 303 to the HTML documentation.

## Maintainer

Hichem Kerkeni  
GitHub: @Hichemkerkeni

The public destination URLs have been tested without authentication.