### PR TITLE
Add A2A Schema Contract namespace

### DIFF
--- a/a2a-schema-contract/.htaccess
+++ b/a2a-schema-contract/.htaccess
@@ -1,0 +1,24 @@
+# A2A Schema Contract Extension
+# Namespace: https://w3id.org/a2a-schema-contract/
+# Project: https://github.com/shashikanth-gs/a2a-schema-contract
+#
+# This is an independent community draft and is not an official A2A extension.
+#
+# Contact
+# Shashi Kanth
+# GitHub username: shashikanth-gs
+
+Options -MultiViews
+RewriteEngine On
+
+# Project home
+RewriteRule ^$ https://github.com/shashikanth-gs/a2a-schema-contract [R=302,L]
+
+# Immutable Draft 0.1 specification
+RewriteRule ^draft/0\.1/?$ https://github.com/shashikanth-gs/a2a-schema-contract/blob/v0.1.0-draft.1/spec/specification.md [R=302,L]
+
+# Human-readable index of the immutable Draft 0.1 schema set
+RewriteRule ^schema/draft/0\.1/?$ https://github.com/shashikanth-gs/a2a-schema-contract/tree/v0.1.0-draft.1/schema [R=302,L]
+
+# Immutable Draft 0.1 machine-readable schemas
+RewriteRule ^schema/draft/0\.1/([A-Za-z0-9][A-Za-z0-9._-]*\.schema\.json)$ https://raw.githubusercontent.com/shashikanth-gs/a2a-schema-contract/refs/tags/v0.1.0-draft.1/schema/$1 [R=302,L,NE]

--- a/a2a-schema-contract/README.md
+++ b/a2a-schema-contract/README.md
@@ -1,0 +1,29 @@
+# A2A Schema Contract Extension namespace
+
+This directory provides permanent identifiers for the independent community
+draft of the [A2A Schema Contract Extension](https://github.com/shashikanth-gs/a2a-schema-contract).
+The project defines provider-neutral discovery, negotiation, and validation
+semantics for schema-constrained and schemaless A2A application payloads.
+
+This project is not an official A2A extension and is not endorsed by the A2A
+Technical Steering Committee. The stable `/v1` namespace is intentionally
+reserved until the extension semantics are declared stable.
+
+## Identifiers
+
+| Identifier | Target |
+|---|---|
+| `https://w3id.org/a2a-schema-contract/` | Project repository |
+| `https://w3id.org/a2a-schema-contract/draft/0.1` | Draft 0.1 specification, pinned to Git tag `v0.1.0-draft.1` |
+| `https://w3id.org/a2a-schema-contract/schema/draft/0.1/` | Draft 0.1 schema index, pinned to the same tag |
+| `https://w3id.org/a2a-schema-contract/schema/draft/0.1/<name>.schema.json` | An individual Draft 0.1 JSON Schema |
+
+The versioned specification and schema targets are immutable. Future breaking
+drafts will receive new draft identifiers rather than changing these targets.
+
+## Maintainer
+
+Shashi Kanth  
+GitHub: [@shashikanth-gs](https://github.com/shashikanth-gs)
+
+Project issues: <https://github.com/shashikanth-gs/a2a-schema-contract/issues>


### PR DESCRIPTION
## Brief Description

Adds the `a2a-schema-contract` W3ID namespace for the independent community draft of the A2A Schema Contract Extension.

The namespace provides:

- a project-root redirect;
- an immutable Draft 0.1 specification identifier; and
- immutable Draft 0.1 JSON Schema identifiers.

All versioned targets are pinned to the `v0.1.0-draft.1` Git tag. The stable `/v1` namespace is intentionally reserved until the extension semantics are declared stable. The README and redirect comments clearly state that this is not an official A2A extension.

Project: https://github.com/shashikanth-gs/a2a-schema-contract

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal.
- [x] Commits only include redirects and basic information.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` and `README.md`.
- [x] The maintainer's GitHub username is listed.

## Testing

The rules were tested with Apache HTTP Server 2.4.68. The project root, draft specification, schema index, and individual schema URLs returned the expected HTTP 302 locations. An unsupported path returned HTTP 404. All seven pinned schema targets returned HTTP 200.