### PR TITLE
Add digest-law (American Legal Digest)

### DIFF
--- a/digest-law/.htaccess
+++ b/digest-law/.htaccess
@@ -1,0 +1,26 @@
+# https://w3id.org/digest-law
+# American Legal Digest — open, source-grounded digests of legal issues,
+# organised by jurisdiction. First jurisdiction: United States (/us/...).
+#
+# ## Contact
+# This space is administered by:
+#
+# Arthur S. Rodrigues
+# arthursrodrigues@gmail.com
+# GitHub username: arthrod
+
+# Turn off MultiViews
+Options -MultiViews
+
+RewriteEngine on
+
+# --- United States corpus: https://w3id.org/digest-law/us/... ---
+# Bundle URIs: /us/{area}/{topic}/  (plus .../sources/{slug}/ and .../audit/)
+RewriteRule ^us/?$ https://arthrod.github.io/digest-law-us/ [R=303,NE,L]
+RewriteRule ^us/(.*)$ https://arthrod.github.io/digest-law-us/$1 [R=302,NE,L]
+
+# --- Namespace root ---
+RewriteRule ^$ https://arthrod.github.io/digest-law-us/ [R=303,NE,L]
+
+# --- Everything else ---
+RewriteRule ^(.*)$ https://arthrod.github.io/digest-law-us/$1 [R=302,NE,L]

--- a/digest-law/README.md
+++ b/digest-law/README.md
@@ -1,0 +1,18 @@
+# digest-law
+
+Permanent identifier base for the **American Legal Digest** — open,
+source-grounded digests of legal issues, organised by jurisdiction. Each digest
+bundle is one researched legal issue: the digest text, its retained public
+sources in full (minimum 2 per bundle), and a machine-readable audit trail.
+
+The namespace is jurisdiction-first; the United States corpus (1,621 digest
+bundles across 42 areas of U.S. law) is the first jurisdiction.
+
+- US digest URIs: `https://w3id.org/digest-law/us/{area}/{topic}/`
+- Retained sources: `https://w3id.org/digest-law/us/{area}/{topic}/sources/{slug}/`
+- Audit trails: `https://w3id.org/digest-law/us/{area}/{topic}/audit/`
+- Published site & data: https://arthrod.github.io/digest-law-us/
+- Source: https://github.com/arthrod/digest-law-us
+- Companion vocabulary (same maintainer): https://w3id.org/legal-taxonomy/
+
+**Maintainer:** Arthur S. Rodrigues — arthursrodrigues@gmail.com — GitHub: [@arthrod](https://github.com/arthrod)


### PR DESCRIPTION
Adds the `digest-law` namespace for the **American Legal Digest** — open, source-grounded digests of legal issues with per-bundle retained sources and machine-readable audit trails, organised by jurisdiction.

**Structure (jurisdiction-first):**
- `https://w3id.org/digest-law/us/{area}/{topic}/` — a digest bundle (US corpus: 1,621 bundles across 42 areas of U.S. law)
- `https://w3id.org/digest-law/us/{area}/{topic}/sources/{slug}/` — a retained source document
- `https://w3id.org/digest-law/us/{area}/{topic}/audit/` — the bundle's audit trail

**Redirect target:** https://arthrod.github.io/digest-law-us/ (live; source repo: https://github.com/arthrod/digest-law-us). Root and `us/…` paths redirect there; the full per-bundle site is being built on the same paths, so identifiers minted now stay stable.

**Related namespace:** this is a companion to [`legal-taxonomy`](https://w3id.org/legal-taxonomy/) (added in #6235, merged 2026-06-23) — digest topics carry SKOS relations into that vocabulary. Same maintainer.

**Contact:** Arthur S. Rodrigues — arthursrodrigues@gmail.com — GitHub [@arthrod](https://github.com/arthrod) (recorded in `.htaccess` and `README.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
