### PR TITLE
Add estleg PURL for the Estonian Legal Ontology

### DIFF
--- a/estleg/.htaccess
+++ b/estleg/.htaccess
@@ -2,8 +2,10 @@
 # Adopted in issue #516, replacing the non-resolvable, government-owned
 # data.riik.ee/ontology/estleg# scheme.
 #
-# Maintainer / contact: Henrik Aavik — https://github.com/henrikaavik
-# Project / source:      https://github.com/henrikaavik/estonian-legal-ontology
+# Maintainer / contact: Henrik Aavik
+# email: henrik.aavik@gmail.com
+# GitHub username: henrikaavik
+# Project / source: https://github.com/henrikaavik/estonian-legal-ontology
 #
 # A content-negotiating 303 resolver (RDF vs HTML per Accept) is planned. Until
 # it is stood up, term IRIs temporarily redirect to the project repository so

--- a/estleg/.htaccess
+++ b/estleg/.htaccess
@@ -1,0 +1,25 @@
+# https://w3id.org/estleg/ — Estonian Legal Ontology namespace (estleg).
+# Adopted in issue #516, replacing the non-resolvable, government-owned
+# data.riik.ee/ontology/estleg# scheme.
+#
+# Maintainer / contact: Henrik Aavik — https://github.com/henrikaavik
+# Project / source:      https://github.com/henrikaavik/estonian-legal-ontology
+#
+# A content-negotiating 303 resolver (RDF vs HTML per Accept) is planned. Until
+# it is stood up, term IRIs temporarily redirect to the project repository so
+# the identifiers resolve to something human-usable ("stable ID now, resolver
+# later").
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# Version IRI (https://w3id.org/estleg/1.0.0) → tagged GitHub Release.
+RewriteRule ^1\.0\.0/?$ https://github.com/henrikaavik/estonian-legal-ontology/releases/tag/v1.0.0 [R=302,L]
+
+# (Future) content negotiation to the machine-readable graph:
+#   RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+#   RewriteCond %{HTTP_ACCEPT} application/ld\+json
+#   RewriteRule ^(.*)$ https://github.com/henrikaavik/estonian-legal-ontology/releases/download/v1.0.0/combined_ontology.jsonld.gz [R=303,L]
+
+# Interim: send every IRI under this namespace to the project repository.
+RewriteRule ^(.*)$ https://github.com/henrikaavik/estonian-legal-ontology [R=302,L]

--- a/estleg/README.md
+++ b/estleg/README.md
@@ -1,0 +1,18 @@
+# `https://w3id.org/estleg/` — Estonian Legal Ontology
+
+Persistent namespace for the **Estonian Legal Ontology** (`estleg`): a
+machine-readable JSON-LD/RDF ontology of Estonian and EU law.
+
+- **Namespace:** `https://w3id.org/estleg/`
+- **Term IRI shape:** `https://w3id.org/estleg/<LocalName>` (e.g.
+  `https://w3id.org/estleg/KarS_Par_141`)
+- **Ontology / version IRI:** `https://w3id.org/estleg`, `https://w3id.org/estleg/<version>`
+- **Project / source:** <https://github.com/henrikaavik/estonian-legal-ontology>
+- **Current release:** <https://github.com/henrikaavik/estonian-legal-ontology/releases/tag/v1.0.0>
+- **Maintainer / contact:** Henrik Aavik — <https://github.com/henrikaavik>
+
+A content-negotiating 303 resolver (RDF vs HTML per `Accept`) is planned.
+Until that resolver is stood up, term IRIs redirect to the project
+repository so the identifiers resolve to something human-usable. The
+version IRI `https://w3id.org/estleg/1.0.0` redirects to the tagged
+GitHub Release.

--- a/estleg/README.md
+++ b/estleg/README.md
@@ -9,7 +9,7 @@ machine-readable JSON-LD/RDF ontology of Estonian and EU law.
 - **Ontology / version IRI:** `https://w3id.org/estleg`, `https://w3id.org/estleg/<version>`
 - **Project / source:** <https://github.com/henrikaavik/estonian-legal-ontology>
 - **Current release:** <https://github.com/henrikaavik/estonian-legal-ontology/releases/tag/v1.0.0>
-- **Maintainer / contact:** Henrik Aavik — <https://github.com/henrikaavik>
+- **Maintainer / contact:** Henrik Aavik — <https://github.com/henrikaavik> — henrik.aavik@gmail.com
 
 A content-negotiating 303 resolver (RDF vs HTML per `Accept`) is planned.
 Until that resolver is stood up, term IRIs redirect to the project


### PR DESCRIPTION
## Purpose

Register `https://w3id.org/estleg/` as the persistent namespace for the
**Estonian Legal Ontology** (`estleg`): a machine-readable JSON-LD/RDF
ontology of Estonian and EU law.

The identifiers are already minted in the published v1.0.0 dataset
(`https://w3id.org/estleg/<LocalName>`). Without this directory they 404.

## Files

- `estleg/.htaccess` — interim 302 to the project repository; `1.0.0` goes to the tagged GitHub Release. A content-negotiating 303 (RDF vs HTML) is planned and left commented.
- `estleg/README.md` — human-readable identifier page + maintainer contact.

## Contact

- Maintainer: Henrik Aavik — https://github.com/henrikaavik
- Project: https://github.com/henrikaavik/estonian-legal-ontology
- Current release: https://github.com/henrikaavik/estonian-legal-ontology/releases/tag/v1.0.0

## Test

After merge:

- `https://w3id.org/estleg/` → 302 to the GitHub repository
- `https://w3id.org/estleg/KarS_Par_141` → 302 to the GitHub repository
- `https://w3id.org/estleg/1.0.0` → 302 to the v1.0.0 GitHub Release