### PR TITLE
Add quadpod namespace redirects

### DIFF
--- a/quadpod/.htaccess
+++ b/quadpod/.htaccess
@@ -1,0 +1,17 @@
+# # /quadpod/
+#
+# Namespace for quadpod, a Solid personal data server. Terms live in the hash
+# namespace of one document, so adding a term needs no change here.
+#
+# Maintainer details are in README.md.
+
+RewriteEngine on
+
+RewriteCond %{HTTP_ACCEPT} text/turtle          [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^ns/?$ https://tophcodes.github.io/quadpod/ns/quadpod.ttl [R=302,L]
+
+RewriteRule ^ns/?$ https://tophcodes.github.io/quadpod/ns/ [R=302,L]

--- a/quadpod/README.md
+++ b/quadpod/README.md
@@ -1,0 +1,14 @@
+# /quadpod/
+
+Permanent identifiers for the [quadpod](https://github.com/tophcodes/quadpod)
+vocabulary. quadpod implements the Solid Protocol in Rust: LDP over HTTP, Web
+Access Control, and every resource stored as a named graph in one embedded
+quad store.
+
+The vocabulary carries the terms quadpod has to mint because no registered
+vocabulary can make the claim. Everything it can express in LDP, WAC, SHACL,
+PROV-O or schema.org is expressed there instead.
+
+## Contact
+
+Christopher Mühl, <toki@toph.so>, GitHub username `tophcodes`.


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description

Adds the quadpod root namespace to w3id.org. quadpod is a Solid personal data server implementation in Rust. The project is under active development, with no release yet.

Its vocabulary document is currently served from the project's GitHub Pages, but needs a permanent home for an eventual release. Content negotiation sends an RDF client to the Turtle document and everyone else to the HTML page.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested (against a local Apache with the repository mounted)
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.
