### PR TITLE
Add mtbc-atlas persistent identifier

### DIFF
--- a/mtbc-atlas/.htaccess
+++ b/mtbc-atlas/.htaccess
@@ -1,0 +1,25 @@
+# mtbc-atlas -- MTBC Gene Atlas, a continuously updated functional re-annotation of the
+# Mycobacterium tuberculosis complex gene set, anchored on the MTBC0 ancestral genome.
+# Maintainer: Christophe Guyeux, FEMTO-ST Institute (CNRS UMR 6174), Besancon, France.
+# Target instance: https://mtbc.gclab.fr
+# 302 (temporary) on purpose: the instance may move, and a 301 would be cached by clients,
+# which is exactly the lock-in this identifier exists to avoid.
+
+# CORS, as the entries that front a data service do (cf. w3id.org/oc, w3id.org/arco): without it
+# a browser-side client calling the REST API through this identifier is blocked by the same-origin
+# policy, and the persistent identifier would be usable for reading pages but not for querying data.
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+# Per-gene pages, the URLs cited in publications: /gene/Rv1908c
+RewriteRule ^gene/(.+)$ https://mtbc.gclab.fr/gene/$1 [R=302,L]
+
+# REST API, versioned upstream: /api/v1/genes/Rv1908c
+RewriteRule ^api/(.*)$ https://mtbc.gclab.fr/api/$1 [R=302,L]
+
+# Landing page
+RewriteRule ^$ https://mtbc.gclab.fr/ [R=302,L]
+
+# Anything else keeps its path
+RewriteRule ^(.*)$ https://mtbc.gclab.fr/$1 [R=302,L]

--- a/mtbc-atlas/README.md
+++ b/mtbc-atlas/README.md
@@ -1,0 +1,19 @@
+# mtbc-atlas
+
+Persistent identifier for the **MTBC Gene Atlas**, a continuously updated, structure- and
+population-scale functional re-annotation of the *Mycobacterium tuberculosis* complex gene set,
+anchored on the MTBC0 ancestral genome. It serves one record per gene with per-layer evidence,
+dated sources and a graded confidence level, and is intended as a successor to Mycobrowser
+(EPFL/UNIBE), which is no longer maintained.
+
+- Instance redirected to: https://mtbc.gclab.fr
+- Archived releases (concept DOI, resolves to the latest): https://doi.org/10.5281/zenodo.20815246
+- Pipeline source code (MIT): https://github.com/cguyeux/mtbc-gene-atlas
+- Data licence: CC-BY 4.0
+
+Redirections are 302 rather than 301 so that the target can be changed later without clients
+caching a stale destination.
+
+Maintainer and contact: Christophe Guyeux, FEMTO-ST Institute (CNRS UMR 6174),
+Universite Marie et Louis Pasteur, Besancon, France, guyeux@gmail.com,
+GitHub @cguyeux.


### PR DESCRIPTION
Adds a persistent identifier for the **MTBC Gene Atlas**, a continuously updated, structure- and population-scale functional re-annotation of the *Mycobacterium tuberculosis* complex gene set, anchored on the MTBC0 ancestral genome. It is intended as a successor to Mycobrowser (EPFL/UNIBE), which is no longer maintained.

- Instance redirected to: https://mtbc.gclab.fr
- Archived releases (concept DOI, resolves to the latest): https://doi.org/10.5281/zenodo.20815246
- Pipeline source code (MIT): https://github.com/cguyeux/mtbc-gene-atlas
- Data licence: CC-BY 4.0

Redirects are 302 (temporary), not 301, so the target instance can move without a cached redirect locking clients to a stale destination — the convention I found used by other data-service entries in this repository (`oc`, `arco`). `Access-Control-Allow-Origin *` is set for the same reason those entries set it: without it, a browser-side client can read pages through the identifier but cannot query the REST API behind it.

Maintainer and contact: Christophe Guyeux, FEMTO-ST Institute (CNRS UMR 6174), Universite Marie et Louis Pasteur, Besancon, France, guyeux@gmail.com, GitHub @cguyeux.