### PR TITLE
Add w3id.org/resonatus permanent identifier (Resonatus Ontology v1.0.0)

### DIFF
--- a/resonatus/.htaccess
+++ b/resonatus/.htaccess
@@ -1,0 +1,25 @@
+# /resonatus/
+#
+# Permanent identifiers for the Resonatus Ontology
+# (an OWL 2 DL model of persistent causal trace processes, with a SHACL validation profile).
+#
+#   https://w3id.org/resonatus         -> canonical ontology (current version)
+#   https://w3id.org/resonatus/1.0.0   -> version 1.0.0, pinned to an immutable commit
+#
+# Source repository:
+#   https://github.com/halvrenofviryel/resonatus-ontology
+#
+# ## Contact
+# This space is administered by:
+#
+#   Ali Toygar Abak
+#   GitHub username: halvrenofviryel
+#   Email: founder@phionyx.ai
+
+RewriteEngine on
+
+# Version IRI -> immutable commit-SHA raw ontology (this target never changes)
+RewriteRule ^1\.0\.0/?$ https://raw.githubusercontent.com/halvrenofviryel/resonatus-ontology/f7be377d3b355f1dbe1911f12bf597d62355619d/ontology/resonatus.ttl [R=302,L]
+
+# Root IRI -> current canonical ontology (only this line is updated for a future version)
+RewriteRule ^$ https://raw.githubusercontent.com/halvrenofviryel/resonatus-ontology/f7be377d3b355f1dbe1911f12bf597d62355619d/ontology/resonatus.ttl [R=302,L]

--- a/resonatus/README.md
+++ b/resonatus/README.md
@@ -1,0 +1,24 @@
+# w3id.org/resonatus
+
+Permanent identifiers for the **Resonatus Ontology** — an OWL 2 DL model of persistent causal
+trace processes, with a SHACL validation profile, competency questions, and reproducible
+verification artefacts.
+
+| IRI | Resolves to |
+|-----|-------------|
+| `https://w3id.org/resonatus` | Canonical ontology (current version) |
+| `https://w3id.org/resonatus/1.0.0` | Version 1.0.0, pinned to an immutable commit |
+
+- **Namespace:** `https://w3id.org/resonatus#`
+- **Source repository:** <https://github.com/halvrenofviryel/resonatus-ontology>
+- **Archival DOI:** `10.5281/zenodo.21939903`
+
+The versioned identifier redirects to the ontology file at a fixed commit SHA, so `1.0.0` always
+resolves to exactly the released bytes. Only the root identifier is re-pointed when a new version
+is published.
+
+## Contact
+
+- Ali Toygar Abak
+- GitHub: [@halvrenofviryel](https://github.com/halvrenofviryel)
+- Email: founder@phionyx.ai


### PR DESCRIPTION
Adds a permanent identifier for the **Resonatus Ontology** — an OWL 2 DL model of persistent causal
trace processes, with a SHACL validation profile and reproducible verification artefacts.

**New directory:** `resonatus/` (`.htaccess` + `README.md`). It does not conflict with any existing entry.

**Redirects (simple 302):**

| IRI | Target |
|-----|--------|
| `https://w3id.org/resonatus` | canonical ontology (current version) |
| `https://w3id.org/resonatus/1.0.0` | ontology pinned to an immutable commit SHA |

The versioned identifier points at the ontology file at a fixed commit
(`…/resonatus-ontology/f7be377d…/ontology/resonatus.ttl`) so `1.0.0` always resolves to exactly the
released bytes; only the root identifier is re-pointed for future versions.

- Source repository: https://github.com/halvrenofviryel/resonatus-ontology
- Namespace: `https://w3id.org/resonatus#`

**Contact:** Ali Toygar Abak · GitHub @halvrenofviryel · founder@phionyx.ai
