### PR TITLE
Add /certvas — Certvas Ontology (CC0 schema for African & emerging-market company data)

### DIFF
--- a/certvas/.htaccess
+++ b/certvas/.htaccess
@@ -1,5 +1,7 @@
 # w3id.org/certvas — permanent identifier redirects for the Certvas Ontology.
 #
+# Maintainer: R.T. Mandase — GitHub @KingMandase — mandase@certvas.com
+#
 # TO REGISTER: open a PR against https://github.com/perma-id/w3id.org adding this file as
 # `certvas/.htaccess`. w3id is a community service run by the W3C Permanent Identifier Community
 # Group; PRs are reviewed by hand and usually merged within a few days. Nothing here can be

--- a/certvas/.htaccess
+++ b/certvas/.htaccess
@@ -1,0 +1,52 @@
+# w3id.org/certvas — permanent identifier redirects for the Certvas Ontology.
+#
+# TO REGISTER: open a PR against https://github.com/perma-id/w3id.org adding this file as
+# `certvas/.htaccess`. w3id is a community service run by the W3C Permanent Identifier Community
+# Group; PRs are reviewed by hand and usually merged within a few days. Nothing here can be
+# deployed by Certvas — that is the point of a permanent identifier: it survives us moving hosts.
+#
+# WHY A PERMANENT IDENTIFIER AT ALL. The schema's `id:` is https://w3id.org/certvas/ontology, and
+# that IRI is baked into every generated JSON-LD context and every published record. If it pointed
+# at certvas.com directly, then a domain lapse, a rebrand or a host migration would break every
+# document anyone ever produced against the schema. The indirection is the durable part.
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# ---------------------------------------------------------------------------------------------
+# CONTENT NEGOTIATION. A browser wants the docs; a tool wants the machine-readable schema. Serving
+# HTML to a JSON-LD processor is the usual way a "resolvable" ontology IRI turns out to be useless
+# in practice, so the machine formats are matched FIRST and the human page is the fallback.
+#
+# Order matters: mod_rewrite takes the first matching rule, so the most specific Accept headers
+# must come before the catch-all.
+# ---------------------------------------------------------------------------------------------
+
+# JSON-LD context — what a linked-data client asks for.
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^ontology/?$ https://certvas-ontology.pages.dev/certvas.context.jsonld [R=302,L]
+
+# The LinkML source — the single source of truth, for anyone regenerating artifacts.
+RewriteCond %{HTTP_ACCEPT} text/yaml [OR]
+RewriteCond %{HTTP_ACCEPT} application/yaml [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-yaml
+RewriteRule ^ontology/?$ https://certvas-ontology.pages.dev/certvas-ontology.yaml [R=302,L]
+
+# Explicit extensions, so a link can bypass negotiation entirely. Content negotiation is fragile
+# through proxies and impossible to paste into a chat message; a plain URL always works.
+RewriteRule ^ontology\.yaml$   https://certvas-ontology.pages.dev/certvas-ontology.yaml [R=302,L]
+RewriteRule ^ontology\.jsonld$ https://certvas-ontology.pages.dev/certvas.context.jsonld [R=302,L]
+RewriteRule ^ontology\.json$   https://certvas-ontology.pages.dev/certvas.schema.json [R=302,L]
+RewriteRule ^ontology\.sql$    https://certvas-ontology.pages.dev/certvas.sql [R=302,L]
+
+# Per-term IRIs: https://w3id.org/certvas/ontology/Fundamentals -> its documentation page.
+# Every slot and class in the JSON-LD context resolves under this prefix, so a reader who follows
+# a term from a document lands on the definition of that term rather than on a homepage.
+RewriteRule ^ontology/([A-Za-z_][A-Za-z0-9_]*)$ https://certvas-ontology.pages.dev/$1 [R=302,L]
+
+# 302 NOT 301, deliberately. A permanent redirect is cached by browsers and intermediaries
+# indefinitely, which makes a hosting change take years to propagate — the opposite of what a
+# permanent identifier is for. The IRI is permanent; where it points today is not.
+RewriteRule ^ontology/?$ https://certvas-ontology.pages.dev/ [R=302,L]
+RewriteRule ^/?$        https://certvas.com/ontology [R=302,L]

--- a/certvas/.htaccess
+++ b/certvas/.htaccess
@@ -1,54 +1,42 @@
-# w3id.org/certvas — permanent identifier redirects for the Certvas Ontology.
+# # /certvas/
 #
-# Maintainer: R.T. Mandase — GitHub @KingMandase — mandase@certvas.com
+# Permanent identifiers for the Certvas Ontology, a CC0 LinkML schema describing company,
+# fundamentals, procurement and macro data for African and emerging markets.
 #
-# TO REGISTER: open a PR against https://github.com/perma-id/w3id.org adding this file as
-# `certvas/.htaccess`. w3id is a community service run by the W3C Permanent Identifier Community
-# Group; PRs are reviewed by hand and usually merged within a few days. Nothing here can be
-# deployed by Certvas — that is the point of a permanent identifier: it survives us moving hosts.
+# https://w3id.org/certvas/ontology redirects to
+# https://certvas-ontology.pages.dev/
 #
-# WHY A PERMANENT IDENTIFIER AT ALL. The schema's `id:` is https://w3id.org/certvas/ontology, and
-# that IRI is baked into every generated JSON-LD context and every published record. If it pointed
-# at certvas.com directly, then a domain lapse, a rebrand or a host migration would break every
-# document anyone ever produced against the schema. The indirection is the durable part.
+# Redirects are 302, not 301: the IRI is permanent, but where it points today is not, and a
+# cached permanent redirect would make a future change of host take years to clear.
+#
+# ## Contact
+# This space is administered by:
+#
+# Rebaone Theo Mandase
+# GitHub username: KingMandase
+# mandase@certvas.com
 
 Options +FollowSymLinks
 RewriteEngine on
 
-# ---------------------------------------------------------------------------------------------
-# CONTENT NEGOTIATION. A browser wants the docs; a tool wants the machine-readable schema. Serving
-# HTML to a JSON-LD processor is the usual way a "resolvable" ontology IRI turns out to be useless
-# in practice, so the machine formats are matched FIRST and the human page is the fallback.
-#
-# Order matters: mod_rewrite takes the first matching rule, so the most specific Accept headers
-# must come before the catch-all.
-# ---------------------------------------------------------------------------------------------
-
-# JSON-LD context — what a linked-data client asks for.
+# Content negotiation: machine formats first, human documentation as the fallback.
 RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
 RewriteCond %{HTTP_ACCEPT} application/json
 RewriteRule ^ontology/?$ https://certvas-ontology.pages.dev/certvas.context.jsonld [R=302,L]
 
-# The LinkML source — the single source of truth, for anyone regenerating artifacts.
 RewriteCond %{HTTP_ACCEPT} text/yaml [OR]
 RewriteCond %{HTTP_ACCEPT} application/yaml [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-yaml
 RewriteRule ^ontology/?$ https://certvas-ontology.pages.dev/certvas-ontology.yaml [R=302,L]
 
-# Explicit extensions, so a link can bypass negotiation entirely. Content negotiation is fragile
-# through proxies and impossible to paste into a chat message; a plain URL always works.
+# Explicit extensions, for links that should bypass negotiation.
 RewriteRule ^ontology\.yaml$   https://certvas-ontology.pages.dev/certvas-ontology.yaml [R=302,L]
 RewriteRule ^ontology\.jsonld$ https://certvas-ontology.pages.dev/certvas.context.jsonld [R=302,L]
 RewriteRule ^ontology\.json$   https://certvas-ontology.pages.dev/certvas.schema.json [R=302,L]
 RewriteRule ^ontology\.sql$    https://certvas-ontology.pages.dev/certvas.sql [R=302,L]
 
-# Per-term IRIs: https://w3id.org/certvas/ontology/Fundamentals -> its documentation page.
-# Every slot and class in the JSON-LD context resolves under this prefix, so a reader who follows
-# a term from a document lands on the definition of that term rather than on a homepage.
+# Per-term IRIs: /ontology/Fundamentals resolves to that term's documentation page.
 RewriteRule ^ontology/([A-Za-z_][A-Za-z0-9_]*)$ https://certvas-ontology.pages.dev/$1 [R=302,L]
 
-# 302 NOT 301, deliberately. A permanent redirect is cached by browsers and intermediaries
-# indefinitely, which makes a hosting change take years to propagate — the opposite of what a
-# permanent identifier is for. The IRI is permanent; where it points today is not.
 RewriteRule ^ontology/?$ https://certvas-ontology.pages.dev/ [R=302,L]
-RewriteRule ^/?$        https://certvas.com/ontology [R=302,L]
+RewriteRule ^/?$         https://certvas.com/ontology [R=302,L]

--- a/certvas/README.md
+++ b/certvas/README.md
@@ -1,46 +1,36 @@
-# w3id.org/certvas
+# /certvas/
 
 Permanent identifiers for the **Certvas Ontology** — a CC0 LinkML schema describing company,
 fundamentals, procurement and macro data for African and emerging markets.
+
+`https://w3id.org/certvas/ontology` is the schema's `id:`, and is already baked into the published
+JSON-LD context, the PyPI package and the Zenodo deposit. Pointing it at our own domain would mean
+a lapse, a rebrand or a change of host breaks every document produced against the schema.
 
 ## Identifiers
 
 | IRI | resolves to |
 |---|---|
-| `https://w3id.org/certvas/ontology` | the human documentation (or the machine format, by content negotiation) |
-| `https://w3id.org/certvas/ontology.yaml` | the LinkML source — the single source of truth |
+| `https://w3id.org/certvas/ontology` | the documentation, or a machine format by content negotiation |
+| `https://w3id.org/certvas/ontology.yaml` | the LinkML source |
 | `https://w3id.org/certvas/ontology.jsonld` | the JSON-LD context |
 | `https://w3id.org/certvas/ontology.json` | JSON Schema |
 | `https://w3id.org/certvas/ontology.sql` | SQL DDL |
 | `https://w3id.org/certvas/ontology/{Term}` | that class or slot's documentation page |
 
-Content negotiation on `/ontology`: `application/ld+json` returns the JSON-LD context, `text/yaml`
-returns the LinkML source, anything else returns the docs. Explicit extensions bypass negotiation,
-because negotiation is fragile through proxies and impossible to paste into a chat message.
-
-Redirects are **302, not 301**. A permanent redirect is cached by intermediaries indefinitely,
-which would make a future hosting change take years to propagate — the opposite of what a permanent
-identifier is for. The IRI is permanent; where it points today is not.
-
-## Why the indirection
-
-The IRI is the schema's `id:` and is baked into every generated JSON-LD context, the published
-package and the Zenodo deposit. Pointing it at our own domain would mean a lapse, a rebrand or a
-host migration breaks every document anyone ever produced against the schema.
+Redirects are 302, not 301: the IRI is permanent, but where it points today is not.
 
 ## Project
 
-- **Docs** — <https://certvas-ontology.pages.dev>
-- **DOI** — <https://doi.org/10.5281/zenodo.21986492>
-- **Package** — <https://pypi.org/project/certvas-ontology/>
-- **Licence** — CC0-1.0. (The datasets the schema describes carry their own per-source terms; the
-  schema being public domain is deliberate and separate.)
+- Docs — <https://certvas-ontology.pages.dev>
+- DOI — <https://doi.org/10.5281/zenodo.21986492>
+- Package — <https://pypi.org/project/certvas-ontology/>
+- Licence — CC0-1.0
 
 ## Contact
 
-R.T. Mandase — GitHub [@KingMandase](https://github.com/KingMandase) — mandase@certvas.com
-— <https://certvas.com>
+This space is administered by:
 
-The GitHub handle is here because w3id review asks for it: a permanent identifier outlives
-any one email address, so the maintainer needs to be reachable through the same forge the
-registration lives in.
+Rebaone Theo Mandase
+GitHub username: KingMandase
+mandase@certvas.com

--- a/certvas/README.md
+++ b/certvas/README.md
@@ -1,0 +1,41 @@
+# w3id.org/certvas
+
+Permanent identifiers for the **Certvas Ontology** — a CC0 LinkML schema describing company,
+fundamentals, procurement and macro data for African and emerging markets.
+
+## Identifiers
+
+| IRI | resolves to |
+|---|---|
+| `https://w3id.org/certvas/ontology` | the human documentation (or the machine format, by content negotiation) |
+| `https://w3id.org/certvas/ontology.yaml` | the LinkML source — the single source of truth |
+| `https://w3id.org/certvas/ontology.jsonld` | the JSON-LD context |
+| `https://w3id.org/certvas/ontology.json` | JSON Schema |
+| `https://w3id.org/certvas/ontology.sql` | SQL DDL |
+| `https://w3id.org/certvas/ontology/{Term}` | that class or slot's documentation page |
+
+Content negotiation on `/ontology`: `application/ld+json` returns the JSON-LD context, `text/yaml`
+returns the LinkML source, anything else returns the docs. Explicit extensions bypass negotiation,
+because negotiation is fragile through proxies and impossible to paste into a chat message.
+
+Redirects are **302, not 301**. A permanent redirect is cached by intermediaries indefinitely,
+which would make a future hosting change take years to propagate — the opposite of what a permanent
+identifier is for. The IRI is permanent; where it points today is not.
+
+## Why the indirection
+
+The IRI is the schema's `id:` and is baked into every generated JSON-LD context, the published
+package and the Zenodo deposit. Pointing it at our own domain would mean a lapse, a rebrand or a
+host migration breaks every document anyone ever produced against the schema.
+
+## Project
+
+- **Docs** — <https://certvas-ontology.pages.dev>
+- **DOI** — <https://doi.org/10.5281/zenodo.21986492>
+- **Package** — <https://pypi.org/project/certvas-ontology/>
+- **Licence** — CC0-1.0. (The datasets the schema describes carry their own per-source terms; the
+  schema being public domain is deliberate and separate.)
+
+## Contact
+
+R.T. Mandase — mandase@certvas.com — <https://certvas.com>

--- a/certvas/README.md
+++ b/certvas/README.md
@@ -38,4 +38,9 @@ host migration breaks every document anyone ever produced against the schema.
 
 ## Contact
 
-R.T. Mandase — mandase@certvas.com — <https://certvas.com>
+R.T. Mandase — GitHub [@KingMandase](https://github.com/KingMandase) — mandase@certvas.com
+— <https://certvas.com>
+
+The GitHub handle is here because w3id review asks for it: a permanent identifier outlives
+any one email address, so the maintainer needs to be reachable through the same forge the
+registration lives in.


### PR DESCRIPTION
Adds `certvas/.htaccess` and `certvas/README.md` for the **Certvas Ontology**, a CC0 LinkML schema describing company, fundamentals, procurement and macro data for African and emerging markets.

**What the IRI identifies**

`https://w3id.org/certvas/ontology` is the schema's `id:`, and is already baked into the published JSON-LD context, the PyPI package and the Zenodo deposit. The indirection is the point: if it pointed at our own domain, a lapse or a rebrand would break every document produced against the schema.

**Already live, so nothing here redirects into the void**

| target | |
|---|---|
| Docs site | https://certvas-ontology.pages.dev |
| DOI | https://doi.org/10.5281/zenodo.21986492 |
| Package | https://pypi.org/project/certvas-ontology/ |

All seven redirect targets return 200 (verified immediately before opening this PR).

**Behaviour**

- Content negotiation: `application/ld+json` → the JSON-LD context, `text/yaml` → the LinkML source, anything else → the human docs.
- Per-term IRIs: `…/ontology/Fundamentals` resolves to that term's documentation page, so a reader following a term from a document lands on its definition rather than a homepage.
- Explicit extensions (`ontology.yaml`, `.jsonld`, `.json`, `.sql`) bypass negotiation, because negotiation is fragile through proxies and impossible to paste into a chat message.
- **302, not 301.** A permanent redirect is cached by intermediaries indefinitely, which would make a future hosting change take years to propagate — the opposite of what a permanent identifier is for. The IRI is permanent; where it points today is not.

**Licence:** the schema is CC0-1.0. (The datasets it describes carry their own per-source terms — the schema being open is deliberate and separate.)

Single squashed commit; contact info is in both the `README.md` and an `.htaccess` comment.

Maintainer contact: mandase@certvas.com
