### PR TITLE
Add pr2graph namespace: Pr²Graph ontology

### DIFF
--- a/pr2graph/.htaccess
+++ b/pr2graph/.htaccess
@@ -1,0 +1,34 @@
+# Privacy Practice Analyze — Pr²Graph
+#
+# Persistent w3id namespace for the Pr²Graph Knowledge Graph ontology,
+# accompanying the ISWC 2026 Resource Track paper:
+#   "A Semantic Resource Suite for Privacy Policy Formalization"
+#
+#   https://w3id.org/pr2graph  →  schema ontology (pr2graph.ttl)
+#
+# Hash namespace: append #ClassName or #propertyName to resolve terms
+#   e.g. https://w3id.org/pr2graph#DataPractice
+# (the fragment is handled client-side and never sent to the server)
+#
+# Content negotiation:
+#   - browsers / HTML-accepting clients → human-readable landing page
+#   - RDF clients                        → pr2graph.ttl (text/turtle)
+#
+# ## Contact
+# This space is administered by:
+#
+# Rui Zhao
+# GitHub username: renyuneyun
+# Email: zhaorui@tju.edu.cn
+
+RewriteEngine on
+
+# Serve the HTML landing page to browsers
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://renyuneyun.github.io/pr2graph/ [R=303,L]
+
+# Serve the RDF ontology to machines
+RewriteRule ^$ https://renyuneyun.github.io/pr2graph/pr2graph.ttl [R=303,L]

--- a/pr2graph/README.md
+++ b/pr2graph/README.md
@@ -1,0 +1,35 @@
+# w3id.org namespace: pr2graph
+
+Persistent URI namespace for the **Pr²Graph** (Privacy Practice Graph) ontology, accompanying the ISWC 2026 Resource Track paper:
+
+> *"A Semantic Resource Suite for Privacy Policy Formalization"* — Rui Zhao, Vladyslav Melnychuk, Jesse Wright, Jun Zhao, Nigel Shadbolt.
+
+## Redirect
+
+| w3id URI | Target | Description |
+|---|---|---|
+| `https://w3id.org/pr2graph` | `https://renyuneyun.github.io/pr2graph/pr2graph.ttl` | Pr²Graph schema ontology — classes (`DataPractice`, `PrivacyPolicy`, `Service`, `Recipient`) and properties |
+| `https://w3id.org/pr2graph` (browser / HTML) | `https://renyuneyun.github.io/pr2graph/` | Human-readable landing page |
+
+Content negotiation is handled in `.htaccess`: browsers (or clients whose `Accept` header includes HTML) get the landing page; RDF clients get the Turtle serialization.
+
+This is a **hash namespace** — append `#ClassName` or `#propertyName` to resolve individual terms:
+
+- `https://w3id.org/pr2graph#DataPractice`
+- `https://w3id.org/pr2graph#data`
+- `https://w3id.org/pr2graph#Recipient`
+
+## Hosting
+
+The ontology is hosted in the dedicated [pr2graph](https://github.com/renyuneyun/pr2graph) repository (`pr2graph.ttl` + `index.html`), served via GitHub Pages at `https://renyuneyun.github.io/pr2graph/`. GitHub Pages serves `.ttl` with `Content-Type: text/turtle`, which RDF tooling dereferences cleanly.
+
+## Related resources
+
+- Pr²Graph ontology repo: <https://github.com/renyuneyun/pr2graph>
+- GitHub workflow (pp-analyzer): <https://github.com/renyuneyun/pp-analyzer>
+- Enriched Policy-IE dataset: <https://doi.org/10.5281/zenodo.15392162>
+- Pr²Graph KG + formal policies: <https://doi.org/10.5281/zenodo.20081062>
+
+## Maintainer
+
+- **Rui Zhao** — zhaorui@tju.edu.cn — GitHub: [renyuneyun](https://github.com/renyuneyun)


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->

Add a new namespace called `pr2graph`, for the Pr²Graph ontology (Privacy Practice Graph), accompanying our ISWC 2026 Resource Track paper "A Semantic Resource Suite for Privacy Policy Formalization"

Target URL is the `ontology/pr2graph.ttl` file in my own repo (`renyuneyun/pp-analyzer`), under my control.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.