### PR TITLE
Add immutable ESKA v0.1.0 version routes

### DIFF
--- a/eska/.htaccess
+++ b/eska/.htaccess
@@ -2,10 +2,9 @@
 # Point of contact: Gerhard Balz — GitHub @GerhardBalz
 # Canonical project: https://github.com/GerhardBalz/executable-semantic-knowledge-architecture
 #
-# PRE-ACTIVATION ROUTING PACKAGE.
-# This file is prepared for submission to perma-id/w3id.org/eska/.htaccess.
-# Do not treat https://w3id.org/eska as active until the upstream W3ID PR is merged
-# and these routes have been verified from an external client.
+# Permanent namespace active since perma-id/w3id.org#6530.
+# Unversioned routes follow governed main; versioned routes below resolve only to
+# immutable ESKA release tags.
 
 Options +FollowSymLinks -Indexes
 RewriteEngine On
@@ -20,12 +19,11 @@ RewriteRule ^$ https://github.com/GerhardBalz/executable-semantic-knowledge-arch
 # Human-readable documentation.
 RewriteRule ^docs/?$ https://github.com/GerhardBalz/executable-semantic-knowledge-architecture/blob/main/docs/namespace-publication-versioning.md [R=303,NE,L]
 
-# Combined RDF distribution.
+# Combined current RDF distribution.
 RewriteRule ^dist/eska\.ttl$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/main/dist/eska.ttl [R=303,NE,L]
 
 # Stable unversioned module documents. RDF clients receive raw Turtle; browsers
-# receive GitHub-rendered source. Versioned routes are intentionally not configured
-# until immutable governed release targets exist.
+# receive GitHub-rendered source.
 RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
 RewriteRule ^model/core/?$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/main/model/eska-core.ttl [R=303,NE,L]
 RewriteRule ^model/core/?$ https://github.com/GerhardBalz/executable-semantic-knowledge-architecture/blob/main/model/eska-core.ttl [R=303,NE,L]
@@ -45,3 +43,32 @@ RewriteRule ^model/agent/?$ https://github.com/GerhardBalz/executable-semantic-k
 RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
 RewriteRule ^model/deployment/?$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/main/model/eska-deployment.ttl [R=303,NE,L]
 RewriteRule ^model/deployment/?$ https://github.com/GerhardBalz/executable-semantic-knowledge-architecture/blob/main/model/eska-deployment.ttl [R=303,NE,L]
+
+# Immutable ontology-version IRIs. Each route resolves to the exact repository
+# release tag that first published that module version.
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^model/core/0\.1\.0/?$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/eska-v0.1.0/model/eska-core.ttl [R=303,NE,L]
+RewriteRule ^model/core/0\.1\.0/?$ https://github.com/GerhardBalz/executable-semantic-knowledge-architecture/blob/eska-v0.1.0/model/eska-core.ttl [R=303,NE,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^model/capability/0\.2\.0/?$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/eska-v0.1.0/model/eska-capability.ttl [R=303,NE,L]
+RewriteRule ^model/capability/0\.2\.0/?$ https://github.com/GerhardBalz/executable-semantic-knowledge-architecture/blob/eska-v0.1.0/model/eska-capability.ttl [R=303,NE,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^model/service/0\.4\.0/?$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/eska-v0.1.0/model/eska-service.ttl [R=303,NE,L]
+RewriteRule ^model/service/0\.4\.0/?$ https://github.com/GerhardBalz/executable-semantic-knowledge-architecture/blob/eska-v0.1.0/model/eska-service.ttl [R=303,NE,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^model/agent/0\.3\.0/?$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/eska-v0.1.0/model/eska-agent.ttl [R=303,NE,L]
+RewriteRule ^model/agent/0\.3\.0/?$ https://github.com/GerhardBalz/executable-semantic-knowledge-architecture/blob/eska-v0.1.0/model/eska-agent.ttl [R=303,NE,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^model/deployment/0\.1\.0/?$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/eska-v0.1.0/model/eska-deployment.ttl [R=303,NE,L]
+RewriteRule ^model/deployment/0\.1\.0/?$ https://github.com/GerhardBalz/executable-semantic-knowledge-architecture/blob/eska-v0.1.0/model/eska-deployment.ttl [R=303,NE,L]
+
+# Immutable module distribution routes defined by the ESKA publication contract.
+RewriteRule ^dist/0\.1\.0/eska-core\.ttl$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/eska-v0.1.0/model/eska-core.ttl [R=303,NE,L]
+RewriteRule ^dist/0\.2\.0/eska-capability\.ttl$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/eska-v0.1.0/model/eska-capability.ttl [R=303,NE,L]
+RewriteRule ^dist/0\.4\.0/eska-service\.ttl$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/eska-v0.1.0/model/eska-service.ttl [R=303,NE,L]
+RewriteRule ^dist/0\.3\.0/eska-agent\.ttl$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/eska-v0.1.0/model/eska-agent.ttl [R=303,NE,L]
+RewriteRule ^dist/0\.1\.0/eska-deployment\.ttl$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/eska-v0.1.0/model/eska-deployment.ttl [R=303,NE,L]

--- a/eska/README.md
+++ b/eska/README.md
@@ -1,6 +1,6 @@
 # ESKA permanent identifier configuration
 
-This directory is the prepared upstream contribution payload for:
+Permanent identifier namespace for **Executable Semantic Knowledge Architecture (ESKA)**:
 
 ```text
 https://w3id.org/eska
@@ -8,51 +8,43 @@ https://w3id.org/eska
 
 Project:
 
-- **Executable Semantic Knowledge Architecture (ESKA)**
 - Repository: `GerhardBalz/executable-semantic-knowledge-architecture`
 - Point of contact: **Gerhard Balz** — GitHub `@GerhardBalz`
 
 ## Status
 
-**Prepared, not active.**
-
-The authoritative ESKA ontology source still uses the provisional term namespace:
-
-```text
-urn:eska:core:
-```
-
-The adopted permanent target namespace is:
+**Active.** The ESKA namespace was activated by perma-id/w3id.org#6530 and externally verified before the ontology source migrated to the permanent term namespace:
 
 ```text
 https://w3id.org/eska#
 ```
 
-The `.htaccess` file in this directory must be submitted to the upstream `perma-id/w3id.org` repository under `eska/.htaccess` and merged before ESKA source ontology IRIs are migrated.
+The former `urn:eska:core:` identifiers are retained only as historical predecessors in the ESKA namespace-migration record; they are not asserted `owl:sameAs`.
 
-## Initial redirects
+## Current routes
 
-The prepared routing package provides:
+The unversioned routes represent the current governed ESKA publication and follow the repository `main` branch:
 
 - vocabulary base / hash-namespace document;
 - human-readable namespace/publication documentation;
 - combined Turtle distribution;
-- stable unversioned module routes for `core`, `capability`, `service`, `agent`, and `deployment`;
+- stable module routes for `core`, `capability`, `service`, `agent`, and `deployment`;
 - content negotiation for `text/turtle` on the vocabulary base and module routes.
 
-Versioned module routes are intentionally **not** configured yet. They will be added only when immutable governed release targets exist.
+## Immutable version routes
 
-## Activation order
+Versioned ontology and distribution routes resolve only to immutable governed ESKA release tags. The first governed repository release is:
 
 ```text
-1. Merge ESKA backend publication targets
-2. Verify public GitHub HTML/RDF backend URLs
-3. Fork perma-id/w3id.org
-4. Copy this directory to w3id.org/eska/
-5. Submit W3ID PR
-6. Wait for upstream merge
-7. Verify https://w3id.org/eska externally
-8. Only then migrate ESKA terms/ontology IRIs atomically
+eska-v0.1.0
 ```
 
-This ordering prevents the repository from claiming persistent semantic identifiers before the redirect infrastructure actually exists.
+It publishes these module versions:
+
+- core `0.1.0`
+- capability `0.2.0`
+- service `0.4.0`
+- agent `0.3.0`
+- deployment `0.1.0`
+
+Repository release versions and ontology-module semantic versions are intentionally independent.


### PR DESCRIPTION
Add immutable versioned routes for the first governed ESKA release, eska-v0.1.0.

The existing unversioned https://w3id.org/eska routes remain unchanged and continue to represent the current ESKA publication.

This update adds versioned ontology and distribution routes for:

* core 0.1.0
* capability 0.2.0
* service 0.4.0
* agent 0.3.0
* deployment 0.1.0

All versioned routes resolve to the immutable Git tag eska-v0.1.0, not to the mutable main branch.

It also updates the comments in .htaccess to reflect that the ESKA namespace is now active following #6530.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## Update ID Directory Checklist

- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directory being changed.