### PR TITLE
Add persistent identifier for DataFly system

### DIFF
--- a/datafly/.htaccess
+++ b/datafly/.htaccess
@@ -1,0 +1,4 @@
+RewriteEngine On
+
+# DataFly project website
+RewriteRule ^$ https://datafly.algo.cit.tum.de/ [R=302,L]

--- a/datafly/README.md
+++ b/datafly/README.md
@@ -1,13 +1,9 @@
-
 # DataFly
 This directory provides a persistent identifier for the DataFly system associated with our IEEE VIS 2026 publication.
-
 ## Persistent identifier
 https://w3id.org/datafly
-
 ## Current destination
 https://datafly.algo.cit.tum.de/
-
 ## Maintainer
 - GitHub: @ygie3679
 - Email: ygina587@gmail.com

--- a/datafly/README.md
+++ b/datafly/README.md
@@ -1,33 +1,13 @@
 
 # DataFly
-
-
-
 This directory provides a persistent identifier for the DataFly system associated with our IEEE VIS 2026 publication.
 
-
-
 ## Persistent identifier
-
-
-
 https://w3id.org/datafly
 
-
-
 ## Current destination
-
-
-
 https://datafly.algo.cit.tum.de/
 
-
-
 ## Maintainer
-
-
-
 - GitHub: @ygie3679
-
 - Email: ygina587@gmail.com
-

--- a/datafly/README.md
+++ b/datafly/README.md
@@ -1,0 +1,33 @@
+
+# DataFly
+
+
+
+This directory provides a persistent identifier for the DataFly system associated with our IEEE VIS 2026 publication.
+
+
+
+## Persistent identifier
+
+
+
+https://w3id.org/datafly
+
+
+
+## Current destination
+
+
+
+https://datafly.algo.cit.tum.de/
+
+
+
+## Maintainer
+
+
+
+- GitHub: @ygie3679
+
+- Email: ygina587@gmail.com
+


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description

This PR adds a persistent identifier for the DataFly visualization system associated with our IEEE VIS 2026 publication.

Requested W3ID:
https://w3id.org/datafly

Current destination:
https://datafly.algo.cit.tum.de/

The destination may be updated in the future if the deployment moves to another server.
## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.


**Note:** Our camera-ready paper submission deadline is August 8. We completely understand that reviews take time and greatly appreciate the maintainers’ effort. If possible, we would be very grateful if this PR could be reviewed before the deadline so that we can include the W3ID link in the paper. Thank you very much for your time and help.