### PR TITLE
sstim: route the BioSynCare Ecosystem programme identity

### DIFF
--- a/sstim/.htaccess
+++ b/sstim/.htaccess
@@ -144,9 +144,12 @@ RewriteRule ^$ - [R=406,L]
 # END audited SSTIM manifest routes
 
 # -------------------------------------------------------------------------
-# Stable BSC catalog identities. Framework, application, and component IRIs
-# resolve to their owning static RDF documents; the Patch Studio component is
-# intentionally distinct from the /sstim/patch-studio ontology module.
+# Stable BSC catalog identities. Programme, framework, application, and
+# component IRIs resolve to their owning static RDF documents; the Patch Studio
+# component is intentionally distinct from the /sstim/patch-studio ontology
+# module, and /sstim/ecosystem/{id} (programme instances, slash) is intentionally
+# distinct from /sstim/ecosystem (the OWL module, matched exactly above) and from
+# /sstim/ecosystem-record/{kind}/{id} (live relationship records).
 # -------------------------------------------------------------------------
 # BEGIN audited BSC catalog routes
 # Browser targets are per-entity deep links into the knowledge browser's
@@ -164,6 +167,9 @@ RewriteRule ^$ - [R=406,L]
 # and invisible. The negotiation test now pins every one of them
 # (scripts/w3id-negotiation.test.mjs).
 RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/html|application/xhtml\+xml)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^ecosystem/biosyncare/?$ https://labiosyncare.github.io/graph/#sstim-ecosystem:biosyncare [R=303,L,NE]
+
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/html|application/xhtml\+xml)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
 RewriteRule ^framework/bsc/?$ https://labiosyncare.github.io/graph/#bsc-fw: [R=303,L,NE]
 
 RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/html|application/xhtml\+xml)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
@@ -175,6 +181,10 @@ RewriteRule ^implementation/biosyncare/?$ https://labiosyncare.github.io/graph/#
 RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/html|application/xhtml\+xml)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
 RewriteRule ^implementation/bsclab/component/patch-studio/?$ https://labiosyncare.github.io/graph/#bsclab:component/patch-studio [R=303,L,NE]
 
+RewriteCond %{HTTP_ACCEPT} ^$ [OR]
+RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/turtle|application/x-turtle|\*/\*)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
+RewriteRule ^(ecosystem/biosyncare)/?$ https://labiosyncare.github.io/ontology/instances/programmes/biosyncare-ecosystem.ttl [R=303,L]
+RewriteRule ^(ecosystem/biosyncare)/?$ - [R=406,L]
 RewriteCond %{HTTP_ACCEPT} ^$ [OR]
 RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/turtle|application/x-turtle|\*/\*)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
 RewriteRule ^(framework/bsc)/?$ https://labiosyncare.github.io/ontology/instances/frameworks/bsc.ttl [R=303,L]


### PR DESCRIPTION
## Brief Description

Adds one entity route under the existing `/sstim` directory:
`https://w3id.org/sstim/ecosystem/biosyncare`, the programme identity that groups
the SSTIM ontology, the BSC framework, BSC Lab with its Patch Studio component,
and the BioSynCare application.

It follows the same pattern as the neighbouring catalog identities already in this
file: browsers get a 303 to that entity's node in the knowledge browser, RDF
clients get a 303 to the Turtle document that owns the subject, and any other
Accept gets a 406.

The existing `/sstim/ecosystem` module rule is anchored `^ecosystem$`, so it does
not capture this path; the two are different resources and the block comment now
says so.

Redirect targets are already published and return 200:

- https://labiosyncare.github.io/ontology/instances/programmes/biosyncare-ecosystem.ttl
- https://labiosyncare.github.io/graph/#sstim-ecosystem:biosyncare

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

Not applicable — this updates the existing `/sstim` directory.

## Update ID Directory Checklist

- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers

- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
