### PR TITLE
Add AquaLex-RN persistent identifier

### DIFF
--- a/aqualex-rn/.htaccess
+++ b/aqualex-rn/.htaccess
@@ -1,0 +1,21 @@
+# AquaLex-RN persistent identifiers
+# Maintainer: Gábor Hamp (https://github.com/hampg)
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# The project identifier resolves to the human-readable landing page.
+RewriteRule ^$ https://ravo-nidaba.github.io/aqualex-rn/ [R=303,L]
+
+# Serve the combined reviewed graph according to the requested RDF media type.
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^(ontology(/.*)?|concept/.*|resource/.*|evidence/.*|frame/.*|assertion/.*|relation/.*)$ https://ravo-nidaba.github.io/aqualex-rn/ontology/aqualex-rn.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^(ontology(/.*)?|concept/.*|resource/.*|evidence/.*|frame/.*|assertion/.*|relation/.*)$ https://ravo-nidaba.github.io/aqualex-rn/ontology/aqualex-rn.rdf [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/x-turtle) [NC]
+RewriteRule ^(ontology(/.*)?|concept/.*|resource/.*|evidence/.*|frame/.*|assertion/.*|relation/.*)$ https://ravo-nidaba.github.io/aqualex-rn/ontology/aqualex-rn.ttl [R=303,L]
+
+# Browsers and clients without a supported RDF Accept header receive documentation.
+RewriteRule ^(ontology(/.*)?|concept/.*|resource/.*|evidence/.*|frame/.*|assertion/.*|relation/.*)$ https://ravo-nidaba.github.io/aqualex-rn/ontology/ [R=303,L]

--- a/aqualex-rn/README.md
+++ b/aqualex-rn/README.md
@@ -1,0 +1,16 @@
+# AquaLex-RN persistent identifiers
+
+This directory provides persistent identifiers for **AquaLex-RN**, a review-driven, evidence-linked RDF/OWL domain ontology and legal knowledge-graph pilot for Hungarian water law.
+
+- Project identifier: <https://w3id.org/aqualex-rn/>
+- Ontology namespace: <https://w3id.org/aqualex-rn/ontology#>
+- Public repository: <https://github.com/ravo-nidaba/aqualex-rn>
+- Landing page: <https://ravo-nidaba.github.io/aqualex-rn/>
+
+The redirect rules provide content negotiation for Turtle, RDF/XML, and JSON-LD. Entity and evidence IRIs redirect to the combined reviewed graph, while ordinary browser requests resolve to the ontology documentation page.
+
+## Maintainer
+
+Gábor Hamp  
+GitHub: [@hampg](https://github.com/hampg)  
+ORCID: <https://orcid.org/0000-0002-8035-1745>


### PR DESCRIPTION
Adds the `https://w3id.org/aqualex-rn/` identifier space for the AquaLex-RN Hungarian water-law domain ontology.\n\nThe rules provide 303 redirects to the public GitHub Pages landing page and content negotiation for Turtle, RDF/XML, and JSON-LD. They cover the ontology namespace, version/module ontology IRIs, and the reviewed concept, resource, evidence, frame, assertion, and relation identifiers.\n\nMaintainer and contact information is included in `aqualex-rn/README.md`. All redirect targets are public and currently return HTTP 200 with the expected media types.