### PR TITLE
Add /ssk-gain namespace for the SSK-GAIN semiconductor supply-chain ontology

### DIFF
--- a/ssk-gain/.htaccess
+++ b/ssk-gain/.htaccess
@@ -1,28 +1,30 @@
-# w3id.org persistent-identifier registration for the SSK ontology and KG
+# w3id.org persistent identifiers for the SSK-GAIN ontology and knowledge graph
 # Namespace root: https://w3id.org/ssk-gain/
 #
-# To register (do BEFORE manuscript submission):
-#   1. Fork https://github.com/perma-id/w3id.org
-#   2. Add this file at path:  ssk-gain/.htaccess
-#   3. Targets below point at the deposit repository's raw content root and
-#      follow its layout (system/ontology, system/kg/out). The Zenodo record
-#      carries the citable DOI; this host serves dereferencing.
-#   4. Open a pull request; once merged, the IRIs below resolve.
+# Maintainer: https://github.com/psh2975-dev (Sungho Park, Dong-A University,
+#             psh2975@dau.ac.kr)
 #
-# Until the deposit repository is public and the PR is merged, these IRIs are
-# stable identifiers that name the vocabulary but do not yet dereference.
+# Targets resolve to the deposit repository's raw content. The archived release
+# carries the citable DOI: https://doi.org/10.5281/zenodo.21715914
 
 Options -MultiViews
 RewriteEngine On
 
-# --- Ontology modules -> single ontology document (Turtle) ---
-RewriteRule ^ontology/(core|intl|gvc|bridge)/?$ https://raw.githubusercontent.com/psh2975-dev/ssk-gain-ontology/main/system/ontology/ontology.ttl [R=302,L]
+# Namespace root: human-readable landing page.
+RewriteRule ^$ https://github.com/psh2975-dev/ssk-gain-ontology [R=302,L]
 
-# --- SHACL constraint shapes ---
+# Each module dereferences to its own document, so a consumer can retrieve one
+# module and follow owl:imports rather than take the whole vocabulary.
+RewriteRule ^ontology/(core|intl|gvc|bridge)/?$ https://raw.githubusercontent.com/psh2975-dev/ssk-gain-ontology/main/system/ontology/$1.ttl [R=302,L]
+
+# Merged document carrying all four modules.
+RewriteRule ^ontology/?$ https://raw.githubusercontent.com/psh2975-dev/ssk-gain-ontology/main/system/ontology/ontology.ttl [R=302,L]
+
+# SHACL constraint shapes.
 RewriteRule ^ontology/shapes/?$ https://raw.githubusercontent.com/psh2975-dev/ssk-gain-ontology/main/system/ontology/shapes.ttl [R=302,L]
 
-# --- Direct Turtle requests (e.g. .../ontology/ontology.ttl) ---
+# Direct Turtle requests, e.g. .../ontology/core.ttl
 RewriteRule ^ontology/(.+)\.ttl$ https://raw.githubusercontent.com/psh2975-dev/ssk-gain-ontology/main/system/ontology/$1.ttl [R=302,L]
 
-# --- Knowledge-graph instances ---
+# Knowledge-graph instances.
 RewriteRule ^kg/(.*)$ https://raw.githubusercontent.com/psh2975-dev/ssk-gain-ontology/main/system/kg/out/$1 [R=302,L]

--- a/ssk-gain/.htaccess
+++ b/ssk-gain/.htaccess
@@ -1,0 +1,28 @@
+# w3id.org persistent-identifier registration for the SSK ontology and KG
+# Namespace root: https://w3id.org/ssk-gain/
+#
+# To register (do BEFORE manuscript submission):
+#   1. Fork https://github.com/perma-id/w3id.org
+#   2. Add this file at path:  ssk-gain/.htaccess
+#   3. Targets below point at the deposit repository's raw content root and
+#      follow its layout (system/ontology, system/kg/out). The Zenodo record
+#      carries the citable DOI; this host serves dereferencing.
+#   4. Open a pull request; once merged, the IRIs below resolve.
+#
+# Until the deposit repository is public and the PR is merged, these IRIs are
+# stable identifiers that name the vocabulary but do not yet dereference.
+
+Options -MultiViews
+RewriteEngine On
+
+# --- Ontology modules -> single ontology document (Turtle) ---
+RewriteRule ^ontology/(core|intl|gvc|bridge)/?$ https://raw.githubusercontent.com/psh2975-dev/ssk-gain-ontology/main/system/ontology/ontology.ttl [R=302,L]
+
+# --- SHACL constraint shapes ---
+RewriteRule ^ontology/shapes/?$ https://raw.githubusercontent.com/psh2975-dev/ssk-gain-ontology/main/system/ontology/shapes.ttl [R=302,L]
+
+# --- Direct Turtle requests (e.g. .../ontology/ontology.ttl) ---
+RewriteRule ^ontology/(.+)\.ttl$ https://raw.githubusercontent.com/psh2975-dev/ssk-gain-ontology/main/system/ontology/$1.ttl [R=302,L]
+
+# --- Knowledge-graph instances ---
+RewriteRule ^kg/(.*)$ https://raw.githubusercontent.com/psh2975-dev/ssk-gain-ontology/main/system/kg/out/$1 [R=302,L]


### PR DESCRIPTION
## New namespace: `/ssk-gain`

This PR registers a persistent namespace for the **SSK-GAIN semiconductor
global supply-chain ontology** and its knowledge-graph instances, released as
an open academic research resource accompanying a resource paper submitted to
*Applied Ontology*.

### What it identifies
- An OWL 2 ontology in four modules (core, intl, gvc, bridge) plus SHACL shapes
- A canonical-identifier (LEI / ISO 3166 / Wikidata) entity catalogue served as
  knowledge-graph instances

IRIs under this namespace:
- `https://w3id.org/ssk-gain/ontology/{core,intl,gvc,bridge}#`
- `https://w3id.org/ssk-gain/ontology/shapes#`
- `https://w3id.org/ssk-gain/kg/`

### Redirect behavior
`ssk-gain/.htaccess` performs 302 redirects from the IRIs above to the
deposited Turtle artifacts in the project's public deposit repository
(`psh2975-dev/ssk-gain-ontology`, raw content root). All redirect targets were
verified to return HTTP 200 before opening this PR. The `.htaccess` serves no
content itself.

### Provenance / authority
- Requested by / maintainer: **Sungho Park**, Dept. of Management Information
  Systems, Dong-A University (first author)
- Corresponding author: **Kangbae Lee**, same department
- Publisher: **Glocal AI Network Institute (GAIN), Dong-A University**
- Funding: National Research Foundation of Korea, SSK program
  (**NRF-2024S1A3A2A07046144**)
- The name `ssk-gain` (SSK program + GAIN institute) is not currently used in
  this repository.

### Confirmation
- [x] The `.htaccess` only performs redirects; it serves no content directly.
- [x] I have authority to maintain this namespace on behalf of the project.
- [x] The namespace does not conflict with any existing entry.
