### PR TITLE
Make PSC vocabulary representation routes cache-safe

### DIFF
--- a/psc/vocab/.htaccess
+++ b/psc/vocab/.htaccess
@@ -13,14 +13,15 @@
 Options +FollowSymLinks -MultiViews
 RewriteEngine On
 
-# Canonical scheme and concept IRIs have HTML and RDF representations.
-Header always merge Vary "Accept"
-
-RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
-RewriteRule ^(?:scheme/[A-Za-z0-9._-]+/?|concept/PSC-CV-[0-9]{6}/?)?$ https://pacific-salmon-commission.gitlab.io/psc-data-systems/psc-salmon-vocabularies/psc-vocabularies.ttl [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
-RewriteRule ^(?:scheme/[A-Za-z0-9._-]+/?|concept/PSC-CV-[0-9]{6}/?)?$ https://pacific-salmon-commission.gitlab.io/psc-data-systems/psc-salmon-vocabularies/psc-vocabularies.jsonld [R=303,L]
+# Representation-specific identifiers.  These explicit paths are deliberate:
+# Simple mod_rewrite substring tests do not parse or rank arbitrary HTTP Accept
+# quality values, and current W3ID external 303 responses have not included the
+# configured Vary: Accept header.  Keeping the canonical redirects below
+# invariant is therefore safer for shared caches.
+RewriteRule ^scheme/([A-Za-z0-9._-]+)\.ttl$ https://pacific-salmon-commission.gitlab.io/psc-data-systems/psc-salmon-vocabularies/scheme/$1/index.ttl [R=303,L]
+RewriteRule ^scheme/([A-Za-z0-9._-]+)\.jsonld$ https://pacific-salmon-commission.gitlab.io/psc-data-systems/psc-salmon-vocabularies/scheme/$1/index.jsonld [R=303,L]
+RewriteRule ^concept/(PSC-CV-[0-9]{6})\.ttl$ https://pacific-salmon-commission.gitlab.io/psc-data-systems/psc-salmon-vocabularies/concept/$1/index.ttl [R=303,L]
+RewriteRule ^concept/(PSC-CV-[0-9]{6})\.jsonld$ https://pacific-salmon-commission.gitlab.io/psc-data-systems/psc-salmon-vocabularies/concept/$1/index.jsonld [R=303,L]
 
 # Human-facing namespace and identifier pages.
 RewriteRule ^$ https://pacific-salmon-commission.gitlab.io/psc-data-systems/psc-salmon-vocabularies/ [R=303,L]

--- a/psc/vocab/README.md
+++ b/psc/vocab/README.md
@@ -12,10 +12,23 @@ The current alpha is provisional and is not an adopted PSC standard.
 - Releases: `https://w3id.org/psc/vocab/release/{version}`
 - Schemes: `https://w3id.org/psc/vocab/scheme/{scheme_id}`
 - Concepts: `https://w3id.org/psc/vocab/concept/{concept_id}`
+- Complete Turtle: `https://w3id.org/psc/vocab/psc-vocabularies.ttl`
+- Complete JSON-LD: `https://w3id.org/psc/vocab/psc-vocabularies.jsonld`
+- Scheme Turtle: `https://w3id.org/psc/vocab/scheme/{scheme_id}.ttl`
+- Scheme JSON-LD: `https://w3id.org/psc/vocab/scheme/{scheme_id}.jsonld`
+- Concept Turtle: `https://w3id.org/psc/vocab/concept/{concept_id}.ttl`
+- Concept JSON-LD: `https://w3id.org/psc/vocab/concept/{concept_id}.jsonld`
 
 Vocabulary and assignment data are published under CC BY 4.0; tooling is MIT.
-All redirects use `303 See Other`, and negotiated resources return
-`Vary: Accept`.
+All redirects use `303 See Other`.
+
+Canonical namespace, scheme, and concept identifiers redirect to their public
+HTML authority pages independently of the request's `Accept` header. Machine
+representations use the explicit Turtle and JSON-LD identifiers above. This
+avoids unsafe regex-based `Accept` handling (including incorrect `q=0` and
+quality ordering) and keeps W3ID redirect responses invariant for shared
+caches. The explicit scheme and concept identifiers resolve to focused
+resource graphs; the complete identifiers resolve to the full released graph.
 
 ## Maintainer
 


### PR DESCRIPTION
## What changed

- make the canonical PSC namespace, scheme, and concept redirects invariant across `Accept` headers
- add explicit `.ttl` and `.jsonld` routes for per-scheme and per-concept graphs
- document complete-graph and focused-resource machine endpoints
- preserve every existing persistent IRI, release path, fallback path, and GitLab Pages target

## Why

The existing rules used substring matching on `Accept`. That could return Turtle when it was explicitly excluded with `q=0`, or choose lower-quality Turtle over higher-quality JSON-LD. In observed tests, current W3ID external `303` responses did not include the configured `Vary: Accept` header, which makes negotiated redirects unsafe for shared caches.

Simple `mod_rewrite` substring tests do not parse or rank arbitrary `Accept` quality values. Canonical PSC identifiers therefore now resolve consistently to their human authority pages, while explicit representation identifiers provide deterministic machine access.

## Impact

No canonical identifier or target authority changes. Clients can use the complete graph endpoints or append `.ttl` / `.jsonld` to a scheme or concept path for a focused representation.

The new explicit representation identifiers are intended to remain permanent alongside the canonical PSC identifiers.

## Validation

- Apache 2.4.66 configuration: `Syntax OK`
- local redirect matrix passed 23 canonical, explicit-format, release, fallback, query-string, `q=0`, and differing-quality cases
- explicit Turtle and JSON-LD routes resolve with `303` to deployed files returning the correct RDF media types
- release, query-string, and subordinate fallback routes preserved
- `git diff --check`

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## Update ID Directory Checklist

- [x] GitHub username IDs are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR.

## Optional Requests for W3ID Maintainers

- [ ] Please squash commits for me.
