### PR TITLE
Add PanoVec permanent identifier redirects

### DIFF
--- a/panovec/.htaccess
+++ b/panovec/.htaccess
@@ -1,0 +1,16 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# Maintainer: Yu Su <15525080347@gmail.com>
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^ontology/?$ https://suyu15525080347-hash.github.io/panovec/ontology/0.87/panovec.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^ontology/?$ https://suyu15525080347-hash.github.io/panovec/ontology/0.87/panovec.rdf [R=303,L]
+RewriteRule ^ontology/?$ https://suyu15525080347-hash.github.io/panovec/ontology/0.87/panovec.ttl [R=303,L]
+
+RewriteRule ^release/0\.87/?$ https://suyu15525080347-hash.github.io/panovec/catalog/0.87/catalog.ttl [R=303,L]
+RewriteRule ^context/?$ https://suyu15525080347-hash.github.io/panovec/context/panovec.jsonld [R=303,L]
+RewriteRule ^resource/(.*)$ https://suyu15525080347-hash.github.io/panovec/data/0.87/panovec.ttl [R=303,L]
+RewriteRule ^sparql/?$ https://suyu15525080347-hash.github.io/panovec/sparql/ [R=303,L]
+RewriteRule ^$ https://suyu15525080347-hash.github.io/panovec/ [R=303,L]

--- a/panovec/.htaccess
+++ b/panovec/.htaccess
@@ -4,13 +4,14 @@ RewriteEngine on
 # Maintainer: Yu Su <15525080347@gmail.com>
 
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^ontology/?$ https://suyu15525080347-hash.github.io/panovec/ontology/0.87/panovec.jsonld [R=303,L]
+RewriteRule ^ontology/?$ https://suyu15525080347-hash.github.io/panovec/ontology/0.89/panovec.jsonld [R=303,L]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^ontology/?$ https://suyu15525080347-hash.github.io/panovec/ontology/0.87/panovec.rdf [R=303,L]
-RewriteRule ^ontology/?$ https://suyu15525080347-hash.github.io/panovec/ontology/0.87/panovec.ttl [R=303,L]
+RewriteRule ^ontology/?$ https://suyu15525080347-hash.github.io/panovec/ontology/0.89/panovec.rdf [R=303,L]
+RewriteRule ^ontology/?$ https://suyu15525080347-hash.github.io/panovec/ontology/0.89/panovec.ttl [R=303,L]
 
 RewriteRule ^release/0\.87/?$ https://suyu15525080347-hash.github.io/panovec/catalog/0.87/catalog.ttl [R=303,L]
+RewriteRule ^release/0\.89/?$ https://suyu15525080347-hash.github.io/panovec/catalog/0.89/catalog.ttl [R=303,L]
 RewriteRule ^context/?$ https://suyu15525080347-hash.github.io/panovec/context/panovec.jsonld [R=303,L]
-RewriteRule ^resource/(.*)$ https://suyu15525080347-hash.github.io/panovec/data/0.87/panovec.ttl [R=303,L]
+RewriteRule ^resource/(.*)$ https://suyu15525080347-hash.github.io/panovec/data/0.89/panovec.ttl [R=303,L]
 RewriteRule ^sparql/?$ https://suyu15525080347-hash.github.io/panovec/sparql/ [R=303,L]
 RewriteRule ^$ https://suyu15525080347-hash.github.io/panovec/ [R=303,L]

--- a/panovec/README.md
+++ b/panovec/README.md
@@ -8,6 +8,10 @@ PanoVec is a traceable iconographic knowledge graph for the *Chaoyuan Tu*
 research corpus. Redirects resolve to the versioned public distributions hosted
 from the `suyu15525080347-hash/panovec` GitHub repository.
 
+The current semantic release is v0.89. Versioned v0.87 and v0.89 release
+catalogue redirects remain stable; unversioned ontology and resource redirects
+resolve to v0.89.
+
 ## Maintainer
 
 - Yu Su

--- a/panovec/README.md
+++ b/panovec/README.md
@@ -1,0 +1,19 @@
+# PanoVec permanent identifiers
+
+This directory requests the identifier root:
+
+`https://w3id.org/panovec/`
+
+PanoVec is a traceable iconographic knowledge graph for the *Chaoyuan Tu*
+research corpus. Redirects resolve to the versioned public distributions hosted
+from the `suyu15525080347-hash/panovec` GitHub repository.
+
+## Maintainer
+
+- Yu Su
+- GitHub: [@suyu15525080347-hash](https://github.com/suyu15525080347-hash)
+- Email: 15525080347@gmail.com
+
+## Repository
+
+<https://github.com/suyu15525080347-hash/panovec>


### PR DESCRIPTION
## Brief Description
Add the new `https://w3id.org/panovec/` namespace for PanoVec, a traceable iconographic knowledge graph for the *Chaoyuan Tu* research corpus. The redirects resolve to the public documentation and versioned RDF distributions hosted on GitHub Pages. Unversioned ontology and resource routes resolve to the current v0.89 release, while explicit v0.87 and v0.89 catalogue routes remain stable.

## General Checklist
- [x] Changes have been tested: every redirect target returns HTTP 200 with the expected media type.
- [x] Commits are minimal and limited to the PanoVec identifier directory.
- [x] Commits only include redirects and basic information.

## New ID Directory Checklist
- [x] Maintainer details are in both `.htaccess` and `README.md`.
- [x] GitHub username `suyu15525080347-hash` is listed in the maintainer details.
