### PR TITLE
Add iaic (Industrial AI Connective ontology namespace)

### DIFF
--- a/iaic/.htaccess
+++ b/iaic/.htaccess
@@ -1,0 +1,20 @@
+# w3id.org/iaic — Industrial AI Connective (IAIC)
+# Permanent identifier namespace for the IAIC industrial value-chain
+# ontology: a cross-industry kernel plus per-industry bindings.
+# Redirects to the project host at iaiconnective.org.
+#
+# Contact: Venkitesh Ramadas <vramadas@nextoar.com>
+# GitHub:  https://github.com/vramada
+
+Options -MultiViews
+
+RewriteEngine on
+
+# Redirect everything under /iaic/ to the corresponding path on the
+# project host, preserving sub-paths:
+#   https://w3id.org/iaic/core/Activity
+#     -> https://iaiconnective.org/core/Activity
+#
+# 302 (temporary) while the project site is being stood up; will be
+# switched to 301 once published content is stable.
+RewriteRule ^(.*)$ https://iaiconnective.org/$1 [R=302,L]

--- a/iaic/README.md
+++ b/iaic/README.md
@@ -1,0 +1,26 @@
+# w3id.org/iaic
+
+Permanent identifier namespace for the **Industrial AI Connective (IAIC)**
+ontology project: an open cross-industry kernel ontology for industrial
+value chains (parties, resources, units of work, activities, flows,
+specifications, measurements, commitments, and physical-constraint
+validation), together with per-industry binding ontologies
+(semiconductor first).
+
+All identifiers under `https://w3id.org/iaic/` redirect to the
+corresponding path on the project host, `https://iaiconnective.org/`.
+
+Planned identifier spaces:
+
+| Space | Example |
+|---|---|
+| `iaic/core/` | `https://w3id.org/iaic/core/Activity` |
+| `iaic/physics/` | `https://w3id.org/iaic/physics/Conservation` |
+| `iaic/ind/<industry>/` | `https://w3id.org/iaic/ind/semiconductor/WaferLot` |
+| `iaic/shapes/` | SHACL validation shapes |
+| `iaic/xwalk/` | crosswalks to BFO/IOF, SCOR, ISA-95 |
+
+## Contact
+
+- Venkitesh Ramadas — <vramadas@nextoar.com>
+- GitHub: [vramada](https://github.com/vramada)


### PR DESCRIPTION
Registers `w3id.org/iaic` for the Industrial AI Connective ontology project — an open cross-industry kernel ontology for industrial value chains, with per-industry bindings (semiconductor first).

Redirects to https://iaiconnective.org/ (domain held by the project).

Contact: vramadas@nextoar.com

302 for now; will switch to 301 once published content is stable.