### PR TITLE
sstim: add modular profile, module, and manifest routes

### DIFF
--- a/sstim/.htaccess
+++ b/sstim/.htaccess
@@ -13,17 +13,131 @@ AddType application/rdf+xml   .rdf .owl
 AddType application/ld+json   .jsonld
 AddType application/n-triples .nt
 
-Header set Access-Control-Allow-Origin *
+Header always set Access-Control-Allow-Origin *
+Header always set Vary "Accept"
 
 RewriteEngine On
 
 # -------------------------------------------------------------------------
-# Versioned immutable snapshots. These routes back owl:versionIRI values such
-# as /sstim/0.1.0 and direct frozen-file URLs such as
-# /sstim/0.1.0/sstim-core.ttl. (Turtle only — snapshots are not multi-format.)
+# Versioned immutable snapshots. This generated region is fail-closed: only
+# files that actually exist in a frozen repository snapshot acquire routes.
+# Future modular snapshots add exact /manifest and /manifest.schema.json routes
+# only after those immutable sibling files exist. Regenerate with
+# `node scripts/sstim-w3id-snapshot-routes.mjs --write` after cutting a release.
 # -------------------------------------------------------------------------
-RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/([A-Za-z0-9._-]+\.ttl)$ https://labiosyncare.github.io/ontology/$1/$2 [R=302,L]
-RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://labiosyncare.github.io/ontology/$1/sstim-core.ttl [R=302,L]
+# BEGIN generated exact SSTIM snapshot routes
+RewriteRule ^0\.1\.0/(sstim-alignments\.ttl|sstim-core\.ttl|sstim-patch-studio\.ttl|sstim-shapes\.ttl|sstim-vocab\.ttl)$ https://labiosyncare.github.io/ontology/0.1.0/$1 [R=302,L]
+RewriteRule ^0\.1\.0/?$ https://labiosyncare.github.io/ontology/0.1.0/sstim-core.ttl [R=302,L]
+RewriteRule ^0\.2\.0/(sstim-alignments\.ttl|sstim-core\.ttl|sstim-patch-studio\.ttl|sstim-shapes\.ttl|sstim-vocab\.ttl)$ https://labiosyncare.github.io/ontology/0.2.0/$1 [R=302,L]
+RewriteRule ^0\.2\.0/?$ https://labiosyncare.github.io/ontology/0.2.0/sstim-core.ttl [R=302,L]
+RewriteRule ^0\.3\.0/(sstim-alignments\.ttl|sstim-core\.ttl|sstim-patch-studio\.ttl|sstim-shapes\.ttl|sstim-vocab\.ttl)$ https://labiosyncare.github.io/ontology/0.3.0/$1 [R=302,L]
+RewriteRule ^0\.3\.0/?$ https://labiosyncare.github.io/ontology/0.3.0/sstim-core.ttl [R=302,L]
+RewriteRule ^0\.5\.0/(sstim-alignments\.ttl|sstim-core\.ttl|sstim-exposure\.ttl|sstim-patch-studio\.ttl|sstim-shapes\.ttl|sstim-vocab\.ttl)$ https://labiosyncare.github.io/ontology/0.5.0/$1 [R=302,L]
+RewriteRule ^0\.5\.0/?$ https://labiosyncare.github.io/ontology/0.5.0/sstim-core.ttl [R=302,L]
+RewriteRule ^0\.6\.0/(sstim-alignments\.ttl|sstim-core\.ttl|sstim-exposure\.ttl|sstim-patch-studio\.ttl|sstim-shapes\.ttl|sstim-vocab\.ttl)$ https://labiosyncare.github.io/ontology/0.6.0/$1 [R=302,L]
+RewriteRule ^0\.6\.0/?$ https://labiosyncare.github.io/ontology/0.6.0/sstim-core.ttl [R=302,L]
+RewriteRule ^0\.7\.0/(sstim-alignments\.ttl|sstim-core\.ttl|sstim-ecosystem\.ttl|sstim-exposure\.ttl|sstim-patch-studio\.ttl|sstim-shapes\.ttl|sstim-vocab\.ttl)$ https://labiosyncare.github.io/ontology/0.7.0/$1 [R=302,L]
+RewriteRule ^0\.7\.0/?$ https://labiosyncare.github.io/ontology/0.7.0/sstim-core.ttl [R=302,L]
+RewriteRule ^0\.8\.0/(sstim-alignments\.ttl|sstim-core\.ttl|sstim-ecosystem\.ttl|sstim-exposure\.ttl|sstim-patch-studio\.ttl|sstim-shapes\.ttl|sstim-vocab\.ttl)$ https://labiosyncare.github.io/ontology/0.8.0/$1 [R=302,L]
+RewriteRule ^0\.8\.0/?$ https://labiosyncare.github.io/ontology/0.8.0/sstim-core.ttl [R=302,L]
+RewriteRule ^0\.9\.0/(sstim-alignments\.ttl|sstim-core\.ttl|sstim-ecosystem\.ttl|sstim-exposure\.ttl|sstim-patch-studio\.ttl|sstim-shapes\.ttl|sstim-vocab\.ttl)$ https://labiosyncare.github.io/ontology/0.9.0/$1 [R=302,L]
+RewriteRule ^0\.9\.0/?$ https://labiosyncare.github.io/ontology/0.9.0/sstim-core.ttl [R=302,L]
+RewriteRule ^0\.10\.0/(sstim-alignments\.ttl|sstim-core\.ttl|sstim-ecosystem\.ttl|sstim-exposure\.ttl|sstim-patch-studio\.ttl|sstim-shapes\.ttl|sstim-vocab\.ttl)$ https://labiosyncare.github.io/ontology/0.10.0/$1 [R=302,L]
+RewriteRule ^0\.10\.0/?$ https://labiosyncare.github.io/ontology/0.10.0/sstim-core.ttl [R=302,L]
+RewriteRule ^0\.11\.0/(sstim-alignments\.ttl|sstim-core\.ttl|sstim-ecosystem\.ttl|sstim-exposure\.ttl|sstim-patch-studio\.ttl|sstim-shapes\.ttl|sstim-vocab\.ttl)$ https://labiosyncare.github.io/ontology/0.11.0/$1 [R=302,L]
+RewriteRule ^0\.11\.0/?$ https://labiosyncare.github.io/ontology/0.11.0/sstim-core.ttl [R=302,L]
+RewriteRule ^0\.12\.0/(sstim-alignments\.ttl|sstim-core\.ttl|sstim-ecosystem\.ttl|sstim-exposure\.ttl|sstim-patch-studio\.ttl|sstim-shapes\.ttl|sstim-stimulus\.ttl|sstim-vocab\.ttl)$ https://labiosyncare.github.io/ontology/0.12.0/$1 [R=302,L]
+RewriteRule ^0\.12\.0/?$ https://labiosyncare.github.io/ontology/0.12.0/sstim-core.ttl [R=302,L]
+# END generated exact SSTIM snapshot routes
+
+# -------------------------------------------------------------------------
+# Machine-readable bill of materials, public modules, and profile entrypoints.
+# The alternatives are explicit so a new manifest item cannot silently acquire
+# a persistent route. This is the sole block for manifest-owned latest routes.
+# Explicit RDF types take precedence in JSON-LD, RDF/XML order, then HTML, then
+# Turtle or */*. Media ranges with q=0 are excluded and matching is nocase.
+# -------------------------------------------------------------------------
+# BEGIN audited SSTIM manifest routes
+RewriteRule ^manifest$ https://labiosyncare.github.io/ontology/manifest.json [R=303,L]
+RewriteRule ^manifest-schema/1$ https://labiosyncare.github.io/ontology/manifest.schema.json [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*application/ld\+json\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^profile/(kernel|core|core-plus|full)$ https://labiosyncare.github.io/ontology/sstim-$1-profile.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*application/rdf\+xml\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^profile/(kernel|core|core-plus|full)$ https://labiosyncare.github.io/ontology/sstim-$1-profile.rdf [R=303,L]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/html|application/xhtml\+xml)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^profile/(kernel|core|core-plus|full)$ https://labiosyncare.github.io/ontology/docs/ [R=303,L]
+RewriteCond %{HTTP_ACCEPT} ^$ [OR]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/turtle|application/x-turtle|\*/\*)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^profile/(kernel|core|core-plus|full)$ https://labiosyncare.github.io/ontology/sstim-$1-profile.ttl [R=303,L]
+RewriteRule ^profile/(kernel|core|core-plus|full)$ - [R=406,L]
+
+# The logical Kernel ontology IRI remains /sstim for compatibility. /kernel is
+# its exact small retrieval endpoint; /sstim itself is the namespace catalog.
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*application/ld\+json\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^kernel$ https://labiosyncare.github.io/ontology/sstim-core.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*application/rdf\+xml\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^kernel$ https://labiosyncare.github.io/ontology/sstim-core.rdf [R=303,L]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/html|application/xhtml\+xml)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^kernel$ https://labiosyncare.github.io/ontology/docs/ [R=303,L]
+RewriteCond %{HTTP_ACCEPT} ^$ [OR]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/turtle|application/x-turtle|\*/\*)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^kernel$ https://labiosyncare.github.io/ontology/sstim-core.ttl [R=303,L]
+RewriteRule ^kernel$ - [R=406,L]
+
+# exposure#StimulusChannel is stimulus-owned after ADR 0044, so the namespace
+# document is the generated Stimulus + Exposure union rather than one module.
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*application/ld\+json\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^exposure$ https://labiosyncare.github.io/ontology/sstim-exposure-namespace.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*application/rdf\+xml\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^exposure$ https://labiosyncare.github.io/ontology/sstim-exposure-namespace.rdf [R=303,L]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/html|application/xhtml\+xml)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^exposure$ https://labiosyncare.github.io/ontology/docs/ [R=303,L]
+RewriteCond %{HTTP_ACCEPT} ^$ [OR]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/turtle|application/x-turtle|\*/\*)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^exposure$ https://labiosyncare.github.io/ontology/sstim-exposure-namespace.ttl [R=303,L]
+RewriteRule ^exposure$ - [R=406,L]
+
+# Exact Exposure module retrieval, separate from its hash-namespace catalog.
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*application/ld\+json\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^module/exposure$ https://labiosyncare.github.io/ontology/sstim-exposure.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*application/rdf\+xml\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^module/exposure$ https://labiosyncare.github.io/ontology/sstim-exposure.rdf [R=303,L]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/html|application/xhtml\+xml)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^module/exposure$ https://labiosyncare.github.io/ontology/docs/ [R=303,L]
+RewriteCond %{HTTP_ACCEPT} ^$ [OR]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/turtle|application/x-turtle|\*/\*)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^module/exposure$ https://labiosyncare.github.io/ontology/sstim-exposure.ttl [R=303,L]
+RewriteRule ^module/exposure$ - [R=406,L]
+
+# The SKOS vocabulary has its own pyLODE page; every other module is
+# described by the WIDOCO reference index.
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/html|application/xhtml\+xml)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^vocab$ https://labiosyncare.github.io/ontology/docs/vocab/ [R=303,L]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*application/ld\+json\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^(stimulus|core-shapes|common|technique|configuration|session|evidence|neuromodulation|patch-studio|vocab|ecosystem|neuromodulation-evidence|evidence-exposure|technique-exposure|alignments|shapes)$ https://labiosyncare.github.io/ontology/sstim-$1.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*application/rdf\+xml\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^(stimulus|core-shapes|common|technique|configuration|session|evidence|neuromodulation|patch-studio|vocab|ecosystem|neuromodulation-evidence|evidence-exposure|technique-exposure|alignments|shapes)$ https://labiosyncare.github.io/ontology/sstim-$1.rdf [R=303,L]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/html|application/xhtml\+xml)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^(stimulus|core-shapes|common|technique|configuration|session|evidence|neuromodulation|patch-studio|vocab|ecosystem|neuromodulation-evidence|evidence-exposure|technique-exposure|alignments|shapes)$ https://labiosyncare.github.io/ontology/docs/ [R=303,L]
+RewriteCond %{HTTP_ACCEPT} ^$ [OR]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/turtle|application/x-turtle|\*/\*)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^(stimulus|core-shapes|common|technique|configuration|session|evidence|neuromodulation|patch-studio|vocab|ecosystem|neuromodulation-evidence|evidence-exposure|technique-exposure|alignments|shapes)$ https://labiosyncare.github.io/ontology/sstim-$1.ttl [R=303,L]
+RewriteRule ^(stimulus|core-shapes|common|technique|configuration|session|evidence|neuromodulation|patch-studio|vocab|ecosystem|neuromodulation-evidence|evidence-exposure|technique-exposure|alignments|shapes)$ - [R=406,L]
+
+# /sstim is the generated Full namespace catalog. Fragment IRIs such as
+# /sstim#Preset resolve here even when a concern module owns their statements.
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*application/ld\+json\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^$ https://labiosyncare.github.io/ontology/sstim-namespace.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*application/rdf\+xml\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^$ https://labiosyncare.github.io/ontology/sstim-namespace.rdf [R=303,L]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/html|application/xhtml\+xml)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^$ https://labiosyncare.github.io/ [R=303,L]
+RewriteCond %{HTTP_ACCEPT} ^$ [OR]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/turtle|application/x-turtle|\*/\*)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^$ https://labiosyncare.github.io/ontology/sstim-namespace.ttl [R=303,L]
+RewriteRule ^$ - [R=406,L]
+# END audited SSTIM manifest routes
 
 # -------------------------------------------------------------------------
 # Stable BSC catalog identities. Framework, application, and component IRIs
@@ -31,26 +145,17 @@ RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://labiosyncare.github.io/ontology
 # intentionally distinct from the /sstim/patch-studio ontology module.
 # -------------------------------------------------------------------------
 # BEGIN audited BSC catalog routes
-# Browser targets are precise per-entity deep links into the knowledge-graph
-# browser's node-selection hash, not the bare marketing homepage: `prefix:`
-# with an empty local name addresses a namespace's own root resource (see
-# hashForIri()/resolveHashToNodeId() in src/ui/graph/OntologyGraph.svelte).
-# NE is required on every target below because mod_rewrite otherwise percent-
-# encodes the `#`, turning the fragment into a literal path segment.
-RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^framework/bsc/?$ https://labiosyncare.github.io/graph/#bsc-fw: [R=303,L,NE]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/html|application/xhtml\+xml)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^(framework/bsc|implementation/bsclab|implementation/biosyncare|implementation/bsclab/component/patch-studio)/?$ https://labiosyncare.github.io/ [R=303,L]
 
-RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^implementation/bsclab/?$ https://labiosyncare.github.io/graph/#bsclab: [R=303,L,NE]
-
-RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^implementation/biosyncare/?$ https://labiosyncare.github.io/graph/#biosyncare: [R=303,L,NE]
-
-RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^implementation/bsclab/component/patch-studio/?$ https://labiosyncare.github.io/graph/#bsclab:component/patch-studio [R=303,L,NE]
-
+RewriteCond %{HTTP_ACCEPT} ^$ [OR]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/turtle|application/x-turtle|\*/\*)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
 RewriteRule ^(framework/bsc)/?$ https://labiosyncare.github.io/ontology/instances/frameworks/bsc.ttl [R=303,L]
+RewriteRule ^(framework/bsc)/?$ - [R=406,L]
+RewriteCond %{HTTP_ACCEPT} ^$ [OR]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/turtle|application/x-turtle|\*/\*)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
 RewriteRule ^(implementation/bsclab|implementation/biosyncare|implementation/bsclab/component/patch-studio)/?$ https://labiosyncare.github.io/ontology/instances/implementations/implementations.ttl [R=303,L]
+RewriteRule ^(implementation/bsclab|implementation/biosyncare|implementation/bsclab/component/patch-studio)/?$ - [R=406,L]
 # END audited BSC catalog routes
 
 # -------------------------------------------------------------------------
@@ -64,35 +169,17 @@ RewriteRule ^(implementation/bsclab|implementation/biosyncare|implementation/bsc
 # framework/bsc/technique/ returned 404.
 # -------------------------------------------------------------------------
 # BEGIN audited BSC technique routes
-# Browser targets: the three techniques BSC originated deep-link to their
-# bsc-fw-tech: node (framework instance data); the four retired ones deep-link
-# to the SKOS concept that replaced them (ADR 0033), addressed by bare local
-# name per the sstim/vocab# hash convention (see hashForIri() in
-# src/ui/graph/OntologyGraph.svelte). NE preserves the `#` as a fragment
-# instead of letting mod_rewrite percent-encode it.
-RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^framework/bsc/technique/martigli-breathing-oscillation/?$ https://labiosyncare.github.io/graph/#bsc-fw-tech:martigli-breathing-oscillation [R=303,L,NE]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/html|application/xhtml\+xml)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^(framework/bsc/technique/martigli-breathing-oscillation|framework/bsc/technique/martigli-binaural-hybrid|framework/bsc/technique/symmetry-permutation-entrainment|framework/bsc/technique/binaural-beat-stimulation|framework/bsc/technique/photic-rhythm-stimulation|framework/bsc/technique/audiovisual-rhythm-coordination|framework/bsc/technique/vibrotactile-rhythm-stimulation)/?$ https://labiosyncare.github.io/ [R=303,L]
 
-RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^framework/bsc/technique/martigli-binaural-hybrid/?$ https://labiosyncare.github.io/graph/#bsc-fw-tech:martigli-binaural-hybrid [R=303,L,NE]
-
-RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^framework/bsc/technique/symmetry-permutation-entrainment/?$ https://labiosyncare.github.io/graph/#bsc-fw-tech:symmetry-permutation-entrainment [R=303,L,NE]
-
-RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^framework/bsc/technique/binaural-beat-stimulation/?$ https://labiosyncare.github.io/graph/#techBinauralBeats [R=303,L,NE]
-
-RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^framework/bsc/technique/photic-rhythm-stimulation/?$ https://labiosyncare.github.io/graph/#techPhoticDriving [R=303,L,NE]
-
-RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^framework/bsc/technique/audiovisual-rhythm-coordination/?$ https://labiosyncare.github.io/graph/#techAudiovisualEntrainment [R=303,L,NE]
-
-RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^framework/bsc/technique/vibrotactile-rhythm-stimulation/?$ https://labiosyncare.github.io/graph/#techVibrotactileEntrainment [R=303,L,NE]
-
+RewriteCond %{HTTP_ACCEPT} ^$ [OR]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/turtle|application/x-turtle|\*/\*)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
 RewriteRule ^(framework/bsc/technique/martigli-breathing-oscillation|framework/bsc/technique/martigli-binaural-hybrid|framework/bsc/technique/symmetry-permutation-entrainment)/?$ https://labiosyncare.github.io/ontology/instances/frameworks/bsc.ttl [R=303,L]
+RewriteRule ^(framework/bsc/technique/martigli-breathing-oscillation|framework/bsc/technique/martigli-binaural-hybrid|framework/bsc/technique/symmetry-permutation-entrainment)/?$ - [R=406,L]
+RewriteCond %{HTTP_ACCEPT} ^$ [OR]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/turtle|application/x-turtle|\*/\*)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
 RewriteRule ^(framework/bsc/technique/binaural-beat-stimulation|framework/bsc/technique/photic-rhythm-stimulation|framework/bsc/technique/audiovisual-rhythm-coordination|framework/bsc/technique/vibrotactile-rhythm-stimulation)/?$ https://labiosyncare.github.io/ontology/sstim-vocab.ttl [R=303,L]
+RewriteRule ^(framework/bsc/technique/binaural-beat-stimulation|framework/bsc/technique/photic-rhythm-stimulation|framework/bsc/technique/audiovisual-rhythm-coordination|framework/bsc/technique/vibrotactile-rhythm-stimulation)/?$ - [R=406,L]
 # END audited BSC technique routes
 
 # -------------------------------------------------------------------------
@@ -102,122 +189,30 @@ RewriteRule ^(framework/bsc/technique/binaural-beat-stimulation|framework/bsc/te
 # reserved synthetic-* fixture prefix is deliberately outside these routes.
 # -------------------------------------------------------------------------
 # BEGIN audited live ecosystem namespace routes
-# Browser targets deep-link into the knowledge-graph browser's node-selection
-# hash (`sstim-organization:`, `sstim-specialist:`, `sstim-ecosystem-record:` —
-# curies registered in src/rdf/namespaces.js), landing the visitor on the
-# actual record instead of the bare marketing homepage. NE preserves the `#`
-# as a fragment instead of letting mod_rewrite percent-encode it.
-RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^(specialist|organization)/((?!synthetic-)[A-Za-z0-9._~-]+)/?$ https://labiosyncare.github.io/graph/#sstim-$1:$2 [R=303,L,NE]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/html|application/xhtml\+xml)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^(specialist|organization)/(?!synthetic-)[A-Za-z0-9._~-]+/?$ https://labiosyncare.github.io/ [R=303,L]
 
-RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^ecosystem-record/(relationship|activity|role)/((?!synthetic-)[A-Za-z0-9._~-]+)/?$ https://labiosyncare.github.io/graph/#sstim-ecosystem-record:$1/$2 [R=303,L,NE]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/html|application/xhtml\+xml)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^ecosystem-record/(relationship|activity|role)/(?!synthetic-)[A-Za-z0-9._~-]+/?$ https://labiosyncare.github.io/ [R=303,L]
 
+RewriteCond %{HTTP_ACCEPT} ^$ [OR]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/turtle|application/x-turtle|\*/\*)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
 RewriteRule ^(specialist|organization)/(?!synthetic-)[A-Za-z0-9._~-]+/?$ https://biosyncare-lab.web.app/current.ttl [R=303,L]
+RewriteRule ^(specialist|organization)/(?!synthetic-)[A-Za-z0-9._~-]+/?$ - [R=406,L]
+RewriteCond %{HTTP_ACCEPT} ^$ [OR]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/turtle|application/x-turtle|\*/\*)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
 RewriteRule ^ecosystem-record/(relationship|activity|role)/(?!synthetic-)[A-Za-z0-9._~-]+/?$ https://biosyncare-lab.web.app/current.ttl [R=303,L]
+RewriteRule ^ecosystem-record/(relationship|activity|role)/(?!synthetic-)[A-Za-z0-9._~-]+/?$ - [R=406,L]
 # END audited live ecosystem namespace routes
-
-# -------------------------------------------------------------------------
-# Browser landing page for every module root below, including the bare
-# /sstim root at the bottom of this file: the graph browser, not the
-# marketing homepage. All seven resolve to the identical target, so one
-# rule replaces what would otherwise be seven near-duplicate pairs. A
-# fragment IRI under any of them (e.g. /sstim/vocab#alpha, /sstim#Preset) is
-# never sent to this server, but the browser re-appends it to a Location
-# with no fragment of its own, so this lands the visitor on that exact term,
-# selected, in the graph browser.
-# -------------------------------------------------------------------------
-RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
-RewriteRule ^(vocab|shapes|alignments|patch-studio|exposure|ecosystem)?$ https://labiosyncare.github.io/graph/ [R=303,L]
-
-# -------------------------------------------------------------------------
-# /sstim/vocab — SKOS vocabulary (frequency bands, groups, sub-bands, …)
-# -------------------------------------------------------------------------
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^vocab$ https://labiosyncare.github.io/ontology/sstim-vocab.jsonld [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^vocab$ https://labiosyncare.github.io/ontology/sstim-vocab.rdf [R=303,L]
-
-RewriteRule ^vocab$ https://labiosyncare.github.io/ontology/sstim-vocab.ttl [R=303,L]
-
-# -------------------------------------------------------------------------
-# /sstim/shapes — SHACL validation shapes
-# -------------------------------------------------------------------------
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^shapes$ https://labiosyncare.github.io/ontology/sstim-shapes.jsonld [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^shapes$ https://labiosyncare.github.io/ontology/sstim-shapes.rdf [R=303,L]
-
-RewriteRule ^shapes$ https://labiosyncare.github.io/ontology/sstim-shapes.ttl [R=303,L]
-
-# -------------------------------------------------------------------------
-# /sstim/alignments — external ontology alignments (BFO, OBI, Wikidata, …)
-# -------------------------------------------------------------------------
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^alignments$ https://labiosyncare.github.io/ontology/sstim-alignments.jsonld [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^alignments$ https://labiosyncare.github.io/ontology/sstim-alignments.rdf [R=303,L]
-
-RewriteRule ^alignments$ https://labiosyncare.github.io/ontology/sstim-alignments.ttl [R=303,L]
-
-# -------------------------------------------------------------------------
-# /sstim/patch-studio — Patch Studio authoring-model vocabulary
-# -------------------------------------------------------------------------
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^patch-studio$ https://labiosyncare.github.io/ontology/sstim-patch-studio.jsonld [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^patch-studio$ https://labiosyncare.github.io/ontology/sstim-patch-studio.rdf [R=303,L]
-
-RewriteRule ^patch-studio$ https://labiosyncare.github.io/ontology/sstim-patch-studio.ttl [R=303,L]
-
-# -------------------------------------------------------------------------
-# /sstim/exposure — exposure, delivery, modality, and experiment vocabulary
-# -------------------------------------------------------------------------
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^exposure$ https://labiosyncare.github.io/ontology/sstim-exposure.jsonld [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^exposure$ https://labiosyncare.github.io/ontology/sstim-exposure.rdf [R=303,L]
-
-RewriteRule ^exposure$ https://labiosyncare.github.io/ontology/sstim-exposure.ttl [R=303,L]
-
-# -------------------------------------------------------------------------
-# /sstim/ecosystem — ecosystem relationships and consent lifecycle
-# -------------------------------------------------------------------------
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^ecosystem$ https://labiosyncare.github.io/ontology/sstim-ecosystem.jsonld [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^ecosystem$ https://labiosyncare.github.io/ontology/sstim-ecosystem.rdf [R=303,L]
-
-RewriteRule ^ecosystem$ https://labiosyncare.github.io/ontology/sstim-ecosystem.ttl [R=303,L]
 
 # -------------------------------------------------------------------------
 # /sstim/void — VoID + DCAT dataset description (Turtle only; not exported)
 # -------------------------------------------------------------------------
-RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
+# BEGIN audited SSTIM void routes
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/html|application/xhtml\+xml)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
 RewriteRule ^void$ https://labiosyncare.github.io/ [R=303,L]
-
+RewriteCond %{HTTP_ACCEPT} ^$ [OR]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/turtle|application/x-turtle|\*/\*)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
 RewriteRule ^void$ https://labiosyncare.github.io/ontology/void.ttl [R=303,L]
-
-# -------------------------------------------------------------------------
-# /sstim — core ontology (OWL classes and properties). Fragment IRIs such
-# as /sstim#Preset resolve here; the fragment is handled client-side.
-# -------------------------------------------------------------------------
-# Browser → human-readable landing page: covered by the module-root rule
-# above (bare /sstim is its empty-match case). WIDOCO docs may replace that
-# target in Phase 1 once generated — see docsUrlForIri() in
-# src/ui/graph/OntologyGraph.svelte for where the graph browser already
-# links out to them per term.
-RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^$ https://labiosyncare.github.io/ontology/sstim-core.jsonld [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^$ https://labiosyncare.github.io/ontology/sstim-core.rdf [R=303,L]
-
-# Turtle or unspecified → core ontology file
-RewriteRule ^$ https://labiosyncare.github.io/ontology/sstim-core.ttl [R=303,L]
+RewriteRule ^void$ - [R=406,L]
+# END audited SSTIM void routes

--- a/sstim/README.md
+++ b/sstim/README.md
@@ -20,37 +20,58 @@ Future PRs touching `sstim/` will be authored or approved by
 
 ## Routes
 
-| PID                        | Content                                          |
-|----------------------------|--------------------------------------------------|
-| `/sstim`                   | Core OWL ontology                                |
-| `/sstim/vocab`             | SKOS vocabulary                                  |
-| `/sstim/shapes`            | SHACL validation shapes                          |
-| `/sstim/alignments`        | External alignments (BFO, OBI, IAO, Wikidata, …) |
-| `/sstim/patch-studio`      | Patch Studio authoring-model vocabulary          |
-| `/sstim/exposure`          | Exposure, delivery, and modality vocabulary      |
-| `/sstim/ecosystem`         | Ecosystem relationships and consent lifecycle    |
-| `/sstim/framework/bsc`     | BSC framework catalog record                     |
-| `/sstim/implementation/bsclab` | BSC Lab implementation catalog record        |
-| `/sstim/implementation/biosyncare` | BioSynCare application catalog record    |
+| PID | Content |
+|---|---|
+| `/sstim` | Generated namespace catalogue for `sstim:` hash terms |
+| `/sstim/kernel` | Exact dependency-free kernel distribution |
+| `/sstim/profile/{kernel,core,core-plus,full}` | Conformance profile entry points, with W3C PROF metadata |
+| `/sstim/manifest` | Machine-readable bill of materials (JSON) |
+| `/sstim/manifest-schema/1` | JSON Schema for the manifest |
+| `/sstim/{stimulus,common,technique,configuration,session,evidence,neuromodulation}` | Semantic concern modules |
+| `/sstim/{neuromodulation-evidence,evidence-exposure,technique-exposure}` | Cross-concern bridge modules |
+| `/sstim/{core-shapes,shapes}` | SHACL validation packages |
+| `/sstim/vocab` | SKOS vocabulary |
+| `/sstim/alignments` | External alignments (Wikidata and others) |
+| `/sstim/patch-studio` | Patch Studio authoring-model vocabulary |
+| `/sstim/exposure` | Generated namespace catalogue for `sstim/exposure:` hash terms |
+| `/sstim/module/exposure` | Exact exposure module distribution |
+| `/sstim/ecosystem` | Ecosystem relationships and consent lifecycle |
+| `/sstim/framework/bsc` | BSC framework catalog record |
+| `/sstim/implementation/bsclab` | BSC Lab implementation catalog record |
+| `/sstim/implementation/biosyncare` | BioSynCare application catalog record |
 | `/sstim/implementation/bsclab/component/patch-studio` | Patch Studio software-component catalog record |
 | `/sstim/specialist/{id}` and `/sstim/organization/{id}` namespaces (`synthetic-*` excluded) | Mutable live-only ecosystem projection |
 | `/sstim/ecosystem-record/{relationship,activity,role}/{id}` namespaces (`synthetic-*` excluded) | Mutable live-only ecosystem projection |
-| `/sstim/void`              | VoID + DCAT dataset description (Turtle only)    |
-| `/sstim/{major.minor.patch}` | Versioned immutable snapshots (Turtle only)    |
+| `/sstim/void` | VoID + DCAT dataset description (Turtle only) |
+| `/sstim/{major.minor.patch}` and `/sstim/{major.minor.patch}/{file.ttl}` | Versioned immutable snapshots (Turtle only) |
+| `/sstim/{major.minor.patch}/manifest` and `/{major.minor.patch}/manifest.schema.json` | Frozen manifest and schema, where a release has them |
 
-The base and ontology-module routes negotiate Turtle (default), JSON-LD
-(`application/ld+json`), and RDF/XML (`application/rdf+xml`); HTML requests
-redirect to the project landing page. VoID, versioned snapshots, and the
-instance routes below are Turtle resources. Fragment IRIs such as
-`/sstim#Preset` resolve to the base document.
+The namespace, kernel, module, and profile routes negotiate Turtle (default),
+JSON-LD (`application/ld+json`), and RDF/XML (`application/rdf+xml`); HTML
+requests redirect to project documentation. A request whose `Accept` header
+allows none of these receives `406`. `Vary: Accept` is set, so caches do not
+serve an HTML representation to an RDF client or the reverse. The manifest and
+schema are JSON; VoID, versioned snapshots, and the instance routes below are
+Turtle resources.
+
+`/sstim` and `/sstim/exposure` are namespace catalogues rather than single
+files, because the terms in those two hash namespaces are spread across several
+modules. That is what keeps `/sstim#Preset` and
+`/sstim/exposure#StimulusChannel` resolving to their definitions. Consumers
+wanting one exact module use `/sstim/kernel` or `/sstim/module/exposure`, and
+consumers wanting a defined subset use a `/sstim/profile/` entry point.
+
+Snapshot routes are enumerated per file rather than matched by wildcard, so a
+version or filename that does not exist returns 404 instead of redirecting to a
+missing target.
 
 Audited static catalog routes send RDF clients to the owning Turtle instance
 file. General live ecosystem namespace rules send RDF clients to the mutable,
 live-only `current.ttl` projection. Current synthetic contract subjects reserve
 a `synthetic-*` slug rejected by those rules and are available only through the
-direct fixture artifact; there are no fixture-specific routes. The frozen
-SSTIM 0.7.0 snapshot remains unchanged. HTML requests reach the project landing
-page for static catalog and live ecosystem identifiers.
+direct fixture artifact; there are no fixture-specific routes. Previously
+published frozen snapshots remain unchanged. HTML requests reach the project
+landing page for static catalog and live ecosystem identifiers.
 
 Dataset membership belongs to the live RDF projection, not the registry
 configuration. Adding, correcting, or retracting a record therefore does not


### PR DESCRIPTION
## Brief Description

Updates the existing `sstim/` directory for the SSTIM ontology's modular
reorganisation. All targets are `https://labiosyncare.github.io/ontology/`, as
before; this PR only adds and retargets redirects.

**New routes**

- `/sstim/profile/{kernel,core,core-plus,full}` — the four W3C PROF profile
  entry points that name SSTIM's conformance closures.
- `/sstim/{stimulus,common,technique,configuration,session,evidence,neuromodulation,core-shapes,neuromodulation-evidence,evidence-exposure,technique-exposure}`
  — modules extracted from the former monolithic core file.
- `/sstim/kernel` — the exact two-class kernel distribution.
- `/sstim/module/exposure` — the exact Exposure module.
- `/sstim/manifest` and `/sstim/manifest-schema/1` — the machine-readable bill
  of materials and its JSON Schema.

**Retargeted routes**

- `/sstim` and `/sstim/exposure` now serve generated namespace catalogues rather
  than a single file. Both are hash namespaces whose terms are now spread across
  several modules, so a catalogue is what makes `/sstim#Preset` and
  `/sstim/exposure#StimulusChannel` still dereference to their definitions.
  `/sstim/kernel` and `/sstim/module/exposure` are the exact single-module
  documents for anyone who wants those instead.

**Replaced wildcard**

The snapshot rules were two regex wildcards matching any `X.Y.Z` and any
`*.ttl` under it. They are replaced by explicit per-file rules generated from
the frozen snapshots that actually exist, so a plausible-looking but nonexistent
version or filename now 404s instead of redirecting to a missing target. This
also fixes a latent problem: the wildcard sent every `/sstim/X.Y.Z` to
`sstim-core.ttl`, which was correct while that file was the whole ontology and
would have become wrong at the next release, where it is a two-class kernel.
Future versions get a `/manifest` route only once a frozen `manifest.json`
sibling exists beside them.

`Vary: Accept` is set, since these routes negotiate Turtle, JSON-LD, RDF/XML and
HTML from the same URL.

Rules are generated and verified in the source repository
(`scripts/sstim-w3id-snapshot-routes.mjs`, `scripts/check-w3id-route-targets.mjs`),
which check that the committed route table matches the frozen snapshots on disk
and that every `/ontology/` target is an artifact the project actually
publishes.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

Not applicable — `sstim/` already exists.

- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist

- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

Maintainer: Renato Fabbri, [@ttm](https://github.com/ttm), as recorded in
`sstim/README.md` and previously in #6378, #6391 and #6393.

## Optional Requests for W3ID Maintainers

- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
