### PR TITLE
sstim: add SSTIM 0.13.0 snapshot routes

### DIFF
--- a/sstim/.htaccess
+++ b/sstim/.htaccess
@@ -48,6 +48,10 @@ RewriteRule ^0\.11\.0/(sstim-alignments\.ttl|sstim-core\.ttl|sstim-ecosystem\.tt
 RewriteRule ^0\.11\.0/?$ https://labiosyncare.github.io/ontology/0.11.0/sstim-core.ttl [R=302,L]
 RewriteRule ^0\.12\.0/(sstim-alignments\.ttl|sstim-core\.ttl|sstim-ecosystem\.ttl|sstim-exposure\.ttl|sstim-patch-studio\.ttl|sstim-shapes\.ttl|sstim-stimulus\.ttl|sstim-vocab\.ttl)$ https://labiosyncare.github.io/ontology/0.12.0/$1 [R=302,L]
 RewriteRule ^0\.12\.0/?$ https://labiosyncare.github.io/ontology/0.12.0/sstim-core.ttl [R=302,L]
+RewriteRule ^0\.13\.0/(sstim-alignments\.ttl|sstim-common\.ttl|sstim-configuration\.ttl|sstim-core-plus-profile\.ttl|sstim-core-profile\.ttl|sstim-core-shapes\.ttl|sstim-core\.ttl|sstim-ecosystem\.ttl|sstim-evidence-exposure\.ttl|sstim-evidence\.ttl|sstim-exposure-namespace\.ttl|sstim-exposure\.ttl|sstim-full-profile\.ttl|sstim-kernel-profile\.ttl|sstim-namespace\.ttl|sstim-neuromodulation-evidence\.ttl|sstim-neuromodulation\.ttl|sstim-patch-studio\.ttl|sstim-session\.ttl|sstim-shapes\.ttl|sstim-stimulus\.ttl|sstim-technique-exposure\.ttl|sstim-technique\.ttl|sstim-vocab\.ttl)$ https://labiosyncare.github.io/ontology/0.13.0/$1 [R=302,L]
+RewriteRule ^0\.13\.0/manifest$ https://labiosyncare.github.io/ontology/0.13.0/manifest.json [R=302,L]
+RewriteRule ^0\.13\.0/manifest\.schema\.json$ https://labiosyncare.github.io/ontology/0.13.0/manifest.schema.json [R=302,L]
+RewriteRule ^0\.13\.0/?$ https://labiosyncare.github.io/ontology/0.13.0/sstim-namespace.ttl [R=302,L]
 # END generated exact SSTIM snapshot routes
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
## Brief Description

Adds redirects for the SSTIM `0.13.0` snapshot, released today. Four rules, all targeting `https://labiosyncare.github.io/ontology/0.13.0/`, every one confirmed to return `200` before opening this PR. No existing rule changes.

Two notes, since this snapshot is shaped differently from earlier ones:

- It is the first release with a frozen manifest, so it is the first to get `/sstim/0.13.0/manifest` and `/sstim/0.13.0/manifest.schema.json`. Those rules are emitted only for snapshots that contain those files, so earlier versions are untouched.
- The bare version route resolves to `sstim-namespace.ttl` rather than `sstim-core.ttl`. The ontology was reorganised into modules in this release and `sstim-core.ttl` is now a small dependency-free kernel rather than the whole ontology; since the bare version route resolves `owl:versionIRI`, it has to answer with the complete release. Earlier snapshots keep pointing at `sstim-core.ttl`, which was the whole ontology when they were cut.

Rules are generated from the files actually present in the frozen directory, so a nonexistent version or filename still 404s.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## Update ID Directory Checklist

- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

Maintainer: Renato Fabbri, [@ttm](https://github.com/ttm), as recorded in `sstim/README.md` and in #6480, #6393, #6391 and #6378.

## Optional Requests for W3ID Maintainers

- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.