### PR TITLE
Add MDA persistent identifier namespace

### DIFF
--- a/mda/.htaccess
+++ b/mda/.htaccess
@@ -1,0 +1,22 @@
+RewriteEngine On
+
+# Main project landing page
+RewriteRule ^$ https://rubenzoodsma.github.io/Alarm-Ontologie/ [R=302,L]
+
+# Medical Device Alarm Ontology documentation
+RewriteRule ^ontology/?$ https://rubenzoodsma.github.io/Alarm-Ontologie/ontology/ [R=302,L]
+
+# Individual ontology terms
+# Example:
+# https://w3id.org/mda/ontology/Alarm
+# -> https://rubenzoodsma.github.io/Alarm-Ontologie/ontology/#Alarm
+RewriteRule ^ontology/(.+)$ https://rubenzoodsma.github.io/Alarm-Ontologie/ontology/#$1 [NE,R=302,L]
+
+# Medical Device Alarm Vocabulary
+RewriteRule ^vocab/?$ https://rubenzoodsma.github.io/Alarm-Ontologie/vocab/ [R=302,L]
+
+# Instance data
+RewriteRule ^data/?$ https://rubenzoodsma.github.io/Alarm-Ontologie/data/ [R=302,L]
+
+# Knowledge graphs
+RewriteRule ^graph/?$ https://rubenzoodsma.github.io/Alarm-Ontologie/graph/ [R=302,L]

--- a/mda/README.md
+++ b/mda/README.md
@@ -1,0 +1,27 @@
+# Medical Device Alarm (MDA)
+
+This directory provides persistent identifiers for resources related to the **Medical Device Alarm (MDA)** project.
+
+The base namespace is:
+
+`https://w3id.org/mda/`
+
+The namespace provides persistent access to resources related to the MDA project, including:
+
+- the **Medical Device Alarm Ontology**;
+- the **Medical Device Alarm Vocabulary**;
+- **knowledge graphs** and named graphs;
+- instantiated **data resources**.
+
+Redirects for these resources are defined in the `.htaccess` file in this directory.
+
+## Maintainers
+
+- [Ruben Zoodsma (@RubenZoodsma)](https://github.com/RubenZoodsma)
+- [Margherita Martorana (@mmartora)](https://github.com/ritamargherita)
+
+## Contact
+
+For questions regarding this project, please contact:
+
+- [Ruben Zoodsma (@RubenZoodsma)](https://github.com/RubenZoodsma)

--- a/mda/README.md
+++ b/mda/README.md
@@ -18,7 +18,7 @@ Redirects for these resources are defined in the `.htaccess` file in this direct
 ## Maintainers
 
 - [Ruben Zoodsma (@RubenZoodsma)](https://github.com/RubenZoodsma)
-- [Margherita Martorana (@mmartora)](https://github.com/ritamargherita)
+- [Margherita Martorana (@ritamargherita)](https://github.com/ritamargherita)
 
 ## Contact
 


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
This PR adds the new persistent identifier namespace:
`https://w3id.org/mda/`
for the Medical Device Alarm (MDA) project.

The namespace includes redirects for:
- the main MDA landing page;
- the Medical Device Alarm Ontology;
- the Medical Device Alarm Vocabulary;
- instance data;
- knowledge graphs.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
