### PR TITLE
Add sgrlab namespace

### DIFF
--- a/sgrlab/.htaccess
+++ b/sgrlab/.htaccess
@@ -1,0 +1,21 @@
+# https://w3id.org/sgrlab/ -- Garrett-Roe Lab (University of Pittsburgh)
+#
+# ## Contact
+# This space is administered by:
+#
+# Sean Garrett-Roe
+# sgarrettroe@gmail.com
+# GitHub username: sgarrettroe
+
+Options +FollowSymLinks
+RewriteEngine on
+
+RewriteRule ^$ https://github.com/pitt-SGRLab [R=302,L]
+
+# notes -- the lab's kb-notes system (https://github.com/pitt-SGRLab/kb-notes).
+# Bare /notes goes to the tool itself; /notes/<initials> goes to that lab
+# member's own private notes-data repo, kb-notes-<initials> -- e.g.
+# /notes/sgr -> kb-notes-sgr, /notes/mrl -> kb-notes-mrl. Assumes every lab
+# member's data repo follows the kb-notes-<initials> naming convention.
+RewriteRule ^notes/?$ https://github.com/pitt-SGRLab/kb-notes [R=302,L]
+RewriteRule ^notes/([A-Za-z0-9-]+)/?$ https://github.com/pitt-SGRLab/kb-notes-$1 [R=302,L,NC]

--- a/sgrlab/README.md
+++ b/sgrlab/README.md
@@ -1,0 +1,12 @@
+# sgrlab
+
+Permanent identifier namespace for the Garrett-Roe Lab (University of Pittsburgh).
+
+## Sub-identifiers
+
+- `notes` — the lab's notes knowledge base tooling ([kb-notes](https://github.com/pitt-SGRLab/kb-notes)). `notes/<initials>` redirects to that lab member's own private notes-data repo (`kb-notes-<initials>`, e.g. `notes/sgr` → [kb-notes-sgr](https://github.com/pitt-SGRLab/kb-notes-sgr)) — will point at each person's real per-resource site once GitHub Pages/EMU-SSO deployment lands (see kb-notes' §4b item 15).
+- `experiments`, `instruments` — reserved, not yet registered.
+
+## Contact
+
+Sean Garrett-Roe ([@sgarrettroe](https://github.com/sgarrettroe)) — sgarrettroe@gmail.com


### PR DESCRIPTION
New top-level namespace for the Garrett-Roe Lab (University of Pittsburgh) — first registration for this lab, no existing `sgr*` directory found in this repo.

- `notes` → the lab's [kb-notes](https://github.com/pitt-SGRLab/kb-notes) knowledge-base tooling. `notes/<initials>` redirects to that lab member's own private notes-data repo (`kb-notes-<initials>`, e.g. `notes/sgr` → [kb-notes-sgr](https://github.com/pitt-SGRLab/kb-notes-sgr)) — a general pattern rule so future lab members (students) get a working redirect automatically once they create their own `kb-notes-<initials>` repo, no further `.htaccess` edit needed per person.
- `experiments`, `instruments` — reserved for future registration, not yet added as active redirect rules (nothing to point them at yet).

Contact info included in both `.htaccess` and `README.md` per the repo's own conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)