### PR TITLE
added ro-crate-masp profile to ro directory

### DIFF
--- a/ro/.htaccess
+++ b/ro/.htaccess
@@ -31,6 +31,8 @@ RewriteRule ^bagit/profile$ https://cdn.jsdelivr.net/gh/ResearchObject/bagit-ro@
 # RO Curate profiles
 RewriteRule ^curate/profile/(.*)$  https://www.researchobject.org/ro-curate/$1-profile.ttl [R=302,L]
 
+RewriteRule ^ro-crate-masp/profile$ https://language-research-technology.github.io/ro-crate-masp/profiles/ro-crate-masp/profile-crate/index.html [R=302,L]
+
 # crate/ is handled by crate/.htaccess
 # terms/ is handled by terms/.htacmess
 


### PR DESCRIPTION
Added ro-crate-masp/profile to ro directory.
ro-crate-masp is starting to see some adoption so we need a profile URI.
https://w3id.org/ro/ro-crate-masp/profile
At the moment this is housed in a masp tools repository, when the profile is more mature it will be moved to the research object github.
@ptsefton for approval.
