### PR TITLE
Add object-provenance vocabulary redirect

### DIFF
--- a/object-provenance/.htaccess
+++ b/object-provenance/.htaccess
@@ -1,0 +1,32 @@
+# # /object-provenance/
+#
+# A vocabulary of terms for recording, batching, and archiving provenance
+# claims about physical objects. See README.md in this directory.
+#
+# https://w3id.org/object-provenance/v1# redirects to
+# https://object-provenance.github.io/vocab/v1/
+# with content negotiation for JSON-LD.
+#
+# The namespace is hash-based, so the fragment never reaches the server and
+# these rules serve the whole vocabulary.
+#
+# 302 rather than 301: a 301 is cached permanently by browsers and
+# intermediaries and cannot be recalled, which would destroy the repointing
+# ability this service exists to provide.
+#
+# ## Contact
+# This space is administered by:
+#
+# RelicQuery — hello@relicquery.org
+# GitHub username: RichardHerold
+
+Options +FollowSymLinks
+RewriteEngine on
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^v1/?$ https://object-provenance.github.io/vocab/v1/context.jsonld [R=302,L]
+
+RewriteRule ^v1/?$ https://object-provenance.github.io/vocab/v1/ [R=302,L]
+
+RewriteRule ^/?$ https://object-provenance.github.io/vocab/ [R=302,L]

--- a/object-provenance/README.md
+++ b/object-provenance/README.md
@@ -1,0 +1,17 @@
+# object-provenance
+
+Permanent identifiers for a vocabulary of terms describing the recording,
+batching, and archival of provenance claims about physical objects.
+
+Namespace: `https://w3id.org/object-provenance/v1#` — hash-based and
+versioned; terms are fragments of the versioned namespace document.
+
+Documentation, the JSON-LD context, and the frozen key set are served from
+the redirect target: <https://object-provenance.github.io/vocab/v1/>
+
+## Contact
+
+This space is administered by:
+
+- RelicQuery — hello@relicquery.org
+- GitHub username: RichardHerold


### PR DESCRIPTION
## Brief Description

Supersedes #6468 (cc @dgarijo) — apologies for the slow response to review;
the PR was closed before I acted on the feedback, and I don't have
permission to reopen it, so I'm refiling with the change made.

**What changed:** the README is cut to a minimal entry — namespace, redirect
target, contact. All vocabulary documentation now lives on the redirect
target, per @davidlehn's feedback. `.htaccess` is unchanged from the version
reviewed in #6468.

Claims the top-level identifier `object-provenance` for a vocabulary of
terms describing the recording, batching, and archival of provenance claims
about physical objects.

- **Identifier:** `https://w3id.org/object-provenance/v1#` — hash-based and
  versioned; terms are fragments.
- **Redirect target:** <https://object-provenance.github.io/vocab/v1/> —
  content-negotiated for JSON-LD, live and returning 200.
- **302, not 301,** so the redirect stays repointable; rationale in the
  `.htaccess` header.
- Distinct from the existing `provenance/` (a CIDOC-CRM artwork database):
  this is a vocabulary namespace.

## General Checklist

- [x] Changes have been tested. *(Reproduced the repo's Apache recipe
  locally — httpd 2.4, `AllowOverride All`, full tree; all request shapes
  redirect as filed. Full test matrix in #6468.)*
- [x] The number of commits is minimal. Squash if needed. *(single commit)*
- [x] Commits only include redirects and basic information. Serving content
  and full documentation is not supported on this service. *(two files:
  `.htaccess` + a minimal `README.md`; all documentation is served from the
  redirect target)*

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` or `README.md`. *(both)*
- [x] GitHub username ids are listed in the maintainer details.

## Contact

RelicQuery — <hello@relicquery.org> · GitHub: [@RichardHerold](https://github.com/RichardHerold)
