### PR TITLE
Repoint arknet namespace redirects to GitHub

### DIFF
--- a/arknet/.htaccess
+++ b/arknet/.htaccess
@@ -12,28 +12,52 @@ AddType application/n-triples .nt
 AddType application/ld+json .json
 
 
-### Ontology modules: core, process, architecture, tech, privacy
+### Ontology modules: core, ddd, provenance, project, requirements, process (arknet-actor.ttl)
+# Not (yet) published, no live consumer / known-bad module cut:
+#   - tech (arktech:)         -- module not shipped yet
+#   - architecture (arkarch:) -- zero references in code, no BC
+#   - privacy (arkpriv:)      -- zero references in code, no BC
+# ddd (arkddd:) is live for BoundedContext/Domain/Subdomain only (arknet-ddd.ttl); Context
+# Mapping and the tactical-DDD block stay parked (parked/arknet-ddd_parked.ttl, not routed
+# here) even though they share the same namespace.
+# process (arkproc:) is live: only the Actor taxonomy is used (by ubiquitous-language,
+# use-cases); it now ships as its own file arknet-actor.ttl, while the namespace stays
+# process# unchanged (already live in production data). File name != URL segment here,
+# so it needs its own rule below instead of the generic $1 alternation.
+
 # Serve Turtle content for ontology modules
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle
-RewriteRule ^(core|process|architecture|tech|privacy)$ https://git.changinggraph.org/kogn-io/arknet/raw/branch/main/ontology/$1.ttl [R=303,L]
+RewriteRule ^(core|ddd|provenance|project|requirements)$ https://raw.githubusercontent.com/kogn-io/arknet/main/arknet-ontology/src/main/resources/arknet-$1.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^process$ https://raw.githubusercontent.com/kogn-io/arknet/main/arknet-ontology/src/main/resources/arknet-actor.ttl [R=303,L]
 
-# Serve HTML content for ontology modules
+# Serve HTML content for ontology modules (GitHub blob view until a generated doc site exists)
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(core|process|architecture|tech|privacy)$ https://git.changinggraph.org/kogn-io/arknet/src/branch/main/ontology/$1.ttl [R=303,L]
+RewriteRule ^(core|ddd|provenance|project|requirements)$ https://github.com/kogn-io/arknet/blob/main/arknet-ontology/src/main/resources/arknet-$1.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^process$ https://github.com/kogn-io/arknet/blob/main/arknet-ontology/src/main/resources/arknet-actor.ttl [R=303,L]
 
 # Serve RDF/XML content for ontology modules
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^(core|process|architecture|tech|privacy)$ https://git.changinggraph.org/kogn-io/arknet/raw/branch/main/ontology/$1.ttl [R=303,L]
+RewriteRule ^(core|ddd|provenance|project|requirements)$ https://raw.githubusercontent.com/kogn-io/arknet/main/arknet-ontology/src/main/resources/arknet-$1.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^process$ https://raw.githubusercontent.com/kogn-io/arknet/main/arknet-ontology/src/main/resources/arknet-actor.ttl [R=303,L]
 
 
-### SHACL shapes
-RewriteRule ^shapes/(.+)$ https://git.changinggraph.org/kogn-io/arknet/raw/branch/main/shapes/$1.ttl [R=303,L]
+### SHACL shapes: out of scope for this fix, see arknet project notes
+# (flat "shapes#" fragment namespace spans 7 files -- needs its own decision, not touched here)
 
 
 ### Root: redirect to repository
@@ -41,7 +65,7 @@ RewriteRule ^shapes/(.+)$ https://git.changinggraph.org/kogn-io/arknet/raw/branc
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle
-RewriteRule ^$ https://git.changinggraph.org/kogn-io/arknet/raw/branch/main/ontology/core.ttl [R=303,L]
+RewriteRule ^$ https://raw.githubusercontent.com/kogn-io/arknet/main/arknet-ontology/src/main/resources/arknet-core.ttl [R=303,L]
 
 # Default: redirect to repository
-RewriteRule ^$ https://git.changinggraph.org/kogn-io/arknet [R=303,L]
+RewriteRule ^$ https://github.com/kogn-io/arknet [R=303,L]

--- a/arknet/README.md
+++ b/arknet/README.md
@@ -6,7 +6,7 @@ validatable (SHACL), queryable (SPARQL), and AI-ready (MCP).
 
 ### Resources
 
-* Repository: https://git.changinggraph.org/kogn-io/arknet
+* Repository: https://github.com/kogn-io/arknet
 * Part of: https://kogn.io
 
 ### Contact


### PR DESCRIPTION
The arknet project repository moved from Forgejo (git.changinggraph.org) to github.com/kogn-io/arknet. This updates the `arknet/` module routing to redirect to the new location and to the current module cut: core, ddd, provenance, project, requirements, and process (served from arknet-actor.ttl, since the file name diverges from the URL segment). architecture, tech, and privacy have no live consumer yet and stay unrouted. SHACL shapes are out of scope for this change.

## General Checklist
- [x] All 12 redirect targets (6 modules x raw Turtle + GitHub blob view, plus the repository root) verified reachable (HTTP 200) against the new github.com/kogn-io/arknet location. The `.htaccess` rewrite-rule logic itself was not exercised against a local Apache instance.
- [x] The number of commits is minimal (1 commit).
- [x] Commits only include redirects and basic information.

## Update ID Directory Checklist
- [x] GitHub username ids are listed in the maintainer details.
- [x] The GitHub account submitting this PR (hauschel) is listed as a maintainer of the changed directory.