### PR TITLE
Add oo-ld namespace (OO-LD)

### DIFF
--- a/oo-ld/.htaccess
+++ b/oo-ld/.htaccess
@@ -1,0 +1,14 @@
+# OO-LD (Object-Oriented Linked Data) namespace
+# Maintainers (GitHub): @simontaurus, @raederan, @LukasOro
+# Contact: team@oo-ld.org
+#
+# /schemas/* are the OO-LD reference schemas, served from their own site so that a
+# conformance IRI dereferences to the schema JSON itself, e.g.
+#   w3id.org/oo-ld/schemas/quantities/1.0 -> schemas.oo-ld.org/quantities/1.0
+# Everything else is delegated to the main OO-LD site (both GitHub Pages).
+# Accept-based content negotiation can be added here later if a single IRI should serve
+# ttl/jsonld/html by header.
+
+RewriteEngine on
+RewriteRule ^schemas/(.*)$ https://schemas.oo-ld.org/$1 [R=302,L]
+RewriteRule ^(.*)$ https://oo-ld.org/$1 [R=302,L]

--- a/oo-ld/README.md
+++ b/oo-ld/README.md
@@ -1,0 +1,12 @@
+# oo-ld
+
+Namespace for OO-LD (Object-Oriented Linked Data): a document that is at once a
+JSON Schema and a JSON-LD context. Maintained by the OO-LD organization.
+
+- Project: https://github.com/OO-LD (site: https://oo-ld.org)
+- Redirect: `https://w3id.org/oo-ld/*` -> `https://oo-ld.org/*` (302, path-preserving)
+- `/schemas/*` -> `https://schemas.oo-ld.org/*` (the reference schemas, e.g.
+  `/schemas/quantities/1.0`)
+- Maintainers (GitHub): [@simontaurus](https://github.com/simontaurus),
+  [@raederan](https://github.com/raederan), [@LukasOro](https://github.com/LukasOro)
+- Contact: team@oo-ld.org


### PR DESCRIPTION
Requesting the `/oo-ld/` namespace for the OO-LD (Object-Oriented Linked Data) project: a document that is at once a JSON Schema and a JSON-LD context.

- Redirect: `https://w3id.org/oo-ld/*` -> `https://oo-ld.org/*` (302, path-preserving)
- Target already resolves: `https://oo-ld.org` is a live GitHub Pages site (repo OO-LD/oold-schema)
- Sub-paths (e.g. `/profile/<module>/<version>`) address OO-LD profile modules
- Maintained by the OO-LD organization (https://github.com/OO-LD); contact team@oo-ld.org

Adds `oo-ld/.htaccess` and `oo-ld/README.md` in a single commit.