### PR TITLE
Add matsci-sam namespace

### DIFF
--- a/matsci-sam/.htaccess
+++ b/matsci-sam/.htaccess
@@ -1,0 +1,4 @@
+Header set Access-Control-Allow-Origin *
+
+RewriteEngine on
+RewriteRule ^(.*)$ https://ego.cci.drexel.edu/$1 [R=302,L]

--- a/matsci-sam/README.md
+++ b/matsci-sam/README.md
@@ -1,0 +1,23 @@
+# MatSci-SAM
+
+Permanent identifiers for MatSci-SAM, a community vocabulary application for
+materials science with attributed definitions, SKOS knowledge organization,
+and PROV-O provenance. Successor to the MatSci-YAMZ study platform.
+
+All paths redirect to the running application, which serves HTML pages and
+Turtle and JSON-LD documents under the same path grammar. Examples:
+
+- `https://w3id.org/matsci-sam/vocabulary/{term}`: a `skos:Concept`
+- `https://w3id.org/matsci-sam/vocabulary/{term}/definitions/{n}`: one contributed definition
+- `https://w3id.org/matsci-sam/tags/{scheme}/{concept}`: a concept in a `skos:ConceptScheme`
+- `https://w3id.org/matsci-sam/studies/{slug}`: a study, published as a `prov:Activity`
+- `https://w3id.org/matsci-sam/dataset.ttl`: the published graph
+
+## Contact
+
+| Name | GitHub | Email |
+| ---- | ------ | ----- |
+| Christopher Rauch | [cr625](https://github.com/cr625) | christopher.b.rauch@gmail.com |
+
+Project organization: [metadata-research](https://github.com/metadata-research),
+Metadata Research Center, Drexel University.


### PR DESCRIPTION
Permanent identifiers for MatSci-SAM, a community vocabulary application for materials science (Metadata Research Center, Drexel University). One pattern redirect covering the whole path grammar, CORS enabled. I maintain the application and this namespace.