### PR TITLE
Add /shapetrees ns for ShapeTrees

### DIFF
--- a/shapetrees/.htaccess
+++ b/shapetrees/.htaccess
@@ -1,0 +1,8 @@
+# shapetrees
+#
+# https://w3id.org/shapetrees redirects to
+# https://raw.githubusercontent.com/shapetrees/specification/refs/heads/main/shapetrees.ttl
+
+RewriteEngine on
+RewriteRule ^$ https://raw.githubusercontent.com/shapetrees/specification/refs/heads/main/shapetrees.ttl [R=302,L]
+RewriteRule ^(.+)$ https://raw.githubusercontent.com/shapetrees/specification/refs/heads/main/shapetrees.ttl [R=302,L]

--- a/shapetrees/README.md
+++ b/shapetrees/README.md
@@ -1,0 +1,9 @@
+# shapetrees
+
+New namespace for https://github.com/shapetrees/specification
+Previously used domain expired and now someone squats it.
+
+## Maintainers
+* Eric Prud'hommeaux @ericprud
+* Justin Bingham @justinwb
+* elf Pavlik @elf-pavlik


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
ShapeTrees was developed by @ericprud and @justinwb in W3C Solid CG
It used it's own domain name which later expired and now is squatted. This PR mostly aims to secure the prefix and start updating few places referencing the old namespace. Adoption of ShapeTrees is very limited.
While we work on updating old links I would try to coorinate a followup PR here to add spec and primer redirects.

## General Checklist
<!-- For all ID related PRs. -->
- [ ] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

