### PR TITLE
Add support for PaNET URLs

### DIFF
--- a/PaN/PaNET/.htaccess
+++ b/PaN/PaNET/.htaccess
@@ -1,0 +1,60 @@
+Header set Access-Control-Allow-Origin *
+RewriteEngine On
+
+## REDIRECTIONS SUPPORTING LATEST RELEASE
+
+# Download artefacts
+RewriteRule ^latest/PaNET.owl$ https://pan-ontologies.github.io/PaNET/latest/ontology.owl [R=307,L]
+RewriteRule ^latest/PaNET_reasoned.owl$ https://pan-ontologies.github.io/PaNET/latest/ontology_reasoned.owl [R=307,L]
+RewriteRule ^latest/PaNET.ttl$ https://pan-ontologies.github.io/PaNET/latest/ontology.ttl [R=307,L]
+RewriteRule ^latest/PaNET.n3$ https://pan-ontologies.github.io/PaNET/latest/ontology.n3 [R=307,L]
+RewriteRule ^latest/PaNET.jsonld$ https://pan-ontologies.github.io/PaNET/latest/ontology.jsonld [R=307,L]
+
+# Describe IRI (RDF/XML)
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://pan-ontologies.github.io/PaNET/latest/ontology.owl [R=307,L]
+
+# Describe IRI (Turtle)
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^$ https://pan-ontologies.github.io/PaNET/latest/ontology.ttl [R=307,L]
+
+# Describe IRI (N3)
+RewriteCond %{HTTP_ACCEPT} text/n3
+RewriteRule ^$ https://pan-ontologies.github.io/PaNET/latest/ontology.n3 [R=307,L]
+
+# Describe IRI (JSON-LD)
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://pan-ontologies.github.io/PaNET/latest/ontology.jsonld [R=307,L]
+
+# Documentation
+RewriteRule ^$ https://pan-ontologies.github.io/PaNET/index-en.html  [R=307,L]
+
+
+## REDIRECTIONS SUPPORTING SPECIFIC VERSIONS
+
+# Download artefacts
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/PaNET.owl$ https://pan-ontologies.github.io/PaNET/$1/ontology.owl [R=307,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/PaNET_reasoned.owl$ https://pan-ontologies.github.io/PaNET/$1/ontology_reasoned.owl [R=307,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/PaNET.ttl$ https://pan-ontologies.github.io/PaNET/$1/ontology.ttl [R=307,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/PaNET.n3$ https://pan-ontologies.github.io/PaNET/$1/ontology.n3 [R=307,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/PaNET.jsonld$ https://pan-ontologies.github.io/PaNET/$1/ontology.jsonld [R=307,L]
+
+# Describe IRI (RDF/XML)
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)$ https://pan-ontologies.github.io/PaNET/$1/ontology.owl [R=307,L]
+
+# Describe IRI (Turtle)
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)$ https://pan-ontologies.github.io/PaNET/$1/ontology.ttl [R=307,L]
+
+# Describe IRI (N3)
+RewriteCond %{HTTP_ACCEPT} text/n3
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)$ https://pan-ontologies.github.io/PaNET/$1/ontology.n3 [R=307,L]
+
+# Describe IRI (JSON-LD)
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)$ https://pan-ontologies.github.io/PaNET/$1/ontology.jsonld [R=307,L]
+
+# Documentation
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/$ /PaN/PaNET/$1 [R=308]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)$ https://pan-ontologies.github.io/PaNET/$1/index-en.html [R=307,L]

--- a/PaN/PaNET/README.md
+++ b/PaN/PaNET/README.md
@@ -1,0 +1,14 @@
+# PaNET
+
+The Photon and Neutron Experimental Technique (PaNET) ontology
+provides a taxonomy of experimental techniques relevant for the Photon
+and Neutron (PaN) community.
+
+## Repository
+
+[https://github.com/pan-ontologies/PaNET](https://github.com/pan-ontologies/PaNET)
+
+## Contact
+
+* Paul Millar (paul.millar@desy.de), [Deutsches Elektronen-Synchrotron (DESY)](https://desy.de/), Germany, [@paulmillar](https://github.com/paulmillar)
+* Heike Görzig (heike.goerzig@helmholtz-berlin.de), [Helmholtz Zentrum Berlin](https://www.helmholtz-berlin.de/), Germany, [@hgoerzig](https://github.com/hgoerzig)


### PR DESCRIPTION
## Brief Description

From the [PaNET website](https://pan-ontologies.github.io/PaNET/):
> PaNET is a comprehensive, semi-hierarchical vocabulary dedicated to
Photon and Neutron Experimental Techniques. A technique is defined by four major aspects.

This commit updated W3ID.org to include support for PaNET IRIs and related URLs within the existing https://w3id.org/PaN/ namespace.

Thanks go to:
  Heike Görzig
  Rolf Krahl
  Martin Voigt

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.
