### PR TITLE
Add object-provenance vocabulary redirect

### DIFF
--- a/object-provenance/.htaccess
+++ b/object-provenance/.htaccess
@@ -1,0 +1,32 @@
+# # /object-provenance/
+#
+# A vocabulary of terms for recording, batching, and archiving provenance
+# claims about physical objects. See README.md in this directory.
+#
+# https://w3id.org/object-provenance/v1# redirects to
+# https://object-provenance.github.io/vocab/v1/
+# with content negotiation for JSON-LD.
+#
+# The namespace is hash-based, so the fragment never reaches the server and
+# these rules serve the whole vocabulary.
+#
+# 302 rather than 301: a 301 is cached permanently by browsers and
+# intermediaries and cannot be recalled, which would destroy the repointing
+# ability this service exists to provide.
+#
+# ## Contact
+# This space is administered by:
+#
+# RelicQuery — hello@relicquery.org
+# GitHub username: RichardHerold
+
+Options +FollowSymLinks
+RewriteEngine on
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^v1/?$ https://object-provenance.github.io/vocab/v1/context.jsonld [R=302,L]
+
+RewriteRule ^v1/?$ https://object-provenance.github.io/vocab/v1/ [R=302,L]
+
+RewriteRule ^/?$ https://object-provenance.github.io/vocab/ [R=302,L]

--- a/object-provenance/README.md
+++ b/object-provenance/README.md
@@ -1,0 +1,94 @@
+# object-provenance
+
+Permanent identifiers for an object provenance vocabulary: terms describing
+the recording, batching, and archival of provenance claims about physical
+objects (mineral specimens, gemstones, and other collectibles).
+
+## Namespace
+
+    https://w3id.org/object-provenance/v1#
+
+Hash-based. Individual terms are fragments of the versioned namespace
+document, e.g. `https://w3id.org/object-provenance/v1#anchorReferences`.
+The conventional prefix is `op`.
+
+## Scope
+
+The rule this namespace is held to: **mint only terms with no published
+equivalent** — anchor references, archival transaction identifiers, snapshot
+and certificate structures, and the recording mechanics specific to this
+system. Attribution should use PROV-O, bibliographic metadata Dublin Core,
+object description CIDOC CRM via the Object ID category set, and thesaurus
+references Getty AAT and TGN.
+
+**`v1` does not yet meet that rule, and this is stated here rather than
+discovered in the context file.** Five terms duplicate published equivalents:
+
+| Term | Should be |
+|---|---|
+| `op:recordIdentifier` | `dcterms:identifier` |
+| `op:title` | `dcterms:title` |
+| `op:description` | `dcterms:description` |
+| `op:publishedAt` | `dcterms:issued` |
+| `op:provenanceEvents`, `op:ownerDisplayName` | PROV-O attribution |
+
+The mapping is scheduled and is a restructuring rather than a rename, which
+is why it has not simply been done: PROV-O attribution changes the shape of
+the document, not only its key strings. New records will use the mapped terms
+under a later version. Records already anchored under `v1` are never remapped
+— rewriting them would change their hashes, which is the failure this whole
+arrangement exists to prevent.
+
+The permanent identifier is needed either way, and is needed *before* the
+first anchored record rather than after. That is the reason for requesting it
+at this stage rather than waiting for a tidier vocabulary.
+
+## Why a permanent identifier is needed
+
+These IRIs are embedded in canonicalized JSON documents that are hashed and
+committed to a public blockchain. Canonicalization is JCS (RFC 8785), which
+hashes the literal key strings of the document — so the prefixed term keys
+(`op:title`, `op:recordIdentifier`, …) and the `@context` value are all
+inside the hash preimage. A namespace string that changes after a record is
+anchored leaves that record asserting a vocabulary that no longer exists,
+and there is no way to reissue it.
+
+A permanent identifier decoupled from any organizational domain is therefore
+a hard requirement, not a convenience: the alternative is a corpus of
+permanent records whose vocabulary is defined only at a URL one organization
+must keep paying for.
+
+## Versioning
+
+`v1` is frozen once records are anchored against it. Subsequent versions get
+their own path segment. All published versions must continue to resolve
+indefinitely, because records anchored under them remain verifiable forever.
+
+Because canonicalization is JCS rather than RDF Dataset Canonicalization,
+the verification contract for an anchored record is its exact byte-level key
+set, not the expanded IRIs. Each version therefore publishes a frozen key-set
+document alongside the context, and a new version never remaps the keys of an
+older one.
+
+## Redirect target
+
+Currently `https://object-provenance.github.io/vocab/v1/`, live and serving:
+
+- <https://object-provenance.github.io/vocab/v1/> — landing page and term list
+- <https://object-provenance.github.io/vocab/v1/context.jsonld> — JSON-LD context
+- <https://object-provenance.github.io/vocab/v1/KEY-SET.md> — frozen key set
+
+The target is expected to change; the identifier is not.
+
+Content negotiation is JSON-LD and HTML only. Every `v1` term is still
+privately minted pending the mapping onto PROV-O, Dublin Core, and CIDOC CRM
+described above, so an ontology serialization would describe a term set that
+is still moving. Turtle and RDF/XML are added when `v1` freezes, which is the
+first anchored record.
+
+## Contact
+
+This space is administered by:
+
+- RelicQuery — hello@relicquery.org
+- GitHub username: RichardHerold


### PR DESCRIPTION
## Brief Description

Claims the top-level identifier `object-provenance` for a vocabulary of terms describing the recording, batching, and archival of provenance claims about physical objects (mineral specimens, gemstones, and other collectibles).

- **Identifier:** `https://w3id.org/object-provenance/v1#` — versioned and hash-based, so terms are fragments and the rules serve the whole vocabulary.
- **Redirect target:** `https://object-provenance.github.io/vocab/v1/`, content-negotiated for JSON-LD. **Live now:** [landing page](https://object-provenance.github.io/vocab/v1/), [context.jsonld](https://object-provenance.github.io/vocab/v1/context.jsonld), [KEY-SET.md](https://object-provenance.github.io/vocab/v1/KEY-SET.md) all return 200.
- **302, not 301,** deliberately: a 301 is cached permanently and cannot be recalled, which would defeat the repointing ability this service provides.
- **Why permanence is a hard requirement:** these IRIs sit inside canonicalized JSON documents (JCS, RFC 8785) that are hashed and anchored to a public blockchain — a record can never be reissued, so its vocabulary must never depend on one organization's domain. The identifier is needed *before* the first anchored record, which is why the request comes now.
- **Scope:** only terms with no published equivalent are meant to be minted; the README names the five v1 terms that currently duplicate Dublin Core / PROV-O and the plan for them, rather than claiming a discipline the context file doesn't yet meet.
- Distinct from the existing `w3id.org/provenance` (a CIDOC-CRM database of artworks): this is a vocabulary for recording and archival mechanics, not a dataset.

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed. *(single commit)*
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service. *(two files: `.htaccess` + `README.md`; all content is served from the redirect target)*

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`. *(both)*
- [x] GitHub username ids are listed in the maintainer details.

## Testing

Reproduced the repo's Apache recipe locally (httpd 2.4, `AllowOverride All`, `mod_rewrite` + `mod_headers`, full repository tree with this PR's ref checked out) and exercised the rules:

| Request against local checkout | Observed |
|---|---|
| `/object-provenance/v1` · `Accept: application/ld+json` | `302 → https://object-provenance.github.io/vocab/v1/context.jsonld` |
| `/object-provenance/v1` · `Accept: application/json` | `302 → …/vocab/v1/context.jsonld` |
| `/object-provenance/v1` · browser `Accept` | `302 → …/vocab/v1/` |
| `/object-provenance/v1/` (trailing slash) | same as above |
| `/object-provenance/` | `302 → …/vocab/` |

Control entries (`/provenance/`, `/examples/ontology`) behaved per their own files under the same harness, so the harness is faithful. All redirect targets return 200 in production.

## Contact

RelicQuery — hello@relicquery.org · GitHub: @RichardHerold

Happy to adjust the identifier or the rules if anything conflicts with the naming policy or something reserved.
