### PR TITLE
Add /grc namespace for GRC cybersecurity ontology

### DIFF
--- a/grc/.htaccess
+++ b/grc/.htaccess
@@ -1,0 +1,26 @@
+Options +FollowSymLinks
+
+RewriteEngine on
+
+AddType text/turtle .ttl
+
+# Serve Turtle when RDF serialisations are requested
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^ontology/?$ https://raw.githubusercontent.com/MOo207/shacl-risk-grounding/main/ontology/ttl/grc-ontology.ttl [R=303,NE,L]
+
+# NFCRM clause graph
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^nfcrm/?$ https://raw.githubusercontent.com/MOo207/shacl-risk-grounding/main/ontology/ttl/nfcrm-clauses.ttl [R=303,NE,L]
+
+# HTML / default: ontology documentation in the repository
+RewriteRule ^ontology/?$ https://github.com/MOo207/shacl-risk-grounding/blob/main/ontology/README.md [R=303,NE,L]
+RewriteRule ^nfcrm/?$ https://github.com/MOo207/shacl-risk-grounding/blob/main/ontology/ttl/nfcrm-clauses.ttl [R=303,NE,L]
+
+# Everything else under /grc/ resolves to the repository
+RewriteRule ^(.*)$ https://github.com/MOo207/shacl-risk-grounding [R=303,NE,L]

--- a/grc/README.md
+++ b/grc/README.md
@@ -11,18 +11,14 @@ The ontology and its reproducibility package are hosted on GitHub at https://git
 | `/grc/ontology` | GRC ontology (Turtle via content negotiation, documentation otherwise) |
 | `/grc/nfcrm` | NFCRM-1:2025 clause graph (Turtle) |
 
-# Contacts
+## Contacts
 
-**Mohammed Ismail Alamawy**
+### Mohammed Ismail Alamawy
+- GitHub: [@MOo207](https://github.com/MOo207)
+- Faculty of Computer and Information Systems, Islamic University of Madinah, Saudi Arabia
+- email: [461020996@stu.iu.edu.sa](mailto:461020996@stu.iu.edu.sa)
+- ORCID: [0009-0008-4917-1165](https://orcid.org/0009-0008-4917-1165)
 
-Faculty of Computer and Information Systems, Islamic University of Madinah, Saudi Arabia
-
-email: [461020996@stu.iu.edu.sa](mailto:461020996@stu.iu.edu.sa)
-
-ORCID: [0009-0008-4917-1165](https://orcid.org/0009-0008-4917-1165)
-
-**Fayçal Hamdi**
-
-Faculty of Computer and Information Systems, Islamic University of Madinah, Saudi Arabia
-
-ORCID: [0000-0002-5314-1419](https://orcid.org/0000-0002-5314-1419)
+### Fayçal Hamdi
+- Faculty of Computer and Information Systems, Islamic University of Madinah, Saudi Arabia
+- ORCID: [0000-0002-5314-1419](https://orcid.org/0000-0002-5314-1419)

--- a/grc/README.md
+++ b/grc/README.md
@@ -1,0 +1,26 @@
+# /grc
+
+Persistent namespace for the **GRC cybersecurity ontology** — an OWL/RDF knowledge model with SHACL constraint profiles that grounds machine-learning and LLM-based risk inference in cybersecurity Governance, Risk, and Compliance (GRC) concepts (assets, vulnerabilities, controls, risk cases, audit records, and framework references), instantiated with Saudi Arabia's NFCRM-1:2025 framework and ISO/IEC 27005 terminology.
+
+Namespace IRI: `https://w3id.org/grc/ontology#`
+
+The ontology and its reproducibility package are hosted on GitHub at https://github.com/MOo207/shacl-risk-grounding and permanently archived on Zenodo (DOI: [10.5281/zenodo.21869883](https://doi.org/10.5281/zenodo.21869883)). The w3id paths are mapped to the hosted resources in the `.htaccess` file.
+
+| Path | Resolves to |
+|------|-------------|
+| `/grc/ontology` | GRC ontology (Turtle via content negotiation, documentation otherwise) |
+| `/grc/nfcrm` | NFCRM-1:2025 clause graph (Turtle) |
+
+# Contacts
+
+**Mohammed Ismail Alamawy**
+
+Faculty of Computer and Information Systems, Islamic University of Madinah, Saudi Arabia
+
+email: [461020996@stu.iu.edu.sa](mailto:461020996@stu.iu.edu.sa)
+
+**Fayçal Hamdi**
+
+Faculty of Computer and Information Systems, Islamic University of Madinah, Saudi Arabia
+
+ORCID: [0000-0002-5314-1419](https://orcid.org/0000-0002-5314-1419)

--- a/grc/README.md
+++ b/grc/README.md
@@ -11,18 +11,13 @@ The ontology and its reproducibility package are hosted on GitHub at https://git
 | `/grc/ontology` | GRC ontology (Turtle via content negotiation, documentation otherwise) |
 | `/grc/nfcrm` | NFCRM-1:2025 clause graph (Turtle) |
 
-# Contacts
+## Contacts
 
-**Mohammed Ismail Alamawy**
+### Mohammed Ismail Alamawy
+- Faculty of Computer and Information Systems, Islamic University of Madinah, Saudi Arabia
+- email: [461020996@stu.iu.edu.sa](mailto:461020996@stu.iu.edu.sa)
+- ORCID: [0009-0008-4917-1165](https://orcid.org/0009-0008-4917-1165)
 
-Faculty of Computer and Information Systems, Islamic University of Madinah, Saudi Arabia
-
-email: [461020996@stu.iu.edu.sa](mailto:461020996@stu.iu.edu.sa)
-
-ORCID: [0009-0008-4917-1165](https://orcid.org/0009-0008-4917-1165)
-
-**Fayçal Hamdi**
-
-Faculty of Computer and Information Systems, Islamic University of Madinah, Saudi Arabia
-
-ORCID: [0000-0002-5314-1419](https://orcid.org/0000-0002-5314-1419)
+### Fayçal Hamdi
+- Faculty of Computer and Information Systems, Islamic University of Madinah, Saudi Arabia
+- ORCID: [0000-0002-5314-1419](https://orcid.org/0000-0002-5314-1419)

--- a/grc/README.md
+++ b/grc/README.md
@@ -19,6 +19,8 @@ Faculty of Computer and Information Systems, Islamic University of Madinah, Saud
 
 email: [461020996@stu.iu.edu.sa](mailto:461020996@stu.iu.edu.sa)
 
+ORCID: [0009-0008-4917-1165](https://orcid.org/0009-0008-4917-1165)
+
 **Fayçal Hamdi**
 
 Faculty of Computer and Information Systems, Islamic University of Madinah, Saudi Arabia


### PR DESCRIPTION
Registers the /grc namespace for the GRC cybersecurity ontology (OWL/RDF + SHACL) used in the manuscript "Grounding Machine Learning and LLM-Based Risk Inference in a Shared SHACL Knowledge Layer: An NFCRM-1:2025 Case Study" (Islamic University of Madinah / IMSIU).

- Namespace IRI: https://w3id.org/grc/ontology#
- Hosted at: https://github.com/MOo207/shacl-risk-grounding
- Archived on Zenodo: https://doi.org/10.5281/zenodo.21869883
- /grc/ontology serves Turtle via content negotiation, documentation for HTML agents; /grc/nfcrm serves the NFCRM-1:2025 clause graph.

All redirect targets verified reachable (HTTP 200). Two contacts listed in grc/README.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)