### PR TITLE
Add /vson (Visual Scene Ontology Notation)

### DIFF
--- a/vson/.htaccess
+++ b/vson/.htaccess
@@ -1,0 +1,41 @@
+# # /vson/
+#
+# Visual Scene Ontology Notation (VSON) — an OWL 2 RL ontology, SHACL shapes,
+# and three concrete syntaxes for representing visual scenes as validatable
+# RDF graphs. Apache-2.0.
+#
+# Source:  https://github.com/yamancan/visual-scene-ontology
+# Files:   https://vson.pages.dev/v1/
+#
+# ## Maintainer
+#
+# Yamancan
+# GitHub username: yamancan
+
+Options -MultiViews
+RewriteEngine on
+
+# ---------------------------------------------------------------------------
+# v1 namespace documents. Hash namespaces: the fragment never reaches the
+# server, so one rule serves both the term IRIs
+# (…/v1/ontology#Composition) and the document IRI.
+# ---------------------------------------------------------------------------
+
+# HTML for browsers
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^v1/(ontology|rcc8|allen|shapes|shapes-relaxed)$ https://vson.pages.dev/#$1 [R=303,L]
+
+# Turtle — and the default for every non-browser client
+RewriteRule ^v1/(ontology|rcc8|allen|shapes|shapes-relaxed)$ https://vson.pages.dev/v1/$1.ttl [R=303,L]
+
+# JSON-LD context
+RewriteRule ^v1/context\.jsonld$ https://vson.pages.dev/v1/context.jsonld [R=302,L]
+
+# JSON Schemas
+RewriteRule ^v1/schema/(vson-output|vson-jsonld)\.schema\.json$ https://vson.pages.dev/v1/schema/$1.schema.json [R=302,L]
+
+# Everything else under /vson/ -> the landing page
+RewriteRule ^ https://vson.pages.dev/ [R=302,L]

--- a/vson/README.md
+++ b/vson/README.md
@@ -1,0 +1,32 @@
+# /vson/
+
+Permanent identifiers for **VSON — Visual Scene Ontology Notation**: an
+Apache-2.0 OWL 2 RL ontology plus SHACL shapes and three concrete syntaxes
+(Turtle-star, Penman, VSON-X) for representing visual scenes — entities,
+qualities, RCC-8 spatial topology, Allen interval relations, events, and
+perspectival framing — as validatable RDF graphs.
+
+Source repository: <https://github.com/yamancan/visual-scene-ontology>
+
+## Redirects
+
+All targets live at <https://vson.pages.dev/>, a static site assembled from
+the repository's `ontology/`, `shapes/`, and `tools/schema/` directories.
+
+| w3id path | Accept | Target |
+|---|---|---|
+| `/vson/v1/ontology` | `text/turtle` (default) | `…/v1/ontology.ttl` (303) |
+| `/vson/v1/ontology` | `text/html` | landing page `#ontology` (303) |
+| `/vson/v1/{rcc8,allen,shapes,shapes-relaxed}` | as above | `…/v1/$1.ttl` (303) |
+| `/vson/v1/context.jsonld` | — | `…/v1/context.jsonld` (302) |
+| `/vson/v1/schema/*.schema.json` | — | `…/v1/schema/*` (302) |
+| anything else under `/vson/` | — | landing page (302) |
+
+The namespaces are hash-based (`https://w3id.org/vson/v1/ontology#Composition`),
+so a single rule per document serves both term and document IRIs. Content
+types (`text/turtle`, `application/ld+json`, `application/schema+json`) and
+`Access-Control-Allow-Origin: *` are set on the target side.
+
+## Maintainer
+
+- Yamancan — GitHub: [@yamancan](https://github.com/yamancan)


### PR DESCRIPTION
## Brief Description
Claims the new top-level `vson/` identifier for **VSON — Visual Scene Ontology Notation**: an Apache-2.0 OWL 2 RL ontology + SHACL shapes for representing visual scenes as validatable RDF graphs. Source: https://github.com/yamancan/visual-scene-ontology

Redirect targets live at https://vson.pages.dev/ (static site built from the repository; controlled by me). Hash namespaces under `/vson/v1/` get content-negotiated 303s (Turtle default, HTML for browsers); the JSON-LD context and JSON Schemas are direct 302 pass-throughs; everything else lands on the project page. Full IRI table in `vson/README.md`.

Tested each rule shape with `curl -H 'Accept: text/turtle'` / `-H 'Accept: text/html'` against the live targets; all resolve with correct content types and `Access-Control-Allow-Origin: *`.

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Optional Requests for W3ID Maintainers
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.