### PR TITLE
Add /iirds-validate

### DIFF
--- a/iirds-validate/.htaccess
+++ b/iirds-validate/.htaccess
@@ -1,0 +1,13 @@
+# Permanent identifiers for iirds-validate — SHACL shapes for iiRDS
+# Contact: Wooyong Lee <zero8004paz@gmail.com>, github.com/dev365code
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# The shapes namespace and its metadata vocabulary. Fragment IRIs
+# (ivs:M4, ivm:ruleId) resolve to the namespace document.
+RewriteRule ^shapes/meta$ https://github.com/dev365code/iirds-validate/blob/main/shapes/README.md [R=302,L]
+RewriteRule ^shapes$ https://github.com/dev365code/iirds-validate/tree/main/shapes [R=302,L]
+
+# Everything else under the id: the project.
+RewriteRule ^$ https://github.com/dev365code/iirds-validate [R=302,L]

--- a/iirds-validate/README.md
+++ b/iirds-validate/README.md
@@ -1,0 +1,12 @@
+# /iirds-validate
+
+Permanent identifiers for [iirds-validate](https://github.com/dev365code/iirds-validate),
+an offline conformance validator for iiRDS packages, and its published SHACL
+shapes.
+
+Namespaces in use (in the shipped Turtle files):
+
+- `https://w3id.org/iirds-validate/shapes#` — shape IRIs (`ivs:`)
+- `https://w3id.org/iirds-validate/shapes/meta#` — result-annotation vocabulary (`ivm:`)
+
+Contact: Wooyong Lee — zero8004paz@gmail.com — https://github.com/dev365code


### PR DESCRIPTION
Namespace registration for iirds-validate — an Apache-2.0 offline conformance
validator for iiRDS (intelligent information Request and Delivery Standard)
packages — and the SHACL shapes it publishes for iiRDS 1.3
(https://github.com/dev365code/iirds-validate/tree/main/shapes, also attached
to releases). The shipped Turtle files already mint their shape and
annotation IRIs under `https://w3id.org/iirds-validate/shapes#` and
`.../shapes/meta#`; this PR makes those resolve.

Redirects are 302 to the repository (targets may move to versioned docs
later; the w3id IRIs are the stable ones). I am the project author and
maintain the target repository.
