### PR TITLE
Add castello-anima-vocab and castello-edizione-vocab (SKOS namespaces)

### DIFF
--- a/castello-anima-vocab/.htaccess
+++ b/castello-anima-vocab/.htaccess
@@ -1,0 +1,18 @@
+# .htaccess per perma-id/w3id.org — cartella  castello-anima-vocab/
+# NON va in questo repo: va nel fork di perma-id/w3id.org, in una PR.
+# URI dereferenziabili con content negotiation:
+#   - una macchina che chiede Turtle  -> il vocabolario .ttl completo
+#   - un browser (o qualsiasi altro)   -> la pagina leggibile del concetto
+Options +FollowSymLinks
+RewriteEngine On
+
+# 1) Richiesta esplicita di Turtle -> il .ttl completo (dati per le macchine)
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC,OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [NC]
+RewriteRule ^(.*)$ https://luciano-longo77.github.io/castello-anima-TEI-IA/vocab/castello-anima-vocab.ttl [R=303,L]
+
+# 2) Un singolo concetto (o asse) -> la sua pagina umana
+RewriteRule ^([^/]+)/?$ https://luciano-longo77.github.io/castello-anima-TEI-IA/vocab/site/?c=$1 [R=303,L]
+
+# 3) La base del vocabolario -> l'indice
+RewriteRule ^$ https://luciano-longo77.github.io/castello-anima-TEI-IA/vocab/site/ [R=303,L]

--- a/castello-anima-vocab/.htaccess
+++ b/castello-anima-vocab/.htaccess
@@ -1,18 +1,18 @@
-# .htaccess per perma-id/w3id.org — cartella  castello-anima-vocab/
-# NON va in questo repo: va nel fork di perma-id/w3id.org, in una PR.
-# URI dereferenziabili con content negotiation:
-#   - una macchina che chiede Turtle  -> il vocabolario .ttl completo
-#   - un browser (o qualsiasi altro)   -> la pagina leggibile del concetto
+# w3id.org permanent identifier for https://w3id.org/castello-anima-vocab/
+# Dereferenceable URIs with content negotiation:
+#   - a machine requesting Turtle    -> the full .ttl vocabulary
+#   - a browser (or anything else)   -> the human-readable concept page
+# maintainer: @luciano-longo77
 Options +FollowSymLinks
 RewriteEngine On
 
-# 1) Richiesta esplicita di Turtle -> il .ttl completo (dati per le macchine)
+# 1) Explicit Turtle request -> the full .ttl (machine data)
 RewriteCond %{HTTP_ACCEPT} text/turtle [NC,OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle [NC]
 RewriteRule ^(.*)$ https://luciano-longo77.github.io/castello-anima-TEI-IA/vocab/castello-anima-vocab.ttl [R=303,L]
 
-# 2) Un singolo concetto (o asse) -> la sua pagina umana
+# 2) A single concept (or axis) -> its human page
 RewriteRule ^([^/]+)/?$ https://luciano-longo77.github.io/castello-anima-TEI-IA/vocab/site/?c=$1 [R=303,L]
 
-# 3) La base del vocabolario -> l'indice
+# 3) The vocabulary base -> the index
 RewriteRule ^$ https://luciano-longo77.github.io/castello-anima-TEI-IA/vocab/site/ [R=303,L]

--- a/castello-edizione-vocab/.htaccess
+++ b/castello-edizione-vocab/.htaccess
@@ -1,14 +1,21 @@
 # w3id.org permanent identifier for https://w3id.org/castello-edizione-vocab/
 # SKOS vocabulary of the 17 mystical states (twin repo: castello-dell-anima-edizione).
+# Dereferenceable URIs with content negotiation:
+#   - a machine requesting RDF/Turtle -> the full .ttl vocabulary
+#   - a browser (or anything else)    -> the human-readable viewer
 # maintainer: @luciano-longo77
 Options +FollowSymLinks
-RewriteEngine on
+RewriteEngine On
 
-# Content negotiation: explicit RDF request (Turtle / RDF-XML) -> .ttl file
-RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
-RewriteCond %{HTTP_ACCEPT} application/x-turtle
-RewriteRule ^(.*)$ https://luciano-longo77.github.io/castello-dell-anima-edizione/vocab/castello-edizione-vocab.ttl [R=302,L]
+# 1) Explicit RDF/Turtle request -> the full .ttl (machine data)
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC,OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC,OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [NC]
+RewriteRule ^(.*)$ https://luciano-longo77.github.io/castello-dell-anima-edizione/vocab/castello-edizione-vocab.ttl [R=303,L]
 
-# Default (browser and any other request) -> same .ttl
-RewriteRule ^(.*)$ https://luciano-longo77.github.io/castello-dell-anima-edizione/vocab/castello-edizione-vocab.ttl [R=302,L]
+# 2) A single mystical state -> its page in the viewer
+RewriteRule ^([^/]+)/?$ https://luciano-longo77.github.io/castello-dell-anima-edizione/vocab/?c=$1 [R=303,L]
+
+# 3) The vocabulary base -> the viewer index
+RewriteRule ^$ https://luciano-longo77.github.io/castello-dell-anima-edizione/vocab/ [R=303,L]
+

--- a/castello-edizione-vocab/.htaccess
+++ b/castello-edizione-vocab/.htaccess
@@ -1,0 +1,13 @@
+# w3id.org — redirect permanente per https://w3id.org/castello-edizione-vocab/
+# Vocabolario SKOS dei 17 stati-mistici del repo castello-dell-anima-edizione.
+Options +FollowSymLinks
+RewriteEngine on
+
+# Content negotiation: richiesta RDF esplicita (Turtle / RDF-XML) -> file .ttl
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^(.*)$ https://luciano-longo77.github.io/castello-dell-anima-edizione/vocab/castello-edizione-vocab.ttl [R=302,L]
+
+# Default (browser e ogni altra richiesta) -> stesso .ttl
+RewriteRule ^(.*)$ https://luciano-longo77.github.io/castello-dell-anima-edizione/vocab/castello-edizione-vocab.ttl [R=302,L]

--- a/castello-edizione-vocab/.htaccess
+++ b/castello-edizione-vocab/.htaccess
@@ -1,13 +1,14 @@
-# w3id.org — redirect permanente per https://w3id.org/castello-edizione-vocab/
-# Vocabolario SKOS dei 17 stati-mistici del repo castello-dell-anima-edizione.
+# w3id.org permanent identifier for https://w3id.org/castello-edizione-vocab/
+# SKOS vocabulary of the 17 mystical states (twin repo: castello-dell-anima-edizione).
+# maintainer: @luciano-longo77
 Options +FollowSymLinks
 RewriteEngine on
 
-# Content negotiation: richiesta RDF esplicita (Turtle / RDF-XML) -> file .ttl
+# Content negotiation: explicit RDF request (Turtle / RDF-XML) -> .ttl file
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
 RewriteRule ^(.*)$ https://luciano-longo77.github.io/castello-dell-anima-edizione/vocab/castello-edizione-vocab.ttl [R=302,L]
 
-# Default (browser e ogni altra richiesta) -> stesso .ttl
+# Default (browser and any other request) -> same .ttl
 RewriteRule ^(.*)$ https://luciano-longo77.github.io/castello-dell-anima-edizione/vocab/castello-edizione-vocab.ttl [R=302,L]


### PR DESCRIPTION
New w3id namespace for a SKOS controlled vocabulary of a TEI digital edition
(Il Castello dell'anima). Content-negotiated redirect to GitHub Pages
(luciano-longo77.github.io/castello-anima-TEI-IA/). Maintained by the repo owner.