### PR TITLE
Koine: add /koine/ permanent identifier namespace

### DIFF
--- a/koine/.htaccess
+++ b/koine/.htaccess
@@ -1,0 +1,44 @@
+# # /koine/
+#
+# Koine -- an agnostic neuro-symbolic interchange fabric. A set of open
+# specifications by which any conformant producer, consumer, authority, host, or
+# provider exchanges identity, knowledge, media, and capability. Contracts only:
+# there is no runtime code under this namespace.
+#
+# https://w3id.org/koine/ and everything beneath it redirects to the
+# specifications' canonical documentation host:
+#
+#     https://github.com/danieldekerlegand/koine
+#
+# The most-used identifiers under this namespace are the Koine Capability-Bus
+# Protocol (KCB) manifest extension URIs, for example
+#
+#     https://w3id.org/koine/kcb/manifest/0.3
+#
+# which a consumer string-matches to locate the KCB manifest entry inside an A2A
+# AgentCard's capabilities.extensions[] array. Those are *identifying* URIs
+# rather than fetch targets, so they must stay stable independently of any
+# private domain registration -- which is why they live here.
+#
+# ## Contact
+# This space is administered by:
+#
+# Daniel DeKerlegand
+# dldekerl@gmail.com
+# GitHub username: danieldekerlegand
+
+RewriteEngine on
+
+# The KCB manifest AgentCard-extension URI family: /koine/kcb/manifest/<version>
+RewriteRule ^kcb/manifest(/[^/]*)?/?$ https://github.com/danieldekerlegand/koine/blob/main/specs/capability-bus.md#2-the-capability-manifest [R=302,L]
+
+# One rule per specification: /koine/<abbreviation>/...
+RewriteRule ^kinp(/.*)?$ https://github.com/danieldekerlegand/koine/blob/main/specs/identity.md [R=302,L]
+RewriteRule ^kgp(/.*)?$ https://github.com/danieldekerlegand/koine/blob/main/specs/grounding-pack.md [R=302,L]
+RewriteRule ^kcb(/.*)?$ https://github.com/danieldekerlegand/koine/blob/main/specs/capability-bus.md [R=302,L]
+RewriteRule ^kmi(/.*)?$ https://github.com/danieldekerlegand/koine/blob/main/specs/media-interchange.md [R=302,L]
+RewriteRule ^kcs(/.*)?$ https://github.com/danieldekerlegand/koine/blob/main/specs/conformance-scenario.md [R=302,L]
+RewriteRule ^kft(/.*)?$ https://github.com/danieldekerlegand/koine/blob/main/specs/fine-tuning.md [R=302,L]
+
+# Catch-all: anything else under /koine/ resolves to the specification repository.
+RewriteRule ^(.*)$ https://github.com/danieldekerlegand/koine [R=302,L]

--- a/koine/README.md
+++ b/koine/README.md
@@ -1,0 +1,39 @@
+# /koine/
+
+Permanent identifiers for **Koine** — an agnostic *neuro-symbolic interchange fabric*: a set of
+open specifications by which independent AI systems exchange **identity, knowledge, media, and
+capability**. Koine is contracts only — protocols, not programs — and each participant implements
+them in its own codebase.
+
+* **Specifications (redirect target):** <https://github.com/danieldekerlegand/koine>
+
+## What resolves here
+
+| Identifier | Resolves to |
+|---|---|
+| `https://w3id.org/koine/kcb/manifest/<version>` | KCB §2, *The capability manifest* |
+| `https://w3id.org/koine/kinp/…` | KINP — Koine Identity & Naming Protocol |
+| `https://w3id.org/koine/kgp/…` | KGP — Koine Grounding Pack (knowledge plane) |
+| `https://w3id.org/koine/kcb/…` | KCB — Koine Capability-Bus Protocol (control plane) |
+| `https://w3id.org/koine/kmi/…` | KMI — Koine Media Interchange (media plane) |
+| `https://w3id.org/koine/kcs/…` | KCS — Koine Conformance Scenario |
+| `https://w3id.org/koine/kft/…` | KFT — Koine Fine-Tuning profile |
+| anything else under `/koine/` | the specification repository root |
+
+## Why these identifiers need to be permanent
+
+The busiest identifier in this namespace is the KCB **manifest extension URI**
+(`https://w3id.org/koine/kcb/manifest/0.3`). A Koine capability manifest is published as a named
+extension of an [A2A](https://a2a-protocol.org/) `AgentCard` — one entry in the card's
+`capabilities.extensions[]` array — and a consumer finds that entry by **string-matching its
+`uri`**. The URI is therefore a *matching key*, not a fetch target: implementations embed the
+literal string, and changing it is a breaking change for every consumer that has shipped it.
+
+A matching key of that kind must not depend on a private domain registration staying renewed.
+That is exactly what a w3id permanent identifier is for, and it is why this entry exists.
+
+## Maintainer
+
+Daniel DeKerlegand — GitHub [@danieldekerlegand](https://github.com/danieldekerlegand),
+<dldekerl@gmail.com>. Sole maintainer of the Koine specifications; issues and questions are
+welcome at <https://github.com/danieldekerlegand/koine/issues>.


### PR DESCRIPTION
Adds a `/koine/` permanent identifier namespace for the **Koine** specifications — an agnostic
neuro-symbolic interchange fabric: open contracts by which independent AI systems exchange
identity, knowledge, media, and capability. Contracts only, no runtime code.

* **Redirect target:** <https://github.com/danieldekerlegand/koine> (public)
* **Files added:** `koine/.htaccess`, `koine/README.md`

### What resolves

| Identifier | Resolves to |
|---|---|
| `https://w3id.org/koine/kcb/manifest/<version>` | KCB §2, *The capability manifest* |
| `https://w3id.org/koine/{kinp,kgp,kcb,kmi,kcs,kft}/…` | that specification's document |
| anything else under `/koine/` | the specification repository root |

All redirects are `302` and every target was verified `200` before opening this PR.

### Why a permanent identifier is needed here

The busiest identifier in this namespace is the Koine Capability-Bus (KCB) **manifest extension
URI**, `https://w3id.org/koine/kcb/manifest/0.3`. A Koine capability manifest is published as a
named extension of an [A2A](https://a2a-protocol.org/) `AgentCard` — one entry in the card's
`capabilities.extensions[]` array — and a consumer locates that entry by **string-matching its
`uri`**. So the URI is a *matching key*, not a fetch target: implementations embed the literal
string, and changing it breaks every consumer that has shipped it.

The specification previously used a URI under a private domain that turned out never to have been
registered. Rather than register it and depend on a renewal holding for the life of the protocol,
the specification is moving the namespace here — which is the case w3id exists for.

### Contact

Daniel DeKerlegand — GitHub @danieldekerlegand, dldekerl@gmail.com. Sole maintainer of the Koine
specifications. Contact info is also in both added files.
