### PR TITLE
Add openccf permanent identifier for OpenCCF data model

### DIFF
--- a/openccf/.htaccess
+++ b/openccf/.htaccess
@@ -1,0 +1,20 @@
+# /openccf/
+#
+# Permanent identifier for the OpenCCF (Open Corporate Carbon Footprint) data
+# model schema. https://w3id.org/openccf redirects to the generated schema
+# reference site; sub-paths (e.g. https://w3id.org/openccf/EmissionsReport)
+# redirect to the corresponding class/slot documentation page, matching the
+# definition_uri values used throughout the LinkML schema.
+#
+# Source: https://github.com/openccf/openccf-data-model
+#
+# ## Contact
+# This space is administered by:
+#
+# Patrick Stirling
+# GitHub username: patstirling
+# Issues: https://github.com/openccf/openccf-data-model/issues
+
+RewriteEngine on
+RewriteRule ^$ https://openccf.github.io/openccf-data-model/ [R=302,L]
+RewriteRule ^(.*)$ https://openccf.github.io/openccf-data-model/elements/$1/ [R=302,L]

--- a/openccf/README.md
+++ b/openccf/README.md
@@ -16,5 +16,5 @@ systems.
 
 ## Contact
 
-Patrick Stirling ([@patstirling](https://github.com/patstirling))
+Patrick Stirling ([@patstirling](https://github.com/patstirling))<br>
 Issues: <https://github.com/openccf/openccf-data-model/issues>

--- a/openccf/README.md
+++ b/openccf/README.md
@@ -1,0 +1,20 @@
+# openccf
+
+Permanent identifier namespace for **OpenCCF**, an open, CC0-licensed data
+model for exchanging GHG Protocol-aligned corporate carbon footprints between
+systems.
+
+- `https://w3id.org/openccf` redirects to the generated schema reference site.
+- `https://w3id.org/openccf/<Term>` redirects to the documentation page for
+  that class or slot (e.g. `https://w3id.org/openccf/EmissionsReport`),
+  matching the `definition_uri` values used throughout the schema.
+
+## Links
+
+- Schema source: <https://github.com/openccf/openccf-data-model>
+- Project site: <https://openccf.org>
+
+## Contact
+
+Patrick Stirling ([@patstirling](https://github.com/patstirling))
+Issues: <https://github.com/openccf/openccf-data-model/issues>

--- a/openccf/README.md
+++ b/openccf/README.md
@@ -6,7 +6,7 @@ systems.
 
 - `https://w3id.org/openccf` redirects to the generated schema reference site.
 - `https://w3id.org/openccf/<Term>` redirects to the documentation page for
-  that class or slot (e.g. `https://w3id.org/openccf/EmissionsReport`),
+  that class or slot (e.g., `https://w3id.org/openccf/EmissionsReport`),
   matching the `definition_uri` values used throughout the schema.
 
 ## Links


### PR DESCRIPTION
Adds a permanent identifier namespace for **OpenCCF** (Open Corporate Carbon Footprint), an open, CC0-licensed data model for exchanging GHG Protocol-aligned corporate carbon footprints between systems: https://openccf.org

- `https://w3id.org/openccf` redirects to the generated schema reference site.
- `https://w3id.org/openccf/<Term>` redirects to the documentation page for that class or slot, matching the `definition_uri` values used throughout the LinkML schema (e.g. `https://w3id.org/openccf/EmissionsReport`).

Schema source: https://github.com/openccf/openccf-data-model