### PR TITLE
Update AIEF namespace with content negotiation for WIDOCO docs

### DIFF
--- a/aief/.htaccess
+++ b/aief/.htaccess
@@ -1,8 +1,39 @@
 Options -MultiViews
 Require all granted
 
+# Content types for ontology serialisations
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .n3
+AddType application/ld+json .jsonld
+
 RewriteEngine on
 
-RewriteRule ^$ https://raw.githubusercontent.com/navinaamuthan/ai-ethics-framework-tool/main/ai-ethics-final.ttl [R=303,L]
+# HTML / browsers → WIDOCO documentation (GitHub Pages, docs/ on main)
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://navinaamuthan.github.io/ai-ethics-framework-tool/widoco/doc/index-en.html [R=303,L]
 
-RewriteRule ^(.*)$ https://raw.githubusercontent.com/navinaamuthan/ai-ethics-framework-tool/main/$1 [R=303,L]
+# JSON-LD
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://navinaamuthan.github.io/ai-ethics-framework-tool/widoco/doc/ontology.jsonld [R=303,L]
+
+# RDF/XML
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://navinaamuthan.github.io/ai-ethics-framework-tool/widoco/doc/ontology.owl [R=303,L]
+
+# N-Triples
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://navinaamuthan.github.io/ai-ethics-framework-tool/widoco/doc/ontology.nt [R=303,L]
+
+# Turtle (canonical ontology source)
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ https://raw.githubusercontent.com/navinaamuthan/ai-ethics-framework-tool/main/ontology/ai-ethics-final.ttl [R=303,L]
+
+# Default: Turtle (preserves prior RDF-client behaviour)
+RewriteRule ^$ https://raw.githubusercontent.com/navinaamuthan/ai-ethics-framework-tool/main/ontology/ai-ethics-final.ttl [R=303,L]


### PR DESCRIPTION
## Summary
- Adds standard Accept-header content negotiation for https://w3id.org/aief/
- Browsers / `text/html` → WIDOCO documentation on GitHub Pages
- RDF clients → Turtle (canonical ontology), with optional RDF/XML, JSON-LD, and N-Triples

## Targets
| Accept | Redirect |
|--------|----------|
| `text/html` / browsers | https://navinaamuthan.github.io/ai-ethics-framework-tool/widoco/doc/index-en.html |
| `text/turtle` (default) | https://raw.githubusercontent.com/navinaamuthan/ai-ethics-framework-tool/main/ontology/ai-ethics-final.ttl |
| `application/rdf+xml` | …/widoco/doc/ontology.owl |
| `application/ld+json` | …/widoco/doc/ontology.jsonld |
| `application/n-triples` | …/widoco/doc/ontology.nt |

Follows the same WIDOCO-style `.htaccess` pattern used by sibling namespaces (e.g. `tido`, `omicron`, `aipo`).

**Contact:** @navinaamuthan / ganapatn@tcd.ie

## Test plan
- [ ] `curl -sI -H 'Accept: text/turtle' https://w3id.org/aief/` → 303 to Turtle
- [ ] `curl -sI -H 'Accept: text/html' https://w3id.org/aief/` → 303 to WIDOCO `index-en.html`
- [ ] Browser open of https://w3id.org/aief/ lands on WIDOCO docs, not raw RDF


Made with [Cursor](https://cursor.com)