### PR TITLE
Add chemical-exposome namespace

### DIFF
--- a/chemical-exposome/.htaccess
+++ b/chemical-exposome/.htaccess
@@ -1,0 +1,9 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# chemical-exposome namespace
+# Redirects to be configured as resources are published
+# Maintained by: Katarina Rihackova (RECETOX, Masaryk University)
+# ORCID: https://orcid.org/0000-0003-0222-801x
+
+RewriteRule ^(.*)$ https://github.com/KatarinaRi/chemical-exposome-terms [R=303,L]

--- a/chemical-exposome/README.md
+++ b/chemical-exposome/README.md
@@ -1,0 +1,25 @@
+# chemical-exposome
+
+Namespace for the metadata schemas, controlled vocabularies and ontologies
+developed by the chemical exposome community, including the Partnership
+for the Assessment of Risks from Chemicals and EIRENE RI.
+
+Maintained by: Katarina Rihackova (RECETOX, Masaryk University)
+ORCID: https://orcid.org/0000-0003-0222-801x
+
+## Namespace structure
+
+- /term/        Individual concept URIs (all vocabularies)
+- /vocabulary/  SKOS ConceptScheme documents
+- /schema/      Metadata schema documents
+- /ontology/    OWL ontology documents
+- /dataset/     Dataset identifiers
+
+## Published vocabularies
+
+*TBC*
+
+## Terms registry
+
+All concept URIs are registered at:
+*TBC*

--- a/chemical-exposome/README.md
+++ b/chemical-exposome/README.md
@@ -5,6 +5,7 @@ developed by the chemical exposome community, including the Partnership
 for the Assessment of Risks from Chemicals and EIRENE RI.
 
 Maintained by: Katarina Rihackova (RECETOX, Masaryk University)
+GitHub: https://github.com/KatarinaRi
 ORCID: https://orcid.org/0000-0003-0222-801x
 
 ## Namespace structure


### PR DESCRIPTION
## Brief Description

Adding the chemical-exposome namespace to w3id.org. This namespace covers metadata schemas, ontologies and controlled vocabularies for chemical exposome data developed within the chemical exposome community (including PARC project and EIRENE RI).

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
- [ ] GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.