### PR TITLE
Add PSC salmon vocabulary identifiers

### DIFF
--- a/psc/README.md
+++ b/psc/README.md
@@ -1,0 +1,10 @@
+# `/psc/`
+
+Parent namespace for persistent identifiers administered by the
+[Pacific Salmon Commission](https://www.psc.org/).
+
+## Maintainer
+
+Brett Johnson — Data Systems Manager, Pacific Salmon Commission
+
+GitHub: [@Br-Johnson](https://github.com/Br-Johnson)

--- a/psc/vocab/.htaccess
+++ b/psc/vocab/.htaccess
@@ -1,0 +1,18 @@
+Options +FollowSymLinks -MultiViews
+RewriteEngine On
+
+# Canonical scheme and concept IRIs have HTML and RDF representations.
+Header merge Vary "Accept"
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^(?:scheme/[A-Za-z0-9._-]+/?|concept/PSC-CV-[0-9]{6}/?)?$ https://psc-salmon-vocabularies-694ed8.gitlab.io/psc-vocabularies.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^(?:scheme/[A-Za-z0-9._-]+/?|concept/PSC-CV-[0-9]{6}/?)?$ https://psc-salmon-vocabularies-694ed8.gitlab.io/psc-vocabularies.jsonld [R=303,L]
+
+# Human-facing namespace and identifier pages.
+RewriteRule ^$ https://psc-salmon-vocabularies-694ed8.gitlab.io/ [R=303,L]
+RewriteRule ^(scheme/[A-Za-z0-9._-]+|concept/PSC-CV-[0-9]{6}|release/[A-Za-z0-9._-]+)/?$ https://psc-salmon-vocabularies-694ed8.gitlab.io/$1/ [R=303,L]
+
+# Preserve release artifact and future subordinate paths.
+RewriteRule ^(.*)$ https://psc-salmon-vocabularies-694ed8.gitlab.io/$1 [R=303,L]

--- a/psc/vocab/.htaccess
+++ b/psc/vocab/.htaccess
@@ -1,18 +1,30 @@
+# /psc/vocab/
+#
+# Persistent IRI namespace for the Pacific Salmon Commission's public salmon
+# controlled vocabularies.
+#
+# Public authority:
+# https://pacific-salmon-commission.gitlab.io/psc-data-systems/psc-salmon-vocabularies/
+#
+# Maintainer:
+# Brett Johnson
+# GitHub username: Br-Johnson
+
 Options +FollowSymLinks -MultiViews
 RewriteEngine On
 
 # Canonical scheme and concept IRIs have HTML and RDF representations.
-Header merge Vary "Accept"
+Header always merge Vary "Accept"
 
 RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
-RewriteRule ^(?:scheme/[A-Za-z0-9._-]+/?|concept/PSC-CV-[0-9]{6}/?)?$ https://psc-salmon-vocabularies-694ed8.gitlab.io/psc-vocabularies.ttl [R=303,L]
+RewriteRule ^(?:scheme/[A-Za-z0-9._-]+/?|concept/PSC-CV-[0-9]{6}/?)?$ https://pacific-salmon-commission.gitlab.io/psc-data-systems/psc-salmon-vocabularies/psc-vocabularies.ttl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
-RewriteRule ^(?:scheme/[A-Za-z0-9._-]+/?|concept/PSC-CV-[0-9]{6}/?)?$ https://psc-salmon-vocabularies-694ed8.gitlab.io/psc-vocabularies.jsonld [R=303,L]
+RewriteRule ^(?:scheme/[A-Za-z0-9._-]+/?|concept/PSC-CV-[0-9]{6}/?)?$ https://pacific-salmon-commission.gitlab.io/psc-data-systems/psc-salmon-vocabularies/psc-vocabularies.jsonld [R=303,L]
 
 # Human-facing namespace and identifier pages.
-RewriteRule ^$ https://psc-salmon-vocabularies-694ed8.gitlab.io/ [R=303,L]
-RewriteRule ^(scheme/[A-Za-z0-9._-]+|concept/PSC-CV-[0-9]{6}|release/[A-Za-z0-9._-]+)/?$ https://psc-salmon-vocabularies-694ed8.gitlab.io/$1/ [R=303,L]
+RewriteRule ^$ https://pacific-salmon-commission.gitlab.io/psc-data-systems/psc-salmon-vocabularies/ [R=303,L]
+RewriteRule ^(scheme/[A-Za-z0-9._-]+|concept/PSC-CV-[0-9]{6}|release/[A-Za-z0-9._-]+)/?$ https://pacific-salmon-commission.gitlab.io/psc-data-systems/psc-salmon-vocabularies/$1/ [R=303,L]
 
 # Preserve release artifact and future subordinate paths.
-RewriteRule ^(.*)$ https://psc-salmon-vocabularies-694ed8.gitlab.io/$1 [R=303,L]
+RewriteRule ^(.*)$ https://pacific-salmon-commission.gitlab.io/psc-data-systems/psc-salmon-vocabularies/$1 [R=303,L]

--- a/psc/vocab/README.md
+++ b/psc/vocab/README.md
@@ -8,7 +8,7 @@ The current alpha is provisional and is not an adopted PSC standard.
 ## Public authority
 
 - Repository: <https://gitlab.com/pacific-salmon-commission/psc-data-systems/psc-salmon-vocabularies>
-- Documentation: <https://psc-salmon-vocabularies-694ed8.gitlab.io/>
+- Documentation: <https://pacific-salmon-commission.gitlab.io/psc-data-systems/psc-salmon-vocabularies/>
 - Releases: `https://w3id.org/psc/vocab/release/{version}`
 - Schemes: `https://w3id.org/psc/vocab/scheme/{scheme_id}`
 - Concepts: `https://w3id.org/psc/vocab/concept/{concept_id}`

--- a/psc/vocab/README.md
+++ b/psc/vocab/README.md
@@ -1,0 +1,22 @@
+# `/psc/vocab/`
+
+Persistent IRI namespace for the Pacific Salmon Commission's public salmon
+controlled vocabularies.
+
+The current alpha is provisional and is not an adopted PSC standard.
+
+## Public authority
+
+- Repository: <https://gitlab.com/pacific-salmon-commission/psc-data-systems/psc-salmon-vocabularies>
+- Documentation: <https://psc-salmon-vocabularies-694ed8.gitlab.io/>
+- Releases: `https://w3id.org/psc/vocab/release/{version}`
+- Schemes: `https://w3id.org/psc/vocab/scheme/{scheme_id}`
+- Concepts: `https://w3id.org/psc/vocab/concept/{concept_id}`
+
+Vocabulary and assignment data are published under CC BY 4.0; tooling is MIT.
+All redirects use `303 See Other`, and negotiated resources return
+`Vary: Accept`.
+
+## Maintainer
+
+Brett Johnson — GitHub: [Br-Johnson](https://github.com/Br-Johnson)


### PR DESCRIPTION
## Brief Description

Adds the new `/psc/vocab/` persistent namespace for the Pacific Salmon Commission's public salmon controlled vocabularies.

The redirect rules:

- use `303 See Other` for namespace, scheme, concept, release, and artifact requests;
- provide Turtle or JSON-LD representations for namespace, scheme, and concept requests through HTTP `Accept` negotiation;
- return `Vary: Accept` on redirects so negotiated responses are cache-safe;
- direct human-facing requests to the anonymously accessible public GitLab Pages authority; and
- preserve versioned release artifacts and future subordinate paths.

Public authority: <https://pacific-salmon-commission.gitlab.io/psc-data-systems/psc-salmon-vocabularies/>

The published alpha is explicitly provisional and is not an adopted PSC standard.

## Validation

- Apache 2.4.66 configuration syntax: `Syntax OK`.
- Local Apache redirect matrix passed for namespace HTML, Turtle, and JSON-LD; scheme and concept HTML/RDF; release page and manifest; future subordinate paths; query-string preservation; and `Vary: Accept`.
- The public root, Turtle, JSON-LD, representative scheme and concept pages, the `v0.1.0-alpha.1` release page, and its manifest were tested without credentials and returned `200` with the expected media types.
- Published `v0.1.0-alpha.1` manifest SHA-256: `aba5368b2a73b0ad581d9defa09523456d4a77fafa4eb81a5632457600e1cb49`.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` and `README.md`.
- [x] GitHub username IDs are listed in the maintainer details.

## Optional Requests for W3ID Maintainers

- [ ] Please squash commits for me.
