### PR TITLE
Add w3id.org/tbo — The Business Ontology (TBO)

### DIFF
--- a/tbo/.htaccess
+++ b/tbo/.htaccess
@@ -1,7 +1,6 @@
 # w3id.org/tbo — The Business Ontology (TBO)
-# Contact: contact@thebusinessontology.com
-Options +FollowSymLinks
-  RewriteEngine on
+# Maintainer: @arogersonline (GitHub) — contact@thebusinessontology.com
+RewriteEngine on
 RewriteRule ^ns/(.*)$ https://tbont.org/ns/$1 [R=302,L]
 RewriteRule ^example/(.*)$ https://tbont.org/example/$1 [R=302,L]
 RewriteRule ^(.*)$ https://thebusinessontology.com/$1 [R=302,L]

--- a/tbo/.htaccess
+++ b/tbo/.htaccess
@@ -1,0 +1,7 @@
+# w3id.org/tbo — The Business Ontology (TBO)
+# Contact: contact@thebusinessontology.com
+Options +FollowSymLinks
+  RewriteEngine on
+RewriteRule ^ns/(.*)$ https://tbont.org/ns/$1 [R=302,L]
+RewriteRule ^example/(.*)$ https://tbont.org/example/$1 [R=302,L]
+RewriteRule ^(.*)$ https://thebusinessontology.com/$1 [R=302,L]

--- a/tbo/README.md
+++ b/tbo/README.md
@@ -8,4 +8,4 @@ Permanent identifiers for The Business Ontology (TBO).
 | `https://w3id.org/tbo/example/...` | `https://tbont.org/example/...` |
 | `https://w3id.org/tbo/...` | `https://thebusinessontology.com/...` |
 
-Contact: contact@thebusinessontology.com
+Maintainer: [@arogersonline](https://github.com/arogersonline) · Contact: contact@thebusinessontology.com

--- a/tbo/README.md
+++ b/tbo/README.md
@@ -1,0 +1,11 @@
+# tbo — The Business Ontology (TBO)
+
+Permanent identifiers for The Business Ontology (TBO).
+
+| Path | Redirects to |
+| --- | --- |
+| `https://w3id.org/tbo/ns/...` | `https://tbont.org/ns/...` |
+| `https://w3id.org/tbo/example/...` | `https://tbont.org/example/...` |
+| `https://w3id.org/tbo/...` | `https://thebusinessontology.com/...` |
+
+Contact: contact@thebusinessontology.com


### PR DESCRIPTION
## Brief Description
New top-level identifier `tbo` for The Business Ontology (TBO): redirects for ontology namespaces (`/tbo/ns/...`) and designated example data (`/tbo/example/...`) to project-controlled hosting at tbont.org, with a default redirect to the project home. Contact address is included in both README.md and the .htaccess comment.

## General Checklist
- [x] Changes have been tested.*
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## *Comment on testing
Changes have been tested. Simple 302 redirect rules modelled on w3id.org/examples.
Verified by (a) a rule-matrix test of the exact RewriteRule directives (10 representative
paths → expected 302 targets, with a drift check against the committed .htaccess and a
mutation self-test), and (b) an automated resolver contract on the redirect targets
(tbont.org: /ns/* and /example/* serve correctly under GET/HEAD with content negotiation;
no redirect loops across the three domains). Not run under a local httpd checkout — happy
to adjust on review.

## New ID Directory Checklist
- [x] Maintainer details are in .htaccess or README.md.
- [x] GitHub username ids are listed in the maintainer details (@arogersonline in .htaccess and README.md).

Happy for maintainers to squash the commits on merge.