### PR TITLE
Register terranexus namespace

### DIFF
--- a/terranexus/.htaccess
+++ b/terranexus/.htaccess
@@ -1,0 +1,5 @@
+RewriteEngine On
+RewriteBase /terranexus/
+
+# ofp-datamodel -> TerraneXus OFP LinkML docs site
+RewriteRule ^ofp-datamodel/?$ https://ofp-datamodel.terranexus.com.au [R=302,L]

--- a/terranexus/README.md
+++ b/terranexus/README.md
@@ -1,0 +1,12 @@
+# terranexus
+
+Namespace for TerraneXus data model / vocabulary projects.
+
+## Redirects
+
+`https://w3id.org/terranexus/ofp-datamodel` redirects to `https://ofp-datamodel.terranexus.com.au` (LinkML data model for Open Footprint-aligned Scope 1/2 emissions reporting).
+
+## Contact
+
+Maintainer: Chris Hough (GitHub: @chough80, https://github.com/chough80)
+Email: chris.hough@terranexus.com.au


### PR DESCRIPTION
Brief description: Registers a new top-level identifier namespace `terranexus`, with a redirect for `w3id.org/terranexus/ofp-datamodel` to a LinkML data model documentation site. Future TerraneXus projects will add further rules to the same `.htaccess` file.

Checklist confirmation: changes have been tested locally against a live checkout of the site; this PR contains a minimal, single-purpose commit history with only redirect and contact information (no served content); maintainer contact details are included in both `terranexus/.htaccess` and `terranexus/README.md`; the submitting GitHub account (@chough80) is listed as the maintainer in those files.