### PR TITLE
Add matrix2llm persistent redirects

### DIFF
--- a/matrix2llm/.htaccess
+++ b/matrix2llm/.htaccess
@@ -1,0 +1,26 @@
+# matrix2llm: persistent redirects for the interactive companion to
+# Mathematics from Matrices to Language Models.
+#
+# Maintainer: Jih-Jeng Huang
+# GitHub: https://github.com/brite0703
+
+RewriteEngine on
+
+# Landing page and stable chapter entry points used by the textbook QR codes.
+RewriteRule ^$ https://matrix2llm.brite0703.workers.dev/ [R=302,L]
+RewriteRule ^ch01/?$ https://matrix2llm.brite0703.workers.dev/ [R=302,L]
+RewriteRule ^ch02/?$ https://matrix2llm.brite0703.workers.dev/labs/span-rank-nullspace [R=302,L]
+RewriteRule ^ch03/?$ https://matrix2llm.brite0703.workers.dev/labs/linear-map [R=302,L]
+RewriteRule ^ch04/?$ https://matrix2llm.brite0703.workers.dev/labs/projection-least-squares [R=302,L]
+RewriteRule ^ch05/?$ https://matrix2llm.brite0703.workers.dev/labs/svd-low-rank-lora [R=302,L]
+RewriteRule ^ch06/?$ https://matrix2llm.brite0703.workers.dev/labs/gradient-jacobian [R=302,L]
+RewriteRule ^ch07/?$ https://matrix2llm.brite0703.workers.dev/labs/backpropagation [R=302,L]
+RewriteRule ^ch08/?$ https://matrix2llm.brite0703.workers.dev/labs/gradient-descent [R=302,L]
+RewriteRule ^ch09/?$ https://matrix2llm.brite0703.workers.dev/labs/probability-simplex [R=302,L]
+RewriteRule ^ch10/?$ https://matrix2llm.brite0703.workers.dev/labs/softmax-cross-entropy [R=302,L]
+RewriteRule ^ch11/?$ https://matrix2llm.brite0703.workers.dev/labs/layernorm-residual-mlp [R=302,L]
+RewriteRule ^ch12/?$ https://matrix2llm.brite0703.workers.dev/labs/attention [R=302,L]
+RewriteRule ^ch13/?$ https://matrix2llm.brite0703.workers.dev/labs/autoregressive-generation [R=302,L]
+
+# Preserve direct links to all laboratory and micro-scene routes.
+RewriteRule ^(.*)$ https://matrix2llm.brite0703.workers.dev/$1 [R=302,L]

--- a/matrix2llm/README.md
+++ b/matrix2llm/README.md
@@ -1,0 +1,35 @@
+# matrix2llm
+
+This W3ID namespace provides stable links for the interactive companion to the textbook *Mathematics from Matrices to Language Models* (Chinese title: 《從矩陣到語言模型：AI 的核心數學》).
+
+The canonical namespace is:
+
+`https://w3id.org/matrix2llm/`
+
+The namespace redirects to the public Cloudflare Workers deployment. HTTP 302 redirects are intentional: the permanent W3ID URLs remain stable while the hosting destination can be updated when necessary.
+
+## Stable chapter entry points
+
+| Chapter | W3ID path | Current destination |
+|---:|---|---|
+| 1 | `ch01` | `/` |
+| 2 | `ch02` | `/labs/span-rank-nullspace` |
+| 3 | `ch03` | `/labs/linear-map` |
+| 4 | `ch04` | `/labs/projection-least-squares` |
+| 5 | `ch05` | `/labs/svd-low-rank-lora` |
+| 6 | `ch06` | `/labs/gradient-jacobian` |
+| 7 | `ch07` | `/labs/backpropagation` |
+| 8 | `ch08` | `/labs/gradient-descent` |
+| 9 | `ch09` | `/labs/probability-simplex` |
+| 10 | `ch10` | `/labs/softmax-cross-entropy` |
+| 11 | `ch11` | `/labs/layernorm-residual-mlp` |
+| 12 | `ch12` | `/labs/attention` |
+| 13 | `ch13` | `/labs/autoregressive-generation` |
+
+All other paths are forwarded unchanged so that links to individual laboratory scenes remain resolvable.
+
+## Maintainer
+
+Jih-Jeng Huang
+
+GitHub: [@brite0703](https://github.com/brite0703)


### PR DESCRIPTION
## Brief Description

This pull request registers the `/matrix2llm` namespace for the interactive companion to the textbook 《從矩陣到語言模型：AI 的核心數學》.

The namespace provides a landing-page identifier and stable chapter identifiers `ch01` through `ch13`. Each rule uses HTTP 302 deliberately so that the public identifiers remain stable if the hosting destination changes. A final catch-all rule preserves direct links to individual laboratory scenes.

Verification completed before submission:

- the `matrix2llm` namespace is absent from the current upstream `master` branch;
- all 13 Cloudflare destination routes return HTTP 200 and contain the expected chapter title;
- the 13 explicit `.htaccess` rules match the reviewed route manifest exactly.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

Maintainer: Jih-Jeng Huang (@brite0703)