### PR TITLE
Add HerbKG permanent identifier

### DIFF
--- a/herbkg/.htaccess
+++ b/herbkg/.htaccess
@@ -1,0 +1,31 @@
+# ============================================================
+# File: herbkg/.htaccess
+# Place in the perma-id/w3id.org repository under a new folder
+# named "herbkg", then open a pull request.
+# ============================================================
+
+# HerbKG — ontology-guided cross-lingual knowledge graph
+# integrating traditional Chinese medicine and modern biomedicine
+# Contact: Chao Chen <Chao.Chen@nottingham.ac.uk>
+# Source repository: https://github.com/shellezhu/tcm-mm-ontology
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# --- Content negotiation for the ontology schema ---
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/rdf\+turtle
+RewriteRule ^$ https://raw.githubusercontent.com/shellezhu/tcm-mm-ontology/main/ontology-core.ttl [R=302,L]
+
+# --- Direct file access ---
+RewriteRule ^ontology-core\.ttl$ https://raw.githubusercontent.com/shellezhu/tcm-mm-ontology/main/ontology-core.ttl [R=302,L]
+RewriteRule ^ontology-extension-datatypes\.ttl$ https://raw.githubusercontent.com/shellezhu/tcm-mm-ontology/main/ontology-extension-datatypes.ttl [R=302,L]
+
+# --- Released derived subset ---
+RewriteRule ^data/herbkg-derived-core\.ttl$ https://raw.githubusercontent.com/shellezhu/tcm-mm-ontology/main/data/derived/herbkg-derived-core.ttl [R=302,L]
+RewriteRule ^data/herbkg-derived-core\.csv$ https://raw.githubusercontent.com/shellezhu/tcm-mm-ontology/main/data/derived/herbkg-derived-core.csv [R=302,L]
+
+# --- Human-readable default: bare namespace, term URIs, and anything else ---
+RewriteRule ^$ https://github.com/shellezhu/tcm-mm-ontology [R=302,L]
+RewriteRule ^(.*)$ https://github.com/shellezhu/tcm-mm-ontology [R=302,L]

--- a/herbkg/.htaccess
+++ b/herbkg/.htaccess
@@ -1,7 +1,5 @@
 # ============================================================
 # File: herbkg/.htaccess
-# Place in the perma-id/w3id.org repository under a new folder
-# named "herbkg", then open a pull request.
 # ============================================================
 
 # HerbKG — ontology-guided cross-lingual knowledge graph

--- a/herbkg/.htaccess
+++ b/herbkg/.htaccess
@@ -6,7 +6,7 @@
 
 # HerbKG — ontology-guided cross-lingual knowledge graph
 # integrating traditional Chinese medicine and modern biomedicine
-# Contact: Chao Chen <Chao.Chen@nottingham.ac.uk>
+# Contact: Xian Zhu <zhuxian@njucm.edu.cn>  
 # Source repository: https://github.com/shellezhu/tcm-mm-ontology
 
 Options +FollowSymLinks

--- a/herbkg/README.md
+++ b/herbkg/README.md
@@ -7,7 +7,7 @@ Preferred prefix: `herbkg:`
 Source repository: https://github.com/shellezhu/tcm-mm-ontology
 Archived release: https://doi.org/10.5281/zenodo.19358396
 Maintainer: Institute of Literature Research, Nanjing University of Chinese Medicine
-Contact: Chao Chen Chao.Chen@nottingham.ac.uk
+Contact: Xian Zhu zhuxian@njucm.edu.cn
 Licence: CC BY 4.0
 Resolution
 URI	Resolves to

--- a/herbkg/README.md
+++ b/herbkg/README.md
@@ -1,0 +1,18 @@
+HerbKG
+Permanent identifier for the HerbKG ontology schema — an ontology-guided,
+cross-lingual knowledge graph integrating traditional Chinese medicine (TCM)
+and modern biomedical knowledge.
+Namespace: https://w3id.org/herbkg/
+Preferred prefix: `herbkg:`
+Source repository: https://github.com/shellezhu/tcm-mm-ontology
+Archived release: https://doi.org/10.5281/zenodo.19358396
+Maintainer: Institute of Literature Research, Nanjing University of Chinese Medicine
+Contact: Chao Chen Chao.Chen@nottingham.ac.uk
+Licence: CC BY 4.0
+Resolution
+URI	Resolves to
+`https://w3id.org/herbkg/`	Source repository (HTML), or `ontology-core.ttl` under Turtle content negotiation
+`https://w3id.org/herbkg/ontology-core.ttl`	Core ontology schema (TBox)
+`https://w3id.org/herbkg/ontology-extension-datatypes.ttl`	Optional datatype-property extensions
+`https://w3id.org/herbkg/data/herbkg-derived-core.ttl`	Released derived graph subset (Turtle)
+`https://w3id.org/herbkg/data/herbkg-derived-core.csv`	Released derived graph subset (CSV)

--- a/herbkg/README.md
+++ b/herbkg/README.md
@@ -1,18 +1,23 @@
-HerbKG
+# HerbKG
+
 Permanent identifier for the HerbKG ontology schema — an ontology-guided,
 cross-lingual knowledge graph integrating traditional Chinese medicine (TCM)
 and modern biomedical knowledge.
-Namespace: https://w3id.org/herbkg/
-Preferred prefix: `herbkg:`
-Source repository: https://github.com/shellezhu/tcm-mm-ontology
-Archived release: https://doi.org/10.5281/zenodo.19358396
-Maintainer: Institute of Literature Research, Nanjing University of Chinese Medicine
-Contact: Xian Zhu zhuxian@njucm.edu.cn
-Licence: CC BY 4.0
-Resolution
-URI	Resolves to
-`https://w3id.org/herbkg/`	Source repository (HTML), or `ontology-core.ttl` under Turtle content negotiation
-`https://w3id.org/herbkg/ontology-core.ttl`	Core ontology schema (TBox)
-`https://w3id.org/herbkg/ontology-extension-datatypes.ttl`	Optional datatype-property extensions
-`https://w3id.org/herbkg/data/herbkg-derived-core.ttl`	Released derived graph subset (Turtle)
-`https://w3id.org/herbkg/data/herbkg-derived-core.csv`	Released derived graph subset (CSV)
+
+- **Namespace:** https://w3id.org/herbkg/
+- **Preferred prefix:** `herbkg:`
+- **Source repository:** https://github.com/shellezhu/tcm-mm-ontology
+- **Archived release:** https://doi.org/10.5281/zenodo.19358396
+- **Maintainer:** Institute of Literature Research, Nanjing University of Chinese Medicine
+- **Contact:** Xian Zhu ([shellezhu](https://github.com/shellezhu)), zhuxian@njucm.edu.cn
+- **Licence:** CC BY 4.0
+
+## Resolution
+
+| URI | Resolves to |
+| --- | --- |
+| `https://w3id.org/herbkg/` | Source repository (HTML), or `ontology-core.ttl` under Turtle content negotiation |
+| `https://w3id.org/herbkg/ontology-core.ttl` | Core ontology schema (TBox) |
+| `https://w3id.org/herbkg/ontology-extension-datatypes.ttl` | Optional datatype-property extensions |
+| `https://w3id.org/herbkg/data/herbkg-derived-core.ttl` | Released derived graph subset (Turtle) |
+| `https://w3id.org/herbkg/data/herbkg-derived-core.csv` | Released derived graph subset (CSV) |


### PR DESCRIPTION
Adds https://w3id.org/herbkg/ for the HerbKG ontology schema,
an ontology-guided cross-lingual knowledge graph integrating
traditional Chinese medicine and modern biomedical knowledge.

Source: https://github.com/shellezhu/tcm-mm-ontology
Contact: Xian Zhu <zhuxian@njucm.edu.cn>
Maintainer: School of Health Economics and Management, Nanjing University of Chinese Medicine