### PR TITLE
Add /quay/ namespace for QUAY ontology

### DIFF
--- a/quay/.htaccess
+++ b/quay/.htaccess
@@ -1,0 +1,39 @@
+# .htaccess for QUAY ontology permanent URIs
+# Maintainer: Thomas Hanke <thomas.hanke@iwm.fraunhofer.de> [@ThHanke]
+RewriteEngine On
+
+SetEnvIf Request_URI ^/quay$                          ONT_BASE=https://ThHanke.github.io/quay ONT_DOC=/dev/doc
+SetEnvIf Request_URI ^/quay/(.*)$                     ONT_BASE=https://ThHanke.github.io/quay ONT_DOC=/dev/doc ONT_ANCHOR=$1
+SetEnvIf Request_URI ^/quay/(\d+\.\d+\.\d+)$         ONT_BASE=https://ThHanke.github.io/quay ONT_DOC=/$1/doc
+SetEnvIf Request_URI ^/quay/(\d+\.\d+\.\d+)/(.*)$    ONT_BASE=https://ThHanke.github.io/quay ONT_DOC=/$1/doc ONT_ANCHOR=$2
+
+# HTML
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteRule ^(.*)$ %{ENV:ONT_BASE}%{ENV:ONT_DOC}/index-en.html#%{ENV:ONT_ANCHOR} [R=303,L,NE]
+
+# JSON-LD
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(.*)$ %{ENV:ONT_BASE}%{ENV:ONT_DOC}/ontology.jsonld [R=303,L]
+
+# RDF/XML
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(.*)$ %{ENV:ONT_BASE}%{ENV:ONT_DOC}/ontology.owl [R=303,L]
+
+# N-Triples
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^(.*)$ %{ENV:ONT_BASE}%{ENV:ONT_DOC}/ontology.nt [R=303,L]
+
+# Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^(.*)$ %{ENV:ONT_BASE}%{ENV:ONT_DOC}/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} .+
+RewriteRule ^.*$ %{ENV:ONT_BASE}%{ENV:ONT_DOC}/406.html [R=406,L]
+
+# Default
+RewriteRule ^(.*)$ %{ENV:ONT_BASE}%{ENV:ONT_DOC}/ontology.owl [R=303,L]

--- a/quay/README.md
+++ b/quay/README.md
@@ -1,0 +1,19 @@
+# /quay/
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the QUAY ontology (Qualified Usage, Access and Yield).
+
+## Uses
+This namespace provides permanent identifiers for the QUAY ontology — a DCAT Profile for Data Access, Storage and Authorization Metadata.
+
+- `https://w3id.org/quay` — QUAY ontology (latest)
+- `https://w3id.org/quay/{version}` — specific version (e.g., `1.0.0`)
+
+Content negotiation redirects to the appropriate format (HTML documentation, RDF/XML, Turtle, JSON-LD, N-Triples) hosted on GitHub Pages.
+
+## Contact
+Current maintainer:
+* [@ThHanke](https://github.com/ThHanke)
+
+This space is administered by:
+
+**Thomas Hanke**
+GitHub: [ThHanke](https://github.com/ThHanke)


### PR DESCRIPTION
## Brief Description
Permanent URI redirects for QUAY (Qualified Usage, Access and Yield) — a DCAT Profile for Data Access, Storage and Authorization Metadata. Content negotiation serves HTML, RDF/XML, Turtle, JSON-LD, and N-Triples from https://ThHanke.github.io/quay with versioned and dev paths.

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Optional Requests for W3ID Maintainers
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
