### PR TITLE
Add ESKA permanent identifier redirects

### DIFF
--- a/eska/.htaccess
+++ b/eska/.htaccess
@@ -1,0 +1,47 @@
+# ESKA — Executable Semantic Knowledge Architecture
+# Point of contact: Gerhard Balz — GitHub @GerhardBalz
+# Canonical project: https://github.com/GerhardBalz/executable-semantic-knowledge-architecture
+#
+# PRE-ACTIVATION ROUTING PACKAGE.
+# This file is prepared for submission to perma-id/w3id.org/eska/.htaccess.
+# Do not treat https://w3id.org/eska as active until the upstream W3ID PR is merged
+# and these routes have been verified from an external client.
+
+Options +FollowSymLinks -Indexes
+RewriteEngine On
+
+# Vocabulary base / hash namespace document.
+# RDF clients receive the combined Turtle distribution; browsers receive project docs.
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/main/dist/eska.ttl [R=303,NE,L]
+
+RewriteRule ^$ https://github.com/GerhardBalz/executable-semantic-knowledge-architecture [R=303,NE,L]
+
+# Human-readable documentation.
+RewriteRule ^docs/?$ https://github.com/GerhardBalz/executable-semantic-knowledge-architecture/blob/main/docs/namespace-publication-versioning.md [R=303,NE,L]
+
+# Combined RDF distribution.
+RewriteRule ^dist/eska\.ttl$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/main/dist/eska.ttl [R=303,NE,L]
+
+# Stable unversioned module documents. RDF clients receive raw Turtle; browsers
+# receive GitHub-rendered source. Versioned routes are intentionally not configured
+# until immutable governed release targets exist.
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^model/core/?$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/main/model/eska-core.ttl [R=303,NE,L]
+RewriteRule ^model/core/?$ https://github.com/GerhardBalz/executable-semantic-knowledge-architecture/blob/main/model/eska-core.ttl [R=303,NE,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^model/capability/?$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/main/model/eska-capability.ttl [R=303,NE,L]
+RewriteRule ^model/capability/?$ https://github.com/GerhardBalz/executable-semantic-knowledge-architecture/blob/main/model/eska-capability.ttl [R=303,NE,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^model/service/?$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/main/model/eska-service.ttl [R=303,NE,L]
+RewriteRule ^model/service/?$ https://github.com/GerhardBalz/executable-semantic-knowledge-architecture/blob/main/model/eska-service.ttl [R=303,NE,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^model/agent/?$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/main/model/eska-agent.ttl [R=303,NE,L]
+RewriteRule ^model/agent/?$ https://github.com/GerhardBalz/executable-semantic-knowledge-architecture/blob/main/model/eska-agent.ttl [R=303,NE,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^model/deployment/?$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/main/model/eska-deployment.ttl [R=303,NE,L]
+RewriteRule ^model/deployment/?$ https://github.com/GerhardBalz/executable-semantic-knowledge-architecture/blob/main/model/eska-deployment.ttl [R=303,NE,L]

--- a/eska/README.md
+++ b/eska/README.md
@@ -1,0 +1,58 @@
+# ESKA permanent identifier configuration
+
+This directory is the prepared upstream contribution payload for:
+
+```text
+https://w3id.org/eska
+```
+
+Project:
+
+- **Executable Semantic Knowledge Architecture (ESKA)**
+- Repository: `GerhardBalz/executable-semantic-knowledge-architecture`
+- Point of contact: **Gerhard Balz** — GitHub `@GerhardBalz`
+
+## Status
+
+**Prepared, not active.**
+
+The authoritative ESKA ontology source still uses the provisional term namespace:
+
+```text
+urn:eska:core:
+```
+
+The adopted permanent target namespace is:
+
+```text
+https://w3id.org/eska#
+```
+
+The `.htaccess` file in this directory must be submitted to the upstream `perma-id/w3id.org` repository under `eska/.htaccess` and merged before ESKA source ontology IRIs are migrated.
+
+## Initial redirects
+
+The prepared routing package provides:
+
+- vocabulary base / hash-namespace document;
+- human-readable namespace/publication documentation;
+- combined Turtle distribution;
+- stable unversioned module routes for `core`, `capability`, `service`, `agent`, and `deployment`;
+- content negotiation for `text/turtle` on the vocabulary base and module routes.
+
+Versioned module routes are intentionally **not** configured yet. They will be added only when immutable governed release targets exist.
+
+## Activation order
+
+```text
+1. Merge ESKA backend publication targets
+2. Verify public GitHub HTML/RDF backend URLs
+3. Fork perma-id/w3id.org
+4. Copy this directory to w3id.org/eska/
+5. Submit W3ID PR
+6. Wait for upstream merge
+7. Verify https://w3id.org/eska externally
+8. Only then migrate ESKA terms/ontology IRIs atomically
+```
+
+This ordering prevents the repository from claiming persistent semantic identifiers before the redirect infrastructure actually exists.


### PR DESCRIPTION
## Brief Description

Add the `https://w3id.org/eska` permanent identifier namespace for
Executable Semantic Knowledge Architecture (ESKA).

The redirects provide:

- the ESKA vocabulary/documentation entry point;
- content negotiation for Turtle on the vocabulary base;
- the combined ESKA Turtle distribution;
- stable module routes for `core`, `capability`, `service`, `agent`, and `deployment`.

Project repository:
https://github.com/GerhardBalz/executable-semantic-knowledge-architecture

The ESKA ontology still uses its provisional `urn:eska:core:` namespace.
Migration to the permanent `https://w3id.org/eska#` namespace will happen
only after this W3ID configuration is merged and the redirects have been
externally verified.

## General Checklist

- [x] Changes have been tested.
- [ ] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist

- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers

- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs..
