### PR TITLE
Add /fairenoughbook/ namespace

### DIFF
--- a/fairenoughbook/.htaccess
+++ b/fairenoughbook/.htaccess
@@ -1,0 +1,33 @@
+# # /fairenoughbook/
+#
+# Namespace for the WildObs running example of the book
+# "FAIR Enough: A practical guide to make data FAIR(er)".
+#
+# https://w3id.org/fairenoughbook/ redirects to
+# https://luizbonino.github.io/FAIREnough-companion/ns/
+#
+# Clients that ask for RDF receive the WildObs graph in Turtle. Browsers
+# receive the namespace documentation.
+#
+# ## Contact
+# This space is administered by:
+#
+# Luiz Olavo Bonino da Silva Santos
+# l.o.boninodasilvasantos@utwente.nl
+# GitHub username: luizbonino
+
+AddType text/turtle .ttl
+
+RewriteEngine on
+
+# RDF representations of the WildObs example data
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/n-triples [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^wildobs(/.*)?$ https://luizbonino.github.io/FAIREnough-companion/ns/wildobs.ttl [R=303,L]
+
+# Human-readable documentation of the namespace
+RewriteRule ^wildobs(/.*)?$ https://luizbonino.github.io/FAIREnough-companion/ns/ [R=302,L]
+RewriteRule ^$ https://luizbonino.github.io/FAIREnough-companion/ns/ [R=302,L]
+RewriteRule ^(.*)$ https://luizbonino.github.io/FAIREnough-companion/ns/$1 [R=302,L]

--- a/fairenoughbook/README.md
+++ b/fairenoughbook/README.md
@@ -1,0 +1,43 @@
+# /fairenoughbook/
+
+Permanent identifiers for the running example of the book *FAIR Enough: A practical
+guide to make data FAIR(er)* (Springer).
+
+The book follows one dataset, WildObs, through a complete FAIRification: from two
+untidy spreadsheets to a published, assessed FAIR resource. The identifiers minted
+during that process are printed in the book, so they need to resolve. This namespace
+provides them.
+
+## Redirection
+
+| Request | Response |
+|---------|----------|
+| `https://w3id.org/fairenoughbook/` | Namespace documentation (HTML) |
+| `https://w3id.org/fairenoughbook/wildobs/...` with `Accept: text/turtle` | The WildObs graph in Turtle (303) |
+| `https://w3id.org/fairenoughbook/wildobs/...` from a browser | Namespace documentation (HTML) |
+
+The target is the GitHub Pages site of the book's companion repository,
+<https://luizbonino.github.io/FAIREnough-companion/ns/>.
+
+## Resource patterns
+
+| Pattern | What it identifies |
+|---------|--------------------|
+| `wildobs/occurrence/{id}` | One occurrence record, i.e., one sighting |
+| `wildobs/taxon/{name}` | A taxon as held locally, before reconciliation to a taxonomic authority |
+| `wildobs/country/{name}` | A country as held locally, before reconciliation to a country register |
+| `wildobs/agent/{name}` | An observer as held locally, before reconciliation to ORCID |
+
+## Note on the data
+
+WildObs is a teaching example. Its records are synthetic, its observer names and
+e-mail addresses are invented, and its coordinates do not report real locations of
+threatened species.
+
+## Contact
+
+This space is administered by:
+
+Luiz Olavo Bonino da Silva Santos<br>
+l.o.boninodasilvasantos@utwente.nl<br>
+GitHub username: [luizbonino](https://github.com/luizbonino)


### PR DESCRIPTION
This pull request adds the `/fairenoughbook/` namespace, used for the running example of the book *FAIR Enough: A practical guide to make data FAIR(er)* (Springer).

The book follows one dataset, WildObs, through a complete FAIRification, and the identifiers minted along the way are printed in the text. They therefore need to resolve.

**Redirection target:** the GitHub Pages site of the book's companion repository, <https://luizbonino.github.io/FAIREnough-companion/ns/>, which is live and already serves both the documentation and the RDF.

- Browsers receive the namespace documentation.
- Clients sending `Accept: text/turtle` (or n-triples, or RDF/XML) receive the WildObs graph as Turtle, with a 303.

Both `.htaccess` and `README.md` are included, with maintainer contact details and GitHub username as requested in the contribution guidelines.

The example data is synthetic. Observer names and e-mail addresses are invented, and the coordinates do not report real locations of threatened species.