### PR TITLE
nfdi4cat/voc4cat: Fix turtle content negotiation

### DIFF
--- a/nfdi4cat/.htaccess
+++ b/nfdi4cat/.htaccess
@@ -6,9 +6,12 @@ RewriteEngine on
 RewriteRule ^$ https://nfdi4cat.org/ [R=303,L]
 
 # VOC4CAT: TURTLE - individual concept or collection turtle files of latest release
+# Concepts and collections are stored in subdirectories holding 1000 ids each, named
+# "IDs<first 4 digits>xxx". voc4cat ids are 7 digits (id_length in its idranges.toml),
+# so the subdirectory is the id with its last 3 digits replaced by "xxx".
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
-RewriteRule "^voc4cat_([0-9]{7,})" https://nfdi4cat.github.io/voc4cat/latest/voc4cat/$1.ttl [R=303,L,NE]
+RewriteRule "^voc4cat_([0-9]{4})([0-9]{3})$" https://nfdi4cat.github.io/voc4cat/latest/voc4cat/IDs$1xxx/$1$2.ttl [R=303,L,NE]
 
 # VOC4Cat: HTML - documentation
 # redirect to fragment-urls should work fine https://stackoverflow.com/a/2305927

--- a/nfdi4cat/voc4cat/.htaccess
+++ b/nfdi4cat/voc4cat/.htaccess
@@ -12,10 +12,17 @@ RewriteEngine on
 
 # === version-tagged releases ===
 
-# TURTLE - individual concept or collection turtle files of
+# TURTLE - individual concept or collection turtle files
+# Releases from v2026-02-24 on store concepts and collections in subdirectories holding
+# 1000 ids each, named "IDs<first 4 digits>xxx". Releases up to v2025-10-14 predate that
+# scheme and are published flat; they are immutable, so both layouts must stay reachable.
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
-RewriteRule "^v?([0-9]{4}\-[0-9]{2}\-[0-9]{2})\/voc4cat_([0-9]{7,})" https://nfdi4cat.github.io/voc4cat/v$1/voc4cat/$2.ttl [R=303,L,NE,NC]
+RewriteRule "^v?(20(?:2[6-9]|[3-9][0-9])\-[0-9]{2}\-[0-9]{2})\/voc4cat_([0-9]{4})([0-9]{3})$" https://nfdi4cat.github.io/voc4cat/v$1/voc4cat/IDs$2xxx/$2$3.ttl [R=303,L,NE,NC]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule "^v?(20(?:[01][0-9]|2[0-5])\-[0-9]{2}\-[0-9]{2})\/voc4cat_([0-9]{7,})$" https://nfdi4cat.github.io/voc4cat/v$1/voc4cat/$2.ttl [R=303,L,NE,NC]
 
 # HTML - documentation individual concept or collection
 RewriteCond %{HTTP_ACCEPT} text/html
@@ -42,9 +49,10 @@ RewriteRule "^v?([0-9]{4}\-[0-9]{2}\-[0-9]{2})" https://nfdi4cat.github.io/voc4c
 # === "in development" version (last commit to main) ===
 
 # TURTLE - individual concept or collection turtle files
+# Subdirectory scheme as described for the version-tagged releases above.
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
-RewriteRule "^dev/voc4cat_([0-9]{7,})" https://nfdi4cat.github.io/voc4cat/dev/voc4cat/$1.ttl [R=303,L,NE,NC]
+RewriteRule "^dev/voc4cat_([0-9]{4})([0-9]{3})$" https://nfdi4cat.github.io/voc4cat/dev/voc4cat/IDs$1xxx/$1$2.ttl [R=303,L,NE,NC]
 
 # HTML - documentation individual concept or collection
 RewriteCond %{HTTP_ACCEPT} text/html

--- a/nfdi4cat/voc4cat/README.md
+++ b/nfdi4cat/voc4cat/README.md
@@ -13,7 +13,10 @@ Documentation / vocabulary as one large turtle file
 
 Individual turtle files for concepts or collections
 
--  https://w3id.org/nfdi4cat/voc4cat_0000002 <BR>-(turtle)-> https://nfdi4cat.github.io/voc4cat/latest/voc4cat/0000002.ttl<BR>-(html)-> https://nfdi4cat.github.io/voc4cat/latest/voc4cat/index.html#https://w3id.org/nfdi4cat/voc4cat_0000002
+-  https://w3id.org/nfdi4cat/voc4cat_0000002 <BR>-(turtle)-> https://nfdi4cat.github.io/voc4cat/latest/voc4cat/IDs0000xxx/0000002.ttl<BR>-(html)-> https://nfdi4cat.github.io/voc4cat/latest/voc4cat/index.html#https://w3id.org/nfdi4cat/voc4cat_0000002
+
+Turtle files are grouped into subdirectories of 1000 ids named `IDs<first 4 digits>xxx`,
+so the file for id `0000002` lives in `IDs0000xxx/`.
 
 ## Redirects to releases using the release tag
 
@@ -22,8 +25,13 @@ Documentation / vocabulary as one large turtle file
 - https://w3id.org/nfdi4cat/voc4cat/2023-08-17 <BR>-(turtle)-> https://nfdi4cat.github.io/voc4cat/v2023-08-17/voc4cat.ttl <BR>-(xml/rdf)-> https://nfdi4cat.github.io/voc4cat/v2023-08-17/voc4cat.xml <BR>-(html)-> https://nfdi4cat.github.io/voc4cat/v2023-08-17/voc4cat/index.html
 
 Individual turtle files for concepts or collections
+- https://w3id.org/nfdi4cat/voc4cat/2026-02-24/voc4cat_0000002 <BR>-(turtle)-> https://nfdi4cat.github.io/voc4cat/v2026-02-24/voc4cat/IDs0000xxx/0000002.ttl
+    <BR>-(html)-> https://nfdi4cat.github.io/voc4cat/v2026-02-24/voc4cat/index.html#https://w3id.org/nfdi4cat/voc4cat_0000002
+
+Releases up to v2025-10-14 predate the `IDs<first 4 digits>xxx` subdirectories and are
+published flat, so their turtle redirects keep the old shape:
+
 - https://w3id.org/nfdi4cat/voc4cat/2023-08-17/voc4cat_0000002 <BR>-(turtle)-> https://nfdi4cat.github.io/voc4cat/v2023-08-17/voc4cat/0000002.ttl
-    <BR>-(html)-> https://nfdi4cat.github.io/voc4cat/v2023-08-17/voc4cat/index.html#https://w3id.org/nfdi4cat/voc4cat_0000002
 
 ## Redirects for "in-development" version
 
@@ -34,7 +42,7 @@ Documentation / vocabulary as one large turtle file
 - https://w3id.org/nfdi4cat/voc4cat/dev <BR>-(turtle)-> https://nfdi4cat.github.io/voc4cat/dev/voc4cat.ttl  <BR>-(xml/rdf)-> https://nfdi4cat.github.io/voc4cat/dev/voc4cat.xml <BR>-(html)-> https://nfdi4cat.github.io/voc4cat/dev/voc4cat/index.html
 
 Individual turtle files for concepts or collections
-- https://w3id.org/nfdi4cat/voc4cat/dev/voc4cat_0000002 <BR>-(turtle)-> https://nfdi4cat.github.io/voc4cat/dev/voc4cat/0000002.ttl<BR>-(html)-> https://nfdi4cat.github.io/voc4cat/dev/voc4cat/index.html#https://w3id.org/nfdi4cat/voc4cat_0000002
+- https://w3id.org/nfdi4cat/voc4cat/dev/voc4cat_0000002 <BR>-(turtle)-> https://nfdi4cat.github.io/voc4cat/dev/voc4cat/IDs0000xxx/0000002.ttl<BR>-(html)-> https://nfdi4cat.github.io/voc4cat/dev/voc4cat/index.html#https://w3id.org/nfdi4cat/voc4cat_0000002
 
 ## Contacts
 


### PR DESCRIPTION
## Brief Description

Concept and collection turtle files are published in subdirectories holding 1000 ids each ("IDs<first 4 digits>xxx") since release v2026-02-24. The redirects still pointed at the former flat paths, so every request for a single concept as turtle returned 404.

Releases up to v2025-10-14 were published flat and are immutable, so the version-tagged rule selects the layout by release year and keeps both reachable.

Fixes https://github.com/nfdi4cat/voc4cat/issues/277

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## Update ID Directory Checklist

- [ ] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.
