### PR TITLE
Add minerval namespace

### DIFF
--- a/minerval/.htaccess
+++ b/minerval/.htaccess
@@ -1,0 +1,15 @@
+# Permanent identifiers for Minerval (https://minerval.ai).
+# w3id.org convention: 302 (not 301) so the w3id form stays the identifier
+# clients keep citing while the target remains free to move.
+Options +FollowSymLinks
+RewriteEngine on
+
+# https://w3id.org/minerval/claim/<claim-id> -> the claim's page
+RewriteRule ^claim/(.+)$ https://minerval.ai/claims/$1 [R=302,L]
+
+# https://w3id.org/minerval/vocab -> the RDF vocabulary documentation
+# (used by the nanopublication export's mv: namespace)
+RewriteRule ^vocab$ https://github.com/minerval-ai/minerval/blob/main/docs/vocab.md [R=302,L]
+
+# Namespace root
+RewriteRule ^$ https://minerval.ai/ [R=302,L]

--- a/minerval/README.md
+++ b/minerval/README.md
@@ -1,0 +1,21 @@
+# /minerval/
+
+Permanent identifiers for [Minerval](https://minerval.ai), a knowledge graph
+of canonicalized claims with transparent, versioned validity assessments.
+
+Redirects:
+
+- `https://w3id.org/minerval/claim/<claim-id>` → the claim's page at
+  `https://minerval.ai/claims/<claim-id>`. Claim ids are stable UUIDs; these
+  identifiers appear in scholarly citations of claims and their assessments,
+  so the namespace is expected to be long-lived.
+- `https://w3id.org/minerval/vocab` → the documentation of the `mv:` RDF
+  vocabulary (`https://w3id.org/minerval/vocab#...`) used by the graph's
+  nanopublication export.
+- `https://w3id.org/minerval/` → `https://minerval.ai/`.
+
+Maintainers / contact:
+
+- Jackson Hurley — jackson@minerval.ai — GitHub: [jacksonqueenking](https://github.com/jacksonqueenking)
+
+Source: [minerval-ai/minerval](https://github.com/minerval-ai/minerval)


### PR DESCRIPTION
## Brief Description
Adds the `minerval` namespace: permanent identifiers for claims in
[Minerval](https://minerval.ai), a knowledge graph of canonicalized claims
with versioned validity assessments. The identifiers are used in scholarly
citations and an RDF/nanopublication export.

- `/minerval/claim/<claim-id>` → `https://minerval.ai/claims/<claim-id>`
- `/minerval/vocab` → RDF vocabulary documentation
- `/minerval/` → `https://minerval.ai/`

## General Checklist
- [ ] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
