### PR TITLE
Redirect APD HTML to the directory URL, not index.html

### DIFF
--- a/APD/.htaccess
+++ b/APD/.htaccess
@@ -52,12 +52,12 @@ RewriteRule ^ https://traitecoevo.github.io/APD/APD.ttl [R=303,L]
 # ------------------------------------------------------------------------------
 # Rewrite rule to serve HTML
 # Don't need RewriteCond as only processed if none of the above are satisfied
-RewriteRule ^release/(\d+)\.(\d+)\.(\d+)(.+)?$ https://traitecoevo.github.io/APD/release/$1.$2.$3/index.html [R=303,L]
+RewriteRule ^release/(\d+)\.(\d+)\.(\d+)(.+)?$ https://traitecoevo.github.io/APD/release/$1.$2.$3/ [R=303,L]
 
-RewriteRule ^traits/([^/]+)/?$ https://traitecoevo.github.io/APD/index.html#$1 [R=303,NE,L]
-RewriteRule ^traits/?$ https://traitecoevo.github.io/APD/index.html#trait-concepts [R=303,NE,L]
-RewriteRule ^glossary/glossary_(.+)/?$ https://traitecoevo.github.io/APD/index.html#glossary_$1 [R=303,NE,L]
-RewriteRule ^glossary/?$ https://traitecoevo.github.io/APD/index.html#glossary [R=303,NE,L]
+RewriteRule ^traits/([^/]+)/?$ https://traitecoevo.github.io/APD/#$1 [R=303,NE,L]
+RewriteRule ^traits/?$ https://traitecoevo.github.io/APD/#trait-concepts [R=303,NE,L]
+RewriteRule ^glossary/glossary_(.+)/?$ https://traitecoevo.github.io/APD/#glossary_$1 [R=303,NE,L]
+RewriteRule ^glossary/?$ https://traitecoevo.github.io/APD/#glossary [R=303,NE,L]
 
 ## Final call should catch all remaining calls that haven't been matched above 
-RewriteRule ^ https://traitecoevo.github.io/APD/index.html [R=303,L]
+RewriteRule ^ https://traitecoevo.github.io/APD/ [R=303,L]

--- a/APD/README.md
+++ b/APD/README.md
@@ -25,6 +25,7 @@ Suggestions for changes are welcome and can be posted at https://github.com/trai
 
 - the `.htaccess` code is written to process calls to variants of the machine-readable representations before any queries to `html`, i.e., `*.ttl`, `*.nq`, `*.nt`, and `*.json`, before `*.html`. This reduces the number of `RewriteCond` statements needed in the `html` section. 
 - tested with https://htaccess.madewithlove.com (using `https://w3id.org/` as the base URL; `https://w3id.org/APD/` won't work, as code is written as though you're already in that subfolder)
+- the HTML targets end in `/`, **not** `/index.html` — `https://traitecoevo.github.io/APD/#<slug>` rather than `.../APD/index.html#<slug>`. Both paths serve the same 6 MB document, so naming both gave one page two URLs: two browser cache entries, two downloads, and two things for search engines to index. `/APD/` is the form the site declares as its own (`site-url`) and the form its internal links resolve to, so it is the one to redirect into. Don't put `index.html` back.
 - the following flags are used
   - `[R=303]` — A redirect. When a server responds with a `303` status code, it provides a `Location` pointing to a different URI. The client, upon receiving a `303` response, automatically makes a `GET` request to the URI specified in the `Location` header.  
   - `[L]` — If the previous conditions pass, this rule is executed, and no more evaluation is done. 


### PR DESCRIPTION
Follow-up to #6444. Same directory, same six-rule block; I administer the APD space (contact details in `APD/README.md`).

## The problem

`https://traitecoevo.github.io/APD/` and `.../APD/index.html` serve **the same 6 MB document** — byte-identical, same ETag. Naming the second gave one page two URLs. The browser cache is keyed on URL, so a visitor who reaches the dictionary both ways downloads it twice, and search engines have two things to index.

`/APD/` is the form the site declares as its own `site-url`, and the form its 6,366 internal links resolve to. So it's the one the redirects should land on.

## The change

Six HTML-serving rules, all in the same block:

```
traits/<slug>      ->  /APD/#<slug>
traits/            ->  /APD/#trait-concepts
glossary/<slug>    ->  /APD/#glossary_<slug>
glossary/          ->  /APD/#glossary
release/X.Y.Z/...  ->  /APD/release/X.Y.Z/
catch-all          ->  /APD/
```

**Fragments are unchanged**, so every published identifier still resolves to the same place in the document. The four machine-readable rules (`APD.ttl`, `.nt`, `.nq`, `.json`) are untouched — the content-negotiation block above is not in the path of this change.

## Verification

Every resulting target returns 200, checked live:

```
/APD/                    200
/APD/release/2.1.1/      200
/APD/release/2.1.0/      200
/APD/release/1.0.0/      200
```

The `release/` rule is the only one whose *path* changes rather than just losing a suffix, hence checking each snapshot directory rather than one sample.

Also added a note to `APD/README.md`'s design section recording why the targets omit `index.html`, since that file documents the rules and previously said nothing about it.

## Downstream

The APD site's own search index also hardcoded `index.html`, which was the other half of this; that's fixed on our side in traitecoevo/APD#60.