### PR TITLE
Add rlps — Regulatory Localization Pack Specification vocabulary

### DIFF
--- a/rlps/.htaccess
+++ b/rlps/.htaccess
@@ -1,0 +1,9 @@
+# Permanent identifier for the RLPS vocabulary
+# (Regulatory Localization Pack Specification — https://github.com/squillo/r14n)
+Options +FollowSymLinks
+RewriteEngine on
+
+# https://w3id.org/rlps        -> the vocabulary (content-negotiated: JSON-LD / Turtle)
+# https://w3id.org/rlps/<file> -> the direct artifacts (context.jsonld, rlps.ttl)
+RewriteRule ^$ https://r14n.squillo.com/ns [R=302,L]
+RewriteRule ^(.+)$ https://r14n.squillo.com/ns/$1 [R=302,L]

--- a/rlps/README.md
+++ b/rlps/README.md
@@ -1,0 +1,17 @@
+# RLPS — Regulatory Localization Pack Specification
+
+Permanent identifiers for the RLPS vocabulary: JSON-LD `@context` and SKOS/RDFS term
+definitions used by RLPS decision receipts.
+
+- `https://w3id.org/rlps` redirects to `https://r14n.squillo.com/ns` (content-negotiated:
+  `application/ld+json` and `text/turtle`).
+- `https://w3id.org/rlps/context.jsonld` and `https://w3id.org/rlps/rlps.ttl` redirect to the
+  direct artifacts.
+
+Project: <https://github.com/squillo/r14n> (Apache-2.0 / CC-BY-4.0).
+
+## Contact
+
+| Name | GitHub | Email |
+|------|--------|-------|
+| Scott Wyatt (Squillo, Inc.) | [@scott-wyatt](https://github.com/scott-wyatt) | legal@squillo.com |


### PR DESCRIPTION
Adds the `rlps` permanent identifier for the RLPS (Regulatory Localization Pack Specification) vocabulary — the JSON-LD `@context` and SKOS/RDFS term definitions referenced by RLPS decision receipts.

- `https://w3id.org/rlps` → `https://r14n.squillo.com/ns` (content-negotiated: `application/ld+json` / `text/turtle`; live and serving)
- `https://w3id.org/rlps/<file>` → the direct artifacts (`context.jsonld`, `rlps.ttl`)

Project: https://github.com/squillo/r14n (public; Apache-2.0 code / CC-BY-4.0 vocabulary). Contact in `rlps/README.md`: @scott-wyatt, legal@squillo.com.
