### PR TITLE
Update OntoJourney redirects for Core v0.9.1

### DIFF
--- a/ontojourney/.htaccess
+++ b/ontojourney/.htaccess
@@ -1,21 +1,35 @@
 Options -MultiViews
 RewriteEngine On
 
-# OntoJourney Core: content negotiation for the ontology and version IRI.
+# OntoJourney Core: immutable v0.9 representation targets.
 RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
-RewriteRule ^core(?:/0\.9)?/?$ https://luisfcosta2015.github.io/ontojourney/artifacts/0.9.0/ontojourney-core.jsonld [R=303,L]
+RewriteRule ^core/0\.9/?$ https://luisfcosta2015.github.io/ontojourney/artifacts/0.9.0/ontojourney-core.jsonld [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/(?:rdf\+xml|owl\+xml) [NC]
-RewriteRule ^core(?:/0\.9)?/?$ https://luisfcosta2015.github.io/ontojourney/artifacts/0.9.0/ontojourney-core.rdf [R=303,L]
+RewriteRule ^core/0\.9/?$ https://luisfcosta2015.github.io/ontojourney/artifacts/0.9.0/ontojourney-core.rdf [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/n-triples [NC]
-RewriteRule ^core(?:/0\.9)?/?$ https://luisfcosta2015.github.io/ontojourney/artifacts/0.9.0/ontojourney-core.nt [R=303,L]
+RewriteRule ^core/0\.9/?$ https://luisfcosta2015.github.io/ontojourney/artifacts/0.9.0/ontojourney-core.nt [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
-RewriteRule ^core(?:/0\.9)?/?$ https://luisfcosta2015.github.io/ontojourney/artifacts/0.9.0/ontojourney-core.ttl [R=303,L]
+RewriteRule ^core/0\.9/?$ https://luisfcosta2015.github.io/ontojourney/artifacts/0.9.0/ontojourney-core.ttl [R=303,L]
+
+# OntoJourney Core v0.9.1 and unversioned latest representation targets.
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^core(?:/0\.9\.1)?/?$ https://luisfcosta2015.github.io/ontojourney/artifacts/0.9.1/ontojourney-core.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/(?:rdf\+xml|owl\+xml) [NC]
+RewriteRule ^core(?:/0\.9\.1)?/?$ https://luisfcosta2015.github.io/ontojourney/artifacts/0.9.1/ontojourney-core.rdf [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples [NC]
+RewriteRule ^core(?:/0\.9\.1)?/?$ https://luisfcosta2015.github.io/ontojourney/artifacts/0.9.1/ontojourney-core.nt [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^core(?:/0\.9\.1)?/?$ https://luisfcosta2015.github.io/ontojourney/artifacts/0.9.1/ontojourney-core.ttl [R=303,L]
 
 # Human-readable defaults.
 RewriteRule ^core/0\.9/?$ https://luisfcosta2015.github.io/ontojourney/releases/0.9.0/ [R=303,L]
+RewriteRule ^core/0\.9\.1/?$ https://luisfcosta2015.github.io/ontojourney/releases/0.9.1/ [R=303,L]
 RewriteRule ^core/?$ https://luisfcosta2015.github.io/ontojourney/model/ [R=303,L]
 
 # Project root.

--- a/ontojourney/README.md
+++ b/ontojourney/README.md
@@ -7,11 +7,17 @@ ontology for narrative-heroic learning journeys.
 
 - `https://w3id.org/ontojourney/core` — ontology IRI
 - `https://w3id.org/ontojourney/core#` — entity namespace
-- `https://w3id.org/ontojourney/core/0.9` — Core v0.9 version IRI
+- `https://w3id.org/ontojourney/core/0.9` — immutable Core v0.9.0 version IRI
+- `https://w3id.org/ontojourney/core/0.9.1` — Core v0.9.1 version IRI
 
 The rules negotiate HTML, Turtle, RDF/XML, JSON-LD, and N-Triples. Entity
 fragments such as `#JourneyModel` are resolved by the client after the base
 ontology IRI is redirected.
+
+The unversioned ontology IRI negotiates the current public release. Versioned
+IRIs remain fixed: adding v0.9.1 does not change the v0.9 targets. The
+post-deployment redirect test is maintained in the
+[OntoJourney repository](https://github.com/luisfcosta2015/ontojourney/tree/main/w3id).
 
 ## Maintainer
 


### PR DESCRIPTION
## Brief Description

Update the existing OntoJourney redirects for Core v0.9.1. The unversioned `/ontojourney/core` identifier now negotiates the current v0.9.1 RDF representations, while `/ontojourney/core/0.9` remains immutable at v0.9.0. This PR also adds the explicit `/ontojourney/core/0.9.1` HTML and RDF routes and documents the versioned-identifier policy.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information.

## New ID Directory Checklist

Not applicable: this PR updates the existing `/ontojourney` directory.

## Update ID Directory Checklist

- [x] GitHub username ids are listed in the maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directory changed in this PR.

## Validation

- all v0.9.1 HTML, Turtle, RDF/XML, JSON-LD, and N-Triples targets return HTTP 200;
- all tested targets return the expected media type;
- the historical v0.9.0 HTML and RDF targets remain available;
- the v0.9.1 GitHub Release and GitHub Pages deployment completed successfully.

Project repository: https://github.com/luisfcosta2015/ontojourney  
Documentation: https://luisfcosta2015.github.io/ontojourney/  
Release: https://github.com/luisfcosta2015/ontojourney/releases/tag/v0.9.1

Maintainer: Luis Felipe Coimbra Costa (@luisfcosta2015)