### PR TITLE
Add /kno namespace for Korean Neologism Observatory

### DIFF
--- a/kno/.htaccess
+++ b/kno/.htaccess
@@ -1,6 +1,6 @@
 # Korean Neologism Observatory (KNO)
 # 한국어 신어 관측 시스템
-# Contact: koreanneology@gmail.com
+# Maintainer: @KorNEO (koreanneology@gmail.com)
 # Repository: https://github.com/KorNEO/KNO
 
 Options +FollowSymLinks

--- a/kno/.htaccess
+++ b/kno/.htaccess
@@ -1,0 +1,9 @@
+# Korean Neologism Observatory (KNO)
+# 한국어 신어 관측 시스템
+# Contact: koreanneology@gmail.com
+# Repository: https://github.com/KorNEO/KNO
+
+Options +FollowSymLinks
+RewriteEngine on
+
+RewriteRule ^(.*)$ https://korneo.github.io/KNO/$1 [R=302,L]


### PR DESCRIPTION
## Brief Description

Requesting a new ID directory `/kno` for the Korean Neologism Observatory (KNO),
a corpus-based observatory of Korean neologisms.

KNO publishes lexicographic data on Korean neologisms — headword entries with
frequency, dispersion, and diffusion metrics derived from a monitor corpus of
Korean news articles and user comments. The dataset is being published as Linked
Open Data using OntoLex-Lemon and the FrAC (Frequency, Attestation and Corpus)
module, which requires persistent, dereferenceable IRIs for lexical entries,
forms, senses, frequency observations, and attestations.

* Namespace: `https://w3id.org/kno/`
* Example entry IRI: `https://w3id.org/kno/entry/h000001/`
* Redirect target: https://korneo.github.io/KNO/
* Project repository: https://github.com/KorNEO/KNO
* Maintainer: [@KorNEO](https://github.com/KorNEO) (koreanneology@gmail.com)

This PR adds a single file, `kno/.htaccess`, containing only a 302 redirect to
the current hosting location. No content is served from this service.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist

N/A — this is a new ID directory.

## Optional Requests for W3ID Maintainers

- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.