### PR TITLE
Add NEDT persistent identifier redirect

### DIFF
--- a/nedt/.htaccess
+++ b/nedt/.htaccess
@@ -1,0 +1,26 @@
+# NEDT (National Energy Digital Twin) persistent identifier
+# Namespace: https://w3id.org/nedt#
+# Source: https://github.com/buildinginformaticslab/nedt-ontology
+
+Options -MultiViews
+Options +FollowSymLinks
+RewriteEngine On
+
+# Human-readable ontology landing page.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://github.com/buildinginformaticslab/nedt-ontology/blob/main/DT_ontology.ttl [R=303,L]
+
+# Machine-readable JSON-LD, RDF/XML and Turtle serialisations. Turtle is the
+# canonical/default representation until additional serialisations are hosted.
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/owl\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^$ https://raw.githubusercontent.com/buildinginformaticslab/nedt-ontology/main/DT_ontology.ttl [R=303,L]
+
+# Default for clients without an Accept header, and for hash-term IRIs (whose
+# fragments are not sent to the server).
+RewriteRule ^$ https://raw.githubusercontent.com/buildinginformaticslab/nedt-ontology/main/DT_ontology.ttl [R=303,L]

--- a/nedt/README.md
+++ b/nedt/README.md
@@ -1,0 +1,28 @@
+# NEDT persistent identifier
+
+This directory registers the persistent namespace
+[`https://w3id.org/nedt#`](https://w3id.org/nedt#) for the National Energy
+Digital Twin (NEDT) ontology.
+
+The namespace redirects to the canonical OWL/Turtle ontology maintained at
+<https://github.com/buildinginformaticslab/nedt-ontology>. Hash-term IRIs are
+intended to remain stable across repository and hosting changes.
+
+## Contact and maintenance
+
+- Project organisation: [Building Informatics Lab](https://github.com/buildinginformaticslab)
+- Source repository: <https://github.com/buildinginformaticslab/nedt-ontology>
+- Maintenance contact: open an issue at
+  <https://github.com/buildinginformaticslab/nedt-ontology/issues>
+
+## Maintainers
+
+[Divyanshu Sood](https://github.com/divyanshusood)
+
+## Redirect behaviour
+
+Browser requests are redirected to the human-readable GitHub ontology page.
+Turtle, RDF/XML, JSON-LD, and default non-browser requests are redirected with
+HTTP 303 to the canonical Turtle serialisation. The ontology currently has no
+separate JSON-LD or RDF/XML release; those requests deliberately receive the
+canonical Turtle document rather than a fabricated representation.


### PR DESCRIPTION
## Add NEDT persistent identifier

This pull request registers `https://w3id.org/nedt#` for the National Energy
Digital Twin (NEDT) ontology.

- Canonical source: <https://github.com/buildinginformaticslab/nedt-ontology>
- Default machine-readable target: `DT_ontology.ttl`
- Browser target: the repository's ontology page
- Redirect code: HTTP 303

The ontology uses hash IRIs, so all terms resolve through the namespace URI.
The project organisation maintains the source repository; its issue tracker is
the maintenance contact listed in `nedt/README.md`.

