### PR TITLE
Fix APD redirect so categorical trait values resolve

### DIFF
--- a/APD/.htaccess
+++ b/APD/.htaccess
@@ -54,7 +54,7 @@ RewriteRule ^ https://traitecoevo.github.io/APD/APD.ttl [R=303,L]
 # Don't need RewriteCond as only processed if none of the above are satisfied
 RewriteRule ^release/(\d+)\.(\d+)\.(\d+)(.+)?$ https://traitecoevo.github.io/APD/release/$1.$2.$3/index.html [R=303,L]
 
-RewriteRule ^traits/trait_(.+)$ https://traitecoevo.github.io/APD/index.html#trait_$1 [R=303,NE,L]
+RewriteRule ^traits/([^/]+)/?$ https://traitecoevo.github.io/APD/index.html#$1 [R=303,NE,L]
 RewriteRule ^traits/?$ https://traitecoevo.github.io/APD/index.html#trait-concepts [R=303,NE,L]
 RewriteRule ^glossary/glossary_(.+)/?$ https://traitecoevo.github.io/APD/index.html#glossary_$1 [R=303,NE,L]
 RewriteRule ^glossary/?$ https://traitecoevo.github.io/APD/index.html#glossary [R=303,NE,L]

--- a/APD/README.md
+++ b/APD/README.md
@@ -30,7 +30,7 @@ Suggestions for changes are welcome and can be posted at https://github.com/trai
   - `[L]` — If the previous conditions pass, this rule is executed, and no more evaluation is done. 
   - `[NE]` — (noescape) Prevents conversion of special characters to their hexcode equivalent; needed for links including a `#`.
 - the following matches are used
-  - `RewriteRule ^traits/trait_(.+)$ https://...` - the `(.+)` captures the 1 or more characters after `trait_` in the URL
+  - `RewriteRule ^traits/([^/]+)/?$ https://...` - the `([^/]+)` captures the whole slug after `traits/`, whatever form it takes. It deliberately does **not** match only `trait_*`: allowable categorical trait values are published under `traits/` as well and do not carry that prefix (e.g. `traits/plant_growth_form_tree`), so a `trait_`-only rule left 819 of the 1,449 `traits/` identifiers falling through to the catch-all and landing at the top of the page with no fragment. `[^/]+` rather than a character class, because slugs contain `+` as well as letters, digits, `_` and `-` (e.g. `traits/seed_germination_treatment_heat+smoke`). It requires at least one character, so `traits/` itself does not match and falls through to the next rule.
   - `RewriteRule ^ https://...` - captures any URL that hasn't been matched by the previous rules. Same behaviour as `RewriteRule ^(.*)$ https://...`. Note behaves differently to `RewriteRule ^$ https://...` which would only match the root URL. 
 
 ## Usage


### PR DESCRIPTION
One-line fix to `APD/.htaccess`, plus the design note in `APD/README.md` that documented the old pattern. I administer the APD space (contact details in that README).

## The problem

The rule matched `^traits/trait_(.+)$`. But allowable **categorical trait values** are published under `traits/` as well, and they do not carry that prefix — they look like `traits/plant_growth_form_tree`. So **819 of the 1,449 `traits/` identifiers** fell through to the catch-all and landed at the top of `index.html` with no fragment:

```
traits/trait_0000012            ->  index.html#trait_0000012      OK
traits/trait_group_0000008      ->  index.html#trait_group_...    OK
traits/plant_growth_form_tree   ->  index.html                    BROKEN
```

Trait concepts and trait groups were fine, which is why it went unnoticed. The AusTraits Plant Dictionary paper ([Sci Data 11:537](https://doi.org/10.1038/s41597-024-03368-z), p.8) commits to every trait concept *and* categorical value resolving to its own content, so this is a published promise that has not been kept for those 819.

## The change

```diff
-RewriteRule ^traits/trait_(.+)$ https://traitecoevo.github.io/APD/index.html#trait_$1 [R=303,NE,L]
+RewriteRule ^traits/([^/]+)/?$ https://traitecoevo.github.io/APD/index.html#$1 [R=303,NE,L]
```

**Target-only — no published URI changes.** Trait and trait-group URIs resolve to exactly the fragments they do today.

`[^/]+` rather than a character class, deliberately: slugs also contain `+`, as in `traits/seed_germination_treatment_heat+smoke`. A class like `[A-Za-z][A-Za-z0-9_.-]*` matches 1,448 of 1,449 and leaves that one broken — worse than the status quo, because it looks finished.

## Verification

I simulated the rules in file order against every published identifier rather than eyeballing the regex:

| | |
|---|---|
| trait concepts + groups | **630 / 630** resolve to their own fragment (unchanged) |
| categorical values | **819 / 819** — the fix |
| glossary terms | **24 / 24** unaffected |

Adjacent rules checked and unaffected:

- `^traits/?$` still catches the bare collection URI — `[^/]+` requires at least one character, so `traits/` does not match the line above it
- `glossary/` needs no change: all 24 slugs are `glossary_*`, already matched by its own rule
- content negotiation (lines 18–50) and the versioned `release/X.Y.Z/` rules are evaluated earlier and are not in the path of this change

I also confirmed all 1,473 anchors are present in the deployed `index.html`, so every URI the widened rule points at resolves to real content.

## After merge

`traits/plant_growth_form_tree` should go from `index.html` to `index.html#plant_growth_form_tree`. A scheduled check in the APD repo re-tests the full matrix weekly against the live service.