### PR TITLE
Add gUFOevents identifiers to the nemo space

### DIFF
--- a/nemo/.htaccess
+++ b/nemo/.htaccess
@@ -6,13 +6,72 @@
 # https://w3id.org/nemo/gufoshapes redirects to
 # https://nemo-ufes.github.io/gufoshapes/gufoshapes.ttl
 #
+# gUFOevents <https://github.com/nemo-ufes/gufoevents>:
+#
+# https://w3id.org/nemo/gufoevents            the ontology (Turtle), or its
+#                                             documentation for a web browser
+# https://w3id.org/nemo/gufoevents/1.0.0      the version 1.0.0 ontology
+# https://w3id.org/nemo/doc/gufoevents        the documentation
+# https://w3id.org/nemo/gufoevents/shapes/*   the SHACL shapes
+# https://w3id.org/nemo/gufoevents/examples/* the worked examples
+#
 # ## Contact
-# This space is administered by:  
+# This space is administered by:
 #
 # João Paulo A. Almeida
 # GitHub username: jpalmeida
 
-Options +FollowSymLinks
+Options +FollowSymLinks -MultiViews
 RewriteEngine on
+
+# ---------------------------------------------------------------------------
+# gUFOevents
+# ---------------------------------------------------------------------------
+
+# Documentation.
+RewriteRule "^doc/gufoevents/?$"          "https://nemo-ufes.github.io/gufoevents/docs/" [R=302,L]
+RewriteRule "^doc/gufoevents/explorer/?$" "https://nemo-ufes.github.io/gufoevents/docs/explorer.html" [R=302,L]
+
+# The version IRI resolves to a tag and not to the default branch: a version
+# IRI that followed the branch would stop denoting version 1.0.0 on the next
+# commit.
+RewriteRule "^gufoevents/1\.0\.0/?$" "https://raw.githubusercontent.com/nemo-ufes/gufoevents/v1.0.0/gufoevents.ttl" [R=302,L]
+
+# The ontology IRI, and with it the http://w3id.org/nemo/gufoevents# namespace.
+#
+# A web browser is sent to the documentation and everything else to the Turtle.
+# The test is on text/html, and comes first, because browsers ask for more than
+# they will use: Firefox sends
+# "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", so a rule
+# that looked for application/xml first would hand browsers the raw ontology.
+# Tools that want RDF do not ask for text/html -- Protege sends
+# "application/rdf+xml, application/xml;q=0.5, text/xml;q=0.3, */*;q=0.2" --
+# and curl with no Accept header falls through to the same place.
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule "^gufoevents/?$" "https://nemo-ufes.github.io/gufoevents/docs/" [R=302,L]
+RewriteRule "^gufoevents/?$" "https://nemo-ufes.github.io/gufoevents/gufoevents.ttl" [R=302,L]
+
+# The SHACL shapes.
+RewriteRule "^gufoevents/shapes/core/?$"           "https://nemo-ufes.github.io/gufoevents/event-sourcing/shapes-core.ttl" [R=302,L]
+RewriteRule "^gufoevents/shapes/event-sourcing/?$" "https://nemo-ufes.github.io/gufoevents/event-sourcing/shapes-event-sourcing.ttl" [R=302,L]
+
+# The eight worked examples. Each slug is the namespace the example declares;
+# the file names carry a reading order that the namespaces do not.
+RewriteRule "^gufoevents/examples/order/?$"      "https://nemo-ufes.github.io/gufoevents/examples/01-order-fulfilment.ttl" [R=302,L]
+RewriteRule "^gufoevents/examples/person/?$"     "https://nemo-ufes.github.io/gufoevents/examples/02-person-life-phases.ttl" [R=302,L]
+RewriteRule "^gufoevents/examples/bicycle/?$"    "https://nemo-ufes.github.io/gufoevents/examples/03-bicycle-maintenance.ttl" [R=302,L]
+RewriteRule "^gufoevents/examples/museum/?$"     "https://nemo-ufes.github.io/gufoevents/examples/04-museum-conservation.ttl" [R=302,L]
+RewriteRule "^gufoevents/examples/employment/?$" "https://nemo-ufes.github.io/gufoevents/examples/05-employment-relators.ttl" [R=302,L]
+RewriteRule "^gufoevents/examples/corporate/?$"  "https://nemo-ufes.github.io/gufoevents/examples/06-corporate-restructuring.ttl" [R=302,L]
+RewriteRule "^gufoevents/examples/clinical/?$"   "https://nemo-ufes.github.io/gufoevents/examples/07-clinical-episode.ttl" [R=302,L]
+RewriteRule "^gufoevents/examples/account/?$"    "https://nemo-ufes.github.io/gufoevents/examples/08-event-sourced-account.ttl" [R=302,L]
+RewriteRule "^gufoevents/examples/?$"            "https://github.com/nemo-ufes/gufoevents/tree/master/examples" [R=302,L]
+
+# Anything else below the ontology, so that a path this file has not caught up
+# with lands on the repository rather than on the group's website.
+RewriteRule "^gufoevents/(.+)$" "https://github.com/nemo-ufes/gufoevents/blob/master/$1" [R=302,L]
+
+# ---------------------------------------------------------------------------
+
 RewriteRule "^gufoshapes" "https://nemo-ufes.github.io/gufoshapes/gufoshapes.ttl" [R=302,L]
 RewriteRule "^(.*)$" "https://nemo.inf.ufes.br/$1" [R=302,L]

--- a/nemo/README.md
+++ b/nemo/README.md
@@ -4,6 +4,23 @@ The Ontology & Conceptual Modeling Research Group (NEMO) at the Federal Universi
 
 The w3id.org URLs are used to create permanent URLs to the projects, open-source code and resources of this research group.
 
+## Identifiers
+
+Anything not listed below redirects to the group's website.
+
+| Identifier | Resolves to |
+| --- | --- |
+| `/nemo/gufoshapes` | the gUFO SHACL shapes |
+| `/nemo/gufoevents` | the gUFOevents ontology, or its documentation for a web browser |
+| `/nemo/gufoevents/1.0.0` | version 1.0.0 of the ontology, from the `v1.0.0` tag |
+| `/nemo/doc/gufoevents` | the gUFOevents documentation |
+| `/nemo/doc/gufoevents/explorer` | the interactive companion to the examples |
+| `/nemo/gufoevents/shapes/core` | the core SHACL shapes |
+| `/nemo/gufoevents/shapes/event-sourcing` | the event-sourcing SHACL shapes |
+| `/nemo/gufoevents/examples/{order, person, bicycle, museum, employment, corporate, clinical, account}` | the eight worked examples |
+
+gUFOevents is at <https://github.com/nemo-ufes/gufoevents>.
+
 ## Website
 [https://nemo.inf.ufes.br](https://nemo.inf.ufes.br)
 


### PR DESCRIPTION
## Brief Description

To add a newly published ontology (gUFOevents).

gUFOevents (https://github.com/nemo-ufes/gufoevents) is an extension of gUFO with an account of events. Its ontology IRI, version IRI, documentation, SHACL shapes and eight example namespaces are all under https://w3id.org/nemo/, and until now every one of them fell through to the group's website.

The ontology IRI is content negotiated: a browser is sent to the documentation and everything else to the Turtle. The test is on text/html and comes first, because browsers ask for more than they will use -- Firefox sends application/xml;q=0.9 -- while RDF tooling does not ask for text/html at all.

The version IRI resolves to a tag rather than to the default branch, so that it keeps denoting version 1.0.0.

Tested with a local Apache checkout: all 21 identifiers redirect as intended under no Accept header, a browser's, Protege's and text/turtle, and the existing gufoshapes and catch-all rules are unaffected.

Contact: João Paulo A. Almeida (GitHub: jpalmeida)

## General Checklist
- [ x ] Changes have been tested.
- [ x ] The number of commits is minimal. Squash if needed.
- [ x ] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.
