### PR TITLE
Add /coresense/ for the CORESENSE project and the CoreSense Ontology

### DIFF
--- a/coresense/.htaccess
+++ b/coresense/.htaccess
@@ -1,0 +1,82 @@
+# CoreSense Ontology (CSO)
+#
+# Permanent identifier for the ontology developed by the CORESENSE project,
+# funded by the European Union under Horizon Europe grant #101070254.
+#
+#   https://w3id.org/coresense/cso
+#
+# Term IRIs are hash-style (e.g. https://w3id.org/coresense/cso#Modelet), so the
+# fragment is never sent to the server and the rules below resolve every term in
+# the vocabulary. Browsers get the HTML documentation; reasoners get the Turtle.
+#
+# Redirect target : https://coresenseeu.github.io/cso/
+# Source repo     : https://github.com/CoreSenseEU/ontology
+# Project website : https://www.coresense.eu
+#
+# ## Contact
+# This space is administered by:
+#
+# Ricardo Sanz <ricardo.sanz@upm.es>
+# Autonomous Systems Laboratory, Universidad Politecnica de Madrid
+# GitHub username: rsanz
+
+Options -MultiViews
+Options +FollowSymLinks
+
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .nt
+AddType application/ld+json .jsonld
+
+RewriteEngine on
+
+# ---------------------------------------------------------------------------
+# Version IRIs:  https://w3id.org/coresense/cso/YYYY-MM-DD
+# Each release is snapshotted under a date-stamped directory and never changes.
+# ---------------------------------------------------------------------------
+
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^cso/([0-9]{4}-[0-9]{2}-[0-9]{2})/?$ https://coresenseeu.github.io/cso/$1/index.html [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^cso/([0-9]{4}-[0-9]{2}-[0-9]{2})/?$ https://coresenseeu.github.io/cso/$1/cso.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^cso/([0-9]{4}-[0-9]{2}-[0-9]{2})/?$ https://coresenseeu.github.io/cso/$1/cso.owl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^cso/([0-9]{4}-[0-9]{2}-[0-9]{2})/?$ https://coresenseeu.github.io/cso/$1/cso.nt [R=303,L]
+
+# Turtle is the canonical serialization, and the default for non-browser clients.
+RewriteRule ^cso/([0-9]{4}-[0-9]{2}-[0-9]{2})/?$ https://coresenseeu.github.io/cso/$1/cso.ttl [R=303,L]
+
+# ---------------------------------------------------------------------------
+# Latest version:  https://w3id.org/coresense/cso
+# ---------------------------------------------------------------------------
+
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^cso/?$ https://coresenseeu.github.io/cso/index.html [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^cso/?$ https://coresenseeu.github.io/cso/cso.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^cso/?$ https://coresenseeu.github.io/cso/cso.owl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^cso/?$ https://coresenseeu.github.io/cso/cso.nt [R=303,L]
+
+# Turtle, including the no-Accept-header and */* cases.
+RewriteRule ^cso/?$ https://coresenseeu.github.io/cso/cso.ttl [R=303,L]
+
+# ---------------------------------------------------------------------------
+# Anything else under /coresense/ goes to the project website.
+# ---------------------------------------------------------------------------
+
+RewriteRule ^$ https://www.coresense.eu [R=302,L]

--- a/coresense/README.md
+++ b/coresense/README.md
@@ -1,0 +1,53 @@
+# /coresense/
+
+Permanent identifiers for the **CORESENSE** project — an EU Horizon Europe
+project (grant #101070254) on cognitive architectures for robot autonomy,
+building understanding-based robot systems.
+
+* Project website: <https://www.coresense.eu>
+* GitHub organisation: <https://github.com/CoreSenseEU>
+
+## Identifiers
+
+| Identifier | Resolves to | Purpose |
+| --- | --- | --- |
+| `https://w3id.org/coresense/cso` | <https://coresenseeu.github.io/cso/> | The CoreSense Ontology (CSO), latest version |
+| `https://w3id.org/coresense/cso/YYYY-MM-DD` | `https://coresenseeu.github.io/cso/YYYY-MM-DD/` | A specific, immutable release of CSO |
+
+### The CoreSense Ontology (CSO)
+
+CSO is an OWL 2 ontology, serialized in Turtle, describing model-based cognition
+in autonomous systems: entities, systems and their environments; models,
+modelets and the engines that exert them; goals, tasks, missions and
+capabilities; and the action-control pipeline.
+
+Term IRIs are hash-style — `https://w3id.org/coresense/cso#Modelet`,
+`#Engine`, `#exerts` — so the fragment is never sent to the server and a single
+pair of rules resolves the whole vocabulary.
+
+Content is negotiated on `Accept`:
+
+| `Accept` | Served |
+| --- | --- |
+| `text/html` (or a `Mozilla/*` user agent) | HTML documentation |
+| `text/turtle` | `cso.ttl` |
+| `application/rdf+xml` | `cso.owl` |
+| `application/ld+json` | `cso.jsonld` |
+| `application/n-triples` | `cso.nt` |
+| anything else, or no `Accept` | `cso.ttl` (the canonical serialization) |
+
+The redirect target is a GitHub Pages site published from
+[CoreSenseEU/cso](https://github.com/CoreSenseEU/cso), which is generated on
+every release from the ontology source in
+[CoreSenseEU/ontology](https://github.com/CoreSenseEU/ontology).
+
+Released under the Apache License 2.0.
+Copyright © 2022–2026 The CORESENSE Consortium.
+
+## Contact
+
+This space is administered by:
+
+**Ricardo Sanz** <ricardo.sanz@upm.es>
+Autonomous Systems Laboratory, Universidad Politécnica de Madrid
+GitHub username: [rsanz](https://github.com/rsanz)


### PR DESCRIPTION
This registers `https://w3id.org/coresense/cso` for the **CoreSense Ontology (CSO)**, an OWL 2 ontology on model-based cognition in autonomous systems, developed by the EU Horizon Europe project [CORESENSE](https://www.coresense.eu) (grant #101070254).

The `coresense` top-level directory is currently unused.

### What resolves

| Identifier | Target |
| --- | --- |
| `https://w3id.org/coresense/cso` | <https://coresenseeu.github.io/cso/> |
| `https://w3id.org/coresense/cso/YYYY-MM-DD` | `https://coresenseeu.github.io/cso/YYYY-MM-DD/` (immutable release snapshots) |

Term IRIs are hash-style (`.../cso#Modelet`), so the fragment never reaches the server and one pair of rules resolves the whole vocabulary. Content is negotiated on `Accept`: HTML documentation for browsers, Turtle for reasoners and as the default, plus RDF/XML, JSON-LD and N-Triples.

The redirect target is a GitHub Pages site published from [CoreSenseEU/cso](https://github.com/CoreSenseEU/cso), generated on each release from the ontology source in [CoreSenseEU/ontology](https://github.com/CoreSenseEU/ontology). Both are controlled by the CORESENSE consortium.

### Testing

Rules were tested against Apache 2.4 with `mod_rewrite` using the site's directory layout, then followed through to the live target. All paths return `303` and resolve to `200`:

| Request | Redirect | Final |
| --- | --- | --- |
| `cso` + browser `Accept`/UA | `/cso/index.html` | 200 `text/html` |
| `cso` + `text/turtle` | `/cso/cso.ttl` | 200 `text/turtle` |
| `cso` + `application/rdf+xml` | `/cso/cso.owl` | 200 `application/rdf+xml` |
| `cso` + `application/ld+json` | `/cso/cso.jsonld` | 200 `application/ld+json` |
| `cso` + `application/n-triples` | `/cso/cso.nt` | 200 |
| `cso` + `*/*` or no `Accept` | `/cso/cso.ttl` | 200 `text/turtle` |
| `cso/2026-07-28` + `text/turtle` | `/cso/2026-07-28/cso.ttl` | 200 `text/turtle` |

The Turtle served through the chain parses and self-reports `owl:versionIRI <http://w3id.org/coresense/cso/2026-07-28>`.

Contact info is in both `coresense/.htaccess` and `coresense/README.md`. Single squashed commit.

### Contact

Ricardo Sanz <ricardo.sanz@upm.es> — Autonomous Systems Laboratory, Universidad Politécnica de Madrid — @rsanz