### PR TITLE
OSO: remove Options -Indexes causing 403 Forbidden on /OSO

### DIFF
--- a/earthsemantics/OSO/.htaccess
+++ b/earthsemantics/OSO/.htaccess
@@ -1,4 +1,4 @@
-Options +FollowSymLinks -Indexes
+Options +FollowSymLinks
 RewriteEngine On
 DirectorySlash Off
 


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #6429. After merging the previous PR, `https://w3id.org/earthsemantics/OSO` (without trailing slash) now returns **403 Forbidden** instead of redirecting to `/OSO/`.

### Root cause

`Options -Indexes` (added in #6429) causes Apache to return 403 when:
- `DirectorySlash Off` prevents the automatic trailing-slash redirect
- `Options -Indexes` blocks the directory listing
- No `index.html` exists in the directory

The `RewriteRule` redirect from `/OSO` → `/OSO/` (also added in #6429) should handle this, but Apache's core directory access check with `-Indexes` fires before `mod_rewrite` can intercept.

### Fix

Remove `Options -Indexes`. The `RewriteRule` redirect to `/OSO/` is sufficient to prevent the directory listing from being served — it was the original purpose of that rule.

### Verification

Before (with `-Indexes`):
```
$ curl -sI https://w3id.org/earthsemantics/OSO
HTTP/1.1 403 Forbidden
```

After (without `-Indexes`), expected:
```
$ curl -sI https://w3id.org/earthsemantics/OSO
HTTP/1.1 302 Found
Location: https://w3id.org/earthsemantics/OSO/
```

`/OSO/` (with trailing slash) continues to work correctly (302 → documentation page).