### PR TITLE
fix(tractusx): resolve auth and legacy namespace contexts

### DIFF
--- a/tractusx/.htaccess
+++ b/tractusx/.htaccess
@@ -18,5 +18,14 @@ RewriteBase /
 # Rewrite rule to resolve policy context
 RewriteRule ^policy/v1.0.0(.*)$ https://eclipse-tractusx.github.io/tractusx-profiles/cx/context/policy.context.json [R=302,L]
 
+# Rewrite rule to resolve the legacy Tractus-X namespace context
+RewriteRule ^v0\.0\.1/ns/?$ https://eclipse-tractusx.github.io/tractusx-edc/context/tx-v1.jsonld [R=302,L]
+
+# Rewrite rule to resolve the Tractus-X auth namespace context
+RewriteRule ^auth/?$ https://eclipse-tractusx.github.io/tractusx-edc/context/tx-auth-v1.jsonld [R=302,L]
+
+# Rewrite rule to resolve the Tractus-X auth JSON-LD context
+RewriteRule ^auth/v1\.0\.0$ https://eclipse-tractusx.github.io/tractusx-edc/context/tx-auth-v1.jsonld [R=302,L]
+
 # Rewrite rule to default to the tx webpage
 RewriteRule ^(.*)$ https://eclipse-tractusx.github.io/ [R=303,L]

--- a/tractusx/README.md
+++ b/tractusx/README.md
@@ -6,5 +6,4 @@ This namespace serves as redirection platform for multiple resources from the [E
 Contact: 
 
 - Stephan Bauer <stephan.bauer@catena-x.net> (https://github.com/HFocken)
-- James Marino <jim.marino@gmail.com> (https://github.com/jimmarino)
 - Arno Weiß <arno.weiss@sap.com> (https://github.com/arnoweiss)


### PR DESCRIPTION
## Brief Description

These URLs currently redirect with `303` to the Tractus-X HTML landing page.
This causes JSON-LD processors to reject the remote contexts.

- `https://w3id.org/tractusx/auth/v1.0.0`
- `https://w3id.org/tractusx/auth/`
- `https://w3id.org/tractusx/v0.0.1/ns/`

The new redirects use `302`, consistent with the existing policy-context
mapping:

- Auth URLs: `https://eclipse-tractusx.github.io/tractusx-edc/context/tx-auth-v1.jsonld`
- Namespace URL: `https://eclipse-tractusx.github.io/tractusx-edc/context/tx-v1.jsonld`

The changes were tested offline with the `.htaccess` tester and direct target
requests.

That target returns `200 Content-Type: application/ld+json` and is semantically identical to the canonical source in [`eclipse-tractusx/tractusx-edc`](https://github.com/eclipse-tractusx/tractusx-edc/blob/main/core/json-ld-core/src/main/resources/document/tx-auth-v1.jsonld).

Related Tractus-X tracking issue: https://github.com/eclipse-tractusx/tractusx-edc/issues/2992

## General Checklist

- [x] Changes have been tested: the rule matches only `auth/v1.0.0`; the target returns `application/ld+json`; and its parsed JSON matches the canonical source.
- [x] The number of commits is minimal.
- [x] Commits only include redirects and basic information.

## Update ID Directory Checklist

- [x] GitHub username ids are listed in the existing maintainer details in `tractusx/README.md`.
- [x] Maintainer approval is requested from the directory maintainers: @HFocken @jimmarino.

## Optional Requests for W3ID Maintainers

- [x] Please squash commits for me.