### PR TITLE
Add OntoJourney persistent identifiers

### DIFF
--- a/ontojourney/.htaccess
+++ b/ontojourney/.htaccess
@@ -1,0 +1,22 @@
+Options -MultiViews
+RewriteEngine On
+
+# OntoJourney Core: content negotiation for the ontology and version IRI.
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^core(?:/0\.9)?/?$ https://luisfcosta2015.github.io/ontojourney/artifacts/0.9.0/ontojourney-core.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/(?:rdf\+xml|owl\+xml) [NC]
+RewriteRule ^core(?:/0\.9)?/?$ https://luisfcosta2015.github.io/ontojourney/artifacts/0.9.0/ontojourney-core.rdf [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples [NC]
+RewriteRule ^core(?:/0\.9)?/?$ https://luisfcosta2015.github.io/ontojourney/artifacts/0.9.0/ontojourney-core.nt [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^core(?:/0\.9)?/?$ https://luisfcosta2015.github.io/ontojourney/artifacts/0.9.0/ontojourney-core.ttl [R=303,L]
+
+# Human-readable defaults.
+RewriteRule ^core/0\.9/?$ https://luisfcosta2015.github.io/ontojourney/releases/0.9.0/ [R=303,L]
+RewriteRule ^core/?$ https://luisfcosta2015.github.io/ontojourney/model/ [R=303,L]
+
+# Project root.
+RewriteRule ^$ https://luisfcosta2015.github.io/ontojourney/ [R=302,L]

--- a/ontojourney/README.md
+++ b/ontojourney/README.md
@@ -1,0 +1,24 @@
+# OntoJourney persistent identifiers
+
+This directory defines persistent redirects for OntoJourney, a reference
+ontology for narrative-heroic learning journeys.
+
+## Identifiers
+
+- `https://w3id.org/ontojourney/core` — ontology IRI
+- `https://w3id.org/ontojourney/core#` — entity namespace
+- `https://w3id.org/ontojourney/core/0.9` — Core v0.9 version IRI
+
+The rules negotiate HTML, Turtle, RDF/XML, JSON-LD, and N-Triples. Entity
+fragments such as `#JourneyModel` are resolved by the client after the base
+ontology IRI is redirected.
+
+## Maintainer
+
+- Luis Felipe Coimbra Costa — <https://github.com/luisfcosta2015>
+
+## Project
+
+- Repository: <https://github.com/luisfcosta2015/ontojourney>
+- Documentation: <https://luisfcosta2015.github.io/ontojourney/>
+- License: CC BY 4.0


### PR DESCRIPTION
## Brief Description

Adds the `https://w3id.org/ontojourney/` namespace for OntoJourney Core. The new directory defines redirects for the project root, ontology IRI, and version IRI, with content negotiation for HTML, Turtle, RDF/XML, JSON-LD, and N-Triples.

Public targets:

* Project: https://luisfcosta2015.github.io/ontojourney/
* Ontology documentation: https://luisfcosta2015.github.io/ontojourney/model/
* Version 0.9.0: https://luisfcosta2015.github.io/ontojourney/releases/0.9.0/
* Repository: https://github.com/luisfcosta2015/ontojourney

## General Checklist

* [x] Changes have been tested.
* [x] The number of commits is minimal.
* [x] Commits only include redirects and basic information.

## New ID Directory Checklist

* [x] Maintainer details are in `.htaccess` or `README.md`.
* [x] GitHub username IDs are listed in the maintainer details.
