### PR TITLE
Add varda: dimensional modeling profile for LinkML

### DIFF
--- a/varda/.htaccess
+++ b/varda/.htaccess
@@ -1,0 +1,34 @@
+# # /varda/
+#
+# Varda - a dimensional modeling profile for LinkML.
+#
+# https://w3id.org/varda             profile IRI, content negotiated
+# https://w3id.org/varda/varda.yaml  profile source
+# https://w3id.org/varda/{term}      term documentation, e.g. /varda/role
+#
+# Project: https://github.com/mluttikh/varda
+#
+# ## Contact
+# This space is administered by:
+#
+# GitHub username: mluttikh
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# linkml-runtime appends `.yaml` to an import, so
+# `imports: https://w3id.org/varda/varda` resolves here.
+RewriteRule ^varda\.yaml$ https://raw.githubusercontent.com/mluttikh/varda/main/src/varda/profile/varda.yaml [R=302,L]
+
+# Browsers get the documentation.
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteRule ^$ https://mluttikh.github.io/varda/ [R=302,L]
+
+# Everything else - schema loaders sending */*, curl, YAML media types -
+# gets the profile source.
+RewriteRule ^$ https://raw.githubusercontent.com/mluttikh/varda/main/src/varda/profile/varda.yaml [R=302,L]
+
+# Terms resolve to the vocabulary reference. `NE` keeps Apache from escaping
+# the `#` into `%23`.
+RewriteRule ^(.+)$ https://mluttikh.github.io/varda/reference/vocabulary/#$1 [R=302,L,NE]

--- a/varda/README.md
+++ b/varda/README.md
@@ -1,0 +1,13 @@
+# /varda/
+
+Namespace for Varda, a dimensional modeling profile for
+[LinkML](https://linkml.io/), expressed as annotations on ordinary LinkML
+schemas.
+
+- `https://w3id.org/varda` - profile IRI. Content negotiated: documentation
+  for browsers, the profile source for everything else.
+- `https://w3id.org/varda/varda.yaml` - profile source.
+- `https://w3id.org/varda/{term}` - term documentation, e.g. `/varda/role`.
+- Project: https://github.com/mluttikh/varda
+  (documentation: https://mluttikh.github.io/varda/)
+- Maintainer (GitHub): [@mluttikh](https://github.com/mluttikh)


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
New namespace for Varda, a dimensional modeling profile for LinkML.
`https://w3id.org/varda` is the profile IRI, embedded in every schema that
uses the profile.

Redirects are content negotiated: browsers get the documentation, schema
loaders and other tooling get the profile source. Terms resolve to the
vocabulary reference.

Tested locally with Apache 2.4 + mod_rewrite; all redirect targets return 200.

Maintainer GitHub username: mluttikh

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.