### PR TITLE
Add canonical-english identifier

### DIFF
--- a/canonical-english/.htaccess
+++ b/canonical-english/.htaccess
@@ -1,0 +1,18 @@
+# # /canonical-english/
+#
+# Permanent identifiers for the Canonical English project.
+#
+# https://w3id.org/canonical-english/context/v1 redirects to
+# https://canonical-english.org/ns/v1/context/
+#
+# ## Contact
+# This space is administered by:
+#
+# Michael B. Currie
+# mcurrie@gmail.com
+# GitHub username: MichaelCurrie
+
+RewriteEngine on
+
+# JSON-LD context, version 1
+RewriteRule ^context/v1/?$ https://canonical-english.org/ns/v1/context/ [R=302,L]

--- a/canonical-english/README.md
+++ b/canonical-english/README.md
@@ -1,0 +1,23 @@
+# /canonical-english/
+
+Permanent identifiers for the **Canonical English** project.
+
+## Redirects
+
+| Permanent identifier | Redirects to | HTTP status |
+| --- | --- | --- |
+| [`https://w3id.org/canonical-english/context/v1`](https://w3id.org/canonical-english/context/v1) | [`https://canonical-english.org/ns/v1/context/`](https://canonical-english.org/ns/v1/context/) | 302 |
+
+`https://w3id.org/canonical-english/context/v1` is the stable URI of the
+version 1 JSON-LD context for Canonical English. Documents that reference this
+context in their `@context` will keep resolving even if the hosting location of
+the context file changes.
+
+## Contact
+This space is administered by:  
+
+**Michael B. Currie**
+
+mcurrie@gmail.com
+
+GitHub: [MichaelCurrie](https://github.com/MichaelCurrie)


### PR DESCRIPTION
## Brief Description
Adds a new top-level ID directory `/canonical-english/` for the Canonical English project.

`https://w3id.org/canonical-english/context/v1` -> `https://canonical-english.org/ns/v1/context/` (302)

This is the stable URI for the version 1 JSON-LD context.

## General Checklist
- [ ] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

Maintainer: Michael B. Currie (@MichaelCurrie), mcurrie@gmail.com