### PR TITLE
Add ontodesire redirect (OntoDesire reference ontology)

### DIFF
--- a/ontodesire/.htaccess
+++ b/ontodesire/.htaccess
@@ -1,0 +1,31 @@
+# w3id.org/ontodesire
+#
+# OntoDesire -- a reference ontology for declaring theoretical commitments
+# about desire (OWL 2, CC BY 4.0).
+#
+# Contact: Wesley da Silva Santos <wesley.santos@prof.inteli.edu.br>
+#          GitHub username: santos-wesley
+#          ORCID: https://orcid.org/0000-0003-4405-349X
+#          Inteli -- Instituto de Tecnologia e Lideranca, Sao Paulo, Brazil
+# Source:  https://github.com/santos-wesley/ontodesire
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# ---------------------------------------------------------------- audit
+RewriteCond %{HTTP_ACCEPT} .*(text/turtle|application/x-turtle|text/rdf\+n3|application/rdf\+xml|application/n-triples|application/ld\+json).*
+RewriteRule ^audit/?$ https://santos-wesley.github.io/ontodesire/commitments-audit.ttl [R=302,L]
+RewriteRule ^audit/?$ https://santos-wesley.github.io/ontodesire/ [R=302,L]
+
+# ---------------------------------------------------------- commitments
+RewriteCond %{HTTP_ACCEPT} .*(text/turtle|application/x-turtle|text/rdf\+n3|application/rdf\+xml|application/n-triples|application/ld\+json).*
+RewriteRule ^commitments/?$ https://santos-wesley.github.io/ontodesire/ontodesire-commitments.ttl [R=302,L]
+RewriteRule ^commitments/?$ https://santos-wesley.github.io/ontodesire/ [R=302,L]
+
+# ----------------------------------------------------------------- core
+RewriteCond %{HTTP_ACCEPT} .*(text/turtle|application/x-turtle|text/rdf\+n3|application/rdf\+xml|application/n-triples|application/ld\+json).*
+RewriteRule ^$ https://santos-wesley.github.io/ontodesire/ontodesire-core.ttl [R=302,L]
+RewriteRule ^$ https://santos-wesley.github.io/ontodesire/ [R=302,L]
+
+# --------------------------------------------------- any other sub-path
+RewriteRule ^(.+)$ https://santos-wesley.github.io/ontodesire/$1 [R=302,L]

--- a/ontodesire/README.md
+++ b/ontodesire/README.md
@@ -1,0 +1,28 @@
+# w3id.org/ontodesire
+
+Permanent identifier for **OntoDesire**, a reference ontology for declaring
+theoretical commitments about desire.
+
+| Identifier | Resolves to |
+|---|---|
+| `https://w3id.org/ontodesire` | core module (`ontodesire-core.ttl`) / documentation |
+| `https://w3id.org/ontodesire/commitments` | commitments module (`ontodesire-commitments.ttl`) |
+| `https://w3id.org/ontodesire/audit` | commitments audit (`commitments-audit.ttl`) |
+
+RDF requests (`text/turtle`, `application/rdf+xml`, `application/ld+json`, …)
+are redirected to the corresponding Turtle file; all other requests are
+redirected to the human-readable documentation.
+
+- **Namespace**: `https://w3id.org/ontodesire#` (prefix `odsr:`)
+- **Source repository**: <https://github.com/santos-wesley/ontodesire>
+- **Documentation**: <https://santos-wesley.github.io/ontodesire/>
+- **License**: CC BY 4.0
+
+## Contact
+
+This space is administered by:
+
+Wesley da Silva Santos — <wesley.santos@prof.inteli.edu.br>
+GitHub username: santos-wesley
+ORCID: [0000-0003-4405-349X](https://orcid.org/0000-0003-4405-349X)
+Inteli — Instituto de Tecnologia e Liderança, São Paulo, Brazil


### PR DESCRIPTION
Adds a new permanent identifier: `w3id.org/ontodesire`.

**OntoDesire** is an OWL 2 reference ontology for declaring theoretical commitments about desire. It is published under CC BY 4.0.

| Identifier | Resolves to |
|---|---|
| `https://w3id.org/ontodesire` | `ontodesire-core.ttl` (RDF) or the documentation (HTML) |
| `https://w3id.org/ontodesire/commitments` | `ontodesire-commitments.ttl` |
| `https://w3id.org/ontodesire/audit` | `commitments-audit.ttl` |

Content negotiation: requests accepting an RDF media type are redirected to the corresponding Turtle file; everything else goes to the human-readable documentation.

**Redirect targets are live and returning 200:**
- Documentation: https://santos-wesley.github.io/ontodesire/
- Core module: https://santos-wesley.github.io/ontodesire/ontodesire-core.ttl
- Commitments module: https://santos-wesley.github.io/ontodesire/ontodesire-commitments.ttl
- Audit: https://santos-wesley.github.io/ontodesire/commitments-audit.ttl

**Provenance**
- Source repository: https://github.com/santos-wesley/ontodesire
- Archived release: https://doi.org/10.5281/zenodo.22037194

**Contact:** Wesley da Silva Santos (GitHub: @santos-wesley), wesley.santos@prof.inteli.edu.br, ORCID 0000-0003-4405-349X, Inteli — Instituto de Tecnologia e Lideranca, Sao Paulo, Brazil.

Contact information is included in both `.htaccess` and `README.md`, per the contribution guidelines.