### PR TITLE
Add immutable ESKA core 0.2.0 redirects

### DIFF
--- a/eska/.htaccess
+++ b/eska/.htaccess
@@ -51,6 +51,10 @@ RewriteRule ^model/core/0\.1\.0/?$ https://raw.githubusercontent.com/GerhardBalz
 RewriteRule ^model/core/0\.1\.0/?$ https://github.com/GerhardBalz/executable-semantic-knowledge-architecture/blob/eska-v0.1.0/model/eska-core.ttl [R=303,NE,L]
 
 RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^model/core/0\.2\.0/?$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/eska-v0.2.0/model/eska-core.ttl [R=303,NE,L]
+RewriteRule ^model/core/0\.2\.0/?$ https://github.com/GerhardBalz/executable-semantic-knowledge-architecture/blob/eska-v0.2.0/model/eska-core.ttl [R=303,NE,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
 RewriteRule ^model/capability/0\.2\.0/?$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/eska-v0.1.0/model/eska-capability.ttl [R=303,NE,L]
 RewriteRule ^model/capability/0\.2\.0/?$ https://github.com/GerhardBalz/executable-semantic-knowledge-architecture/blob/eska-v0.1.0/model/eska-capability.ttl [R=303,NE,L]
 
@@ -68,6 +72,7 @@ RewriteRule ^model/deployment/0\.1\.0/?$ https://github.com/GerhardBalz/executab
 
 # Immutable module distribution routes defined by the ESKA publication contract.
 RewriteRule ^dist/0\.1\.0/eska-core\.ttl$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/eska-v0.1.0/model/eska-core.ttl [R=303,NE,L]
+RewriteRule ^dist/0\.2\.0/eska-core\.ttl$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/eska-v0.2.0/model/eska-core.ttl [R=303,NE,L]
 RewriteRule ^dist/0\.2\.0/eska-capability\.ttl$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/eska-v0.1.0/model/eska-capability.ttl [R=303,NE,L]
 RewriteRule ^dist/0\.4\.0/eska-service\.ttl$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/eska-v0.1.0/model/eska-service.ttl [R=303,NE,L]
 RewriteRule ^dist/0\.3\.0/eska-agent\.ttl$ https://raw.githubusercontent.com/GerhardBalz/executable-semantic-knowledge-architecture/eska-v0.1.0/model/eska-agent.ttl [R=303,NE,L]

--- a/eska/README.md
+++ b/eska/README.md
@@ -33,18 +33,29 @@ The unversioned routes represent the current governed ESKA publication and follo
 
 ## Immutable version routes
 
-Versioned ontology and distribution routes resolve only to immutable governed ESKA release tags. The first governed repository release is:
+Versioned ontology and distribution routes resolve only to immutable governed ESKA release tags.
+
+The first governed repository release is `eska-v0.1.0`. It remains the immutable backend for:
+
+- core `0.1.0`;
+- capability `0.2.0`;
+- service `0.4.0`;
+- agent `0.3.0`;
+- deployment `0.1.0`.
+
+The second governed repository release is:
 
 ```text
-eska-v0.1.0
+eska-v0.2.0
 ```
 
-It publishes these module versions:
+It adds the immutable backend for core `0.2.0`:
 
-- core `0.1.0`
-- capability `0.2.0`
-- service `0.4.0`
-- agent `0.3.0`
-- deployment `0.1.0`
+```text
+https://w3id.org/eska/model/core/0.2.0
+https://w3id.org/eska/dist/0.2.0/eska-core.ttl
+```
+
+Both core `0.2.0` routes target only `eska-v0.2.0`; they do not target mutable `main`.
 
 Repository release versions and ontology-module semantic versions are intentionally independent.


### PR DESCRIPTION
## Brief Description

Add immutable version routes for ESKA core 0.2.0.

The ESKA namespace and first immutable module-version routes are already active through #6530 and #6535.

The governed `eska-v0.2.0` release exists and points to commit `a6ce0b9e795d271dce8a2b7be93d44932e8448d4`.

This update adds only the new immutable core 0.2.0 routes. Existing current routes and previously published immutable routes are preserved unchanged.

## General Checklist

- [x] Changes have been tested against the published immutable backend.
- [x] The number of commits is minimal: one focused commit.
- [x] Commits only include redirects and basic information. Content remains hosted in the governed ESKA repository.

## New ID Directory Checklist

Not applicable: this updates the existing `eska/` W3ID directory.

## Update ID Directory Checklist

- [x] GitHub username `@GerhardBalz` remains listed in the maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer.

## Immutable Routes

- Browser requests for `https://w3id.org/eska/model/core/0.2.0` → tagged `eska-v0.2.0/model/eska-core.ttl` on GitHub.
- Turtle requests for `https://w3id.org/eska/model/core/0.2.0` → tagged raw `eska-v0.2.0/model/eska-core.ttl`.
- `https://w3id.org/eska/dist/0.2.0/eska-core.ttl` → tagged raw `eska-v0.2.0/model/eska-core.ttl`.

Every new immutable route targets `eska-v0.2.0`; none targets mutable `main`.

Related project issue: GerhardBalz/executable-semantic-knowledge-architecture#87.
