### PR TITLE
fix(factoryx): resolve policy and credentials namespace

### DIFF
--- a/factoryx/.htaccess
+++ b/factoryx/.htaccess
@@ -14,8 +14,8 @@ RewriteEngine On
 RewriteBase /
 
 # Policy json-ld context resolution
-RewriteRule ^policy/v1.0(.*)$ https://raw.githubusercontent.com/factory-x-contributions/factoryx-edc/refs/heads/main/edc-extensions/fx-json-ld-core/src/main/resources/document/fx-policy-v1.jsonld [R=302,L]
+RewriteRule ^policy/v1.0(.*)$ https://raw.githubusercontent.com/factory-x-contributions/factoryx-edc/refs/heads/main/edc-extensions/json-ld-fx/src/main/resources/document/fx-policy-v1.jsonld [R=302,L]
 
 # Credential json-ld context resolution
-RewriteRule ^credentials/v1.0(.*)$ https://raw.githubusercontent.com/factory-x-contributions/factoryx-edc/refs/heads/main/edc-extensions/fx-json-ld-core/src/main/resources/document/fx-credentials-v1.jsonld [R=302,L]
+RewriteRule ^credentials/v1.0(.*)$ https://raw.githubusercontent.com/factory-x-contributions/factoryx-edc/refs/heads/main/edc-extensions/json-ld-fx/src/main/resources/document/fx-credentials-v1.jsonld [R=302,L]
 


### PR DESCRIPTION
## Brief Description
The Factory-X namespace is no longer resolved because the redirect introduced by the directory rename in https://github.com/factory-x-contributions/factoryx-edc/pull/370 now points to a non-existent location.

The root cause is the renaming of the folder `fx-json-ld-core` to `json-ld-fx`:

These URLs should resolve but the target returns `404 Not Found`
* https://w3id.org/factoryx/policy/v1.0/
  --> https://raw.githubusercontent.com/factory-x-contributions/factoryx-edc/refs/heads/main/edc-extensions/json-ld-fx/src/main/resources/document/fx-policy-v1.jsonld (proper target)
* https://w3id.org/factoryx/credentials/v1.0/
  --> https://raw.githubusercontent.com/factory-x-contributions/factoryx-edc/refs/heads/main/edc-extensions/json-ld-fx/src/main/resources/document/fx-credentials-v1.jsonld (proper target)

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes: @arnoweiss

## Optional Requests for W3ID Maintainers
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
