### PR TITLE
Add portail-fresh/Health-DCAT-AP-plus

### DIFF
--- a/portail-fresh/.htaccess
+++ b/portail-fresh/.htaccess
@@ -1,0 +1,19 @@
+# W3ID .htaccess for portail-fresh
+# Top-level namespace for the portail-fresh GitHub organization's permanent
+# identifiers. See the nested project directories (e.g. Health-DCAT-AP-plus/)
+# for the actual per-project redirect rules.
+# GitHub: https://github.com/portail-fresh
+#
+# ## Contact
+# This space is administered by:
+#
+# Remy Ben Messaoud
+# remy.benmessaoud@gmail.com
+# GitHub username: rbm1996
+
+Header set Access-Control-Allow-Origin "*"
+
+Options +FollowSymLinks
+RewriteEngine on
+
+RewriteRule ^$ https://github.com/portail-fresh [R=302,L]

--- a/portail-fresh/Health-DCAT-AP-plus/.htaccess
+++ b/portail-fresh/Health-DCAT-AP-plus/.htaccess
@@ -1,0 +1,53 @@
+# W3ID .htaccess for Health-DCAT-AP-plus
+# A LinkML schema combining HealthDCAT-AP's health-dataset metadata tiers
+# with DCAT-AP+'s PROV-O provenance extensions (DataGeneratingActivity,
+# Entity, AgenticEntity, Plan).
+# GitHub: https://github.com/portail-fresh/Health-DCAT-AP-plus
+#
+# ## Contact
+# This space is administered by:
+#
+# Remy Ben Messaoud
+# remy.benmessaoud@gmail.com
+# GitHub username: rbm1996
+
+Header set Access-Control-Allow-Origin "*"
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# ====================================
+# General HTML/YAML redirect to GitHub Pages documentation
+# ====================================
+
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://portail-fresh.github.io/Health-DCAT-AP-plus/ [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} text/yaml [OR]
+RewriteCond %{HTTP_ACCEPT} application/yaml
+RewriteRule ^$ https://portail-fresh.github.io/Health-DCAT-AP-plus/schema/health_dcat_ap_plus.yaml [R=302,L]
+
+# ====================================
+# Main schema
+# ====================================
+
+RewriteCond %{HTTP_ACCEPT} application/yaml [OR]
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^latest/schema/health_dcat_ap_plus\.yaml$ https://portail-fresh.github.io/Health-DCAT-AP-plus/schema/health_dcat_ap_plus.yaml [R=302,L]
+
+# ====================================
+# Non-public-tier HealthDCAT-AP schema (imported by health_dcat_ap_plus.yaml
+# itself -- published alongside it so that import resolves too)
+# ====================================
+
+RewriteCond %{HTTP_ACCEPT} application/yaml [OR]
+RewriteCond %{HTTP_ACCEPT} text/html
+RewriteRule ^latest/schema/healthdcat_ap_non_public\.yaml$ https://portail-fresh.github.io/Health-DCAT-AP-plus/schema/healthdcat_ap_non_public.yaml [R=302,L]
+
+# ====================================
+# Fallback -- anything else goes to the documentation homepage
+# ====================================
+
+RewriteRule ^.*$ https://portail-fresh.github.io/Health-DCAT-AP-plus/ [R=302,L]

--- a/portail-fresh/Health-DCAT-AP-plus/README.md
+++ b/portail-fresh/Health-DCAT-AP-plus/README.md
@@ -1,0 +1,17 @@
+# Health-DCAT-AP-plus
+
+A [LinkML](https://linkml.io/) schema combining [HealthDCAT-AP](https://healthdcat-ap.github.io/)'s
+health-dataset metadata tiers with [DCAT-AP+](https://w3id.org/nfdi-de/dcat-ap-plus/)'s PROV-O
+provenance extensions (DataGeneratingActivity, Entity, AgenticEntity, Plan).
+
+* GitHub: https://github.com/portail-fresh/Health-DCAT-AP-plus
+* Documentation: https://portail-fresh.github.io/Health-DCAT-AP-plus/
+* Maintained by: Remy Ben Messaoud
+* Contact: remy.benmessaoud@gmail.com
+* GitHub username: [rbm1996](https://github.com/rbm1996)
+
+## Redirects
+
+* `https://w3id.org/portail-fresh/Health-DCAT-AP-plus` -- documentation homepage
+* `https://w3id.org/portail-fresh/Health-DCAT-AP-plus/latest/schema/health_dcat_ap_plus.yaml` -- the main LinkML schema
+* `https://w3id.org/portail-fresh/Health-DCAT-AP-plus/latest/schema/healthdcat_ap_non_public.yaml` -- the ported HealthDCAT-AP non-public-tier SHACL shapes, imported by the schema above

--- a/portail-fresh/README.md
+++ b/portail-fresh/README.md
@@ -1,0 +1,15 @@
+# portail-fresh
+
+Top-level [w3id.org](https://w3id.org/) namespace for the
+[portail-fresh](https://github.com/portail-fresh) GitHub organization's
+permanent identifiers.
+
+* Maintained by: Remy Ben Messaoud
+* Contact: remy.benmessaoud@gmail.com
+* GitHub username: [rbm1996](https://github.com/rbm1996)
+
+## Sub-identifiers
+
+* [`Health-DCAT-AP-plus/`](Health-DCAT-AP-plus/) -- a LinkML schema combining
+  HealthDCAT-AP's health-dataset metadata tiers with DCAT-AP+'s PROV-O
+  provenance extensions.


### PR DESCRIPTION
Registers a new top-level namespace, `portail-fresh` (matching the GitHub
organization of the same name), with one sub-identifier so far:
`Health-DCAT-AP-plus`, a LinkML schema combining HealthDCAT-AP's
health-dataset metadata tiers with DCAT-AP+'s PROV-O provenance extensions.

- `https://w3id.org/portail-fresh/Health-DCAT-AP-plus` redirects to the
  project's documentation homepage
  (https://portail-fresh.github.io/Health-DCAT-AP-plus/).
- `https://w3id.org/portail-fresh/Health-DCAT-AP-plus/latest/schema/health_dcat_ap_plus.yaml`
  redirects to the main LinkML schema.
- `https://w3id.org/portail-fresh/Health-DCAT-AP-plus/latest/schema/healthdcat_ap_non_public.yaml`
  redirects to a schema module the main one imports.

The rewrite rules closely follow the proven, working pattern in
`nfdi-de/dcat-ap-plus/.htaccess`. I did not spin up a local Apache instance
to test the rules themselves; I confirmed the redirect targets are live and
serving the expected content
(https://portail-fresh.github.io/Health-DCAT-AP-plus/schema/health_dcat_ap_plus.yaml
and the sibling `healthdcat_ap_non_public.yaml`), and verified with LinkML's
own schema loader that the published files resolve correctly end-to-end.

Contact: Remy Ben Messaoud, remy.benmessaoud@gmail.com, GitHub @rbm1996