### PR TITLE
dpp: add /dpp/repo redirect and routes for two new alignment modules

### DIFF
--- a/dpp/.htaccess
+++ b/dpp/.htaccess
@@ -89,6 +89,86 @@ RewriteRule ^alignment/dppo-ceon/(.+)$ https://richzele.github.io/dpp-ontology-s
 RewriteRule ^alignment/dppo-ceon/?$ https://richzele.github.io/dpp-ontology-site/alignment-doc/dppo-ceon/0.1/ontology.owl [R=303,L]
 
 ############################################################################
+# ALIGNMENT ONTOLOGY: dpp-ceon (version 0.1)
+# URI: http://w3id.org/dpp/alignment/dpp-ceon/
+############################################################################
+
+# JSON-LD for dpp-ceon alignment
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^alignment/dpp-ceon/?$ https://richzele.github.io/dpp-ontology-site/alignment-doc/dpp-ceon/0.1/ontology.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^alignment/dpp-ceon/(.+)$ https://richzele.github.io/dpp-ontology-site/alignment-doc/dpp-ceon/0.1/ontology.jsonld [R=303,NE,L]
+
+# HTML documentation for dpp-ceon alignment
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteRule ^alignment/dpp-ceon/?$ https://richzele.github.io/dpp-ontology-site/alignment-doc/dpp-ceon/0.1/index.html [R=303,L]
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteRule ^alignment/dpp-ceon/(.+)$ https://richzele.github.io/dpp-ontology-site/alignment-doc/dpp-ceon/0.1/index.html#$1 [R=303,NE,L]
+
+# RDF/XML for dpp-ceon alignment
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^alignment/dpp-ceon/?$ https://richzele.github.io/dpp-ontology-site/alignment-doc/dpp-ceon/0.1/ontology.owl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^alignment/dpp-ceon/(.+)$ https://richzele.github.io/dpp-ontology-site/alignment-doc/dpp-ceon/0.1/ontology.owl [R=303,NE,L]
+
+# Turtle for dpp-ceon alignment
+RewriteCond %{HTTP_ACCEPT} text/turtle 
+RewriteRule ^alignment/dpp-ceon/?$ https://richzele.github.io/dpp-ontology-site/alignment-doc/dpp-ceon/0.1/ontology.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} text/turtle 
+RewriteRule ^alignment/dpp-ceon/(.+)$ https://richzele.github.io/dpp-ontology-site/alignment-doc/dpp-ceon/0.1/ontology.ttl [R=303,NE,L]
+
+# N-Triples for dpp-ceon alignment
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^alignment/dpp-ceon/?$ https://richzele.github.io/dpp-ontology-site/alignment-doc/dpp-ceon/0.1/ontology.nt [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^alignment/dpp-ceon/(.+)$ https://richzele.github.io/dpp-ontology-site/alignment-doc/dpp-ceon/0.1/ontology.nt [R=303,NE,L]
+
+# Default for dpp-ceon alignment
+RewriteRule ^alignment/dpp-ceon/?$ https://richzele.github.io/dpp-ontology-site/alignment-doc/dpp-ceon/0.1/ontology.owl [R=303,L]
+
+############################################################################
+# ALIGNMENT ONTOLOGY: standards-gs1 (version 0.1)
+# URI: http://w3id.org/dpp/alignment/standards-gs1/
+############################################################################
+
+# JSON-LD for standards-gs1 alignment
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^alignment/standards-gs1/?$ https://richzele.github.io/dpp-ontology-site/alignment-doc/standards-gs1/0.1/ontology.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^alignment/standards-gs1/(.+)$ https://richzele.github.io/dpp-ontology-site/alignment-doc/standards-gs1/0.1/ontology.jsonld [R=303,NE,L]
+
+# HTML documentation for standards-gs1 alignment
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteRule ^alignment/standards-gs1/?$ https://richzele.github.io/dpp-ontology-site/alignment-doc/standards-gs1/0.1/index.html [R=303,L]
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteRule ^alignment/standards-gs1/(.+)$ https://richzele.github.io/dpp-ontology-site/alignment-doc/standards-gs1/0.1/index.html#$1 [R=303,NE,L]
+
+# RDF/XML for standards-gs1 alignment
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^alignment/standards-gs1/?$ https://richzele.github.io/dpp-ontology-site/alignment-doc/standards-gs1/0.1/ontology.owl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^alignment/standards-gs1/(.+)$ https://richzele.github.io/dpp-ontology-site/alignment-doc/standards-gs1/0.1/ontology.owl [R=303,NE,L]
+
+# Turtle for standards-gs1 alignment
+RewriteCond %{HTTP_ACCEPT} text/turtle 
+RewriteRule ^alignment/standards-gs1/?$ https://richzele.github.io/dpp-ontology-site/alignment-doc/standards-gs1/0.1/ontology.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} text/turtle 
+RewriteRule ^alignment/standards-gs1/(.+)$ https://richzele.github.io/dpp-ontology-site/alignment-doc/standards-gs1/0.1/ontology.ttl [R=303,NE,L]
+
+# N-Triples for standards-gs1 alignment
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^alignment/standards-gs1/?$ https://richzele.github.io/dpp-ontology-site/alignment-doc/standards-gs1/0.1/ontology.nt [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^alignment/standards-gs1/(.+)$ https://richzele.github.io/dpp-ontology-site/alignment-doc/standards-gs1/0.1/ontology.nt [R=303,NE,L]
+
+# Default for standards-gs1 alignment
+RewriteRule ^alignment/standards-gs1/?$ https://richzele.github.io/dpp-ontology-site/alignment-doc/standards-gs1/0.1/ontology.owl [R=303,L]
+
+############################################################################
 # PRODUCT MODULE: /dpp/product (version 1.0)
 ############################################################################
 
@@ -416,6 +496,19 @@ RewriteRule ^roles/(.+)$ https://richzele.github.io/dpp-ontology-site/access-con
 RewriteRule ^roles/?$ https://richzele.github.io/dpp-ontology-site/access-control-doc/1.0.0/roles-en.html [R=303,L]
 RewriteRule ^roles/(.+)$ https://richzele.github.io/dpp-ontology-site/access-control-doc/1.0.0/roles-en.html#$1 [R=303,NE,L]
 
+
+############################################################################
+# SOURCE REPOSITORY: /dpp/repo
+# URI: http://w3id.org/dpp/repo
+# Mapping registries, use cases, SHACL shapes and generation scripts.
+# Must precede the MAIN DPP NAMESPACE catch-all below, which matches ^(.+)$.
+############################################################################
+
+# Repository root
+RewriteRule ^repo/?$ https://github.com/RichZele/DPP-DPPO-CEON-Ontology-Alignment [R=303,L]
+
+# Any path below the root resolves to the same path on the default branch
+RewriteRule ^repo/(.+)$ https://github.com/RichZele/DPP-DPPO-CEON-Ontology-Alignment/tree/main/$1 [R=303,NE,L]
 
 ############################################################################
 # MAIN DPP NAMESPACE: /dpp/ (version 1.0)

--- a/dpp/README.md
+++ b/dpp/README.md
@@ -3,6 +3,12 @@
 
 Redirection for project repository: https://w3id.org/dpp -> https://richzele.github.io/dpp-ontology-site/
 
+### Routes
+
+- `https://w3id.org/dpp/` and the module paths below it resolve to the ontology documentation, with content negotiation for Turtle, RDF/XML, JSON-LD and N-Triples.
+- `https://w3id.org/dpp/alignment/<name>/` resolves to the documentation for one alignment module. Currently `dpp-dppo`, `dppo-ceon`, `dpp-ceon` and `standards-gs1`.
+- `https://w3id.org/dpp/repo` and any path below it resolve to the source repository holding the mapping registries, use cases, SHACL shapes and generation scripts: https://github.com/RichZele/DPP-DPPO-CEON-Ontology-Alignment
+
 ### Maintainer
 - [Rahel Kebede](https://ju.se/en/personinfo?id=3691), [@RichZele](https://github.com/RichZele), rahel.kebede@ju.se
 - [Huanyu Li](http://huanyuli.se), [@huanyu-li](https://github.com/huanyu-li), huanyu.li@liu.se


### PR DESCRIPTION
## Brief Description

Updates the existing `dpp/` identifier directory, which I maintain, with two additions:

1. **`/dpp/repo`**, a new route resolving to the source repository that holds the mapping
   registries, use cases, SHACL shapes and generation scripts for this ontology network.
   Any path below it resolves to the same path on the repository's default branch, so
   `https://w3id.org/dpp/repo/shapes` reaches the `shapes` directory. These URIs are cited
   in a journal article currently under submission, which is why they are needed as
   permanent identifiers rather than direct GitHub links.

   The block is placed ahead of the `MAIN DPP NAMESPACE` section because the catch-all
   rule in that section matches `^(.+)$` and would otherwise swallow `repo`.

2. **`/dpp/alignment/dpp-ceon/` and `/dpp/alignment/standards-gs1/`**, content-negotiated
   routes for two new alignment modules, following exactly the pattern already used for
   the existing `dpp-dppo` and `dppo-ceon` modules.

`dpp/README.md` gains a short section documenting the three route families.

The change is additive only. No existing rule is modified or removed: the diff is
99 insertions and 0 deletions.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

Testing: all 17 redirect targets produced by the new rules were requested directly and
each returned HTTP 200, that is the 7 repository paths and the 10 alignment documentation
and serialization files.

## Update ID Directory Checklist

- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

`dpp/README.md` lists [@RichZele](https://github.com/RichZele) (submitting this PR) and
[@huanyu-li](https://github.com/huanyu-li) as maintainers of `dpp/`.