### PR TITLE
Add w3id.org/fyndling namespace (TEI edition of medieval cooking recipes)

### DIFF
--- a/fyndling/.htaccess
+++ b/fyndling/.htaccess
@@ -1,0 +1,41 @@
+# https://w3id.org/fyndling
+#
+# Fyndling: medieval cooking recipes as a digital edition in TEI-P5.
+# 2315 recipes from 34 manuscripts and early prints, 14th to 16th century,
+# each with a diplomatic transcription, a modern German translation and
+# editorial notes.
+#
+# Dataset (TEI-P5, one file per recipe):
+#   https://github.com/neongrau/fyndling-tei
+# Human readable edition:
+#   https://fyndling.de/rezepte/
+#
+# Maintainer and contact: see README.md in this directory.
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# Recipe identifiers are <book>-<number> with an optional letter for
+# sub-recipes: bgs-001, bgs-074a, m5919-101, ri15632-001, w1-059.
+# 34 book prefixes, lowercase, digits allowed inside the prefix.
+# A trailing slash is tolerated.
+
+# 1. TEI-P5 source, for machines.
+#
+# Only application/tei+xml triggers this branch, deliberately not the generic
+# application/xml or text/xml: a browser sends
+#   text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
+# and would be sent to the XML file by a generic match.
+#
+# The target serves exactly one content type per URL. That is a requirement,
+# not a preference: the origin sits behind a CDN that varies its cache only on
+# Accept-Encoding, so two Accept-dependent variants of one URL would be mixed
+# up in the cache. Negotiation therefore happens here and nowhere else.
+RewriteCond %{HTTP_ACCEPT} application/tei\+xml
+RewriteRule ^([a-z][a-z0-9]{1,7}-[0-9]{1,4}[a-z]?)/?$ https://fyndling.de/rezepte-data/tei/$1.xml [R=302,L]
+
+# 2. Everything else, browsers included, gets the human readable page.
+RewriteRule ^([a-z][a-z0-9]{1,7}-[0-9]{1,4}[a-z]?)/?$ https://fyndling.de/rezepte/$1/ [R=302,L]
+
+# 3. Bare namespace and anything unrecognised: the collection itself.
+RewriteRule ^(.*)$ https://fyndling.de/rezepte/ [R=302,L]

--- a/fyndling/README.md
+++ b/fyndling/README.md
@@ -1,0 +1,78 @@
+# w3id.org/fyndling
+
+Persistent identifiers for **Fyndling**, a digital edition of medieval cooking
+recipes in TEI-P5.
+
+The edition currently holds **2315 recipes from 34 manuscripts and early
+prints**, dating from the 14th to the 16th century. Every recipe carries a
+diplomatic transcription of its source, a modern German translation, ingredient
+normdata with recorded provenance, and editorial notes that keep open readings
+open instead of resolving them silently.
+
+- Dataset, one TEI file per recipe: https://github.com/neongrau/fyndling-tei
+- Human readable edition: https://fyndling.de/rezepte/
+
+## Identifier scheme
+
+```
+https://w3id.org/fyndling/{recipe-id}
+```
+
+A recipe id is a book prefix, a hyphen, and a number, with an optional letter
+for sub-recipes:
+
+| Identifier | Resolves to |
+|---|---|
+| `https://w3id.org/fyndling/bgs-001` | recipe 1 of *Das Buch von guter Speise* (Wuerzburg, ca. 1350) |
+| `https://w3id.org/fyndling/bgs-074a` | sub-recipe 74a of the same book |
+| `https://w3id.org/fyndling/ri15632-001` | recipe 1 of Vienna, ONB Cod. 15632 |
+
+The identifiers are stable by construction. They are derived from the source
+book and the recipe's position in its edition, not from a database key, and
+they do not change when metadata, translation or annotations are revised.
+
+## Content negotiation
+
+| Accept | Target |
+|---|---|
+| `application/tei+xml` | `https://fyndling.de/rezepte-data/tei/{id}.xml` |
+| anything else | `https://fyndling.de/rezepte/{id}/` |
+
+All redirects are `302`. The identifier is the stable part; the targets may
+move, and a temporary redirect keeps that possible without stale caches.
+
+Only `application/tei+xml` selects the TEI branch. The generic `application/xml`
+and `text/xml` are deliberately not matched, because browsers send
+`application/xml;q=0.9` in their default Accept header and would otherwise be
+sent to the source file instead of the page.
+
+Example:
+
+```sh
+curl -sI -H "Accept: application/tei+xml" https://w3id.org/fyndling/bgs-001
+curl -sI                                  https://w3id.org/fyndling/bgs-001
+```
+
+## Licence
+
+The edition is mixed licensed and every TEI file states its own licence
+machine readably in
+`teiHeader/fileDesc/publicationStmt/availability/licence/@target`:
+
+- 2297 recipes under CC BY-SA 4.0
+- 18 recipes under CC BY-NC-SA 4.0
+
+The historical texts themselves are in the public domain. The transcriptions
+are third party work and are credited per file in `sourceDesc`, chiefly to
+CoReMA (Cooking Recipes of the Middle Ages, ed. Helmut W. Klug, University of
+Graz, CC BY 4.0) and to Thomas Gloning, University of Giessen. Translations,
+annotations and normdata are ours.
+
+## Contact
+
+- GitHub: [@neongrau](https://github.com/neongrau)
+- Project imprint with postal address and email:
+  https://fyndling.de/impressum.html
+
+Please report problems with the identifiers as an issue on
+https://github.com/neongrau/fyndling-tei.


### PR DESCRIPTION
Requesting the top level directory `fyndling` for a TEI-P5 digital edition of medieval cooking recipes.

## What the identifiers name

**Fyndling** is a digital edition of **2315 cooking recipes from 34 manuscripts and early prints**, dating from the 14th to the 16th century. Each recipe carries a diplomatic transcription of its source, a modern German translation, ingredient normdata with recorded provenance, and editorial notes.

- Dataset, one TEI file per recipe: https://github.com/neongrau/fyndling-tei
- Human readable edition: https://fyndling.de/rezepte/

The identifiers are stable by construction: they are derived from the source book and the recipe's position in its edition, not from a database key, so they do not change when a translation or an annotation is revised.

## Redirects

| Accept | Target |
|---|---|
| `application/tei+xml` | `https://fyndling.de/rezepte-data/tei/{id}.xml` |
| anything else | `https://fyndling.de/rezepte/{id}/` |
| bare namespace or unrecognised path | `https://fyndling.de/rezepte/` |

All redirects are `302`, following the practice of the surrounding namespaces: the identifier is the stable part, the targets may move.

Two deliberate details:

**Only `application/tei+xml` selects the TEI branch.** The generic `application/xml` and `text/xml` are not matched, because a browser sends `text/html,application/xhtml+xml,application/xml;q=0.9,*/*` and a generic match would send every browser to the source file instead of the page.

**Each target serves exactly one content type.** The TEI endpoint always answers `application/tei+xml; charset=utf-8`. That is a requirement rather than a preference: the origin sits behind a CDN that varies its cache only on `Accept-Encoding`, so two Accept dependent variants of one URL would be mixed up in the cache. Negotiation therefore happens in this `.htaccess` and nowhere downstream.

## Verification

Tested locally with Apache 2.4.66 and `mod_rewrite` under `AllowOverride All`, the setup this repository used in its CI:

```
/fyndling/bgs-001      Accept: application/tei+xml   302 -> fyndling.de/rezepte-data/tei/bgs-001.xml
/fyndling/bgs-074a     Accept: application/tei+xml   302 -> fyndling.de/rezepte-data/tei/bgs-074a.xml
/fyndling/ri15632-001  Accept: application/tei+xml   302 -> fyndling.de/rezepte-data/tei/ri15632-001.xml
/fyndling/bgs-001      no Accept                     302 -> fyndling.de/rezepte/bgs-001/
/fyndling/bgs-001      browser Accept                302 -> fyndling.de/rezepte/bgs-001/
/fyndling/w1-059/      trailing slash                302 -> fyndling.de/rezepte/w1-059/
/fyndling/             fallback                      302 -> fyndling.de/rezepte/
```

All 2315 target URLs are live on both branches; the identifier pattern was checked against every id in the dataset.

## Licence and attribution

The edition is mixed licensed and every TEI file states its own licence machine readably in `teiHeader/fileDesc/publicationStmt/availability/licence/@target`: 2297 recipes under CC BY-SA 4.0, 18 under CC BY-NC-SA 4.0. The historical texts are in the public domain; the transcriptions are third party work, credited per file in `sourceDesc`, chiefly to CoReMA (Cooking Recipes of the Middle Ages, ed. Helmut W. Klug, University of Graz, CC BY 4.0) and to Thomas Gloning, University of Giessen.

Contact information is in `fyndling/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
