### PR TITLE
Add Bridge Element Design Rule Ontology identifier

### DIFF
--- a/bedro/.htaccess
+++ b/bedro/.htaccess
@@ -64,6 +64,9 @@ RewriteRule ^bedro.html$ https://noacktim.github.io/BEDRO/ [R=303,L]
 # If suffix rdf, redirect to rdf version
 RewriteRule ^bedro.rdf$ https://noacktim.github.io/BEDRO/bedro.rdf [R=303,L]
 
+# If suffix owl, redirect to owl version
+RewriteRule ^bedro.owl$ https://noacktim.github.io/BEDRO/bedro.owl [R=303,L]
+
 # If suffix jsonld, redirect to jsonld version
 RewriteRule ^bedro.jsonld$ https://noacktim.github.io/BEDRO/bedro.jsonld [R=303,L]
 
@@ -89,6 +92,11 @@ RewriteRule ^bedro-?([0-9]+\.[0-9]+\.[0-9]+)$ https://noacktim.github.io/BEDRO/b
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
 RewriteRule ^bedro-?([0-9]+\.[0-9]+\.[0-9]+)$ https://noacktim.github.io/BEDRO/bedro-$1.rdf [R=302,NE,L]
+
+# Rewrite rule to serve OWL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^bedro-?([0-9]+\.[0-9]+\.[0-9]+)$ https://noacktim.github.io/BEDRO/bedro-$1.owl [R=302,NE,L]
 
 # Rewrite rule to serve N-Triples content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples

--- a/bedro/.htaccess
+++ b/bedro/.htaccess
@@ -1,0 +1,104 @@
+# https://w3id.org/bedro redirects to https://github.com/NoackTim/BEDRO
+#
+# ## Contact
+# This space is administered by:
+#
+# Tim Noack
+# tim.noack@tu-dresden.de
+# GitHub username: NoackTim
+
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType text/n3 .n3
+AddType application/n-triples .nt
+AddType application/ld+json .json
+
+RewriteEngine on
+
+# Turn off MultiViews
+Options -MultiViews
+
+### Rewrite rules for latest version
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://noacktim.github.io/BEDRO/bedro.rdf [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle 
+RewriteRule ^$ https://noacktim.github.io/BEDRO/bedro.ttl [R=303,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://noacktim.github.io/BEDRO/bedro.jsonld [R=303,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://noacktim.github.io/BEDRO/bedro.rdf [R=303,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://noacktim.github.io/BEDRO/bedro.nt [R=303,L]
+
+# Rewrite rule to serve N3 content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} ^.*text/n3.* [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/n3 
+RewriteRule ^$ https://noacktim.github.io/BEDRO/bedro.n3 [R=303,L]
+
+# If suffix ttl, redirect to turtle version
+RewriteRule ^bedro.ttl$ https://noacktim.github.io/BEDRO/bedro.ttl [R=303,L]
+
+# If suffix html, redirect to html version
+RewriteRule ^bedro.html$ https://noacktim.github.io/BEDRO/ [R=303,L]
+
+# If suffix rdf, redirect to rdf version
+RewriteRule ^bedro.rdf$ https://noacktim.github.io/BEDRO/bedro.rdf [R=303,L]
+
+# If suffix jsonld, redirect to jsonld version
+RewriteRule ^bedro.jsonld$ https://noacktim.github.io/BEDRO/bedro.jsonld [R=303,L]
+
+# If suffix nt, redirect to nt version
+RewriteRule ^bedro.nt$ https://noacktim.github.io/BEDRO/bedro.nt [R=303,L]
+
+# If suffix n3, redirect to N3 version
+RewriteRule ^bedro.n3$ https://noacktim.github.io/BEDRO/bedro.n3 [R=303,L]
+
+
+### Rewrite rules for any other version
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^bedro-?([0-9]+\.[0-9]+\.[0-9]+)$ https://noacktim.github.io/BEDRO/bedro-$1.ttl [R=302,NE,L]
+
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^bedro-?([0-9]+\.[0-9]+\.[0-9]+)$ https://noacktim.github.io/BEDRO/bedro-$1.jsonld [R=302,NE,L]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^bedro-?([0-9]+\.[0-9]+\.[0-9]+)$ https://noacktim.github.io/BEDRO/bedro-$1.rdf [R=302,NE,L]
+
+# Rewrite rule to serve N-Triples content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^bedro-?([0-9]+\.[0-9]+\.[0-9]+)$ https://noacktim.github.io/BEDRO/bedro-$1.nt [R=302,NE,L]
+
+# Rewrite rule to serve N3 content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} ^.*text/n3.* [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/n3 
+RewriteRule ^bedro-?([0-9]+\.[0-9]+\.[0-9]+)$ https://noacktim.github.io/BEDRO/bedro-$1.n3 [R=302,NE,L]
+
+### Default response
+RewriteRule ^$ https://noacktim.github.io/BEDRO/ [R=303,L]

--- a/bedro/README.md
+++ b/bedro/README.md
@@ -1,0 +1,10 @@
+# Bridge Element Design Rule Ontology
+
+The **Bridge Element Design Rule Ontology (BEDRO)** allows the representation of bridges, their boundary conditions and components as well as German design rules defining the material and geometry of these components.
+
+Recommended namespace for BEDRO: **`bedro`**.
+
+More information about BEDRO can be found on our GitHub repository: [**NoackTim/BEDRO**](https://github.com/NoackTim/BEDRO)
+
+## Contact
+- **Tim Noack** • [`tim.noack@tu-dresden.de`](tim.noack@tu-dresden.de) • GitHub: [**NoackTim**](https://github.com/NoackTim)

--- a/bedro/README.md
+++ b/bedro/README.md
@@ -1,6 +1,6 @@
 # Bridge Element Design Rule Ontology
 
-The **Bridge Element Design Rule Ontology (BEDRO)** allows the representation of bridges, their boundary conditions and components as well as German design rules defining the material and geometry of these components.
+The **Bridge Element Design Rule Ontology (BEDRO)** allows the representation of bridges, their boundary conditions and components as well as German design rules defining the typology, material and geometry of these components.
 
 Recommended namespace for BEDRO: **`bedro`**.
 


### PR DESCRIPTION
## Brief Description
Creation of a new ID describing the Bridge Element Design Rule Ontology (BEDRO). 

## General Checklist
- [X] Changes have been tested.
- [X] The number of commits is minimal. Squash if needed.
- [X] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [X] Maintainer details are in `.htaccess` or `README.md`.
- [X] GitHub username ids are listed in the maintainer details.
