### PR TITLE
Add atomgraph/rdfa-editor namespace redirect

### DIFF
--- a/atomgraph/README.md
+++ b/atomgraph/README.md
@@ -6,6 +6,7 @@ Homepage:
 
 Projects:
 * [LinkedDataHub](https://atomgraph.github.io/LinkedDataHub/)
+* [RDFa-Editor](https://atomgraph.github.io/RDFa-Editor/)
 * [Processor](https://github.com/AtomGraph/Processor)
 * [Web-Client](https://github.com/AtomGraph/Web-Client)
 * [Core](https://github.com/AtomGraph/Core)

--- a/atomgraph/rdfa-editor/.htaccess
+++ b/atomgraph/rdfa-editor/.htaccess
@@ -1,0 +1,4 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+RewriteRule ^.*$ https://atomgraph.github.io/RDFa-Editor/ [R=302,L]


### PR DESCRIPTION
Adds `atomgraph/rdfa-editor/.htaccess`, registering `https://w3id.org/atomgraph/rdfa-editor` (and its sub-paths `content-model`, `lint`, `rdfa`) for [AtomGraph RDFa-Editor](https://github.com/AtomGraph/RDFa-Editor), redirecting to the project's GitHub Pages site at https://atomgraph.github.io/RDFa-Editor/.

Also adds RDFa-Editor to the project list in `atomgraph/README.md`.

Submitted by the `atomgraph/` tree maintainer listed in `atomgraph/README.md` (martynas@atomgraph.com).

🤖 Generated with [Claude Code](https://claude.com/claude-code)