### PR TITLE
add tpsco

### DIFF
--- a/tpsco/.htaccess
+++ b/tpsco/.htaccess
@@ -1,0 +1,12 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+# 1. Redirection vers le fichier brut (OWL) si c'est une machine ou Protégé qui interroge l'URI
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/xml
+RewriteRule ^$ https://raw.githubusercontent.com/naderabdelmalek/tpsco/main/tpsco.owl [R=303,L]
+
+# 2. Redirection par défaut (HTML) si c'est un humain via un navigateur web
+RewriteRule ^$ https://naderabdelmalek.github.io/tpsco/ [R=303,L]

--- a/tpsco/README
+++ b/tpsco/README
@@ -1,0 +1,8 @@
+# Teacher's Psychological Context Ontology (TPSCO)
+
+This directory defines the redirection rules for the `https://w3id.org/tpsco` namespace, which hosts the Teacher's Psychological Context Ontology (TPSCO).
+
+## Maintainers
+* Nader Abdelmalek (GitHub: @naderabdelmalek)
+* Marie-Hélène Abel
+* Université de Technologie de Compiègne (UTC)


### PR DESCRIPTION
Hello, as requested, this PR registers the namespace for the Teacher's Psychological Context Ontology (TPSCO), an academic project developed at the University of Technology of Compiègne. The namespace will redirect to the OWL file for content negotiation, and to a GitHub Pages documentation site for humans. Thank you!

<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [ ] Changes have been tested.
- [ ] The number of commits is minimal. Squash if needed.
- [ ] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
