### PR TITLE
Add AGSMO (Agent Semantic Memory Ontology) permanent identifiers

### DIFF
--- a/agsmo/.htaccess
+++ b/agsmo/.htaccess
@@ -1,0 +1,38 @@
+# AGSMO — Agent Semantic Memory Ontology
+#
+# Permanent identifiers under:
+#   https://w3id.org/agsmo/
+#
+# Targets (GitHub Pages):
+#   https://sadnanalmanir.github.io/agsmo/
+#
+# ## Contact
+# This space is administered by:
+#
+# Sadnan Al Manir
+# sadnanalmanir@gmail.com
+# GitHub username: sadnanalmanir
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# --- Tutorial ---
+# https://w3id.org/agsmo/tutorial  →  progressive HTML tutorial
+RewriteRule ^tutorial/?$ https://sadnanalmanir.github.io/agsmo/tutorial/ [R=303,L]
+
+# --- Ontology namespace (latest + version 0.1) ---
+# https://w3id.org/agsmo/ns
+# https://w3id.org/agsmo/ns/0.1
+# (Fragment identifiers like #Goal are handled by the client after redirect.)
+RewriteRule ^ns/0\.1/?$ https://sadnanalmanir.github.io/agsmo/ontology/agsmo.ttl [R=303,L]
+RewriteRule ^ns/?$ https://sadnanalmanir.github.io/agsmo/ontology/agsmo.ttl [R=303,L]
+
+# --- Optional: examples directory on Pages ---
+RewriteRule ^examples/?(.*)$ https://sadnanalmanir.github.io/agsmo/examples/$1 [R=303,L]
+
+# --- Project home (WIDOCO docs) ---
+# https://w3id.org/agsmo  and  https://w3id.org/agsmo/
+RewriteRule ^$ https://sadnanalmanir.github.io/agsmo/ [R=303,L]
+
+# --- Fallback: anything else under /agsmo/ → same path on Pages ---
+RewriteRule ^(.+)$ https://sadnanalmanir.github.io/agsmo/$1 [R=303,L]

--- a/agsmo/README.md
+++ b/agsmo/README.md
@@ -1,0 +1,35 @@
+# AGSMO — Agent Semantic Memory Ontology
+
+Permanent identifiers for **AGSMO** (Agent Semantic Memory Ontology).
+
+**Not to be confused with** [ASMO](https://ocdo.github.io/asmo/)
+(Atomistic Simulation Methods Ontology).
+
+## Permanent URLs
+
+| Identifier | Redirects to |
+|------------|----------------|
+| https://w3id.org/agsmo | https://sadnanalmanir.github.io/agsmo/ |
+| https://w3id.org/agsmo/tutorial | https://sadnanalmanir.github.io/agsmo/tutorial/ |
+| https://w3id.org/agsmo/ns | https://sadnanalmanir.github.io/agsmo/ontology/agsmo.ttl |
+| https://w3id.org/agsmo/ns/0.1 | https://sadnanalmanir.github.io/agsmo/ontology/agsmo.ttl |
+
+Ontology namespace (as declared in the OWL file):  
+`https://w3id.org/agsmo/ns#`
+
+## Project links
+
+- Source repository: https://github.com/sadnanalmanir/agsmo
+- Documentation (WIDOCO): https://sadnanalmanir.github.io/agsmo/
+- Progressive tutorial: https://sadnanalmanir.github.io/agsmo/tutorial/
+- Ontology (Turtle): https://sadnanalmanir.github.io/agsmo/ontology/agsmo.ttl
+
+## Maintainer
+
+- **Name:** Sadnan Al Manir  
+- **Email:** sadnanalmanir@gmail.com  
+- **GitHub:** [sadnanalmanir](https://github.com/sadnanalmanir)
+
+## License
+
+Ontology and project materials: MIT (see the source repository).


### PR DESCRIPTION
## Summary

Add permanent identifiers under **`https://w3id.org/agsmo/`** for the **Agent Semantic Memory Ontology (AGSMO)**.

Not to be confused with [ASMO](https://ocdo.github.io/asmo/) (Atomistic Simulation Methods Ontology).

## Redirects

| w3id | Target |
|------|--------|
| https://w3id.org/agsmo | https://sadnanalmanir.github.io/agsmo/ |
| https://w3id.org/agsmo/tutorial | https://sadnanalmanir.github.io/agsmo/tutorial/ |
| https://w3id.org/agsmo/ns | https://sadnanalmanir.github.io/agsmo/ontology/agsmo.ttl |
| https://w3id.org/agsmo/ns/0.1 | https://sadnanalmanir.github.io/agsmo/ontology/agsmo.ttl |
| https://w3id.org/agsmo/examples/… | https://sadnanalmanir.github.io/agsmo/examples/… |

Uses HTTP **303**. Simple redirects (content negotiation can be added later).

## Project

- Source: https://github.com/sadnanalmanir/agsmo
- Docs: https://sadnanalmanir.github.io/agsmo/
- Maintainer: Sadnan Al Manir (@sadnanalmanir) — sadnanalmanir@gmail.com

## Files

- `agsmo/.htaccess`
- `agsmo/README.md`