### PR TITLE
Add immutable SMO v0.1.0 redirects

### DIFF
--- a/smo/.htaccess
+++ b/smo/.htaccess
@@ -2,9 +2,9 @@
 # Point of contact: Gerhard Balz — GitHub @GerhardBalz
 # Canonical project: https://github.com/GerhardBalz/semantic-modeling-ontology
 #
-# Initial activation payload for https://w3id.org/smo
-# Only current routes are activated at this stage. Immutable version routes are
-# added only after the governed smo-v0.1.0 release tag exists.
+# Current permanent namespace active since perma-id/w3id.org#6538.
+# Unversioned routes follow governed main; versioned routes below resolve only to
+# the immutable governed smo-v0.1.0 release tag.
 
 Options +FollowSymLinks -Indexes
 RewriteEngine On
@@ -21,3 +21,12 @@ RewriteRule ^docs/?$ https://github.com/GerhardBalz/semantic-modeling-ontology/b
 
 # Current explicit Turtle distribution route.
 RewriteRule ^dist/smo\.ttl$ https://raw.githubusercontent.com/GerhardBalz/semantic-modeling-ontology/main/model/smo.ttl [R=303,NE,L]
+
+# Immutable ontology-version IRI. RDF clients receive authoritative Turtle from
+# the governed release tag; browsers receive the same immutable source via GitHub.
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^0\.1\.0/?$ https://raw.githubusercontent.com/GerhardBalz/semantic-modeling-ontology/smo-v0.1.0/model/smo.ttl [R=303,NE,L]
+RewriteRule ^0\.1\.0/?$ https://github.com/GerhardBalz/semantic-modeling-ontology/blob/smo-v0.1.0/model/smo.ttl [R=303,NE,L]
+
+# Immutable Turtle distribution route for SMO v0.1.0.
+RewriteRule ^0\.1\.0/dist/smo\.ttl$ https://raw.githubusercontent.com/GerhardBalz/semantic-modeling-ontology/smo-v0.1.0/model/smo.ttl [R=303,NE,L]

--- a/smo/README.md
+++ b/smo/README.md
@@ -16,15 +16,36 @@ https://w3id.org/smo
 - Term namespace: `https://w3id.org/smo#`
 - Ontology IRI: `https://w3id.org/smo`
 
-## Initial activation scope
+## Current routes
 
-This initial W3ID request activates only current governed publication routes:
+The current W3ID namespace was activated through `perma-id/w3id.org#6538`:
 
 - browser requests for `https://w3id.org/smo` → project repository;
 - Turtle requests for `https://w3id.org/smo` → `main/model/smo.ttl`;
-- `https://w3id.org/smo/docs` → namespace/publication documentation;
+- `https://w3id.org/smo/docs` → current namespace/publication documentation;
 - `https://w3id.org/smo/dist/smo.ttl` → current authoritative Turtle.
 
-The ontology declares `owl:versionIRI <https://w3id.org/smo/0.1.0>`, but no immutable version redirect is included in this activation request. That route will be added only after the governed `smo-v0.1.0` release tag exists, so an immutable identifier never points to a mutable or nonexistent backend.
+## Governed immutable v0.1.0 release
+
+The first governed repository release exists as:
+
+```text
+release tag     smo-v0.1.0
+release commit  e6ab3f8cf14bafae466a0150ad356547f164bdab
+```
+
+The ontology declares:
+
+```text
+owl:versionIRI <https://w3id.org/smo/0.1.0>
+```
+
+The immutable version routes resolve only to the governed `smo-v0.1.0` release tag:
+
+- browser requests for `https://w3id.org/smo/0.1.0` → tagged `model/smo.ttl` on GitHub;
+- Turtle requests for `https://w3id.org/smo/0.1.0` → tagged raw `model/smo.ttl`;
+- `https://w3id.org/smo/0.1.0/dist/smo.ttl` → tagged raw `model/smo.ttl`.
+
+No immutable route targets mutable `main`.
 
 GitHub and raw GitHub URLs are replaceable publication backends, not SMO semantic identities.


### PR DESCRIPTION
## Brief Description

Add immutable version routes for the published Semantic Modeling Ontology (SMO) v0.1.0 release.

The current SMO namespace is already active through #6538. The governed `smo-v0.1.0` release exists and points to commit `e6ab3f8cf14bafae466a0150ad356547f164bdab`.

This update adds only immutable version routing; existing current routes are preserved unchanged.

## General Checklist

- [x] Changes have been tested against the published immutable backend.
- [x] The number of commits is minimal: one focused commit.
- [x] Commits only include redirects and basic information. Content remains hosted in the governed SMO repository.

## New ID Directory Checklist

Not applicable: this updates the existing `smo/` W3ID directory.

## Update ID Directory Checklist

- [x] GitHub username `@GerhardBalz` remains listed in the maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer.

## Immutable Routes

- Browser requests for `https://w3id.org/smo/0.1.0` → tagged `smo-v0.1.0/model/smo.ttl` on GitHub.
- Turtle requests for `https://w3id.org/smo/0.1.0` → tagged raw `smo-v0.1.0/model/smo.ttl`.
- `https://w3id.org/smo/0.1.0/dist/smo.ttl` → tagged raw `smo-v0.1.0/model/smo.ttl`.

Every immutable route targets `smo-v0.1.0`; none targets mutable `main`.

Related project issue: GerhardBalz/semantic-modeling-ontology#10.