### PR TITLE
Add /semprini/ for the Semprini metamodel ontology

### DIFF
--- a/semprini/.htaccess
+++ b/semprini/.htaccess
@@ -1,26 +1,10 @@
 # # /semprini/
 #
-# The namespace of the Semprini metamodel ontology.
-#
-# Semprini is an openly licensed compiler that turns the business models and
-# taxonomies an organization already maintains into a governed RDF knowledge
-# graph. Every deployment binds to this one shared metamodel, so the namespace
-# must resolve independently of any single organization's domain.
-#
-# Metamodel terms are hash IRIs under https://w3id.org/semprini/ontology#
-# (for example https://w3id.org/semprini/ontology#Entity), so requests arrive
-# for the ontology document itself:
-#
-#   /semprini/                  -> project home
-#   /semprini/ontology          -> the current ontology: Turtle for RDF clients,
-#                                  documentation for browsers
-#   /semprini/ontology/X.Y.Z    -> that released version of the ontology
-#   /semprini/ontology/sem.ttl  -> the Turtle document, bypassing negotiation
-#
-# The redirect target is the project's own GitHub Pages site. Only Turtle is
-# published, so every RDF media type resolves to the same document.
-#
-# Source repository: https://github.com/JuhaKor/semprini
+# The namespace of the Semprini metamodel ontology. Terms are hash IRIs under
+# https://w3id.org/semprini/ontology# (for example .../ontology#Entity), so
+# requests arrive for the ontology document itself. Redirects target the
+# project's own GitHub Pages site; see README.md and
+# https://juhakor.github.io/semprini/
 #
 # ## Contact
 # This space is administered by:
@@ -33,16 +17,15 @@
 
 RewriteEngine on
 
-# Explicit document URLs, unversioned and versioned. Listed first so that a
-# request naming the file is served regardless of the Accept header.
+# Explicit document URLs first, so a request naming the file is served whatever
+# the Accept header says.
 RewriteRule ^ontology/sem\.ttl$ https://juhakor.github.io/semprini/ontology/sem.ttl [R=302,L]
 RewriteRule ^ontology/([0-9]+\.[0-9]+\.[0-9]+)/sem\.ttl$ https://juhakor.github.io/semprini/ontology/$1/sem.ttl [R=302,L]
 
-# Content negotiation for /ontology and /ontology/X.Y.Z. The optional group is
-# empty when no version is given, so one rule serves both; an unmatched
-# back-reference substitutes as the empty string.
+# /ontology and /ontology/X.Y.Z are negotiated. The optional group is empty when
+# no version is given, so one rule serves both.
 
-# RDF clients get the Turtle document.
+# RDF clients get the Turtle document; only Turtle is published.
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
@@ -51,13 +34,12 @@ RewriteCond %{HTTP_ACCEPT} application/n-triples [OR]
 RewriteCond %{HTTP_ACCEPT} text/n3
 RewriteRule ^ontology(/[0-9]+\.[0-9]+\.[0-9]+)?/?$ https://juhakor.github.io/semprini/ontology$1/sem.ttl [R=302,L]
 
-# Everything else -- browsers, and clients expressing no preference -- gets the
-# human-readable documentation, which links to the Turtle.
+# Everything else -- browsers, and clients sending */* -- gets the documentation.
 RewriteRule ^ontology(/[0-9]+\.[0-9]+\.[0-9]+)?/?$ https://juhakor.github.io/semprini/ontology$1/ [R=302,L]
 
 # Project home.
 RewriteRule ^$ https://juhakor.github.io/semprini/ [R=302,L]
 
-# Anything else under /semprini/ resolves to the same site, so that later
+# Anything else under /semprini/ maps to the same path on the site, so later
 # additions need no change here.
 RewriteRule ^(.*)$ https://juhakor.github.io/semprini/$1 [R=302,L]

--- a/semprini/.htaccess
+++ b/semprini/.htaccess
@@ -1,0 +1,63 @@
+# # /semprini/
+#
+# The namespace of the Semprini metamodel ontology.
+#
+# Semprini is an openly licensed compiler that turns the business models and
+# taxonomies an organization already maintains into a governed RDF knowledge
+# graph. Every deployment binds to this one shared metamodel, so the namespace
+# must resolve independently of any single organization's domain.
+#
+# Metamodel terms are hash IRIs under https://w3id.org/semprini/ontology#
+# (for example https://w3id.org/semprini/ontology#Entity), so requests arrive
+# for the ontology document itself:
+#
+#   /semprini/                  -> project home
+#   /semprini/ontology          -> the current ontology: Turtle for RDF clients,
+#                                  documentation for browsers
+#   /semprini/ontology/X.Y.Z    -> that released version of the ontology
+#   /semprini/ontology/sem.ttl  -> the Turtle document, bypassing negotiation
+#
+# The redirect target is the project's own GitHub Pages site. Only Turtle is
+# published, so every RDF media type resolves to the same document.
+#
+# Source repository: https://github.com/JuhaKor/semprini
+#
+# ## Contact
+# This space is administered by:
+#
+# Juha Korpela
+# juha.korpela@datakor.fi
+# GitHub username: JuhaKor
+#
+# On behalf of Datakor Consulting Oy, Finland.
+
+RewriteEngine on
+
+# Explicit document URLs, unversioned and versioned. Listed first so that a
+# request naming the file is served regardless of the Accept header.
+RewriteRule ^ontology/sem\.ttl$ https://juhakor.github.io/semprini/ontology/sem.ttl [R=302,L]
+RewriteRule ^ontology/([0-9]+\.[0-9]+\.[0-9]+)/sem\.ttl$ https://juhakor.github.io/semprini/ontology/$1/sem.ttl [R=302,L]
+
+# Content negotiation for /ontology and /ontology/X.Y.Z. The optional group is
+# empty when no version is given, so one rule serves both; an unmatched
+# back-reference substitutes as the empty string.
+
+# RDF clients get the Turtle document.
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/n-triples [OR]
+RewriteCond %{HTTP_ACCEPT} text/n3
+RewriteRule ^ontology(/[0-9]+\.[0-9]+\.[0-9]+)?/?$ https://juhakor.github.io/semprini/ontology$1/sem.ttl [R=302,L]
+
+# Everything else -- browsers, and clients expressing no preference -- gets the
+# human-readable documentation, which links to the Turtle.
+RewriteRule ^ontology(/[0-9]+\.[0-9]+\.[0-9]+)?/?$ https://juhakor.github.io/semprini/ontology$1/ [R=302,L]
+
+# Project home.
+RewriteRule ^$ https://juhakor.github.io/semprini/ [R=302,L]
+
+# Anything else under /semprini/ resolves to the same site, so that later
+# additions need no change here.
+RewriteRule ^(.*)$ https://juhakor.github.io/semprini/$1 [R=302,L]

--- a/semprini/README.md
+++ b/semprini/README.md
@@ -1,71 +1,27 @@
 # /semprini/
 
-This W3ID space is the namespace of the **Semprini metamodel ontology**.
+The namespace of the **Semprini metamodel ontology** — the shared `sem:` vocabulary that every
+Semprini deployment binds to. It is on w3id.org so that resolution does not depend on any single
+organization's domain.
 
-Semprini is an openly licensed compiler that turns the business models and taxonomies an
-organization already maintains — in modelling tools and spreadsheets — into a governed RDF
-knowledge graph held in a Git repository. Each adopting organization runs its own instance,
-with its own base IRI for its own content, but every instance binds to one shared metamodel:
-the `sem:` vocabulary published here. A SPARQL query, a SHACL shape or an agent written
-against `sem:` therefore works against every instance.
-
-That shared metamodel is the reason the namespace lives on w3id.org rather than on a company
-domain: resolution must not depend on any single organization keeping a registration alive.
-
-* Source repository: <https://github.com/JuhaKor/semprini>
-* Published by: Datakor Consulting Oy, Finland
-* Licence: the ontology is CC BY 4.0; the compiler is Apache-2.0
-
-## Identifiers in this space
-
-Metamodel terms are hash IRIs — for example `https://w3id.org/semprini/ontology#Entity`,
-`https://w3id.org/semprini/ontology#Relationship`, `https://w3id.org/semprini/ontology#sourceRef`.
-The fragment is not sent to the server, so every term request resolves the ontology document.
+Documentation, the vocabulary and the project: <https://juhakor.github.io/semprini/>
 
 | URL | Resolves to |
 |---|---|
-| `https://w3id.org/semprini/` | Project home |
-| `https://w3id.org/semprini/ontology` | The current ontology — see negotiation below |
-| `https://w3id.org/semprini/ontology/X.Y.Z` | That released version of the ontology |
-| `https://w3id.org/semprini/ontology/sem.ttl` | The Turtle document, bypassing negotiation |
-| `https://w3id.org/semprini/ontology/X.Y.Z/sem.ttl` | That version's Turtle document, bypassing negotiation |
-| anything else under `/semprini/` | The same path on the project site |
+| `https://w3id.org/semprini/ontology` | the ontology — Turtle for RDF `Accept` headers, HTML documentation otherwise |
+| `https://w3id.org/semprini/ontology/X.Y.Z` | the same, for a frozen release |
+| either of those + `/sem.ttl` | the Turtle document, bypassing negotiation |
+| anything else under `/semprini/` | the same path on the project site |
 
-## Content negotiation
+Terms are hash IRIs (`…/ontology#Entity`), so every term request resolves the ontology document.
+Only Turtle is published, so all RDF media types resolve to it. Redirects are `302`: the hosting
+may move, the identifiers may not.
 
-`https://w3id.org/semprini/ontology` is negotiated on the `Accept` header:
+## Maintainer
 
-| `Accept` | Response |
-|---|---|
-| `text/turtle`, `application/x-turtle`, `application/rdf+xml`, `application/ld+json`, `application/n-triples`, `text/n3` | `ontology/sem.ttl` |
-| anything else, including browsers and clients sending `*/*` | the HTML documentation |
+Juha Korpela — [@JuhaKor](https://github.com/JuhaKor) — juha.korpela@datakor.fi, on behalf of
+Datakor Consulting Oy, Finland.
 
-The ontology is published in Turtle only, so all RDF media types resolve to the same Turtle
-document. Clients expressing no preference get the documentation, which links to it.
-
-```console
-$ curl -sIL -H 'Accept: text/turtle' https://w3id.org/semprini/ontology
-$ curl -sIL -H 'Accept: text/html'   https://w3id.org/semprini/ontology
-```
-
-## Versioning
-
-The ontology carries its own version (`owl:versionInfo`), incremented independently of the
-compiler that reads it. `https://w3id.org/semprini/ontology` always names the current version;
-`https://w3id.org/semprini/ontology/X.Y.Z` names a frozen release, so a deployment can cite the
-exact metamodel it was compiled against. Released version documents are never changed or
-removed, and metamodel IRIs are permanent — terms are deprecated in place, never deleted or
-reused.
-
-Redirects use `302` rather than `301`, since the hosting location may change while the
-identifiers may not.
-
-## Maintainers
-
-| Name | GitHub | Contact |
-|---|---|---|
-| Juha Korpela | [@JuhaKor](https://github.com/JuhaKor) | juha.korpela@datakor.fi |
-
-Maintained on behalf of Datakor Consulting Oy. Please open an issue on the
-[Semprini repository](https://github.com/JuhaKor/semprini/issues) for questions about the
-vocabulary itself, and a pull request here for changes to the redirects.
+Questions about the vocabulary belong on the
+[project repository](https://github.com/JuhaKor/semprini/issues); changes to these redirects, in a
+pull request here.

--- a/semprini/README.md
+++ b/semprini/README.md
@@ -1,0 +1,71 @@
+# /semprini/
+
+This W3ID space is the namespace of the **Semprini metamodel ontology**.
+
+Semprini is an openly licensed compiler that turns the business models and taxonomies an
+organization already maintains — in modelling tools and spreadsheets — into a governed RDF
+knowledge graph held in a Git repository. Each adopting organization runs its own instance,
+with its own base IRI for its own content, but every instance binds to one shared metamodel:
+the `sem:` vocabulary published here. A SPARQL query, a SHACL shape or an agent written
+against `sem:` therefore works against every instance.
+
+That shared metamodel is the reason the namespace lives on w3id.org rather than on a company
+domain: resolution must not depend on any single organization keeping a registration alive.
+
+* Source repository: <https://github.com/JuhaKor/semprini>
+* Published by: Datakor Consulting Oy, Finland
+* Licence: the ontology is CC BY 4.0; the compiler is Apache-2.0
+
+## Identifiers in this space
+
+Metamodel terms are hash IRIs — for example `https://w3id.org/semprini/ontology#Entity`,
+`https://w3id.org/semprini/ontology#Relationship`, `https://w3id.org/semprini/ontology#sourceRef`.
+The fragment is not sent to the server, so every term request resolves the ontology document.
+
+| URL | Resolves to |
+|---|---|
+| `https://w3id.org/semprini/` | Project home |
+| `https://w3id.org/semprini/ontology` | The current ontology — see negotiation below |
+| `https://w3id.org/semprini/ontology/X.Y.Z` | That released version of the ontology |
+| `https://w3id.org/semprini/ontology/sem.ttl` | The Turtle document, bypassing negotiation |
+| `https://w3id.org/semprini/ontology/X.Y.Z/sem.ttl` | That version's Turtle document, bypassing negotiation |
+| anything else under `/semprini/` | The same path on the project site |
+
+## Content negotiation
+
+`https://w3id.org/semprini/ontology` is negotiated on the `Accept` header:
+
+| `Accept` | Response |
+|---|---|
+| `text/turtle`, `application/x-turtle`, `application/rdf+xml`, `application/ld+json`, `application/n-triples`, `text/n3` | `ontology/sem.ttl` |
+| anything else, including browsers and clients sending `*/*` | the HTML documentation |
+
+The ontology is published in Turtle only, so all RDF media types resolve to the same Turtle
+document. Clients expressing no preference get the documentation, which links to it.
+
+```console
+$ curl -sIL -H 'Accept: text/turtle' https://w3id.org/semprini/ontology
+$ curl -sIL -H 'Accept: text/html'   https://w3id.org/semprini/ontology
+```
+
+## Versioning
+
+The ontology carries its own version (`owl:versionInfo`), incremented independently of the
+compiler that reads it. `https://w3id.org/semprini/ontology` always names the current version;
+`https://w3id.org/semprini/ontology/X.Y.Z` names a frozen release, so a deployment can cite the
+exact metamodel it was compiled against. Released version documents are never changed or
+removed, and metamodel IRIs are permanent — terms are deprecated in place, never deleted or
+reused.
+
+Redirects use `302` rather than `301`, since the hosting location may change while the
+identifiers may not.
+
+## Maintainers
+
+| Name | GitHub | Contact |
+|---|---|---|
+| Juha Korpela | [@JuhaKor](https://github.com/JuhaKor) | juha.korpela@datakor.fi |
+
+Maintained on behalf of Datakor Consulting Oy. Please open an issue on the
+[Semprini repository](https://github.com/JuhaKor/semprini/issues) for questions about the
+vocabulary itself, and a pull request here for changes to the redirects.


### PR DESCRIPTION
This adds `/semprini/`, the namespace of the Semprini metamodel ontology.

Semprini is an openly licensed (Apache-2.0 / CC BY 4.0) compiler that turns the business
models and taxonomies an organization already maintains into a governed RDF knowledge
graph. Each adopting organization runs its own instance with its own base IRI, but every
instance binds to one shared metamodel — the `sem:` vocabulary published under this
namespace — so a SPARQL query, SHACL shape or agent written against `sem:` works against
any instance. That shared metamodel is why the namespace belongs on w3id.org rather than
on a company domain: resolution must not depend on one organization keeping a domain
registered.

Metamodel terms are hash IRIs, for example `https://w3id.org/semprini/ontology#Entity`,
so requests arrive for the ontology document itself.

**Redirect targets (all live now):**

| Request | Resolves to |
|---|---|
| `/semprini/ontology` with an RDF `Accept` | https://juhakor.github.io/semprini/ontology/sem.ttl |
| `/semprini/ontology` from a browser | https://juhakor.github.io/semprini/ontology/ |
| `/semprini/ontology/0.1.0` | the same pair under `/ontology/0.1.0/` |
| `/semprini/` | https://juhakor.github.io/semprini/ |

The ontology is published in Turtle only, so every RDF media type resolves to the one
document, which is served as `text/turtle`. Redirects are `302` rather than `301`, since
the hosting location may change while the identifiers may not.

The rules were tested locally against 45 path and `Accept` combinations before
submission; every rule targets a URL that currently returns 200.

**Contact:** Juha Korpela (@JuhaKor), juha.korpela@datakor.fi, on behalf of Datakor
Consulting Oy, Finland. Contact details are in both `.htaccess` and `README.md`.

Source repository: https://github.com/JuhaKor/semprini
