### PR TITLE
Add EU AI Act OSCAL permanent identifiers

### DIFF
--- a/eu-ai-act-oscal/.htaccess
+++ b/eu-ai-act-oscal/.htaccess
@@ -1,0 +1,26 @@
+# https://w3id.org/eu-ai-act-oscal
+# Machine-readable OSCAL catalog of the obligations of the EU Artificial Intelligence Act
+# (Regulation (EU) 2024/1689, as amended by Regulation (EU) 2026/1744).
+# Contact: standards@olon.media
+# Repo:    https://github.com/olon-standards/eu-ai-act-oscal
+# Licence: Apache-2.0
+
+Options +FollowSymLinks
+RewriteEngine On
+
+SetEnvIf Request_URI ".*" PUBLISH_BASE=https://olon-standards.github.io/w3id-host/eu-ai-act-oscal
+
+# Property namespace documentation.
+RewriteRule ^ns/?$ %{ENV:PUBLISH_BASE}/ns.html [R=302,L]
+
+# Current machine-readable artifacts.
+RewriteRule ^catalog/?$              %{ENV:PUBLISH_BASE}/catalogs/eu-ai-act/catalog.json [R=302,L]
+RewriteRule ^profiles/(.+)$          %{ENV:PUBLISH_BASE}/profiles/$1 [R=302,L]
+RewriteRule ^assessment-plans/(.+)$  %{ENV:PUBLISH_BASE}/assessment-plans/$1 [R=302,L]
+RewriteRule ^examples/(.+)$          %{ENV:PUBLISH_BASE}/docs/examples/$1 [R=302,L]
+
+# Immutable versioned artifacts.
+RewriteRule ^v/([0-9]+\.[0-9]+\.[0-9]+)/(.*)$ %{ENV:PUBLISH_BASE}/v/$1/$2 [R=302,L]
+
+# Human landing page and any directly mirrored path.
+RewriteRule ^(.*)$ %{ENV:PUBLISH_BASE}/$1 [R=302,L]

--- a/eu-ai-act-oscal/README.md
+++ b/eu-ai-act-oscal/README.md
@@ -15,4 +15,5 @@ snapshot return HTTP 200. Format: NIST OSCAL 1.1.2 JSON, validated with
 `compliance-trestle` 5.0.0. Licence: Apache-2.0 with DCO.
 
 - Maintainer: Miltos Makridis <standards@olon.media>
+- GitHub: [@miltos-thestargazer](https://github.com/miltos-thestargazer)
 - Project: <https://github.com/olon-standards/eu-ai-act-oscal>

--- a/eu-ai-act-oscal/README.md
+++ b/eu-ai-act-oscal/README.md
@@ -1,0 +1,18 @@
+# w3id.org/eu-ai-act-oscal
+
+Permanent identifier namespace for the machine-readable OSCAL catalog of the obligations
+of the EU Artificial Intelligence Act — Regulation (EU) 2024/1689 as amended by
+Regulation (EU) 2026/1744.
+
+- Property namespace: <https://w3id.org/eu-ai-act-oscal/ns>
+- Catalog: <https://w3id.org/eu-ai-act-oscal/catalog>
+- Profiles: `https://w3id.org/eu-ai-act-oscal/profiles/{path}`
+- Assessment plans: `https://w3id.org/eu-ai-act-oscal/assessment-plans/{path}`
+- Versioned artifacts: `https://w3id.org/eu-ai-act-oscal/v/{semver}/{path}`
+
+The redirect target is already public. The current catalog and the immutable `v/0.1.1`
+snapshot return HTTP 200. Format: NIST OSCAL 1.1.2 JSON, validated with
+`compliance-trestle` 5.0.0. Licence: Apache-2.0 with DCO.
+
+- Maintainer: Miltos Makridis <standards@olon.media>
+- Project: <https://github.com/olon-standards/eu-ai-act-oscal>


### PR DESCRIPTION
Adds the `/eu-ai-act-oscal` namespace for the public NIST OSCAL catalog of Regulation (EU) 2024/1689 as amended by Regulation (EU) 2026/1744.\n\nThe redirect targets are already live:\n- namespace documentation: https://olon-standards.github.io/w3id-host/eu-ai-act-oscal/ns.html\n- current catalog: https://olon-standards.github.io/w3id-host/eu-ai-act-oscal/catalogs/eu-ai-act/catalog.json\n- immutable v0.1.1 catalog: https://olon-standards.github.io/w3id-host/eu-ai-act-oscal/v/0.1.1/catalogs/eu-ai-act/catalog.json\n\nMaintainer: Miltos Makridis <standards@olon.media>. Project: https://github.com/olon-standards/eu-ai-act-oscal