### PR TITLE
croissant-policy: redirects for the Croissant Policy Profile

### DIFF
--- a/croissant-policy/.htaccess
+++ b/croissant-policy/.htaccess
@@ -1,0 +1,43 @@
+# Name of the project: Croissant Policy Profile
+#
+# Description: An additive policy layer for Croissant dataset descriptors.
+#   Croissant describes what a dataset is; it does not say what may be done with
+#   it. This profile lets a dataset declare the operations it admits and the
+#   conditions under which it admits them, so that a gate in front of the data
+#   can permit or refuse a request from the descriptor alone and leave a record
+#   of what it checked.
+#
+#   This is an independent profile built on Croissant. It is not an MLCommons
+#   product and carries no endorsement from the Croissant project.
+#
+# Specification, reference implementation and conformance validator:
+#   https://github.com/doytsujin/ok-croissant-policy-profile
+#
+# Contacts:
+# - Alexander Chernov, GitHub username: doytsujin
+
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks -MultiViews
+AddType application/ld+json .jsonld
+
+RewriteEngine on
+
+SetEnvIf Request_URI ^.*$ PROFILE_URL=https://doytsujin.github.io/ok-croissant-policy-profile/ns
+
+# A specific version, asked for as JSON-LD: the context document.
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ %{ENV:PROFILE_URL}/$1/context.jsonld [R=303,L]
+
+# A specific version, asked for by a browser or anything else: the profile.
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ %{ENV:PROFILE_URL}/$1/ [R=303,L]
+
+# A term within a version, e.g. /0.1.0/policy. There is no per-term document,
+# so a term resolves to the profile document that defines it.
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/(.+)$ %{ENV:PROFILE_URL}/$1/ [R=303,L]
+
+# The bare namespace: the version index.
+RewriteRule ^$ %{ENV:PROFILE_URL}/ [R=303,L]
+
+# Anything else.
+RewriteRule ^(.*)$ %{ENV:PROFILE_URL}/ [R=303,L]

--- a/croissant-policy/README.md
+++ b/croissant-policy/README.md
@@ -1,0 +1,44 @@
+## Croissant Policy Profile
+
+An additive policy layer for [Croissant](https://mlcommons.org/working-groups/data/croissant/)
+dataset descriptors.
+
+Croissant describes what a dataset *is*. It does not say what may be *done* with
+it, by whom, in which state, or what happens when a consumer asks for something
+the dataset does not permit. This profile adds a machine-checkable statement of
+the operations a dataset admits and the conditions under which it admits them,
+so that a gate in front of the data can permit or refuse a request from the
+descriptor alone, and leave a record of why. Removing the profile's terms leaves
+a valid Croissant 1.0 document.
+
+**This is an independent profile built on Croissant. It is not an MLCommons
+product and carries no endorsement from the Croissant project.**
+
+### Redirects
+
+| Request | Resolves to |
+|---|---|
+| `https://w3id.org/croissant-policy/` | the version index |
+| `https://w3id.org/croissant-policy/0.1.0` | the human-readable profile document |
+| `https://w3id.org/croissant-policy/0.1.0` with `Accept: application/ld+json` | `context.jsonld`, the term definitions |
+| `https://w3id.org/croissant-policy/0.1.0/<term>` | the profile document defining that term |
+
+All redirects are `303 See Other` to
+`https://doytsujin.github.io/ok-croissant-policy-profile/ns/`.
+
+Versions are never changed in place. Extending the profile's operator set is a
+version bump, because a conforming evaluator must refuse an operator it does not
+implement — so a term silently added to an existing version would turn a permit
+into a refusal for older consumers.
+
+### Source
+
+Specification, reference implementation, conformance validator, and measured
+overhead: <https://github.com/doytsujin/ok-croissant-policy-profile>
+
+Archived at [doi:10.5281/zenodo.22018156](https://doi.org/10.5281/zenodo.22018156),
+which resolves to the newest released version.
+
+Emitted documents are checked against MLCommons' `mlcroissant` validator.
+
+Maintainer: Alexander Chernov (@doytsujin)


### PR DESCRIPTION
Requesting `https://w3id.org/croissant-policy/`.

### What it identifies

An additive policy layer for [Croissant](https://mlcommons.org/working-groups/data/croissant/) dataset descriptors. Croissant describes what a dataset *is*; it does not say what may be *done* with it, by whom, in which state, or what happens when a consumer asks for something the dataset does not permit. This profile adds a machine-checkable statement of the operations a dataset admits and the conditions under which it admits them, so a gate in front of the data can permit or refuse from the descriptor alone and leave a record of what it checked. Stripping the profile's terms leaves a valid Croissant 1.0 document.

**This is an independent profile built on Croissant. It is not an MLCommons product and carries no endorsement from the Croissant project.** Both files state this explicitly.

### Why a permanent identifier

The namespace string is embedded in every conforming document, as a value of `conformsTo`. Documents circulate independently of wherever the profile is hosted, so the identifier has to outlive hosting decisions — which is exactly what w3id is for. Versions are never changed in place: extending the operator set is a version bump, because a conforming evaluator must refuse an operator it does not implement, so a term silently added to an existing version would turn a permit into a refusal for existing consumers.

### Redirects

303 See Other to `https://doytsujin.github.io/ok-croissant-policy-profile/ns/`, which is live and serving now:

| Request | Resolves to |
|---|---|
| `/croissant-policy/` | version index |
| `/croissant-policy/0.1.0` | human-readable profile document |
| `/croissant-policy/0.1.0` with `Accept: application/ld+json` | `context.jsonld` |
| `/croissant-policy/0.1.0/<term>` | the profile document defining that term |

### Source and archive

- Specification, reference implementation, conformance validator and measured overhead: https://github.com/doytsujin/ok-croissant-policy-profile
- Archived: [doi:10.5281/zenodo.22018156](https://doi.org/10.5281/zenodo.22018156)
- Emitted documents are validated against MLCommons' `mlcroissant` 1.1.0

Maintainer: Alexander Chernov (@doytsujin)