### PR TITLE
Add version IRI resolution for w3id.org/bsdo

### DIFF
--- a/bsdo/.htaccess
+++ b/bsdo/.htaccess
@@ -1,7 +1,8 @@
 # BSDO — Battery Swap Domain Ontology
 #
-# https://w3id.org/bsdo      -> terminology (TBox)
-# https://w3id.org/bsdo/abox -> population (ABox)
+# https://w3id.org/bsdo       -> terminology (TBox), current release
+# https://w3id.org/bsdo/abox  -> population (ABox), current release
+# https://w3id.org/bsdo/0.2.0 -> that release, frozen
 #
 # Content negotiation: HTML for browsers, RDF/XML on request,
 # Turtle otherwise. Files are hosted on GitHub Pages at
@@ -15,6 +16,16 @@
 # GitHub username: sidodea-IE
 
 RewriteEngine on
+
+# --- Versioned releases ---
+# A version identifier must keep resolving to the release it names, so these
+# point into a frozen per-release directory rather than at the current files.
+# The pattern is generic, so a new release needs no change here.
+RewriteCond %{HTTP_ACCEPT} text/html [NC]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://sidodea-ie.github.io/BSDO/$1/ [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://sidodea-ie.github.io/BSDO/$1/bsdo.owl [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://sidodea-ie.github.io/BSDO/$1/bsdo.ttl [R=303,L]
 
 # --- Population (ABox) ---
 RewriteCond %{HTTP_ACCEPT} text/html [NC]

--- a/bsdo/README.md
+++ b/bsdo/README.md
@@ -11,16 +11,22 @@ Entity IRIs are minted under `https://w3id.org/bsdo#`.
 
 | Identifier | Resolves to |
 |---|---|
-| `https://w3id.org/bsdo` | terminology (TBox) |
-| `https://w3id.org/bsdo/abox` | population (ABox) |
+| `https://w3id.org/bsdo` | terminology (TBox), current release |
+| `https://w3id.org/bsdo/abox` | population (ABox), current release |
+| `https://w3id.org/bsdo/0.2.0` | that release, frozen |
 
-Both identifiers negotiate on content type: HTML for browsers, RDF/XML when requested, Turtle
+All identifiers negotiate on content type: HTML for browsers, RDF/XML when requested, Turtle
 otherwise. All targets are served from GitHub Pages with the correct media types (`text/turtle` and
 `application/rdf+xml`).
 
-Two rules are required rather than one: the population document declares
+Two rules are needed for the current release rather than one: the population document declares
 `owl:imports <https://w3id.org/bsdo>`, so the terminology identifier must resolve for the import to
 be satisfied.
+
+The version rule is written as a pattern over `MAJOR.MINOR.PATCH` and points into a frozen
+per-release directory, so that an ontology which declared an import of a given version still
+resolves to what it was written against after later releases change the files at the root. A new
+release therefore needs no change here.
 
 ## Where the files live
 


### PR DESCRIPTION
Follow-up to #6460, which registered w3id.org/bsdo.

The version identifier declared by the ontology, https://w3id.org/bsdo/0.2.0,
did not resolve. This adds a rule for it.

The rule is a pattern over MAJOR.MINOR.PATCH and points into a frozen
per-release directory rather than at the current files, so that an ontology
which declared an import of a given version still resolves to what it was
written against after later releases change the files at the root. A new
release therefore needs no further change here.

Targets are live and return HTTP 200 with the expected media types:

  https://sidodea-ie.github.io/BSDO/0.2.0/          text/html
  https://sidodea-ie.github.io/BSDO/0.2.0/bsdo.ttl  text/turtle
  https://sidodea-ie.github.io/BSDO/0.2.0/bsdo.owl  application/rdf+xml

The existing rules for /bsdo and /bsdo/abox are unchanged; the version
pattern does not match either path.