### PR TITLE
provetrail: content negotiation and 303 for versioned predicate paths

### DIFF
--- a/provetrail/.htaccess
+++ b/provetrail/.htaccess
@@ -6,10 +6,17 @@ Header set Access-Control-Allow-Origin *
 Options +FollowSymLinks
 RewriteEngine on
 
-# Versioned predicate-type definitions resolve to the predicate document in the spec.
-RewriteRule "^predicates/run-provenance/v0\.1/?$" "https://github.com/ionalpha/provetrail/blob/main/predicates/run-provenance.md" [R=302,L]
+# Versioned predicate-type definitions are immutable identifiers: a released
+# path keeps resolving to the definition of exactly that version.
+#
+# Content negotiation: clients asking for markdown or plain text get the raw
+# document; everything else gets the rendered page. 303 per the convention for
+# identifiers that name a concept rather than the document itself.
+RewriteCond %{HTTP_ACCEPT} (text/markdown|text/plain) [NC]
+RewriteRule "^predicates/run-provenance/v0\.1/?$" "https://raw.githubusercontent.com/ionalpha/provetrail/main/predicates/run-provenance.md" [R=303,L]
+RewriteRule "^predicates/run-provenance/v0\.1/?$" "https://github.com/ionalpha/provetrail/blob/main/predicates/run-provenance.md" [R=303,L]
 
 # The namespace root and any other path resolve to the standard's repository.
-# This is a temporary target until provetrail.org serves the canonical documents;
-# the redirect can be repointed later without changing any identifier.
+# The targets can be repointed to provetrail.org later without changing any
+# identifier.
 RewriteRule "^(.*)$" "https://github.com/ionalpha/provetrail" [R=302,L]

--- a/provetrail/README.md
+++ b/provetrail/README.md
@@ -4,10 +4,10 @@ Permanent identifier namespace for **Provetrail**, an open, vendor-neutral stand
 
 The namespace is used as the stable `predicateType` identifier for Provetrail statements, so records that embed it keep resolving even if the project's hosting changes.
 
-- `https://w3id.org/provetrail/predicates/run-provenance/v0.1` redirects to the versioned predicate definition.
-- `https://w3id.org/provetrail` and any other path redirects to the standard's repository.
+- `https://w3id.org/provetrail/predicates/run-provenance/v0.1` resolves (303) to the versioned predicate definition. Content is negotiated: a client sending `Accept: text/markdown` (or `text/plain`) receives the raw markdown document; any other client receives the rendered page.
+- `https://w3id.org/provetrail` and any other path redirect to the standard's repository.
 
-The repository target is temporary until provetrail.org serves the canonical documents; only the redirect will change, never the identifier.
+Versioned predicate paths are immutable: a released path keeps resolving to the definition of exactly that version. The repository target is temporary until provetrail.org serves the canonical documents; only the redirect target will change, never an identifier.
 
 Project: https://github.com/ionalpha/provetrail
 


### PR DESCRIPTION
Upgrades the existing `provetrail` namespace (maintainer: @ion-alpha-dev, listed in the entry).

- The versioned predicate path `/provetrail/predicates/run-provenance/v0.1` now answers with a 303 and negotiates content: `Accept: text/markdown` or `text/plain` resolves to the raw markdown definition, anything else to the rendered page. The default target is unchanged.
- Versioned predicate paths are documented as immutable: a released path keeps resolving to the definition of exactly that version.
- README documents the negotiation and keeps the maintainer contact.

The namespace root's catch-all redirect is unchanged. Only the `provetrail/` directory is touched.