### PR TITLE
Add W3ID namespace for RetrieveR

### DIFF
--- a/retrievr/.htaccess
+++ b/retrievr/.htaccess
@@ -1,0 +1,9 @@
+Options +FollowSymLinks
+
+RewriteEngine On
+
+# /retrievr
+RewriteRule ^$ https://github.com/keski/labrador [R=303,L]
+
+# /retrievr/labrador -> GitHub repository
+RewriteRule ^labrador/?$ https://github.com/keski/labrador [R=303,L]

--- a/retrievr/readme.md
+++ b/retrievr/readme.md
@@ -1,0 +1,14 @@
+# RetrievR
+
+RetrievR is a framework for discovering, negotiating, and provisioning virtual RDF streams.
+
+## W3ID Maintainer
+
+Robin Keskisärkkä (GitHub: @keski, robin.keski@gmail.com)
+
+## Contact
+
+* Daniel de Leng <daniel.de.leng@liu.se>
+* Robin Keskisärkkä <robin.keskisarkka@liu.se>
+* Volodymyr Kadzhaia <volodymyr.kadzhaia@kuleuven.be>
+* Pieter Bonte <pieter.bonte@kuleuven.be>


### PR DESCRIPTION
## Brief Description

Adds the `retrievr` W3ID namespace for the RetrievR framework (and the `retrievr/labrador` identifier for the Labrador research prototype implementation).

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information.

## New ID Directory Checklist

- [x] Maintainer details are in `readme.md`.
- [x] GitHub username id is listed in the maintainer details.
