### PR TITLE
Add openllm-mis persistent redirects

### DIFF
--- a/openllm-mis/.htaccess
+++ b/openllm-mis/.htaccess
@@ -1,0 +1,29 @@
+# Persistent redirects for the interactive companion to
+# Open Large Language Models: MIS Perspectives on Theory, Methods, and Business Applications.
+# Chinese title: 開源大型語言模型：資管觀點的理論、方法與商業應用
+#
+# Maintainer: Jih-Jeng Huang
+# Email: jjhuang@scu.edu.tw
+# GitHub: https://github.com/brite0703
+
+RewriteEngine on
+
+RewriteRule ^$ https://openllm-mis.jjhuang0703.chatgpt.site/ [R=302,L]
+RewriteRule ^ch01/?$ https://openllm-mis.jjhuang0703.chatgpt.site/labs/task-technology-fit [R=302,L]
+RewriteRule ^ch02/?$ https://openllm-mis.jjhuang0703.chatgpt.site/labs/open-source-control-frontier [R=302,L]
+RewriteRule ^ch03/?$ https://openllm-mis.jjhuang0703.chatgpt.site/labs/information-behavior [R=302,L]
+RewriteRule ^ch04/?$ https://openllm-mis.jjhuang0703.chatgpt.site/labs/human-ai-work-allocation [R=302,L]
+RewriteRule ^ch05/?$ https://openllm-mis.jjhuang0703.chatgpt.site/labs/data-knowledge-governance [R=302,L]
+RewriteRule ^ch06/?$ https://openllm-mis.jjhuang0703.chatgpt.site/labs/is-value-evaluation [R=302,L]
+RewriteRule ^ch07/?$ https://openllm-mis.jjhuang0703.chatgpt.site/labs/prompt-context-design [R=302,L]
+RewriteRule ^ch08/?$ https://openllm-mis.jjhuang0703.chatgpt.site/labs/rag-evidence-chain [R=302,L]
+RewriteRule ^ch09/?$ https://openllm-mis.jjhuang0703.chatgpt.site/labs/model-adaptation-choice [R=302,L]
+RewriteRule ^ch10/?$ https://openllm-mis.jjhuang0703.chatgpt.site/labs/reasoning-verification [R=302,L]
+RewriteRule ^ch11/?$ https://openllm-mis.jjhuang0703.chatgpt.site/labs/controlled-tool-workflow [R=302,L]
+RewriteRule ^ch12/?$ https://openllm-mis.jjhuang0703.chatgpt.site/labs/solution-architecture [R=302,L]
+RewriteRule ^ch13/?$ https://openllm-mis.jjhuang0703.chatgpt.site/labs/design-science [R=302,L]
+RewriteRule ^ch14/?$ https://openllm-mis.jjhuang0703.chatgpt.site/labs/adoption-work-redesign [R=302,L]
+RewriteRule ^ch15/?$ https://openllm-mis.jjhuang0703.chatgpt.site/labs/service-governance [R=302,L]
+RewriteRule ^ch16/?$ https://openllm-mis.jjhuang0703.chatgpt.site/labs/capstone-decision [R=302,L]
+
+RewriteRule ^(.*)$ https://openllm-mis.jjhuang0703.chatgpt.site/$1 [R=302,L]

--- a/openllm-mis/README.md
+++ b/openllm-mis/README.md
@@ -1,0 +1,31 @@
+# openllm-mis
+
+This namespace provides persistent identifiers for the online interactive companion to the textbook *Open Large Language Models: MIS Perspectives on Theory, Methods, and Business Applications* (Chinese title: 《開源大型語言模型：資管觀點的理論、方法與商業應用》).
+
+- Namespace: `https://w3id.org/openllm-mis/`
+- Interactive site: `https://openllm-mis.jjhuang0703.chatgpt.site/`
+- Maintainer: Jih-Jeng Huang ([@brite0703](https://github.com/brite0703))
+- Contact: `jjhuang@scu.edu.tw`
+
+The root identifier resolves to the interactive site. The chapter identifiers `ch01` through `ch16` resolve to the corresponding learning laboratories.
+
+| Identifier | Destination path |
+|---|---|
+| `ch01` | `/labs/task-technology-fit` |
+| `ch02` | `/labs/open-source-control-frontier` |
+| `ch03` | `/labs/information-behavior` |
+| `ch04` | `/labs/human-ai-work-allocation` |
+| `ch05` | `/labs/data-knowledge-governance` |
+| `ch06` | `/labs/is-value-evaluation` |
+| `ch07` | `/labs/prompt-context-design` |
+| `ch08` | `/labs/rag-evidence-chain` |
+| `ch09` | `/labs/model-adaptation-choice` |
+| `ch10` | `/labs/reasoning-verification` |
+| `ch11` | `/labs/controlled-tool-workflow` |
+| `ch12` | `/labs/solution-architecture` |
+| `ch13` | `/labs/design-science` |
+| `ch14` | `/labs/adoption-work-redesign` |
+| `ch15` | `/labs/service-governance` |
+| `ch16` | `/labs/capstone-decision` |
+
+HTTP 302 is used intentionally so that the persistent identifiers remain unchanged if the hosting destination changes. The fallback rule preserves direct paths below the namespace.


### PR DESCRIPTION
## Brief description

This pull request registers the `/openllm-mis` namespace for the online interactive companion to the textbook 《開源大型語言模型：資管觀點的理論、方法與商業應用》 (*Open Large Language Models: MIS Perspectives on Theory, Methods, and Business Applications*).

The namespace provides a root identifier and stable chapter identifiers `ch01` through `ch16`. HTTP 302 is used deliberately so that the public identifiers can remain stable if the hosting destination changes. A final catch-all rule preserves direct paths below the namespace.

## Verification completed before submission

- the `openllm-mis` namespace is absent from the current upstream `master` branch;
- the root page and all 16 chapter destinations return HTTP 200;
- every destination page contains the expected chapter title;
- the 18 `.htaccess` rules match the reviewed route contract exactly;
- maintainer name, GitHub account, and contact email are included.

## General checklist

- [x] Changes have been tested.
- [x] The pull request contains one commit.
- [x] The commit contains only redirects and basic identifier information.
- [x] Maintainer details are included in `.htaccess` and `README.md`.

Maintainer: Jih-Jeng Huang ([@brite0703](https://github.com/brite0703)).
