### PR TITLE
Update SMARTLHSONTO w3id redirect to raw GitHub ontology

### DIFF
--- a/smartlhs/.htaccess
+++ b/smartlhs/.htaccess
@@ -2,10 +2,10 @@ RewriteEngine On
 
 # SMARTLHS project
 # Default project landing page
-RewriteRule ^$ https://raw.githubusercontent.com/megmaqi-netizen/smartlhs/refs/heads/main/SMARTLHSONTO_release_v3_merged.owl [R=302,L]
+RewriteRule ^$ https://raw.githubusercontent.com/megmaqi-netizen/smartlhs/main/SMARTLHSONTO_release_v3_merged.owl [R=302,L]
 
 # SMARTLHSONTO ontology
-RewriteRule ^ontology/?$ https://raw.githubusercontent.com/megmaqi-netizen/smartlhs/refs/heads/main/SMARTLHSONTO_release_v3_merged.owl [R=302,L]
+RewriteRule ^ontology/?$ https://raw.githubusercontent.com/megmaqi-netizen/smartlhs/main/SMARTLHSONTO_release_v3_merged.owl [R=302,L]
 
 # Future SMARTLHS-Lite
 # RewriteRule ^lite/?$ https://github.com/megmaqi-netizen/smartlhs-lite [R=302,L]

--- a/smartlhs/.htaccess
+++ b/smartlhs/.htaccess
@@ -2,10 +2,10 @@ RewriteEngine On
 
 # SMARTLHS project
 # Default project landing page
-RewriteRule ^$ https://bioportal.bioontology.org/ontologies/SMARTLHSONTOV1 [R=302,L]
+RewriteRule ^$ https://raw.githubusercontent.com/megmaqi-netizen/smartlhs/refs/heads/main/SMARTLHSONTO_release_v3_merged.owl [R=302,L]
 
 # SMARTLHSONTO ontology
-RewriteRule ^ontology/?$ https://bioportal.bioontology.org/ontologies/SMARTLHSONTOV1 [R=302,L]
+RewriteRule ^ontology/?$ https://raw.githubusercontent.com/megmaqi-netizen/smartlhs/refs/heads/main/SMARTLHSONTO_release_v3_merged.owl [R=302,L]
 
 # Future SMARTLHS-Lite
 # RewriteRule ^lite/?$ https://github.com/megmaqi-netizen/smartlhs-lite [R=302,L]


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->

## Brief Description

This PR updates the SMARTLHSONTO (`https://w3id.org/smartlhs`) redirect to point directly to the raw OWL ontology file hosted in the SMARTLHSONTO GitHub repository.

The update enables direct ontology import into Protégé and other Semantic Web tools while maintaining the persistent ontology IRI.

The ontology file is hosted at:

https://github.com/megmaqi-netizen/smartlhs

This change follows best practice for ontology publication by allowing the persistent identifier to resolve directly to the ontology resource rather than a landing page.