### PR TITLE
Add SMO permanent identifier redirects

### DIFF
--- a/smo/.htaccess
+++ b/smo/.htaccess
@@ -1,0 +1,23 @@
+# SMO — Semantic Modeling Ontology
+# Point of contact: Gerhard Balz — GitHub @GerhardBalz
+# Canonical project: https://github.com/GerhardBalz/semantic-modeling-ontology
+#
+# Initial activation payload for https://w3id.org/smo
+# Only current routes are activated at this stage. Immutable version routes are
+# added only after the governed smo-v0.1.0 release tag exists.
+
+Options +FollowSymLinks -Indexes
+RewriteEngine On
+
+# Vocabulary base / hash namespace document.
+# RDF clients receive authoritative Turtle; browsers receive project documentation.
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^$ https://raw.githubusercontent.com/GerhardBalz/semantic-modeling-ontology/main/model/smo.ttl [R=303,NE,L]
+
+RewriteRule ^$ https://github.com/GerhardBalz/semantic-modeling-ontology [R=303,NE,L]
+
+# Human-readable namespace/publication documentation.
+RewriteRule ^docs/?$ https://github.com/GerhardBalz/semantic-modeling-ontology/blob/main/docs/namespace-publication-versioning.md [R=303,NE,L]
+
+# Current explicit Turtle distribution route.
+RewriteRule ^dist/smo\.ttl$ https://raw.githubusercontent.com/GerhardBalz/semantic-modeling-ontology/main/model/smo.ttl [R=303,NE,L]

--- a/smo/README.md
+++ b/smo/README.md
@@ -1,0 +1,30 @@
+# SMO — Semantic Modeling Ontology
+
+Permanent identifier namespace for the Semantic Modeling Ontology (SMO):
+
+```text
+https://w3id.org/smo
+```
+
+## Maintainer
+
+- Gerhard Balz — GitHub [`@GerhardBalz`](https://github.com/GerhardBalz)
+
+## Canonical project
+
+- Repository: `GerhardBalz/semantic-modeling-ontology`
+- Term namespace: `https://w3id.org/smo#`
+- Ontology IRI: `https://w3id.org/smo`
+
+## Initial activation scope
+
+This initial W3ID request activates only current governed publication routes:
+
+- browser requests for `https://w3id.org/smo` → project repository;
+- Turtle requests for `https://w3id.org/smo` → `main/model/smo.ttl`;
+- `https://w3id.org/smo/docs` → namespace/publication documentation;
+- `https://w3id.org/smo/dist/smo.ttl` → current authoritative Turtle.
+
+The ontology declares `owl:versionIRI <https://w3id.org/smo/0.1.0>`, but no immutable version redirect is included in this activation request. That route will be added only after the governed `smo-v0.1.0` release tag exists, so an immutable identifier never points to a mutable or nonexistent backend.
+
+GitHub and raw GitHub URLs are replaceable publication backends, not SMO semantic identities.


### PR DESCRIPTION
## Brief Description

Add the initial permanent identifier routes for the Semantic Modeling Ontology (SMO) at `https://w3id.org/smo`.

This activation intentionally includes only current routes. Immutable `0.1.0` routes are deferred until the governed `smo-v0.1.0` release target exists.

## General Checklist

- [x] Changes have been tested against the prepared SMO publication contract.
- [x] The number of commits is minimal: one focused commit.
- [x] Commits only include redirects and basic information. Content remains hosted in the governed SMO repository.

## New ID Directory Checklist

- [x] Maintainer details are included in `.htaccess` and `README.md`.
- [x] GitHub username `@GerhardBalz` is listed in the maintainer details.

## Routes

- Browser requests for `https://w3id.org/smo` → governed SMO repository.
- Turtle requests for `https://w3id.org/smo` → current authoritative `model/smo.ttl`.
- `https://w3id.org/smo/docs` → namespace/publication documentation.
- `https://w3id.org/smo/dist/smo.ttl` → current authoritative Turtle.

GitHub and raw GitHub URLs are replaceable publication backends, not SMO semantic identities.

Related project issue: GerhardBalz/semantic-modeling-ontology#5.
