### PR TITLE
Add /cod — Canadian Open Government Data knowledge graph

### DIFF
--- a/cod/.htaccess
+++ b/cod/.htaccess
@@ -1,0 +1,25 @@
+# w3id.org/cod
+# COD - Canadian Open Government Data knowledge graph vocabulary
+# Maintainer: Akhil Chaudhary (https://github.com/akhil41)
+
+RewriteEngine on
+
+# Vocabulary document - content negotiation
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} text/n3
+RewriteRule ^vocab$ https://akhil41.github.io/cod/cod_ontology.ttl [R=303,L]
+RewriteRule ^vocab$ https://akhil41.github.io/cod/ [R=303,L]
+
+# Direct file requests
+RewriteRule ^vocab\.ttl$   https://akhil41.github.io/cod/cod_ontology.ttl [R=302,L]
+RewriteRule ^domains\.ttl$ https://akhil41.github.io/cod/cod_domains.ttl [R=302,L]
+
+# Instance and named-graph URIs are stable identifiers rather than
+# per-resource documents; send them to the documentation landing page.
+RewriteRule ^id/(.*)$    https://akhil41.github.io/cod/ [R=303,L]
+RewriteRule ^graph/(.*)$ https://akhil41.github.io/cod/ [R=303,L]
+
+# Default
+RewriteRule ^(.*)$ https://akhil41.github.io/cod/ [R=302,L]

--- a/cod/.htaccess
+++ b/cod/.htaccess
@@ -1,25 +1,13 @@
 # w3id.org/cod
 # COD - Canadian Open Government Data knowledge graph vocabulary
 # Maintainer: Akhil Chaudhary (https://github.com/akhil41)
+#
+# COD URIs are stable identifiers rather than retrieval addresses. The
+# vocabulary and the corpus it describes are archived on Zenodo, so every
+# path redirects to the deposit landing page. A 302 is used deliberately:
+# the target will be repointed to the knowledge-graph deposit once its DOI
+# is issued.
 
 RewriteEngine on
 
-# Vocabulary document - content negotiation
-RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
-RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
-RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
-RewriteCond %{HTTP_ACCEPT} text/n3
-RewriteRule ^vocab$ https://akhil41.github.io/cod/cod_ontology.ttl [R=303,L]
-RewriteRule ^vocab$ https://akhil41.github.io/cod/ [R=303,L]
-
-# Direct file requests
-RewriteRule ^vocab\.ttl$   https://akhil41.github.io/cod/cod_ontology.ttl [R=302,L]
-RewriteRule ^domains\.ttl$ https://akhil41.github.io/cod/cod_domains.ttl [R=302,L]
-
-# Instance and named-graph URIs are stable identifiers rather than
-# per-resource documents; send them to the documentation landing page.
-RewriteRule ^id/(.*)$    https://akhil41.github.io/cod/ [R=303,L]
-RewriteRule ^graph/(.*)$ https://akhil41.github.io/cod/ [R=303,L]
-
-# Default
-RewriteRule ^(.*)$ https://akhil41.github.io/cod/ [R=302,L]
+RewriteRule ^(.*)$ https://doi.org/10.5281/zenodo.20514898 [R=302,L]

--- a/cod/README.md
+++ b/cod/README.md
@@ -14,8 +14,8 @@ The vocabulary reuses DCAT, RDF Data Cube (`qb:`), SKOS, PROV-O, GeoSPARQL,
 SPDX, and schema.org, and defines a small number of COD-specific terms for
 snapshot provenance and column-level source mapping.
 
-Instance and named-graph URIs identify observations, datasets, snapshots, and
-jurisdictions within the corpus. They are stable identifiers rather than
-per-resource documents, so they redirect to the documentation landing page.
+COD URIs are stable identifiers rather than retrieval addresses. The vocabulary
+and corpus are archived on Zenodo, and all paths redirect to the deposit
+landing page: <https://doi.org/10.5281/zenodo.20514898>
 
 **Maintainer:** Akhil Chaudhary — https://github.com/akhil41

--- a/cod/README.md
+++ b/cod/README.md
@@ -1,0 +1,21 @@
+# `w3id.org/cod`
+
+Permanent identifiers for **COD**, a knowledge graph built from Canadian open
+government data harvested across federal, provincial, and territorial data
+portals.
+
+| Namespace | Base |
+|---|---|
+| Vocabulary terms | `https://w3id.org/cod/vocab#` |
+| Instances | `https://w3id.org/cod/id/` |
+| Named graphs | `https://w3id.org/cod/graph/` |
+
+The vocabulary reuses DCAT, RDF Data Cube (`qb:`), SKOS, PROV-O, GeoSPARQL,
+SPDX, and schema.org, and defines a small number of COD-specific terms for
+snapshot provenance and column-level source mapping.
+
+Instance and named-graph URIs identify observations, datasets, snapshots, and
+jurisdictions within the corpus. They are stable identifiers rather than
+per-resource documents, so they redirect to the documentation landing page.
+
+**Maintainer:** Akhil Chaudhary — https://github.com/akhil41


### PR DESCRIPTION
Requesting `https://w3id.org/cod/` for **COD**, a knowledge graph built from Canadian federal, provincial, and territorial open government data portals.

### Namespaces

| Purpose | Base |
|---|---|
| Vocabulary terms | `https://w3id.org/cod/vocab#` |
| Instances | `https://w3id.org/cod/id/` |
| Named graphs | `https://w3id.org/cod/graph/` |

### Redirect target

All paths redirect to the Zenodo deposit that archives the vocabulary and the corpus it describes:

**https://doi.org/10.5281/zenodo.20514898** (resolves, HTTP 200)

COD URIs are stable identifiers rather than retrieval addresses, so a single rule is used rather than per-resource content negotiation. The redirect is a 302 because the target will be repointed to the knowledge-graph deposit once its DOI is issued.

### About

The vocabulary reuses DCAT, RDF Data Cube (`qb:`), SKOS, PROV-O, GeoSPARQL, SPDX, and schema.org, and defines a small number of COD-specific terms for snapshot provenance and column-level source mapping. It supports an academic publication on knowledge graph construction over Canadian open government data.

**Maintainer:** Akhil Chaudhary — https://github.com/akhil41

No existing `/cod` entry is present in this repository, and `https://w3id.org/cod` currently returns 404.