### PR TITLE
sstim: resolve multi-module hash namespaces' HTML to the application

### DIFF
--- a/sstim/.htaccess
+++ b/sstim/.htaccess
@@ -79,12 +79,22 @@ RewriteRule ^kernel$ - [R=406,L]
 
 # exposure#StimulusChannel is stimulus-owned after ADR 0044, so the namespace
 # document is the generated Stimulus + Exposure union rather than one module.
+#
+# HTML goes to the application, matching the bare /sstim namespace below and for
+# the same reason. A server never sees a fragment, so this rule cannot tell
+# /sstim/exposure from /sstim/exposure#StimulusChannelRole and one destination
+# must serve both. The generated reference index cannot serve the second:
+# measured 2026-08-23, WIDOCO anchors by full IRI
+# (id="https://w3id.org/sstim/exposure#StimulusChannelRole") while the browser
+# carries the bare local name, so the reader landed at the top of an index with
+# nothing selected. The knowledge browser reads the fragment client-side,
+# selects the term, and links onward to its reference entry.
 RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*application/ld\+json\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
 RewriteRule ^exposure$ https://labiosyncare.github.io/ontology/sstim-exposure-namespace.jsonld [R=303,L]
 RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*application/rdf\+xml\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
 RewriteRule ^exposure$ https://labiosyncare.github.io/ontology/sstim-exposure-namespace.rdf [R=303,L]
 RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/html|application/xhtml\+xml)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
-RewriteRule ^exposure$ https://labiosyncare.github.io/ontology/docs/ [R=303,L]
+RewriteRule ^exposure$ https://labiosyncare.github.io/ [R=303,L]
 RewriteCond %{HTTP_ACCEPT} ^$ [OR]
 RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/turtle|application/x-turtle|\*/\*)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
 RewriteRule ^exposure$ https://labiosyncare.github.io/ontology/sstim-exposure-namespace.ttl [R=303,L]

--- a/sstim/.htaccess
+++ b/sstim/.htaccess
@@ -112,10 +112,23 @@ RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/turtle|application/x-turtle|\*/\*)\
 RewriteRule ^module/exposure$ https://labiosyncare.github.io/ontology/sstim-exposure.ttl [R=303,L]
 RewriteRule ^module/exposure$ - [R=406,L]
 
-# The SKOS vocabulary has its own pyLODE page; every other module is
-# described by the WIDOCO reference index.
+# vocab and ecosystem are hash namespaces whose terms are defined across more
+# than one module, so a fragment can arrive here just as it can at /sstim and
+# /sstim/exposure, and for the same reason it goes to the application: a server
+# never sees the fragment, and neither generated page can anchor it. Measured
+# 2026-08-23: WIDOCO anchors by full IRI, pyLODE by label (id="Alpha" for
+# sstim-v:alpha, which is also the wrong case), so both left the reader at the
+# top of an index with nothing selected.
+#
+# The pyLODE vocabulary page keeps its address at /ontology/docs/vocab/ and its
+# link from every vocabulary term in the knowledge browser.
+#
+# shapes and core-shapes are deliberately NOT here. SHACL shapes are not
+# drawable nodes in the knowledge browser, so sending a shape IRI there would
+# select nothing; the reference index remains the better answer until shapes are
+# either drawable or anchored by local name.
 RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/html|application/xhtml\+xml)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
-RewriteRule ^vocab$ https://labiosyncare.github.io/ontology/docs/vocab/ [R=303,L]
+RewriteRule ^(vocab|ecosystem)$ https://labiosyncare.github.io/ [R=303,L]
 RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*application/ld\+json\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
 RewriteRule ^(stimulus|core-shapes|common|technique|configuration|session|evidence|neuromodulation|patch-studio|vocab|ecosystem|neuromodulation-evidence|evidence-exposure|technique-exposure|alignments|shapes)$ https://labiosyncare.github.io/ontology/sstim-$1.jsonld [R=303,L]
 RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*application/rdf\+xml\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description

Three redirect targets change in `sstim/.htaccess`, all of them the HTML representation of a hash namespace: `/sstim/exposure`, `/sstim/vocab` and `/sstim/ecosystem` now resolve to the application entrance rather than to a generated documentation index.

A term IRI such as `https://w3id.org/sstim/exposure#StimulusChannelRole` was resolving to a documentation page where the fragment matched nothing, leaving the reader at the top of a long index with the term unselected. The generators anchor differently from what a browser sends:

| Page | Anchor it writes | Fragment the browser carries |
|---|---|---|
| WIDOCO reference index | `id="https://w3id.org/sstim/exposure#StimulusChannelRole"` | `#StimulusChannelRole` |
| pyLODE vocabulary page | `id="Alpha"` | `#alpha` |

Neither matches, and fragment matching is exact and case-sensitive.

A server never receives the fragment, so these rules cannot distinguish a namespace request from a term request and one destination must serve both. The application reads the fragment client-side, selects the term, and links onward to its reference entry, so no documentation becomes unreachable. The pyLODE vocabulary page keeps its own address at `/ontology/docs/vocab/`.

Scope is the three namespaces whose terms are defined across more than one module, which is what makes a fragment arrive at the namespace rather than at a single module. They join the bare `/sstim` namespace, which already resolved HTML to the application for this reason. The `shapes` and `core-shapes` namespaces deliberately keep the reference index: SHACL shapes are not drawable in the application, so a shape IRI sent there would select nothing.

Only the HTML representation changes. Turtle, JSON-LD and RDF/XML continue to serve the same namespace documents, and no other route is touched. The rule count is unchanged at 75, because the existing `vocab` rule widened rather than a new rule being added.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

Testing: the project mirrors these rules and exercises them in CI. On this change the negotiation, staged-routing and route-target suites pass (27 tests), the route inventory gate passes (75 rules, 93 distinct publishable targets), and the full ontology validation suite passes, including a quality audit that rebuilds this route table from the ontology manifest and compares it line by line.

## New ID Directory Checklist
<!-- For new ID PRs. -->
Not applicable: `sstim/` already exists.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.