### PR TITLE
Add headwater namespace

### DIFF
--- a/headwater/.htaccess
+++ b/headwater/.htaccess
@@ -1,0 +1,18 @@
+# headwater — Headwater documentation governance system
+# https://github.com/headwater-ai/headwater
+# Contact: James Baxter <james AT baxter DOT consulting> @jameswbaxter
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# Poor man's conneg
+# ------------------------------------
+RewriteCond %{REQUEST_URI} !\.[^./]+$
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(.*[^/])$ https://headwater.tools/ns/$1.ttl [R=302,L]
+
+# Human-readable documentation
+# ------------------------------------
+RewriteRule ^$ https://headwater.tools/ns/ [R=302,L]
+RewriteRule ^(.*)$ https://headwater.tools/ns/$1 [R=302,L]

--- a/headwater/README.md
+++ b/headwater/README.md
@@ -1,0 +1,26 @@
+headwater
+=========
+
+Namespace for Headwater, a documentation governance system. Identifiers under
+this namespace appear in taxonomy schemas and validation shapes that the tool
+emits, so they have to outlive any domain the project happens to rent.
+
+Prefixes
+* https://w3id.org/headwater/taxonomy/ -- taxonomy schemas (LinkML)
+* https://w3id.org/headwater/shapes/ -- validation shapes (SHACL)
+
+Homepages
+* https://headwater.tools/ -- project home
+* https://headwater.tools/ns/ -- namespace documentation
+
+Docs
+* https://github.com/headwater-ai/headwater -- source and specification
+
+Contact
+* James Baxter james AT baxter DOT consulting @jameswbaxter
+
+Notes
+* Redirects are temporary (302) while the site settles, and become permanent
+  (301) after that.
+* Requests for text/turtle or application/rdf+xml resolve to a .ttl
+  serialization. Everything else resolves to the documentation.


### PR DESCRIPTION
Adds `headwater/` for **Headwater**, a documentation governance system.

Headwater emits taxonomy schemas (LinkML) and validation shapes (SHACL) whose identifiers sit under `https://w3id.org/headwater/`. Those identifiers travel inside generated artifacts held by downstream adopters, so they need to outlive any domain the project rents — which is exactly what this service is for. LinkML, which the schemas import, publishes its metamodel the same way at `https://w3id.org/linkml/`.

**Prefixes**

- `https://w3id.org/headwater/taxonomy/` — taxonomy schemas (LinkML)
- `https://w3id.org/headwater/shapes/` — validation shapes (SHACL)

**Redirects**

Everything resolves to `https://headwater.tools/ns/`, which is live now and returns 200. Requests for `text/turtle` or `application/rdf+xml` go to a `.ttl` serialization, following the "poor man's conneg" pattern used by the neighbouring `linkml/` entry. Redirects are temporary (302) while the site settles and will become permanent (301) after that.

The project is pre-implementation, so no vocabulary is published under the prefixes yet and sub-paths currently 404. `https://w3id.org/headwater/` itself resolves to documentation of both prefixes.

**Details**

- Contact: James Baxter <james@baxter.consulting> @jameswbaxter
- Project: https://github.com/headwater-ai/headwater
- Single squashed commit, rules tested locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZBwU1Rfx4NtASPRhWXpun