### PR TITLE
[READY FOR REVIEW] SPECL: add versioned vocabulary and contract URIs

### DIFF
--- a/specl/.htaccess
+++ b/specl/.htaccess
@@ -1,9 +1,12 @@
-# SPECL — RDF-native, SHACL-validated spec language
-# https://github.com/zwelz3/specl
-#
-# Contact:
-#   Zachary Welz
-#   GitHub: zwelz3
+# Name of the project: SPECL
+# Description: SPECL is an RDF-native, SHACL-validated specification language.
+# Specifications are authored in markdown, translated to RDF, and validated
+# against a tiered SHACL shapes graph. This identifier serves the vocabulary,
+# the shapes graph, the graph-contract descriptions, and the project's own
+# published specifications.
+# Repository: https://github.com/zwelz3/specl
+# Contacts:
+# - Zachary Welz (GitHub: zwelz3)
 
 Options +FollowSymLinks
 RewriteEngine on
@@ -29,8 +32,31 @@ RewriteCond %{HTTP_ACCEPT} ^.*text/turtle.*
 RewriteRule ^shapes/?$ https://zwelz3.github.io/specl/shapes.ttl [R=303,NE,L]
 RewriteRule ^shapes/?$ https://zwelz3.github.io/specl/ [R=303,NE,L]
 
-# Spec instances — hash namespace, single document
-RewriteRule ^spec/?$ https://github.com/zwelz3/specl/tree/main/specs [R=303,NE,L]
+# Version-aware URIs for the vocabulary and shapes. The version is the graph
+# contract rather than the release: a contract changes only in a designated
+# breaking release, and every emitted graph names the one it conforms to. The
+# unversioned URIs above always serve the current contract.
+RewriteRule ^ns/1/?$ https://zwelz3.github.io/specl/ns/1.ttl [R=303,NE,L]
+RewriteRule ^ns/2/?$ https://zwelz3.github.io/specl/ns/2.ttl [R=303,NE,L]
+RewriteRule ^shapes/1/?$ https://zwelz3.github.io/specl/shapes/1.ttl [R=303,NE,L]
+RewriteRule ^shapes/2/?$ https://zwelz3.github.io/specl/shapes/2.ttl [R=303,NE,L]
+
+# Descriptions of each graph contract, naming what a consumer holding a graph
+# of that version may rely on.
+RewriteRule ^contract/1/?$ https://github.com/zwelz3/specl/blob/main/docs/contracts/1.md [R=303,NE,L]
+RewriteRule ^contract/2/?$ https://github.com/zwelz3/specl/blob/main/docs/contracts/2.md [R=303,NE,L]
+
+# Retired instance namespace. Until specl 0.3.0 every specification minted its
+# items under this one shared namespace, so identifiers from different
+# specifications collided. Each specification now declares its own base and this
+# one is not reassigned. Graphs distributed before that change still carry these
+# IRIs, so the rule stays and now resolves to the migration guide.
+RewriteRule ^spec/?$ https://github.com/zwelz3/specl/blob/main/NAMESPACE-MIGRATION.md [R=303,NE,L]
+
+# specl's own specifications, each under its own base.
+RewriteRule ^tool/spec/?$ https://github.com/zwelz3/specl/blob/main/specs/specl_tool/spec.md [R=303,NE,L]
+RewriteRule ^explorer/spec/?$ https://github.com/zwelz3/specl/blob/main/specs/specl_explorer/spec.md [R=303,NE,L]
+RewriteRule ^commitments/spec/?$ https://github.com/zwelz3/specl/blob/main/specs/commitments/spec.md [R=303,NE,L]
 
 # Explorer
 RewriteRule ^explorer/?$ https://zwelz3.github.io/specl/explorer.html [R=303,NE,L]

--- a/specl/README.md
+++ b/specl/README.md
@@ -1,17 +1,39 @@
 # SPECL — `/specl`
 
-RDF-native, SHACL-validated spec language for spec-driven AI
-
-development.
+RDF-native, SHACL-validated spec language for spec-driven AI development.
 
 ## URIs
 
-| URI                               | Purpose                         |
-| --------------------------------- | ------------------------------- |
-| `https://w3id.org/specl/ns#`      | SPECL vocabulary (OWL ontology) |
-| `https://w3id.org/specl/spec#`    | Spec instance namespace         |
-| `https://w3id.org/specl/shapes`   | SHACL shapes graph              |
-| `https://w3id.org/specl/explorer` | Spec explorer (HTML)            |
+| URI | Purpose |
+| --- | --- |
+| `https://w3id.org/specl/ns#` | SPECL vocabulary (OWL ontology), current contract |
+| `https://w3id.org/specl/ns/1` | Vocabulary as published under graph contract 1 |
+| `https://w3id.org/specl/ns/2` | Vocabulary as published under graph contract 2 |
+| `https://w3id.org/specl/shapes` | SHACL shapes graph, current contract |
+| `https://w3id.org/specl/shapes/1` | Shapes as published under graph contract 1 |
+| `https://w3id.org/specl/shapes/2` | Shapes as published under graph contract 2 |
+| `https://w3id.org/specl/contract/1` | What a contract 1 graph guarantees |
+| `https://w3id.org/specl/contract/2` | What a contract 2 graph guarantees |
+| `https://w3id.org/specl/tool/spec#` | Items of the specl tool's own specification |
+| `https://w3id.org/specl/explorer/spec#` | Items of the spec explorer's specification |
+| `https://w3id.org/specl/commitments/spec#` | Items of specl's commitments register |
+| `https://w3id.org/specl/explorer` | Spec explorer (HTML) |
+| `https://w3id.org/specl/spec#` | **Retired.** Redirects to the migration guide |
+
+### About the retired namespace
+
+Until specl 0.3.0, every specification minted its items under
+`https://w3id.org/specl/spec#`, so `#R1.1` from one specification collided with
+`#R1.1` from another. Each specification now declares its own base. The old
+namespace is not reassigned to anything, and its rule is kept so that graphs
+distributed before the change still resolve, now to the migration guide.
+
+### About the versioned URIs
+
+The version in `ns/1` and `shapes/2` is the graph contract, not the release.
+Every emitted graph names the contract it conforms to with `dct:conformsTo`, and
+a contract changes only in a release designated for breaking changes. The
+unversioned `ns` and `shapes` URIs always serve the current contract.
 
 ## Repository
 
@@ -19,6 +41,5 @@ development.
 
 ## Contact
 
-**Zachary Welz**
-
-- GitHub: [@zwelz3](https://github.com/zwelz3)
+Zachary Welz 
+  - GitHub: [@zwelz3](https://github.com/zwelz3)


### PR DESCRIPTION
## Brief Description

Updates the existing `/specl` identifier. Nine redirects added, one target changed, none removed.

specl gave every specification a single shared instance namespace, `https://w3id.org/specl/spec#`, so identifiers from different specifications collided. Each specification now declares its own base. The added rules serve that change:

- `ns/1`, `ns/2`, `shapes/1`, `shapes/2` — version-aware URIs for the vocabulary and shapes graph. The version is the graph contract rather than a release number, and the unversioned `ns` and `shapes` continue to serve the current one.
- `contract/1`, `contract/2` — descriptions of what a consumer holding a graph of each contract version may rely on.
- `tool/spec`, `explorer/spec`, `commitments/spec` — the project's own three specifications, each now under its own base.

The one changed target is `^spec/?$`. It is retired rather than reassigned, and now resolves to the migration guide so that graphs distributed before the change still land somewhere that explains them. Nothing is removed, so no identifier already in use stops resolving.

`README.md` is updated to match: it previously listed `https://w3id.org/specl/spec#` as the live instance namespace, which is the one being retired.

## General Checklist

- [x] Changes have been tested.

Every path was resolved against the rules locally before submitting: `/specl/`, `ns`, `ns/1`, `ns/2`, `shapes`, `shapes/1`, `shapes/2`, `contract/1`, `contract/2`, `spec`, `tool/spec`, `explorer/spec`, `commitments/spec`, and `explorer`. Sixteen cases including the `text/turtle`, `application/ld+json`, and `text/html` variants of `ns`. I also checked that no specific rule is shadowed by a more general one, since `^spec/?$` sits near `^tool/spec/?$`. Every redirect target is verified to exist at its destination.

- [x] The number of commits is minimal. Squash if needed.

One commit.

- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

No content is served from w3id.org; every rule is a 303 to GitHub or to the project's GitHub Pages site. The `README.md` additions are identifier information, describing what each URI is for and why one is retired, rather than project documentation, which lives in the project repository.

## New ID Directory Checklist

Not applicable. `/specl` already exists; this updates it.

## Update ID Directory Checklist

- [x] GitHub username ids are listed in the changed maintainer details.

`@zwelz3`, in both `specl/.htaccess` and `specl/README.md`.

- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR.

`@zwelz3` is the maintainer listed in the current `specl/.htaccess` and is submitting this PR.

## Optional Requests for W3ID Maintainers

- ~~Please squash commits for me.~~

Not needed; this is a single commit.