### PR TITLE
bedro directory: update .htaccess to link to html file not to rdf

### DIFF
--- a/bedro/.htaccess
+++ b/bedro/.htaccess
@@ -28,7 +28,7 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^$ https://noacktim.github.io/BEDRO/bedro.rdf [R=303,L]
+RewriteRule ^$ https://noacktim.github.io/BEDRO/ [R=303,L]
 
 # Rewrite rule to serve TTL content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.* [OR]


### PR DESCRIPTION
## Brief Description
Bridge Element Design Rule Ontology (BEDRO): The old .htaccess linked directly to the rdf-file if the https://w3id.org/bedro link was used. The update changes the redirect to the html page.

## General Checklist
- [X] Changes have been tested.
- [X] The number of commits is minimal. Squash if needed.
- [X] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## Update ID Directory Checklist
- [X] GitHub username ids are listed in the changed maintainer details.
- [X] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
- [X] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
