### PR TITLE
Add /adiro namespace (ADIRO ontologies, Buro Happold)

### DIFF
--- a/adiro/.htaccess
+++ b/adiro/.htaccess
@@ -1,0 +1,37 @@
+# https://w3id.org/adiro  —  ADIRO: AEC Drawing Information Representation Ontologies
+#
+# An open bundle of OWL/TTL ontologies for making Architecture / Engineering /
+# Construction drawings machine-readable (drawing metadata, cross-discipline
+# symbols, domain-specific symbols).
+#
+# Maintainer : Buro Happold — Machine Learning R&D
+# Project    : https://github.com/BuroHappoldMachineLearning/ADIRO
+# Docs       : https://burohappoldmachinelearning.github.io/ADIRO/
+# Contacts   : see README.md in this directory
+#
+# The backing host (GitHub Pages) cannot content-negotiate, so this .htaccess
+# does it: the bare ontology IRI serves Turtle to RDF clients and the HTML
+# documentation to browsers. 302 (temporary) keeps w3id.org/adiro the stable
+# identifier and lets the backing host change later (host-independence).
+
+Options +FollowSymLinks
+RewriteEngine on
+RewriteBase /adiro/
+
+# 1. Versioned ontology IRI:  /adiro/<module>/<x.y.z>  (no trailing file)
+#    Only Turtle is published per version, so all clients get the versioned .ttl.
+#    (Explicit .../<module>/<x.y.z>/<module>.ttl requests fall through to rule 3.)
+RewriteRule ^([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://burohappoldmachinelearning.github.io/ADIRO/$1/$2/$1.ttl [R=302,L]
+
+# 2. Latest ontology IRI (content negotiation):  /adiro/<module>
+#    Single bare segment, no dot. Term IRIs (/adiro/<module>#Term) also arrive
+#    here — the #fragment is resolved client-side against the same document.
+#    RDF clients -> Turtle:
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/x-turtle|application/rdf\+xml|application/n-triples|application/ld\+json|text/n3|application/trig|application/n-quads) [NC]
+RewriteRule ^([^/.]+)$ https://burohappoldmachinelearning.github.io/ADIRO/$1.ttl [R=302,L]
+#    Everything else (browsers, */*) -> pyLODE HTML documentation:
+RewriteRule ^([^/.]+)$ https://burohappoldmachinelearning.github.io/ADIRO/$1.html [R=302,L]
+
+# 3. Passthrough for explicit files & sub-paths (<module>.ttl, <module>.html,
+#    <module>/<x.y.z>/<module>.ttl, ontologies/<module>/, assets, the landing page).
+RewriteRule ^(.*)$ https://burohappoldmachinelearning.github.io/ADIRO/$1 [R=302,L]

--- a/adiro/.htaccess
+++ b/adiro/.htaccess
@@ -14,7 +14,6 @@
 # documentation to browsers. 302 (temporary) keeps w3id.org/adiro the stable
 # identifier and lets the backing host change later (host-independence).
 
-Options +FollowSymLinks
 RewriteEngine on
 
 # 1. Versioned ontology IRI:  /adiro/<module>/<x.y.z>  (no trailing file)

--- a/adiro/.htaccess
+++ b/adiro/.htaccess
@@ -7,7 +7,7 @@
 # Maintainer : Buro Happold — Machine Learning R&D
 # Project    : https://github.com/BuroHappoldMachineLearning/ADIRO
 # Docs       : https://burohappoldmachinelearning.github.io/ADIRO/
-# Contacts   : see README.md in this directory
+# Contacts   : see README.md in this directory (GitHub usernames + emails)
 #
 # The backing host (GitHub Pages) cannot content-negotiate, so this .htaccess
 # does it: the bare ontology IRI serves Turtle to RDF clients and the HTML
@@ -16,7 +16,6 @@
 
 Options +FollowSymLinks
 RewriteEngine on
-RewriteBase /adiro/
 
 # 1. Versioned ontology IRI:  /adiro/<module>/<x.y.z>  (no trailing file)
 #    Only Turtle is published per version, so all clients get the versioned .ttl.

--- a/adiro/README.md
+++ b/adiro/README.md
@@ -26,8 +26,8 @@ to the ADIRO GitHub Pages site:
 
 Buro Happold — Machine Learning R&D:
 
-- Alessio Lombardi &lt;alessio.lombardi@burohappold.com&gt;
-- Ahmed Elnagar &lt;ahmed.elnagar@burohappold.com&gt;
-- Sepehr Najjarpour &lt;sepehr.najjarpour@burohappold.com&gt;
-- Tianyang Huang &lt;tianyang.huang@burohappold.com&gt;
-- Ahmed Zalouk &lt;ahmed.zalouk@burohappold.com&gt;
+- Alessio Lombardi — [@alelom](https://github.com/alelom) &lt;alessio.lombardi@burohappold.com&gt;
+- Ahmed Elnagar — [@AhmedElnagar1](https://github.com/AhmedElnagar1) &lt;ahmed.elnagar@burohappold.com&gt;
+- Sepehr Najjarpour — [@sn-bh](https://github.com/sn-bh) &lt;sepehr.najjarpour@burohappold.com&gt;
+- Tianyang Huang — [@BH-Tianyang](https://github.com/BH-Tianyang) &lt;tianyang.huang@burohappold.com&gt;
+- Ahmed Zalouk — [@Zaalouk122576](https://github.com/Zaalouk122576) &lt;ahmed.zalouk@burohappold.com&gt;

--- a/adiro/README.md
+++ b/adiro/README.md
@@ -1,0 +1,33 @@
+# w3id.org/adiro
+
+Permanent, resolvable identifiers for **ADIRO** — *AEC Drawing Information
+Representation Ontologies*: an open bundle of OWL/TTL ontologies that make
+Architecture / Engineering / Construction drawings machine-readable (drawing
+metadata, cross-discipline symbols, and domain-specific symbols).
+
+| | |
+|---|---|
+| **Project / source** | https://github.com/BuroHappoldMachineLearning/ADIRO |
+| **Documentation** | https://burohappoldmachinelearning.github.io/ADIRO/ |
+| **Maintainer** | Buro Happold — Machine Learning R&D |
+
+## Resolution
+
+`.htaccess` performs HTTP `Accept`-header content negotiation, redirecting (302)
+to the ADIRO GitHub Pages site:
+
+- `https://w3id.org/adiro/<module>` — the latest ontology IRI:
+  - RDF clients (`Accept: text/turtle`, `application/rdf+xml`, …) → the Turtle file;
+  - browsers (`Accept: text/html`) → the HTML documentation.
+- `https://w3id.org/adiro/<module>/<x.y.z>` — a specific version → that version's Turtle.
+- explicit file URLs (`…/<module>.ttl`, `…/<module>.html`) are passed through unchanged.
+
+## Maintainers / contact
+
+Buro Happold — Machine Learning R&D:
+
+- Alessio Lombardi &lt;alessio.lombardi@burohappold.com&gt;
+- Ahmed Elnagar &lt;ahmed.elnagar@burohappold.com&gt;
+- Sepehr Najjarpour &lt;sepehr.najjarpour@burohappold.com&gt;
+- Tianyang Huang &lt;tianyang.huang@burohappold.com&gt;
+- Ahmed Zalouk &lt;ahmed.zalouk@burohappold.com&gt;


### PR DESCRIPTION
This PR registers the **`/adiro`** namespace for **ADIRO** — *AEC Drawing Information Representation Ontologies*, an open OWL/TTL ontology suite by Buro Happold's Machine Learning R&D team for making Architecture / Engineering / Construction drawings machine-readable.

**`adiro/.htaccess`** performs HTTP `Accept`-header content negotiation, redirecting (`302`) to the project's GitHub Pages site:

- bare ontology IRI `w3id.org/adiro/<module>` → Turtle for RDF clients, pyLODE HTML documentation for browsers;
- versioned IRI `w3id.org/adiro/<module>/<x.y.z>` → that version's Turtle;
- explicit file URLs and sub-paths are passed through unchanged.

**`adiro/README.md`** describes the namespace and lists maintainer contacts.

- Project / source: https://github.com/BuroHappoldMachineLearning/ADIRO
- Documentation: https://burohappoldmachinelearning.github.io/ADIRO/

Thanks for maintaining w3id.org!
