### PR TITLE
Add /censo - an ontology for censored environmental observations

### DIFF
--- a/censo/.htaccess
+++ b/censo/.htaccess
@@ -9,31 +9,26 @@
 # ## Contact
 # This space is administered by:
 #
-# Recep Can Altinbag
-# recep.altinbag@bogazici.edu.tr
+# Recep Can Altinbag <recep.altinbag@bogazici.edu.tr>
 # GitHub username: recepcanaltinbag
-# Bogazici University, Institute of Environmental Sciences
+# Bogazici University, Institute of Environmental Sciences, Istanbul, Turkiye
+
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure files are served as the appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .jsonld
 
 RewriteEngine on
 
 # ---------------------------------------------------------------------------
-# Versioned URIs.
-#
-# The ontology's own owl:versionIRI is https://w3id.org/censo/1.0.0, so this
-# rule is not a convenience: the IRI appears inside the published file and has
-# to resolve, or the artefact points at a 404 of its own making.
-# ---------------------------------------------------------------------------
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
-RewriteCond %{HTTP_ACCEPT} application/xml
-RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://recepcanaltinbag.github.io/censo/releases/$1/censo-full.owl [R=303,L]
-
-RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://recepcanaltinbag.github.io/censo/releases/$1/censo-full.ttl [R=303,L]
-
-# ---------------------------------------------------------------------------
 # Named modules. These are DIFFERENT documents, not other serialisations of the
-# core vocabulary, so they must be matched before the content-negotiation rules
-# below -- an earlier version folded them into the same pattern and returned
-# the core file for all three.
+# core vocabulary, so they are matched before the content negotiation below.
 # ---------------------------------------------------------------------------
 RewriteRule ^reg/tr-ysky-2016/?$     https://recepcanaltinbag.github.io/censo/reg/tr-ysky-2016.ttl [R=303,L]
 RewriteRule ^reg/eu-2008-105-2026/?$ https://recepcanaltinbag.github.io/censo/reg/eu-2008-105-2026.ttl [R=303,L]
@@ -41,25 +36,52 @@ RewriteRule ^reg/?$                  https://recepcanaltinbag.github.io/censo/ce
 RewriteRule ^shapes/?$               https://recepcanaltinbag.github.io/censo/censo-shapes.ttl [R=303,L]
 
 # ---------------------------------------------------------------------------
-# Content negotiation on the core vocabulary.
+# Latest version.
+#
+# The first condition is negative and is AND-ed with the rest: it excludes
+# clients that ask for RDF/XML ahead of HTML, which a plain ordering cannot
+# distinguish because RewriteCond matches substrings and cannot read q-values.
+# The User-Agent test catches browsers that send an unhelpful Accept header.
 # ---------------------------------------------------------------------------
-RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
-RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
-RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
-RewriteCond %{HTTP_ACCEPT} application/turtle
-RewriteRule ^$ https://recepcanaltinbag.github.io/censo/censo-full.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://recepcanaltinbag.github.io/censo/index.html [R=303,L]
 
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
-RewriteCond %{HTTP_ACCEPT} application/xml [OR]
-RewriteCond %{HTTP_ACCEPT} text/xml
-RewriteRule ^$ https://recepcanaltinbag.github.io/censo/censo-full.owl [R=303,L]
-
-RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
-RewriteCond %{HTTP_ACCEPT} application/json
+# Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
 RewriteRule ^$ https://recepcanaltinbag.github.io/censo/censo-full.jsonld [R=303,L]
 
-# ---- a browser, or anything that did not ask for RDF, gets the docs --------
-RewriteRule ^$ https://recepcanaltinbag.github.io/censo/ [R=303,L]
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://recepcanaltinbag.github.io/censo/censo-full.owl [R=303,L]
+
+# Rewrite rule to serve TTL content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ https://recepcanaltinbag.github.io/censo/censo-full.ttl [R=303,L]
+
+# ---------------------------------------------------------------------------
+# Version-aware URIs.
+#
+# The ontology's own owl:versionIRI is https://w3id.org/censo/1.0.0, so this is
+# not a convenience: the IRI is inside the published file and has to resolve,
+# or the artefact points at a 404 of its own making.
+# ---------------------------------------------------------------------------
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://recepcanaltinbag.github.io/censo/index.html [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://recepcanaltinbag.github.io/censo/releases/$1/censo-full.owl [R=303,L]
+
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://recepcanaltinbag.github.io/censo/releases/$1/censo-full.ttl [R=303,L]
 
 # ---- everything else passes through ---------------------------------------
 RewriteRule ^(.*)$ https://recepcanaltinbag.github.io/censo/$1 [R=303,L]

--- a/censo/.htaccess
+++ b/censo/.htaccess
@@ -1,0 +1,65 @@
+# CENSO: an ontology for censored environmental observations
+#
+# https://w3id.org/censo/ redirects to https://recepcanaltinbag.github.io/censo/
+#
+# CENSO extends SOSA/SSN so that a non-detection can be represented as the
+# interval it establishes rather than as a zero, and so that "cannot be
+# determined" is an explicit compliance outcome.
+#
+# ## Contact
+# This space is administered by:
+#
+# Recep Can Altinbag
+# recep.altinbag@bogazici.edu.tr
+# GitHub username: recepcanaltinbag
+# Bogazici University, Institute of Environmental Sciences
+
+RewriteEngine on
+
+# ---------------------------------------------------------------------------
+# Versioned URIs.
+#
+# The ontology's own owl:versionIRI is https://w3id.org/censo/1.0.0, so this
+# rule is not a convenience: the IRI appears inside the published file and has
+# to resolve, or the artefact points at a 404 of its own making.
+# ---------------------------------------------------------------------------
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/xml
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://recepcanaltinbag.github.io/censo/releases/$1/censo-full.owl [R=303,L]
+
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://recepcanaltinbag.github.io/censo/releases/$1/censo-full.ttl [R=303,L]
+
+# ---------------------------------------------------------------------------
+# Named modules. These are DIFFERENT documents, not other serialisations of the
+# core vocabulary, so they must be matched before the content-negotiation rules
+# below -- an earlier version folded them into the same pattern and returned
+# the core file for all three.
+# ---------------------------------------------------------------------------
+RewriteRule ^reg/tr-ysky-2016/?$     https://recepcanaltinbag.github.io/censo/reg/tr-ysky-2016.ttl [R=303,L]
+RewriteRule ^reg/eu-2008-105-2026/?$ https://recepcanaltinbag.github.io/censo/reg/eu-2008-105-2026.ttl [R=303,L]
+RewriteRule ^reg/?$                  https://recepcanaltinbag.github.io/censo/censo-regulation.ttl [R=303,L]
+RewriteRule ^shapes/?$               https://recepcanaltinbag.github.io/censo/censo-shapes.ttl [R=303,L]
+
+# ---------------------------------------------------------------------------
+# Content negotiation on the core vocabulary.
+# ---------------------------------------------------------------------------
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/turtle
+RewriteRule ^$ https://recepcanaltinbag.github.io/censo/censo-full.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/xml
+RewriteRule ^$ https://recepcanaltinbag.github.io/censo/censo-full.owl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^$ https://recepcanaltinbag.github.io/censo/censo-full.jsonld [R=303,L]
+
+# ---- a browser, or anything that did not ask for RDF, gets the docs --------
+RewriteRule ^$ https://recepcanaltinbag.github.io/censo/ [R=303,L]
+
+# ---- everything else passes through ---------------------------------------
+RewriteRule ^(.*)$ https://recepcanaltinbag.github.io/censo/$1 [R=303,L]

--- a/censo/README.md
+++ b/censo/README.md
@@ -2,35 +2,26 @@
 
 `https://w3id.org/censo/`
 
-## What it is
-
 CENSO extends SOSA/SSN for measurements produced by a method that has a limit of
-detection. Its single modelling commitment is that **the detection limit belongs
-to the analytical run, not to the instrument**. Because the limit travels with
-the result, a non-detection can be typed as the interval `[0, LOD]` it actually
-establishes rather than stored as a zero, and compliance becomes four-valued:
-*compliant*, *exceeding*, *possibly exceeding*, and *cannot be determined*.
+detection, so that a non-detection can be represented as the interval it
+establishes rather than stored as a zero, and so that *cannot be determined* is
+an explicit compliance outcome alongside *compliant*, *exceeding* and *possibly
+exceeding*.
 
-The fourth outcome is not a convenience. Article of the consolidated
-Directive 2008/105/EC requires that a result reported as below the limit of
-quantification, where that limit exceeds the environmental quality standard,
-"shall not be considered for the purposes of assessing the overall chemical
-status of that water body". A two-valued data model cannot express that
-requirement, so it cannot be audited.
+Documentation and the files themselves are hosted at
+<https://recepcanaltinbag.github.io/censo/>. This directory contains only the
+redirects.
 
-## Contents
+## What resolves where
 
-| IRI | What it resolves to |
+| IRI | Redirects to |
 |---|---|
-| `https://w3id.org/censo/` | the vocabulary (Turtle, RDF/XML or JSON-LD by content negotiation) |
-| `https://w3id.org/censo/1.0.0` | that specific release |
+| `https://w3id.org/censo/` | the vocabulary — HTML, Turtle, RDF/XML or JSON-LD by content negotiation |
+| `https://w3id.org/censo/1.0.0` | that release (the ontology's own `owl:versionIRI`) |
 | `https://w3id.org/censo/reg/` | the regulation-package vocabulary |
-| `https://w3id.org/censo/reg/tr-ysky-2016` | Turkish surface water standards, 434 thresholds |
-| `https://w3id.org/censo/reg/eu-2008-105-2026` | EU Annex I as in force 10 May 2026, 114 thresholds |
-| `https://w3id.org/censo/shapes` | SHACL shapes for validation and materialisation |
-
-Regulation packages contribute individuals only — no class, no property — which
-is what makes one safe to load in place of, or alongside, another.
+| `https://w3id.org/censo/reg/eu-2008-105-2026` | EU Annex I, in force 10 May 2026 |
+| `https://w3id.org/censo/reg/tr-ysky-2016` | Turkish surface water standards |
+| `https://w3id.org/censo/shapes` | SHACL shapes |
 
 ## Licence
 
@@ -38,7 +29,5 @@ CC BY 4.0.
 
 ## Maintainer
 
-Recep Can Altınbağ
+Recep Can Altınbağ <recep.altinbag@bogazici.edu.tr> (GitHub: recepcanaltinbag)
 Boğaziçi University, Institute of Environmental Sciences, Istanbul, Türkiye
-recep.altinbag@bogazici.edu.tr
-GitHub: [@recepcanaltinbag](https://github.com/recepcanaltinbag)

--- a/censo/README.md
+++ b/censo/README.md
@@ -1,0 +1,44 @@
+# CENSO — an ontology for censored environmental observations
+
+`https://w3id.org/censo/`
+
+## What it is
+
+CENSO extends SOSA/SSN for measurements produced by a method that has a limit of
+detection. Its single modelling commitment is that **the detection limit belongs
+to the analytical run, not to the instrument**. Because the limit travels with
+the result, a non-detection can be typed as the interval `[0, LOD]` it actually
+establishes rather than stored as a zero, and compliance becomes four-valued:
+*compliant*, *exceeding*, *possibly exceeding*, and *cannot be determined*.
+
+The fourth outcome is not a convenience. Article of the consolidated
+Directive 2008/105/EC requires that a result reported as below the limit of
+quantification, where that limit exceeds the environmental quality standard,
+"shall not be considered for the purposes of assessing the overall chemical
+status of that water body". A two-valued data model cannot express that
+requirement, so it cannot be audited.
+
+## Contents
+
+| IRI | What it resolves to |
+|---|---|
+| `https://w3id.org/censo/` | the vocabulary (Turtle, RDF/XML or JSON-LD by content negotiation) |
+| `https://w3id.org/censo/1.0.0` | that specific release |
+| `https://w3id.org/censo/reg/` | the regulation-package vocabulary |
+| `https://w3id.org/censo/reg/tr-ysky-2016` | Turkish surface water standards, 434 thresholds |
+| `https://w3id.org/censo/reg/eu-2008-105-2026` | EU Annex I as in force 10 May 2026, 114 thresholds |
+| `https://w3id.org/censo/shapes` | SHACL shapes for validation and materialisation |
+
+Regulation packages contribute individuals only — no class, no property — which
+is what makes one safe to load in place of, or alongside, another.
+
+## Licence
+
+CC BY 4.0.
+
+## Maintainer
+
+Recep Can Altınbağ
+Boğaziçi University, Institute of Environmental Sciences, Istanbul, Türkiye
+recep.altinbag@bogazici.edu.tr
+GitHub: [@recepcanaltinbag](https://github.com/recepcanaltinbag)


### PR DESCRIPTION
## Brief Description

Add `/censo/` — CENSO, an ontology for censored environmental observations (version 1.0.0).

CENSO extends SOSA/SSN for measurements produced by a method that has a limit of detection, so that a non-detection can be represented as the interval it establishes rather than stored as a zero, and so that *cannot be determined* is an explicit compliance outcome alongside *compliant*, *exceeding* and *possibly exceeding*.

Redirect target: https://recepcanaltinbag.github.io/censo/ 

The `.htaccess` follows `examples/ontology/.htaccess` and `example/.htaccess`: MultiViews off, `AddType` directives, content negotiation using the negative RDF/XML condition together with the `Mozilla` User-Agent fallback, and version-aware URIs as in Example 5 — the ontology's own `owl:versionIRI` is `https://w3id.org/censo/1.0.0`, which resolves to `releases/1.0.0/`.

Named modules (`/reg/`, `/reg/<package>`, `/shapes`) are separate documents rather than alternative serialisations of the core vocabulary, so they are matched ahead of the content-negotiation rules.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist

<!-- Not applicable: this is a new ID. -->

## Optional Requests for W3ID Maintainers

- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.

