### PR TITLE
Add xny namespace for the did:xny DID method

### DIFF
--- a/xny/.htaccess
+++ b/xny/.htaccess
@@ -1,0 +1,10 @@
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+# Method specification (also the target for vocabulary IRIs such as
+# https://w3id.org/xny#owner)
+RewriteRule ^$ https://github.com/humanbased-ai/xny-did/blob/main/docs/xny-did-method.md [R=302,L]
+
+# JSON-LD context, version 1
+RewriteRule ^v1$ https://humanbased-ai.github.io/xny-did/ns/v1.jsonld [R=302,L]

--- a/xny/README.md
+++ b/xny/README.md
@@ -1,0 +1,23 @@
+# xny
+
+Namespace for the `did:xny` DID method — a W3C-registered DID method whose
+documents are anchored on Base.
+
+- Method specification: https://github.com/humanbased-ai/xny-did/blob/main/docs/xny-did-method.md
+- DID method registry entry: https://github.com/w3c/did-extensions/blob/main/methods/xny.json
+- Source: https://github.com/humanbased-ai/xny-did
+
+## Identifiers
+
+| Identifier | Resolves to |
+|---|---|
+| `https://w3id.org/xny` | the method specification; also the base for vocabulary IRIs such as `https://w3id.org/xny#owner` |
+| `https://w3id.org/xny/v1` | the JSON-LD context defining this method's terms, served as `application/ld+json` |
+
+`https://w3id.org/xny/v1` is immutable. Terms may be added in a later version,
+but a published version URL will never change an existing term's IRI or
+definition; a breaking change gets a new version URL.
+
+## Maintainers
+
+- George Huang (@chababa9) · george@inductive.network


### PR DESCRIPTION
Requests the `xny` namespace for the `did:xny` DID method.

## Identifiers

| Identifier | Redirects to |
|---|---|
| `https://w3id.org/xny` | the method specification; also the base for vocabulary IRIs such as `https://w3id.org/xny#owner` |
| `https://w3id.org/xny/v1` | the JSON-LD context defining the method's terms |

## Background

`did:xny` is registered in the W3C DID method registry: [`w3c/did-extensions`, `methods/xny.json`](https://github.com/w3c/did-extensions/blob/main/methods/xny.json) (status: `registered`).

Its DID documents carry nine method-specific terms — `owner`, four custom `verificationMethod.type` values, and their four value fields — which are undefined under the DID Core context alone, so a JSON-LD processor currently discards every one of them. This namespace is what lets those terms be defined at a permanent URL, which is why the stability guarantee w3id.org provides is the point rather than a convenience.

## Redirect target is already live

Both targets resolve today, so the rules can be checked immediately:

```
$ curl -sI https://humanbased-ai.github.io/xny-did/ns/v1.jsonld | head -2
HTTP/2 200
content-type: application/ld+json
```

The context was validated by expanding a real DID document with `jsonld@9` while fetching that URL over the network: all nine terms expand to IRIs under `https://w3id.org/xny#`, and the four verification method types are type-scoped so each value field is only defined within its own method type.

## Stability

`https://w3id.org/xny/v1` is intended to be immutable. Terms may be added in a later version, but a published version URL will never change an existing term's IRI or definition — a breaking change gets a new version URL. The backing host may be repointed over time; the w3id identifier is the stable one.

## Contact

George Huang — [@chababa9](https://github.com/chababa9), george@inductive.network
