### PR TITLE
Repoint catalysis-data-format at EmpaEconversion

### DIFF
--- a/catalysis-data-format/.htaccess
+++ b/catalysis-data-format/.htaccess
@@ -1,22 +1,73 @@
-Options -MultiViews
-ErrorDocument 404 /errors/404.html
+# This namespace is maintained by Empa, Materials for Energy Conversion.
+# https://github.com/EmpaEconversion/catalysis-data-format-ontology
+#
+# Current maintainers are:
+# Corsin Battaglia (https://github.com/CorsinBattaglia) - Empa
+# Graham Kimbell (https://github.com/g-kimbell) - Empa
+#
+# Catalysis Data Format (CDF), a tabular format for electrochemical catalysis
+# time-series data, extending the Battery Data Format (BDF).
+
+Options +FollowSymLinks
+RewriteEngine On
 
 Header set Access-Control-Allow-Origin *
-Options +FollowSymLinks
 
-# Redirect ontology IRI with content negotiation
-RewriteEngine on
+# ==============================================
+# Non-versioned
+# ==============================================
 
-# ── Ontology TTL (exact path) ──────────────────────────────────────────────
-# Machines requesting Turtle
-RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
-RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
-RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
-RewriteCond %{HTTP_ACCEPT} \*/\*
-RewriteRule ^ontology/catalysis-data-format$ https://catalysis-data-alliance.github.io/catalysis-data-format-ontology/catalysis-data-format.ttl [R=303,L]
+# [R1] /ontology -> the rendered term reference for browsers with anchors for terms.
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteRule ^ontology/?$ https://empaeconversion.github.io/catalysis-data-format-ontology/ [R=303,NE,L]
 
-# Browsers (HTML) for the ontology IRI
-RewriteRule ^ontology/catalysis-data-format$ https://github.com/catalysis-data-alliance/catalysis-data-format [R=303,L]
+# [R2] /ontology -> JSON-LD context when explicitly requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^ontology/?$ https://empaeconversion.github.io/catalysis-data-format-ontology/context/context.json [R=303,NE,L]
 
-# ── Catch-all for any sub-path ────────────────────────────────────────────
-RewriteRule ^(.*)$ https://github.com/catalysis-data-alliance/catalysis-data-format/$1 [R=303,L]
+# [R3] /ontology -> Turtle fallback for all other agents
+RewriteRule ^ontology/?$ https://empaeconversion.github.io/catalysis-data-format-ontology/catalysis-data-format.ttl [R=303,NE,L]
+
+# [R4] /context
+RewriteRule ^context/?$ https://empaeconversion.github.io/catalysis-data-format-ontology/context/context.json [R=303,NE,L]
+
+# [R5] /schema/vendors/{vendor} -- must precede R6
+RewriteRule ^schema/vendors/([^/]+)/?$ https://empaeconversion.github.io/catalysis-data-format-ontology/schema/vendors/$1.json [R=303,NE,L]
+
+# [R6] /schema
+RewriteRule ^schema/?$ https://empaeconversion.github.io/catalysis-data-format-ontology/schema/schema.json [R=303,NE,L]
+
+# [R7] /source -> Turtle from the default branch
+RewriteRule ^source/?$ https://raw.githubusercontent.com/EmpaEconversion/catalysis-data-format-ontology/main/catalysis-data-format.ttl [R=303,NE,L]
+
+# ==============================================
+# Versioned
+# ==============================================
+
+# [R8] /{version}/ontology -> HTML for browsers
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/ontology/?$ https://empaeconversion.github.io/catalysis-data-format-ontology/versions/$1/ [R=303,NE,L]
+
+# [R9] /{version}/ontology -> JSON-LD context when explicitly requested
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/ontology/?$ https://empaeconversion.github.io/catalysis-data-format-ontology/versions/$1/context/context.json [R=303,NE,L]
+
+# [R10] /{version}/ontology -> Turtle fallback
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/ontology/?$ https://empaeconversion.github.io/catalysis-data-format-ontology/versions/$1/catalysis-data-format.ttl [R=303,NE,L]
+
+# [R11] /{version}/context
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/context/?$ https://empaeconversion.github.io/catalysis-data-format-ontology/versions/$1/context/context.json [R=303,NE,L]
+
+# [R12] /{version}/schema/vendors/{vendor} -- must precede R13
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/schema/vendors/([^/]+)/?$ https://empaeconversion.github.io/catalysis-data-format-ontology/versions/$1/schema/vendors/$2.json [R=303,NE,L]
+
+# [R13] /{version}/schema
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/schema/?$ https://empaeconversion.github.io/catalysis-data-format-ontology/versions/$1/schema/schema.json [R=303,NE,L]
+
+# ==============================================
+# Catch-all
+# ==============================================
+
+RewriteRule ^(.*)$ https://empaeconversion.github.io/catalysis-data-format-ontology/$1 [R=303,NE,L]

--- a/catalysis-data-format/README.md
+++ b/catalysis-data-format/README.md
@@ -1,17 +1,28 @@
 # catalysis-data-format
 
-**Catalysis Data Format (CDF)** — a standardised tabular format for electrochemical catalysis (electrolysis) time-series data.
+**Catalysis Data Format (CDF)**, a standardised tabular format for electrochemical
+catalysis (electrolysis) time-series data, extending the
+[Battery Data Format](https://w3id.org/battery-data-alliance/ontology/battery-data-format).
 
 | Field | Value |
 |-------|-------|
 | Namespace | `https://w3id.org/catalysis-data-format/` |
-| Maintainer | CorsinBattaglia |
-| GitHub | https://github.com/catalysis-data-alliance/catalysis-data-format |
-| Contact | 104415854+CorsinBattaglia@users.noreply.github.com |
+| Organisation | Empa, Materials for Energy Conversion |
+| GitHub | https://github.com/EmpaEconversion/catalysis-data-format-ontology |
+
+## Maintainers
+
+- Corsin Battaglia (https://github.com/CorsinBattaglia), Empa
+- Graham Kimbell (https://github.com/g-kimbell) - Empa
 
 ## Namespace structure
 
 | Path | Resolves to |
 |------|-------------|
-| `/ontology/catalysis-data-format` | Ontology TTL (machines) / GitHub repo (browsers) |
-| `/catalysis-data-format/*` | GitHub repo (catch-all) |
+| `/ontology` | Turtle (machines), JSON-LD context (`application/ld+json`), repo (browsers) |
+| `/ontology#{term}` | Term IRIs, dereference to the ontology above |
+| `/context` | JSON-LD context |
+| `/schema` | CSVW table schema |
+| `/schema/vendors/{vendor}` | Instrument-specific column mapping |
+| `/source` | Turtle from the default branch |
+| `/{version}/...` | Versioned snapshot of any of the above |


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
Repoints the `catalysis-data-format` namespace to the live site at https://empaeconversion.github.io/catalysis-data-format-ontology/, and adds content negotiation/versioned paths. The namespace currently points to a deleted org and every IRI returns 404. Nothing that currently resolves is affected by this change.

Adds @g-kimbell to the maintainer list.

@CorsinBattaglia registered this namespace and is its listed maintainer, tagging for approval.

<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
