### PR TITLE
Add mathematical-systems namespace

### DIFF
--- a/mathematical-systems/.htaccess
+++ b/mathematical-systems/.htaccess
@@ -1,0 +1,26 @@
+# https://w3id.org/mathematical-systems/
+#
+# Permanent identifiers for the Mathematical Systems project — a catalogue of
+# formal mathematical definitions of "system" and the maps between them.
+#
+# Maintainer: Shingai Thornton (GitHub: @rsthornton) <rsthornton@gmail.com>
+# ORCID:   https://orcid.org/0009-0001-8261-1109
+# Source:  https://github.com/halcyonic-systems/mathematical-systems
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# --- machines: content negotiation on the catalogue -------------------------
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/n3
+RewriteRule ^atlas(/.*)?$ https://math.systems/data/atlas.ttl [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/owl\+xml
+RewriteRule ^atlas(/.*)?$ https://math.systems/data/atlas.owl [R=302,L]
+
+# --- people -----------------------------------------------------------------
+RewriteRule ^atlas/entry/(.+)$ https://math.systems/entry/$1 [R=302,L]
+RewriteRule ^atlas/?$          https://math.systems/         [R=302,L]
+RewriteRule ^(.*)$             https://math.systems/$1       [R=302,L]

--- a/mathematical-systems/README.md
+++ b/mathematical-systems/README.md
@@ -1,0 +1,23 @@
+# mathematical-systems
+
+Permanent identifiers for **Mathematical Systems** — a catalogue of formal
+mathematical definitions of "system" drawn from the systems theory and systems
+science traditions, with the relations between them.
+
+Each entry records a definition transcribed verbatim from its primary source,
+the location it was taken from, the terms it uses as primitives, and an evidence
+code recording how the encoding was established. Entries are aligned to BFO/CCO
+at the annotation layer.
+
+Identifiers resolve to human-readable pages by default and to RDF under content
+negotiation (`text/turtle`, `application/rdf+xml`).
+
+```
+https://w3id.org/mathematical-systems/atlas/entry/klir-2001-eq-1-1
+https://w3id.org/mathematical-systems/atlas/
+```
+
+- **Maintainer:** Shingai Thornton — GitHub [@rsthornton](https://github.com/rsthornton) · rsthornton@gmail.com
+- **ORCID:** https://orcid.org/0009-0001-8261-1109
+- **Source:** https://github.com/halcyonic-systems/mathematical-systems
+- **Licence:** catalogue CC BY 4.0; tooling MIT


### PR DESCRIPTION
## Brief Description
Adds the `mathematical-systems` namespace — permanent identifiers for a catalogue
of formal mathematical definitions of "system" from the systems theory and systems
science traditions. Identifiers resolve to human-readable pages by default and to
RDF under content negotiation (`text/turtle`, `application/rdf+xml`).

Note: the redirect target is a domain currently mid-transfer between registrars,
so it may not resolve when you look. Updating the target once it lands is a
one-line follow-up PR.

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.