### PR TITLE
Add persistent identifiers for TBM Tunnel Collapse Ontology

### DIFF
--- a/tbm-collapse/.htaccess
+++ b/tbm-collapse/.htaccess
@@ -1,0 +1,10 @@
+RewriteEngine On
+
+# TBM Tunnel Collapse Ontology
+# Maintainer: Weijiang Kong
+# Email: kongwj@my.swjtu.edu.cn
+# GitHub: https://github.com/WeijiangK
+
+RewriteRule ^ontology/?$ https://doi.org/10.5281/zenodo.22079738 [R=303,L]
+
+RewriteRule ^ontology/1\.0\.0/?$ https://doi.org/10.5281/zenodo.22079738 [R=303,L]

--- a/tbm-collapse/.htaccess
+++ b/tbm-collapse/.htaccess
@@ -6,5 +6,6 @@ RewriteEngine On
 # GitHub: https://github.com/WeijiangK
 
 RewriteRule ^ontology/?$ https://doi.org/10.5281/zenodo.22079738 [R=303,L]
-
 RewriteRule ^ontology/1\.0\.0/?$ https://doi.org/10.5281/zenodo.22079738 [R=303,L]
+RewriteRule ^shapes/?$ https://doi.org/10.5281/zenodo.22079738 [R=303,L]
+RewriteRule ^example/?$ https://doi.org/10.5281/zenodo.22079738 [R=303,L]

--- a/tbm-collapse/.htaccess
+++ b/tbm-collapse/.htaccess
@@ -5,7 +5,12 @@ RewriteEngine On
 # Email: kongwj@my.swjtu.edu.cn
 # GitHub: https://github.com/WeijiangK
 
-RewriteRule ^ontology/?$ https://doi.org/10.5281/zenodo.22079738 [R=303,L]
+# Stable ontology IRI -> all-version/concept DOI
+RewriteRule ^ontology/?$ https://doi.org/10.5281/zenodo.22079737 [R=303,L]
+
+# Version-specific IRI -> v1.0.0 DOI
 RewriteRule ^ontology/1\.0\.0/?$ https://doi.org/10.5281/zenodo.22079738 [R=303,L]
-RewriteRule ^shapes/?$ https://doi.org/10.5281/zenodo.22079738 [R=303,L]
-RewriteRule ^example/?$ https://doi.org/10.5281/zenodo.22079738 [R=303,L]
+
+# Auxiliary namespaces -> project-level DOI
+RewriteRule ^shapes/?$ https://doi.org/10.5281/zenodo.22079737 [R=303,L]
+RewriteRule ^example/?$ https://doi.org/10.5281/zenodo.22079737 [R=303,L]

--- a/tbm-collapse/README.md
+++ b/tbm-collapse/README.md
@@ -1,0 +1,21 @@
+# TBM Tunnel Collapse Ontology
+
+This W3ID namespace provides persistent identifiers for the
+TBM Tunnel Collapse Ontology.
+
+## Persistent identifier
+
+https://w3id.org/tbm-collapse/ontology
+
+## Ontology release
+
+Version: 1.0.0
+
+Zenodo DOI:
+https://doi.org/10.5281/zenodo.22079738
+
+## Maintainer
+
+Name: Weijiang Kong
+Email: kongwj@my.swjtu.edu.cn
+GitHub: https://github.com/WeijiangK

--- a/tbm-collapse/README.md
+++ b/tbm-collapse/README.md
@@ -3,19 +3,46 @@
 This W3ID namespace provides persistent identifiers for the
 TBM Tunnel Collapse Ontology.
 
-## Persistent identifier
+## Persistent identifiers
+
+Main ontology:
 
 https://w3id.org/tbm-collapse/ontology
 
-## Ontology release
+Version 1.0.0:
+
+https://w3id.org/tbm-collapse/ontology/1.0.0
+
+SHACL shapes:
+
+https://w3id.org/tbm-collapse/shapes
+
+Example namespace:
+
+https://w3id.org/tbm-collapse/example
+
+## Archived releases
+
+Concept DOI (all versions):
+
+https://doi.org/10.5281/zenodo.22079737
+
+Version 1.0.0 DOI:
+
+https://doi.org/10.5281/zenodo.22079738
+
+## Release information
 
 Version: 1.0.0
 
-Zenodo DOI:
-https://doi.org/10.5281/zenodo.22079738
+License: Creative Commons Attribution 4.0 International (CC BY 4.0)
 
 ## Maintainer
 
 Name: Weijiang Kong
+
+ORCID: https://orcid.org/0009-0003-4345-5830
+
 Email: kongwj@my.swjtu.edu.cn
+
 GitHub: https://github.com/WeijiangK


### PR DESCRIPTION
## Brief Description

This PR adds a new W3ID namespace for the TBM Tunnel Collapse Ontology.

Requested persistent identifiers:

- https://w3id.org/tbm-collapse/ontology
- https://w3id.org/tbm-collapse/ontology/1.0.0
- https://w3id.org/tbm-collapse/shapes
- https://w3id.org/tbm-collapse/example

The ontology is archived on Zenodo.

Concept DOI:
https://doi.org/10.5281/zenodo.22079737

Version 1.0.0 DOI:
https://doi.org/10.5281/zenodo.22079738

The main ontology IRI resolves to the Zenodo Concept DOI, while the
version-specific IRI resolves to the fixed v1.0.0 release DOI.

## General Checklist

- [ ] Changes have been tested.
- [ ] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist

- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers

- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.