### PR TITLE
OSO: fix bare ontology IRI returning a directory listing (mod_alias instead of mod_rewrite)

### DIFF
--- a/earthsemantics/OSO/.htaccess
+++ b/earthsemantics/OSO/.htaccess
@@ -2,18 +2,9 @@ Options +FollowSymLinks
 RewriteEngine On
 DirectorySlash Off
 
-# ====================================================================
-# Content-Type override for O'FAIRe content negotiation (A1Q3)
-# ====================================================================
-# O'FAIRe's ResolvableURLTest disables redirect following and only
-# accepts HTTP 200/302 with Content-Type matching the Accept header.
-# The T= flag does NOT work on redirect responses. Instead, we use
-# SetEnvIf to detect the Accept header and Header always set to
-# override the Content-Type on the 302 response.
-# O'FAIRe tests these 5 formats: application/json, application/xml,
-# text/html, text/plain, application/rdf+xml.
-# text/html already has correct CT on 302 (text/html; charset=iso-8859-1),
-# so no override is needed for it.
+# O'FAIRe does not follow redirects and requires the Content-Type of the
+# 302 to match the Accept header. The T= flag has no effect on redirects,
+# so the Content-Type is forced via SetEnvIf + Header instead.
 SetEnvIf Accept "application/json" CT_JSON
 SetEnvIf Accept "application/xml" CT_XML
 SetEnvIf Accept "text/plain" CT_PLAIN
@@ -28,18 +19,13 @@ Header always set Content-Type "application/rdf+xml" env=CT_RDFXML
 Header always set Content-Type "text/turtle" env=CT_TURTLE
 Header always set Content-Type "text/n3" env=CT_N3
 
-# ====================================================================
-# Redirect directory root without trailing slash to trailing slash
-# ====================================================================
+# Trailing slash for the bare IRI. Must be mod_alias: for /earthsemantics/OSO
+# mod_rewrite cannot strip the per-directory prefix ".../OSO/" from the
+# filename ".../OSO", declines, and every RewriteRule below is skipped --
+# mod_autoindex then serves a directory listing as 200.
+RedirectMatch 302 ^/earthsemantics/OSO$ /earthsemantics/OSO/
 
-RewriteCond %{REQUEST_FILENAME} -d
-RewriteCond %{REQUEST_URI} !/$
-RewriteRule ^.*$ %{REQUEST_URI}/ [R=302,L]
-
-# ====================================================================
-# Versioned ontology IRI content negotiation
-# R=302 (not 303) for O'FAIRe F1Q4 compatibility (only accepts 200/302)
-# ====================================================================
+# Versioned IRIs -- 302 (not 303) for O'FAIRe F1Q4, which only accepts 200/302
 
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
@@ -58,7 +44,7 @@ RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://virtuoso.ifremer.fr/oso-version
 RewriteCond %{HTTP_ACCEPT} text/n3
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.n3 [R=302,L]
 
-# application/json -> OSO.json (twin of OSO.jsonld served as application/json)
+# OSO.json is OSO.jsonld served as application/json
 RewriteCond %{HTTP_ACCEPT} application/json
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.json [R=302,L]
 
@@ -66,10 +52,9 @@ RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://emso-eric.github.io/oso-ontology/ [R=302,L]
 
-# Default fallback -> Turtle (R=302 for O'FAIRe F1Q4)
+# Fallback -> Turtle
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.ttl [R=302,L]
 
-# Explicit versioned serializations
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)\.ttl/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.ttl [R=303,L]
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)\.owl/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.owl [R=303,L]
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)\.rdf/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.owl [R=303,L]
@@ -78,71 +63,46 @@ RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)\.nt/?$ https://virtuoso.ifremer.fr/oso-ver
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)\.n3/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.n3 [R=303,L]
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)\.trig/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.trig [R=303,L]
 
-# ====================================================================
 # SPARQL endpoint and UI
-# ====================================================================
-
 RewriteRule ^sparql/?$ https://virtuoso.ifremer.fr/oso/sparql [R=303,L]
 RewriteRule ^ui/?$ https://virtuoso.ifremer.fr/oso/ [R=303,L]
 
-# ====================================================================
-# Main ontology IRI content negotiation
-# https://w3id.org/earthsemantics/OSO
-# R=302 (not 303) for O'FAIRe A1Q1/A1Q3 compatibility.
-# O'FAIRe does not follow redirects and only accepts 200/302 with
-# matching Content-Type. Content-Type is overridden via SetEnvIf +
-# Header directives above (T= flag does not work on redirects).
-# Content is served from Virtuoso DAV versioned URLs (currently 1.1.0).
-# ====================================================================
-
-# HTML documentation
+# Main ontology IRI (https://w3id.org/earthsemantics/OSO), pinned to 1.1.0.
+# 302 (not 303) for O'FAIRe A1Q1/A1Q3, which only accepts 200/302.
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
 RewriteRule ^$ https://emso-eric.github.io/oso-ontology/ [R=302,L]
 
-# Turtle
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
 RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.ttl [R=302,L]
 
-# RDF/XML
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.owl [R=302,L]
-
-# Generic XML fallback
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} application/xml
 RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.owl [R=302,L]
 
-# JSON-LD
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
 RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.jsonld [R=302,L]
 
-# JSON (twin of JSON-LD served as application/json for EarthPortal checker)
 RewriteCond %{HTTP_ACCEPT} application/json
 RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.json [R=302,L]
 
-# N-Triples
 RewriteCond %{HTTP_ACCEPT} application/n-triples
 RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.nt [R=302,L]
 
-# N3
 RewriteCond %{HTTP_ACCEPT} text/n3
 RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.n3 [R=302,L]
 
-# TriG
 RewriteCond %{HTTP_ACCEPT} application/trig
 RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.trig [R=302,L]
 
-# Plain text fallback -> Turtle
 RewriteCond %{HTTP_ACCEPT} text/plain
 RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.ttl [R=302,L]
 
-# Default fallback -> documentation (R=302 for O'FAIRe A1Q1)
+# Fallback -> documentation
 RewriteRule ^$ https://emso-eric.github.io/oso-ontology/ [R=302,L]
 
-# ====================================================================
 # Explicit serialization URLs
-# ====================================================================
 RewriteRule ^OSO\.ttl/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.ttl [R=303,L]
 RewriteRule ^OSO\.owl/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.owl [R=303,L]
 RewriteRule ^OSO\.rdf/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.owl [R=303,L]
@@ -160,9 +120,6 @@ RewriteRule ^nt/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.nt [R=303,
 RewriteRule ^n3/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.n3 [R=303,L]
 RewriteRule ^trig/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.trig [R=303,L]
 
-# ====================================================================
 # Metadata artifacts
-# ====================================================================
-
 RewriteRule ^void/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/void.ttl [R=303,L]
 RewriteRule ^dcat/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/dcat.ttl [R=303,L]


### PR DESCRIPTION
## Problem

`https://w3id.org/earthsemantics/OSO` (the bare ontology IRI, no trailing slash) returns **HTTP 200 with an Apache directory listing** instead of negotiating content:

```console
$ curl -sI -H "Accept: text/turtle" https://w3id.org/earthsemantics/OSO
HTTP/1.1 200 OK
Content-Type: text/turtle          # <-- forced by the Header directives

$ curl -s -H "Accept: text/turtle" https://w3id.org/earthsemantics/OSO | head -1
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
```

Because the HTML listing is relabelled as `application/xml` for a browser's `Accept`, browsers fail with:

> error on line 1 at column 55: Space required after the Public Identifier

`https://w3id.org/earthsemantics/OSO/` (with trailing slash) has always worked correctly.

## Root cause

With `DirectorySlash Off`, the request resolves to the `OSO/` directory, but **mod_rewrite cannot process it at all**. In per-directory context mod_rewrite strips the per-directory prefix `.../OSO/` from the filename; for this request the filename is `.../OSO` (no trailing slash), the strip fails, mod_rewrite declines, and **every `RewriteRule` in `OSO/.htaccess` is skipped**. The request falls through to `mod_autoindex`, while the `Header always set Content-Type` directives — which are *not* mod_rewrite and so still apply — relabel the listing.

I confirmed this on a local Apache 2.4 with the repo's `.htaccess` files mounted as-is and `LogLevel rewrite:trace4`. Replacing the whole file with a single catch-all:

```apache
RewriteRule ^(.*)$ http://diag.invalid/uri=$1 [R=302,L]
```

still returns 200 for `/earthsemantics/OSO` — the rule never fires — while `/earthsemantics/OSO/` and `/earthsemantics/OSO/ttl` both redirect as expected. Only `Header`/`SetEnvIf` survive.

This also explains the two earlier attempts:

- **#6429** added `RewriteCond %{REQUEST_FILENAME} -d` + `RewriteCond %{REQUEST_URI} !/$`. It could never have worked: the rules are skipped entirely, and in this context `%{REQUEST_URI}` is already `/earthsemantics/OSO/` **with** a trailing slash, so `!/$` never matches. The trace shows `RewriteCond: input='/earthsemantics/OSO/' pattern='!/$' =>` failing.
- **#6429** also added `Options -Indexes`, which only converted the listing into a `403 Forbidden`. **#6449** removed it, which restored the listing.

## Fix

Use `mod_alias`, which has no per-directory prefix limitation and runs in the fixup phase, before the autoindex handler:

```apache
RedirectMatch 302 ^/earthsemantics/OSO$ /earthsemantics/OSO/
```

`302` (not `301`) keeps O'FAIRe's `A1Q1`/`A1Q3` satisfied — it does not follow redirects and accepts only 200/302 — and the existing `Content-Type` overrides still apply to this redirect, so the negotiated type is preserved on the first hop.

`mod_alias` is already relied upon by 29 other `.htaccess` files in this repository, so it is guaranteed to be enabled.

This PR also trims the comment blocks in this file (180 → 126 lines), keeping only the non-obvious rationale.

## Verification

Apache 2.4 in Docker, `AllowOverride All`, both `earthsemantics/.htaccess` and `earthsemantics/OSO/.htaccess` mounted byte-identical to this branch.

Main IRI, before → after:

| `Accept` | `/OSO` before | `/OSO` after | `/OSO/` (unchanged) |
|---|---|---|---|
| `text/html` | 200 listing | 302 → `/OSO/` | 302 → `emso-eric.github.io/oso-ontology/` |
| `text/turtle` | 200 listing | 302 → `/OSO/`, `text/turtle` | 302 → `OSO.ttl` |
| `application/rdf+xml` | 200 listing | 302 → `/OSO/`, `application/rdf+xml` | 302 → `OSO.owl` |
| `application/xml` | 200 listing | 302 → `/OSO/`, `application/xml` | 302 → `OSO.owl` |
| `application/ld+json` | 200 listing | 302 → `/OSO/` | 302 → `OSO.jsonld` |
| `application/json` | 200 listing | 302 → `/OSO/`, `application/json` | 302 → `OSO.json` |
| `application/n-triples` | 200 listing | 302 → `/OSO/` | 302 → `OSO.nt` |
| `text/n3` | 200 listing | 302 → `/OSO/`, `text/n3` | 302 → `OSO.n3` |
| `application/trig` | 200 listing | 302 → `/OSO/` | 302 → `OSO.trig` |
| `text/plain` | 200 listing | 302 → `/OSO/`, `text/plain` | 302 → `OSO.ttl` |
| browser `Accept` string | 200 listing | 302 → `/OSO/`, `application/xml` | 302 → `emso-eric.github.io/oso-ontology/` |
| no `Accept` header | 200 listing | 302 → `/OSO/` | 302 → `emso-eric.github.io/oso-ontology/` |

No regressions elsewhere:

- All 22 explicit paths still return 302/303: `OSO.{ttl,owl,rdf,jsonld,json,nt,n3,trig}`, the bare `{ttl,owl,rdf,jsonld,json,nt,n3,trig}` aliases, `sparql`, `ui`, `void`, `dcat`.
- Versioned IRIs unchanged: `/OSO/1.1.0` negotiates per `Accept`, and with no `Accept` returns 302 → `OSO.ttl` (O'FAIRe `F1Q4`).
- `/OSO/<unknown>` returns a clean 404.
- The parent namespace still redirects: `/earthsemantics/Other` → 302 → `earthportal.eu/ontologies/Other`.
- No directory listing and no 403 is reachable under `/earthsemantics/OSO`.
