### PR TITLE
Add Construct-DCAT persistent identifier

### DIFF
--- a/construct-dcat/.htaccess
+++ b/construct-dcat/.htaccess
@@ -1,0 +1,27 @@
+# Construct-DCAT persistent identifier
+#
+# Namespace: https://w3id.org/construct-dcat#
+# Project: https://github.com/jundahuang9123/ConstructDCAT
+#
+# Maintainer:
+# Junda Huang
+# Email: huang@uni-wuppertal.de
+# GitHub: jundahuang9123
+
+Options -MultiViews
+
+AddType text/turtle .ttl
+AddType application/ld+json .jsonld
+
+RewriteEngine On
+
+# Turtle representation
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^$ https://jundahuang9123.github.io/ConstructDCAT/construct-dcat.ttl [R=303,L]
+
+# JSON-LD representation
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^$ https://jundahuang9123.github.io/ConstructDCAT/construct-dcat.jsonld [R=303,L]
+
+# Human-readable documentation and fallback
+RewriteRule ^$ https://jundahuang9123.github.io/ConstructDCAT/ [R=303,L]

--- a/construct-dcat/README.md
+++ b/construct-dcat/README.md
@@ -1,0 +1,16 @@
+# Construct-DCAT
+
+Persistent identifier configuration for the Construct-DCAT vocabulary.
+
+- Vocabulary IRI: `https://w3id.org/construct-dcat`
+- Namespace: `https://w3id.org/construct-dcat#`
+- Preferred prefix: `cx`
+- Project: https://github.com/jundahuang9123/ConstructDCAT
+- Documentation: https://jundahuang9123.github.io/ConstructDCAT/
+
+## Maintainer
+
+Junda Huang<br>
+University of Wuppertal<br>
+Email: huang@uni-wuppertal.de<br>
+GitHub: [jundahuang9123](https://github.com/jundahuang9123)


### PR DESCRIPTION
## Brief Description

This pull request adds the persistent namespace for Construct-DCAT, a lightweight DCAT-compatible semantic anchoring vocabulary for heterogeneous construction datasets.

Requested identifiers:

- `https://w3id.org/construct-dcat`
- `https://w3id.org/construct-dcat#...`

Redirect behavior:

- browser/default requests → human-readable GitHub Pages documentation;
- `Accept: text/turtle` → Turtle vocabulary;
- `Accept: application/ld+json` → JSON-LD vocabulary.

The machine-readable targets are served through GitHub Pages so the final responses retain `text/turtle` and `application/ld+json` media types. The required root serializations are also public in the project repository.

Maintainer information is included in both `.htaccess` and `README.md`.

The destination resources are public and were tested before submission.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.
