### PR TITLE
Point ARK ontology redirects at GitHub Pages

### DIFF
--- a/ARK/.htaccess
+++ b/ARK/.htaccess
@@ -1,38 +1,159 @@
 Header set Access-Control-Allow-Origin *
-Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
+Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type
 Options +FollowSymLinks
 RewriteEngine on
 
-RewriteRule ^$ http://openark.adaptcentre.ie/ [R=302,L]
+RewriteRule ^$ https://adapt-ark.github.io/ark-websites/ [R=302,L]
 
-RewriteRule ^Cube$ http://openark.adaptcentre.ie/Ontologies/ARKCube [R=302,L]
-RewriteRule ^Cube/$ http://openark.adaptcentre.ie/Ontologies/ARKCube [R=302,L]
-RewriteRule ^Cube/(.*)$ http://openark.adaptcentre.ie/Ontologies/ARKCube#$1 [NE,R=302,L]
+# ---------------------------------------------------------------------------
+# ARK Cube
+RewriteRule ^Cube$ /ARK/Cube/ [R=301,L]
 
-RewriteRule ^Platform$ http://openark.adaptcentre.ie/Ontologies/ARKPlatform [R=302,L]
-RewriteRule ^Platform/$ http://openark.adaptcentre.ie/Ontologies/ARKPlatform [R=302,L]
-RewriteRule ^Platform/(.*)$ http://openark.adaptcentre.ie/Ontologies/ARKPlatform#$1 [NE,R=302,L]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^Cube/$ https://adapt-ark.github.io/ark-ontology/ARKCube/ontology.jsonld [R=303,L]
 
-RewriteRule ^RiskTerminology$ http://openark.adaptcentre.ie/Ontologies/ARKRiskTerminology [R=302,L]
-RewriteRule ^RiskTerminology/$ http://openark.adaptcentre.ie/Ontologies/ARKRiskTerminology [R=302,L]
-RewriteRule ^RiskTerminology/(.*)$ http://openark.adaptcentre.ie/Ontologies/ARKRiskTerminology#$1 [NE,R=302,L]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^Cube/$ https://adapt-ark.github.io/ark-ontology/ARKCube/ontology.ttl [R=303,L]
 
-RewriteRule ^HealthTerminology$ http://openark.adaptcentre.ie/Ontologies/ARKHealthTerminology [R=302,L]
-RewriteRule ^HealthTerminology/$ http://openark.adaptcentre.ie/Ontologies/ARKHealthTerminology [R=302,L]
-RewriteRule ^HealthTerminology/(.*)$ http://openark.adaptcentre.ie/Ontologies/ARKHealthTerminology#$1 [NE,R=302,L]
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^Cube/$ https://adapt-ark.github.io/ark-ontology/ARKCube/ontology.nt [R=303,L]
 
-RewriteRule ^HospitalAdverseIncidentsCategoriesAndSubcategoriesTerminology$ http://openark.adaptcentre.ie/Ontologies/HAdvIncCats [R=302,L]
-RewriteRule ^HospitalAdverseIncidentsCategoriesAndSubcategoriesTerminology/$ http://openark.adaptcentre.ie/Ontologies/HAdvIncCats [R=302,L]
-RewriteRule ^HospitalAdverseIncidentsCategoriesAndSubcategoriesTerminology/(.*)$ http://openark.adaptcentre.ie/Ontologies/HAdvIncCats#$1 [NE,R=302,L]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^Cube/$ https://adapt-ark.github.io/ark-ontology/ARKCube/ontology.owl [R=303,L]
 
-RewriteRule ^ControlsOntology$ http://openark.adaptcentre.ie/Ontologies/ARKControlsOntology [R=302,L]
-RewriteRule ^ControlsOntology/$ http://openark.adaptcentre.ie/Ontologies/ARKControlsOntology [R=302,L]
-RewriteRule ^ControlsOntology/(.*)$ http://openark.adaptcentre.ie/Ontologies/ARKControlsOntology#$1 [NE,R=302,L]
+RewriteRule ^Cube/$ https://adapt-ark.github.io/ark-ontology/ARKCube/index-en.html [R=303,L]
 
-RewriteRule ^CybersecurityTerminology$ http://openark.adaptcentre.ie/Ontologies/CybersecurityTerminology [R=302,L]
-RewriteRule ^CybersecurityTerminology/$ http://openark.adaptcentre.ie/Ontologies/CybersecurityTerminology [R=302,L]
-RewriteRule ^CybersecurityTerminology/(.*)$ http://openark.adaptcentre.ie/Ontologies/CybersecurityTerminology#$1 [NE,R=302,L]
+RewriteRule ^Cube/(.+)$ https://adapt-ark.github.io/ark-ontology/ARKCube/index-en.html#$1 [NE,R=302,L]
 
-RewriteRule ^LoggingOntology$ http://openark.adaptcentre.ie/Ontologies/ARKLoggingOntology [R=302,L]
-RewriteRule ^LoggingOntology/$ http://openark.adaptcentre.ie/Ontologies/ARKLoggingOntology [R=302,L]
-RewriteRule ^LoggingOntology/(.*)$ http://openark.adaptcentre.ie/Ontologies/ARKLoggingOntology#$1 [NE,R=302,L]
+# ---------------------------------------------------------------------------
+# ARK Platform
+RewriteRule ^Platform$ /ARK/Platform/ [R=301,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^Platform/$ https://adapt-ark.github.io/ark-ontology/ARKPlatform/ontology.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^Platform/$ https://adapt-ark.github.io/ark-ontology/ARKPlatform/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^Platform/$ https://adapt-ark.github.io/ark-ontology/ARKPlatform/ontology.nt [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^Platform/$ https://adapt-ark.github.io/ark-ontology/ARKPlatform/ontology.owl [R=303,L]
+
+RewriteRule ^Platform/$ https://adapt-ark.github.io/ark-ontology/ARKPlatform/index.html [R=303,L]
+
+RewriteRule ^Platform/(.+)$ https://adapt-ark.github.io/ark-ontology/ARKPlatform/index.html#$1 [NE,R=302,L]
+
+# ---------------------------------------------------------------------------
+# ARK Risk Terminology (TTL only)
+RewriteRule ^RiskTerminology$ /ARK/RiskTerminology/ [R=301,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^RiskTerminology/$ https://adapt-ark.github.io/ark-ontology/ARKRiskTerminology/terms.ttl [R=303,L]
+
+RewriteRule ^RiskTerminology/$ https://adapt-ark.github.io/ark-ontology/ARKRiskTerminology/index.html [R=303,L]
+
+RewriteRule ^RiskTerminology/(.+)$ https://adapt-ark.github.io/ark-ontology/ARKRiskTerminology/index.html#$1 [NE,R=302,L]
+
+# ---------------------------------------------------------------------------
+# ARK Health Terminology (TTL only)
+RewriteRule ^HealthTerminology$ /ARK/HealthTerminology/ [R=301,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^HealthTerminology/$ https://adapt-ark.github.io/ark-ontology/ARKHealthTerminology/healthTerms.ttl [R=303,L]
+
+RewriteRule ^HealthTerminology/$ https://adapt-ark.github.io/ark-ontology/ARKHealthTerminology/index.html [R=303,L]
+
+RewriteRule ^HealthTerminology/(.+)$ https://adapt-ark.github.io/ark-ontology/ARKHealthTerminology/index.html#$1 [NE,R=302,L]
+
+# ---------------------------------------------------------------------------
+# ARK Platform Terminology (TTL only)
+RewriteRule ^PlatformTerminology$ /ARK/PlatformTerminology/ [R=301,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^PlatformTerminology/$ https://adapt-ark.github.io/ark-ontology/ARKPlatformTerminology/ARKPlatformTerms.ttl [R=303,L]
+
+RewriteRule ^PlatformTerminology/$ https://adapt-ark.github.io/ark-ontology/ARKPlatformTerminology/index.html [R=303,L]
+
+RewriteRule ^PlatformTerminology/(.+)$ https://adapt-ark.github.io/ark-ontology/ARKPlatformTerminology/index.html#$1 [NE,R=302,L]
+
+# ---------------------------------------------------------------------------
+# Hospital Adverse Incidents Categories and Subcategories Terminology (TTL only)
+RewriteRule ^HospitalAdverseIncidentsCategoriesAndSubcategoriesTerminology$ /ARK/HospitalAdverseIncidentsCategoriesAndSubcategoriesTerminology/ [R=301,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^HospitalAdverseIncidentsCategoriesAndSubcategoriesTerminology/$ https://adapt-ark.github.io/ark-ontology/HAdvIncCats/AIRCatSubcatTerms.ttl [R=303,L]
+
+RewriteRule ^HospitalAdverseIncidentsCategoriesAndSubcategoriesTerminology/$ https://adapt-ark.github.io/ark-ontology/HAdvIncCats/index.html [R=303,L]
+
+RewriteRule ^HospitalAdverseIncidentsCategoriesAndSubcategoriesTerminology/(.+)$ https://adapt-ark.github.io/ark-ontology/HAdvIncCats/index.html#$1 [NE,R=302,L]
+
+# ---------------------------------------------------------------------------
+# ARK Controls Ontology
+RewriteRule ^ControlsOntology$ /ARK/ControlsOntology/ [R=301,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^ControlsOntology/$ https://adapt-ark.github.io/ark-ontology/ARKControlsOntology/ontology.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^ControlsOntology/$ https://adapt-ark.github.io/ark-ontology/ARKControlsOntology/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^ControlsOntology/$ https://adapt-ark.github.io/ark-ontology/ARKControlsOntology/ontology.nt [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^ControlsOntology/$ https://adapt-ark.github.io/ark-ontology/ARKControlsOntology/ontology.owl [R=303,L]
+
+RewriteRule ^ControlsOntology/$ https://adapt-ark.github.io/ark-ontology/ARKControlsOntology/index.html [R=303,L]
+
+RewriteRule ^ControlsOntology/(.+)$ https://adapt-ark.github.io/ark-ontology/ARKControlsOntology/index.html#$1 [NE,R=302,L]
+
+# ---------------------------------------------------------------------------
+# ARK Cybersecurity Terminology
+RewriteRule ^CybersecurityTerminology$ /ARK/CybersecurityTerminology/ [R=301,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^CybersecurityTerminology/$ https://adapt-ark.github.io/ark-ontology/CybersecurityTerminology/ontology.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^CybersecurityTerminology/$ https://adapt-ark.github.io/ark-ontology/CybersecurityTerminology/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^CybersecurityTerminology/$ https://adapt-ark.github.io/ark-ontology/CybersecurityTerminology/ontology.nt [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^CybersecurityTerminology/$ https://adapt-ark.github.io/ark-ontology/CybersecurityTerminology/ontology.owl [R=303,L]
+
+RewriteRule ^CybersecurityTerminology/$ https://adapt-ark.github.io/ark-ontology/CybersecurityTerminology/index.html [R=303,L]
+
+RewriteRule ^CybersecurityTerminology/(.+)$ https://adapt-ark.github.io/ark-ontology/CybersecurityTerminology/index.html#$1 [NE,R=302,L]
+
+# ---------------------------------------------------------------------------
+# ARK Logging Ontology
+RewriteRule ^LoggingOntology$ /ARK/LoggingOntology/ [R=301,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^LoggingOntology/$ https://adapt-ark.github.io/ark-ontology/ARKLoggingOntology/ontology.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^LoggingOntology/$ https://adapt-ark.github.io/ark-ontology/ARKLoggingOntology/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^LoggingOntology/$ https://adapt-ark.github.io/ark-ontology/ARKLoggingOntology/ontology.nt [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^LoggingOntology/$ https://adapt-ark.github.io/ark-ontology/ARKLoggingOntology/ontology.owl [R=303,L]
+
+RewriteRule ^LoggingOntology/$ https://adapt-ark.github.io/ark-ontology/ARKLoggingOntology/index.html [R=303,L]
+
+RewriteRule ^LoggingOntology/(.+)$ https://adapt-ark.github.io/ark-ontology/ARKLoggingOntology/index.html#$1 [NE,R=302,L]

--- a/ARK/readme.md
+++ b/ARK/readme.md
@@ -10,6 +10,7 @@ ARK Ontologies:
 - Platform <https://w3id.org/ARK/Platform>
 - Risk Terminology <https://w3id.org/ARK/RiskTerminology>
 - Health Terminology <https://w3id.org/ARK/HealthTerminology>
+- Platform Terminology <https://w3id.org/ARK/PlatformTerminology>
 - Hospital Adverse Incidents Categories And Subcategories Terminology <https://w3id.org/ARK/HAdvIncCats>
 - Controls Ontology: <https://w3id.org/ARK/ControlsOntology>
 - Cybersecurity Terminology: <https://w3id.org/ARK/CybersecurityTerminology>
@@ -18,4 +19,4 @@ ARK Ontologies:
 Contacts:
 
 - Rob Brennan <rob.brennan@ucd.ie>
-- Junli Liang <junli.liang@adaptcentre.ie>
+- Junli Liang <junli.liang@adaptcentre.ie> (GitHub: [@junli-liang-johnny](https://github.com/junli-liang-johnny))


### PR DESCRIPTION
## Brief Description

Move ARK ontology hosting from openark.adaptcentre.ie (Apache) to
adapt-ark.github.io/ark-ontology (GitHub Pages), replicating content
negotiation via Accept-header redirects since Pages can't do
server-side rewrites. Root now points to the ARK project homepage,
and PlatformTerminology is added.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
N/A — updating an existing `ARK` directory, not creating a new one.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
