### PR TITLE
Add persistent identifier for VTMO20 ontology

### DIFF
--- a/vtmo/.htaccess
+++ b/vtmo/.htaccess
@@ -1,0 +1,26 @@
+# VTMO20 - Vietnamese Traditional Medicinal Plant Ontology
+# Persistent Identifier Configuration
+#
+# Maintainer: Tran Phong Vu
+# GitHub: https://github.com/phongvutayninh
+# Repository: https://github.com/phongvutayninh/VTMO20
+
+RewriteEngine On
+
+# ------------------------------------------------------------
+# VTMO20 ontology - canonical ontology IRI
+# ------------------------------------------------------------
+
+RewriteRule ^ontology/?$ https://github.com/phongvutayninh/VTMO20/releases/download/v1.0.0/VTMO20_Core_v1.0_Public.rdf [R=303,L]
+
+# ------------------------------------------------------------
+# VTMO20 ontology - version 1.0.0
+# ------------------------------------------------------------
+
+RewriteRule ^ontology/1\.0\.0/?$ https://github.com/phongvutayninh/VTMO20/releases/download/v1.0.0/VTMO20_Core_v1.0_Public.rdf [R=303,L]
+
+# ------------------------------------------------------------
+# VTMO20 namespace root
+# ------------------------------------------------------------
+
+RewriteRule ^$ https://github.com/phongvutayninh/VTMO20 [R=302,L]

--- a/vtmo/README.md
+++ b/vtmo/README.md
@@ -1,0 +1,43 @@
+# VTMO20 Persistent Identifier
+
+This directory provides persistent identifiers for the Vietnamese Traditional Medicinal Plant Ontology (VTMO20).
+
+## Ontology
+
+**Name:** Vietnamese Traditional Medicinal Plant Ontology  
+**Acronym:** VTMO20  
+**Ontology IRI:** https://w3id.org/vtmo/ontology  
+**Version IRI:** https://w3id.org/vtmo/ontology/1.0.0  
+**Current public core version:** 1.0.0
+
+VTMO20 is a competency-driven OWL ontology developed for the structured representation and semantic retrieval of Vietnamese traditional medicinal plant knowledge.
+
+## Persistent Identifier Policy
+
+The `https://w3id.org/vtmo/` namespace provides persistent identifiers for VTMO20 resources.
+
+The ontology identifier:
+
+https://w3id.org/vtmo/ontology
+
+is intended to provide a persistent entry point for the VTMO20 ontology.
+
+Version-specific identifiers under:
+
+https://w3id.org/vtmo/ontology/
+
+are intended to identify stable ontology releases.
+
+## Repository
+
+The source repository, documentation, and public ontology releases are maintained in the VTMO20 GitHub repository.
+
+## Maintainer
+
+**Trần Phong Vũ**
+
+GitHub: **phongvutayninh**
+
+## Contact
+
+For questions concerning the VTMO20 persistent identifier namespace, please contact the maintainer through the VTMO20 GitHub repository.


### PR DESCRIPTION
## Brief Description

This pull request adds a persistent identifier configuration for VTMO20 (Vietnamese Traditional Medicinal Plant Ontology).

VTMO20 is a competency-driven OWL ontology developed for structured representation and semantic retrieval of Vietnamese traditional medicinal plant knowledge.

## Persistent Identifier

Ontology IRI:

https://w3id.org/vtmo/ontology

Version IRI:

https://w3id.org/vtmo/ontology/1.0.0

## Redirect Target

The persistent identifier redirects to the public VTMO20 Core v1.0.0 ontology release hosted in the VTMO20 GitHub repository.

## Repository

https://github.com/phongvutayninh/VTMO20

## Configuration

The new `/vtmo/` namespace contains:

- `.htaccess` – redirect configuration for the ontology IRI and version IRI
- `README.md` – documentation of the VTMO20 persistent identifier namespace

## Maintainer

Trần Phong Vũ  
GitHub: phongvutayninh

## Validation

The VTMO20 Core v1.0.0 public ontology has been validated through RDF/XML parsing, Apache Jena Fuseki loading, ontology metadata inspection, component counting, entity-level semantic inspection, and SPARQL-based competency-question testing.