### PR TITLE
Croissant Policy Profile: add /croissant-policy namespace

### DIFF
--- a/croissant-policy/.htaccess
+++ b/croissant-policy/.htaccess
@@ -1,0 +1,60 @@
+# Name of the project: Croissant Policy Profile
+#
+# Description: An additive policy layer for Croissant dataset descriptors.
+#   Croissant describes what a dataset is; it does not say what may be done with
+#   it. This profile lets a dataset declare the operations it admits and the
+#   conditions under which it admits them, so that a gate in front of the data
+#   can permit or refuse a request from the descriptor alone and leave a record
+#   of what it checked.
+#
+#   This is an independent profile built on Croissant. It is not an MLCommons
+#   product and carries no endorsement from the Croissant project.
+#
+# Specification, reference implementation and conformance validator:
+#   https://github.com/doytsujin/ok-croissant-policy-profile
+#
+# Contacts:
+# - Alexander Chernov, GitHub username: doytsujin
+#   ORCID: https://orcid.org/0009-0007-3198-2712
+#   Preferred route: issues on the repository above
+
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks -MultiViews
+AddType application/ld+json .jsonld
+AddType text/turtle .ttl
+
+RewriteEngine on
+
+SetEnvIf Request_URI ^.*$ PROFILE_URL=https://doytsujin.github.io/ok-croissant-policy-profile/ns
+
+# A specific version, asked for as JSON-LD: the context document.
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ %{ENV:PROFILE_URL}/$1/context.jsonld [R=303,L]
+
+# A specific version, asked for by a browser or anything else: the profile.
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ %{ENV:PROFILE_URL}/$1/ [R=303,L]
+
+# The named artifacts of a version. These are files rather than terms, and each
+# resolves to itself: the PROF description of the profile and its resources, the
+# SHACL shapes for the static conformance clauses, and the context.
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/profile\.jsonld$ %{ENV:PROFILE_URL}/$1/profile.jsonld [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/shapes\.ttl$ %{ENV:PROFILE_URL}/$1/shapes.ttl [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/shapes-odrl\.ttl$ %{ENV:PROFILE_URL}/$1/shapes-odrl.ttl [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/context\.jsonld$ %{ENV:PROFILE_URL}/$1/context.jsonld [R=303,L]
+
+# The ODRL carrier is a profile in its own right, with its own identifier: ODRL
+# requires a processor to stop on a profile identifier it does not recognise, so
+# the two forms must not share one. It resolves to the same profile document,
+# which describes both.
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/odrl/?$ %{ENV:PROFILE_URL}/$1/ [R=303,L]
+
+# A term within a version, e.g. /0.1.0/policy. There is no per-term document,
+# so a term resolves to the profile document that defines it.
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/(.+)$ %{ENV:PROFILE_URL}/$1/ [R=303,L]
+
+# The bare namespace: the version index.
+RewriteRule ^$ %{ENV:PROFILE_URL}/ [R=303,L]
+
+# Anything else.
+RewriteRule ^(.*)$ %{ENV:PROFILE_URL}/ [R=303,L]

--- a/croissant-policy/README.md
+++ b/croissant-policy/README.md
@@ -1,0 +1,67 @@
+## Croissant Policy Profile
+
+An additive policy layer for [Croissant](https://mlcommons.org/working-groups/data/croissant/)
+dataset descriptors.
+
+Croissant describes what a dataset *is*. It does not say what may be *done* with
+it, by whom, in which state, or what happens when a consumer asks for something
+the dataset does not permit. This profile adds a machine-checkable statement of
+the operations a dataset admits and the conditions under which it admits them,
+so that a gate in front of the data can permit or refuse a request from the
+descriptor alone, and leave a record of why. Removing the profile's terms leaves
+a valid Croissant 1.0 document.
+
+**This is an independent profile built on Croissant. It is not an MLCommons
+product and carries no endorsement from the Croissant project.**
+
+### Redirects
+
+| Request | Resolves to |
+|---|---|
+| `https://w3id.org/croissant-policy/` | the version index |
+| `https://w3id.org/croissant-policy/0.1.0` | the human-readable profile document |
+| `https://w3id.org/croissant-policy/0.1.0` with `Accept: application/ld+json` | `context.jsonld`, the term definitions |
+| `https://w3id.org/croissant-policy/0.1.0/profile.jsonld` | the PROF description: which artifact plays which role |
+| `https://w3id.org/croissant-policy/0.1.0/shapes.ttl` | SHACL shapes for the static conformance clauses |
+| `https://w3id.org/croissant-policy/0.1.0/odrl` | the ODRL carrier profile, described in the same document |
+| `https://w3id.org/croissant-policy/0.1.0/<term>` | the profile document defining that term |
+
+All redirects are `303 See Other` to
+`https://doytsujin.github.io/ok-croissant-policy-profile/ns/`.
+
+Versions are never changed in place. Extending the profile's operator set is a
+version bump, because a conforming evaluator must refuse an operator it does not
+implement — so a term silently added to an existing version would turn a permit
+into a refusal for older consumers.
+
+### What resolves
+
+| Artifact | Served as |
+|---|---|
+| Profile document | `text/html` |
+| `context.jsonld` — the JSON-LD context | `application/ld+json` |
+| `profile.jsonld` — a `prof:Profile` description of the profile's resources | `application/ld+json` |
+| `shapes.ttl` — SHACL shapes for the profile's conformance clauses | `text/turtle` |
+| `shapes-odrl.ttl` — the same clauses for the ODRL carrier | `text/turtle` |
+
+All of them are live at the redirect target today; the redirect is the only
+missing piece.
+
+### Source
+
+Specification, reference implementation, conformance validator, SHACL shapes and
+measured overhead: <https://github.com/doytsujin/ok-croissant-policy-profile>
+
+Archived at [doi:10.5281/zenodo.22018156](https://doi.org/10.5281/zenodo.22018156),
+a concept DOI resolving to the newest released version.
+
+Emitted documents are checked against MLCommons' `mlcroissant` validator, and
+the rewrite rules in this directory are checked by
+`tests/test_w3id_redirects.py` in the repository above, which applies them to
+every path in the table at the top of this file.
+
+### Contact
+
+Alexander Chernov — GitHub [@doytsujin](https://github.com/doytsujin),
+ORCID [0009-0007-3198-2712](https://orcid.org/0009-0007-3198-2712).
+Issues on the repository above reach the maintainer and are the preferred route.


### PR DESCRIPTION
## What this adds

`/croissant-policy` — a persistent namespace for the **Croissant Policy Profile**, an additive policy profile for [Croissant](https://mlcommons.org/working-groups/data/croissant/) dataset descriptors.

Croissant 1.1 lets a dataset carry machine-readable data use conditions; it does not specify how any of them is evaluated. This profile supplies that half: a dataset declares the operations it admits and the conditions under which it admits them, from a closed set of five operators, so a gate in front of the data can permit or refuse a request from the descriptor alone and leave a record of what was checked.

This is an independent profile built on Croissant. It is not an MLCommons product and carries no endorsement from the Croissant project.

## Redirects

All `303 See Other` to `https://doytsujin.github.io/ok-croissant-policy-profile/ns/`.

| Request | Resolves to | Media type |
|---|---|---|
| `/croissant-policy/` | version index | `text/html` |
| `/croissant-policy/0.1.0` | profile document | `text/html` |
| `/croissant-policy/0.1.0` with `Accept: application/ld+json` | `context.jsonld` | `application/ld+json` |
| `/croissant-policy/0.1.0/profile.jsonld` | PROF description of the profile's resources | `application/ld+json` |
| `/croissant-policy/0.1.0/shapes.ttl` | SHACL shapes for the conformance clauses | `text/turtle` |
| `/croissant-policy/0.1.0/shapes-odrl.ttl` | the same clauses for the ODRL carrier | `text/turtle` |
| `/croissant-policy/0.1.0/<term>` | the profile document defining that term | `text/html` |

303 rather than 302 because the namespace identifies a profile rather than a document.

## Testing

Every target above returns `200` with the media type listed, today — the redirect is the only missing piece.

The rules themselves are checked by [`tests/test_w3id_redirects.py`](https://github.com/doytsujin/ok-croissant-policy-profile/blob/main/tests/test_w3id_redirects.py) in the source repository, which parses this `.htaccess` and applies it to every path in the table: rule ordering and the `[L]` flag, the `SetEnvIf` base variable, and the one `Accept` condition. It also asserts the things ordering makes easy to get wrong — that the named artifacts are not shadowed by the generic term rule, and that the catch-all is last.

## Versioning

A version is never changed in place, and a new version gets a new path rather than a new host. Extending the profile's operator set is a version bump rather than a profile extension, because a conforming evaluator must refuse an operator it does not implement — so a term added silently to an existing version would turn a permit into a refusal for older consumers.

## Contact

Alexander Chernov — GitHub [@doytsujin](https://github.com/doytsujin), ORCID [0009-0007-3198-2712](https://orcid.org/0009-0007-3198-2712).

Source, specification and issues: <https://github.com/doytsujin/ok-croissant-policy-profile>
Archived at [doi:10.5281/zenodo.22018156](https://doi.org/10.5281/zenodo.22018156).
