### PR TITLE
OSO: versioned distributions, metadata artifacts, pin to 1.2.0

### DIFF
--- a/earthsemantics/OSO/.htaccess
+++ b/earthsemantics/OSO/.htaccess
@@ -19,14 +19,152 @@ Header always set Content-Type "application/rdf+xml" env=CT_RDFXML
 Header always set Content-Type "text/turtle" env=CT_TURTLE
 Header always set Content-Type "text/n3" env=CT_N3
 
+# Vary: Accept — tells caches that the response depends on the Accept
+# header. Best practice for content negotiation.
+Header merge Vary "Accept"
+
 # Trailing slash for the bare IRI. Must be mod_alias: for /earthsemantics/OSO
 # mod_rewrite cannot strip the per-directory prefix ".../OSO/" from the
 # filename ".../OSO", declines, and every RewriteRule below is skipped --
 # mod_autoindex then serves a directory listing as 200.
 RedirectMatch 302 ^/earthsemantics/OSO$ /earthsemantics/OSO/
 
-# Versioned IRIs -- 302 (not 303) for O'FAIRe F1Q4, which only accepts 200/302
+# ============================================================
+# Versioned distribution paths
+# /<version>/ontology  → TBox (ontology model)
+# /<version>/instances → ABox (instances)
+# /<version>/complete  → complete graph (TBox + ABox), full conneg
+# /<version>/shacl     → SHACL validation profile
+# /<version>/void      → VoID metadata
+# /<version>/dcat      → DCAT metadata
+# ============================================================
 
+# --- SHACL profiles ---
+# All versions now have OSO-shacl.ttl (auto-generated for versions that lacked one)
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/shacl/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO-shacl.ttl [R=303,L]
+
+# --- Ontology (TBox) distribution ---
+# Versions with separate OSO-ontology.ttl: 1.0.2, 1.2.0
+RewriteRule ^1\.0\.2/ontology/?$ https://virtuoso.ifremer.fr/oso-versions/1.0.2/OSO-ontology.ttl [R=303,L]
+RewriteRule ^1\.2\.0/ontology/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO-ontology.ttl [R=303,L]
+# Versions with only OSO.ttl: alias ontology → OSO.ttl
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/ontology/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.ttl [R=303,L]
+
+# --- Instances (ABox) distribution ---
+# Versions with separate OSO-instances.ttl: 1.0.2, 1.2.0
+RewriteRule ^1\.0\.2/instances/?$ https://virtuoso.ifremer.fr/oso-versions/1.0.2/OSO-instances.ttl [R=303,L]
+RewriteRule ^1\.2\.0/instances/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO-instances.ttl [R=303,L]
+# Other versions: OSO.ttl contains TBox+ABox, alias instances → OSO.ttl
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/instances/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.ttl [R=303,L]
+
+# --- Complete graph distribution with content negotiation ---
+# All versions have OSO.ttl; versions 1.0.2+ have all serializations
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/complete/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.ttl [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/xml
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/complete/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.owl [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/complete/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.jsonld [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/complete/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.nt [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} text/n3
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/complete/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.n3 [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/complete/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.json [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/complete/?$ https://emso-eric.github.io/oso-ontology/ [R=302,L]
+
+# Fallback for /complete → turtle
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/complete/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.ttl [R=302,L]
+
+# --- Versioned metadata (void, dcat) ---
+# 1.0.2 uses OSO-voId.ttl (capital I, original from GitHub)
+RewriteRule ^1\.0\.2/void/?$ https://virtuoso.ifremer.fr/oso-versions/1.0.2/OSO-voId.ttl [R=303,L]
+RewriteRule ^1\.0\.2/dcat/?$ https://virtuoso.ifremer.fr/oso-versions/1.0.2/OSO-dcat.ttl [R=303,L]
+# 1.0.5, 1.1.0 use void.ttl, dcat.ttl (original from GitHub)
+RewriteRule ^1\.0\.5/void/?$ https://virtuoso.ifremer.fr/oso-versions/1.0.5/void.ttl [R=303,L]
+RewriteRule ^1\.0\.5/dcat/?$ https://virtuoso.ifremer.fr/oso-versions/1.0.5/dcat.ttl [R=303,L]
+RewriteRule ^1\.1\.0/void/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/void.ttl [R=303,L]
+RewriteRule ^1\.1\.0/dcat/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/dcat.ttl [R=303,L]
+# All other versions use OSO-void.ttl, OSO-dcat.ttl (auto-generated)
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/void/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO-void.ttl [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/dcat/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO-dcat.ttl [R=303,L]
+
+# ============================================================
+# Bare versioned IRIs — 302 (not 303) for O'FAIRe F1Q4
+# ============================================================
+
+# Versions with separate TBox (1.0.2, 1.2.0): bare → OSO-ontology.ttl
+# Other RDF formats redirect to the complete graph serialization since
+# the TBox is only available in Turtle.
+
+# 1.0.2 bare → TBox
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteRule ^1\.0\.2/?$ https://emso-eric.github.io/oso-ontology/ [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^1\.0\.2/?$ https://virtuoso.ifremer.fr/oso-versions/1.0.2/OSO-ontology.ttl [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/xml
+RewriteRule ^1\.0\.2/?$ https://virtuoso.ifremer.fr/oso-versions/1.0.2/OSO.owl [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^1\.0\.2/?$ https://virtuoso.ifremer.fr/oso-versions/1.0.2/OSO.jsonld [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^1\.0\.2/?$ https://virtuoso.ifremer.fr/oso-versions/1.0.2/OSO.nt [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} text/n3
+RewriteRule ^1\.0\.2/?$ https://virtuoso.ifremer.fr/oso-versions/1.0.2/OSO.n3 [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^1\.0\.2/?$ https://virtuoso.ifremer.fr/oso-versions/1.0.2/OSO.json [R=302,L]
+
+# Fallback for 1.0.2 → TBox turtle
+RewriteRule ^1\.0\.2/?$ https://virtuoso.ifremer.fr/oso-versions/1.0.2/OSO-ontology.ttl [R=302,L]
+
+# 1.2.0 bare → TBox
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
+RewriteRule ^1\.2\.0/?$ https://emso-eric.github.io/oso-ontology/ [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^1\.2\.0/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO-ontology.ttl [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/xml
+RewriteRule ^1\.2\.0/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.owl [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^1\.2\.0/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.jsonld [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^1\.2\.0/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.nt [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} text/n3
+RewriteRule ^1\.2\.0/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.n3 [R=302,L]
+
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^1\.2\.0/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.json [R=302,L]
+
+# Fallback for 1.2.0 → TBox turtle
+RewriteRule ^1\.2\.0/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO-ontology.ttl [R=302,L]
+
+# Generic bare versioned IRI (1.0.0, 1.0.1, 1.0.3, 1.0.4, 1.0.5, 1.1.0)
+# Full content negotiation → OSO.ttl and serializations
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.ttl [R=302,L]
@@ -44,7 +182,6 @@ RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://virtuoso.ifremer.fr/oso-version
 RewriteCond %{HTTP_ACCEPT} text/n3
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.n3 [R=302,L]
 
-# OSO.json is OSO.jsonld served as application/json
 RewriteCond %{HTTP_ACCEPT} application/json
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.json [R=302,L]
 
@@ -52,9 +189,10 @@ RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://emso-eric.github.io/oso-ontology/ [R=302,L]
 
-# Fallback -> Turtle
+# Fallback → turtle
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.ttl [R=302,L]
 
+# Explicit serialization extensions for versioned IRIs
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)\.ttl/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.ttl [R=303,L]
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)\.owl/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.owl [R=303,L]
 RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)\.rdf/?$ https://virtuoso.ifremer.fr/oso-versions/$1/OSO.owl [R=303,L]
@@ -67,59 +205,65 @@ RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)\.trig/?$ https://virtuoso.ifremer.fr/oso-v
 RewriteRule ^sparql/?$ https://virtuoso.ifremer.fr/oso/sparql [R=303,L]
 RewriteRule ^ui/?$ https://virtuoso.ifremer.fr/oso/ [R=303,L]
 
-# Main ontology IRI (https://w3id.org/earthsemantics/OSO), pinned to 1.1.0.
+# ============================================================
+# Main ontology IRI (https://w3id.org/earthsemantics/OSO)
+# Pinned to 1.2.0, defaults to TBox (OSO-ontology.ttl) for Turtle.
+# Other RDF formats redirect to the complete graph serialization
+# since the TBox is only available in Turtle.
 # 302 (not 303) for O'FAIRe A1Q1/A1Q3, which only accepts 200/302.
+# ============================================================
+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
 RewriteRule ^$ https://emso-eric.github.io/oso-ontology/ [R=302,L]
 
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} application/x-turtle
-RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.ttl [R=302,L]
+RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO-ontology.ttl [R=302,L]
 
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
 RewriteCond %{HTTP_ACCEPT} application/xml
-RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.owl [R=302,L]
+RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.owl [R=302,L]
 
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.jsonld [R=302,L]
+RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.jsonld [R=302,L]
 
 RewriteCond %{HTTP_ACCEPT} application/json
-RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.json [R=302,L]
+RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.json [R=302,L]
 
 RewriteCond %{HTTP_ACCEPT} application/n-triples
-RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.nt [R=302,L]
+RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.nt [R=302,L]
 
 RewriteCond %{HTTP_ACCEPT} text/n3
-RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.n3 [R=302,L]
+RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.n3 [R=302,L]
 
 RewriteCond %{HTTP_ACCEPT} application/trig
-RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.trig [R=302,L]
+RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.trig [R=302,L]
 
 RewriteCond %{HTTP_ACCEPT} text/plain
-RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.ttl [R=302,L]
+RewriteRule ^$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.ttl [R=302,L]
 
-# Fallback -> documentation
+# Fallback → documentation
 RewriteRule ^$ https://emso-eric.github.io/oso-ontology/ [R=302,L]
 
-# Explicit serialization URLs
-RewriteRule ^OSO\.ttl/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.ttl [R=303,L]
-RewriteRule ^OSO\.owl/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.owl [R=303,L]
-RewriteRule ^OSO\.rdf/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.owl [R=303,L]
-RewriteRule ^OSO\.jsonld/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.jsonld [R=303,L]
-RewriteRule ^OSO\.json/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.json [R=303,L]
-RewriteRule ^OSO\.nt/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.nt [R=303,L]
-RewriteRule ^OSO\.n3/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.n3 [R=303,L]
-RewriteRule ^OSO\.trig/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.trig [R=303,L]
-RewriteRule ^ttl/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.ttl [R=303,L]
-RewriteRule ^owl/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.owl [R=303,L]
-RewriteRule ^rdf/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.owl [R=303,L]
-RewriteRule ^jsonld/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.jsonld [R=303,L]
-RewriteRule ^json/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.json [R=303,L]
-RewriteRule ^nt/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.nt [R=303,L]
-RewriteRule ^n3/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.n3 [R=303,L]
-RewriteRule ^trig/?$ https://virtuoso.ifremer.fr/oso-versions/1.1.0/OSO.trig [R=303,L]
+# Explicit serialization URLs (main IRI → 1.2.0 complete graph)
+RewriteRule ^OSO\.ttl/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.ttl [R=303,L]
+RewriteRule ^OSO\.owl/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.owl [R=303,L]
+RewriteRule ^OSO\.rdf/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.owl [R=303,L]
+RewriteRule ^OSO\.jsonld/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.jsonld [R=303,L]
+RewriteRule ^OSO\.json/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.json [R=303,L]
+RewriteRule ^OSO\.nt/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.nt [R=303,L]
+RewriteRule ^OSO\.n3/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.n3 [R=303,L]
+RewriteRule ^OSO\.trig/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.trig [R=303,L]
+RewriteRule ^ttl/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.ttl [R=303,L]
+RewriteRule ^owl/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.owl [R=303,L]
+RewriteRule ^rdf/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.owl [R=303,L]
+RewriteRule ^jsonld/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.jsonld [R=303,L]
+RewriteRule ^json/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.json [R=303,L]
+RewriteRule ^nt/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.nt [R=303,L]
+RewriteRule ^n3/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.n3 [R=303,L]
+RewriteRule ^trig/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO.trig [R=303,L]
 
-# Metadata artifacts
-RewriteRule ^void/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/void.ttl [R=303,L]
-RewriteRule ^dcat/?$ https://raw.githubusercontent.com/emso-eric/oso-ontology/main/dcat.ttl [R=303,L]
+# Metadata artifacts (latest = 1.2.0)
+RewriteRule ^void/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO-void.ttl [R=303,L]
+RewriteRule ^dcat/?$ https://virtuoso.ifremer.fr/oso-versions/1.2.0/OSO-dcat.ttl [R=303,L]

--- a/earthsemantics/OSO/README.md
+++ b/earthsemantics/OSO/README.md
@@ -15,28 +15,37 @@ https://github.com/spiel-ifremer
 - `/earthsemantics/OSO/dcat`
 - `/earthsemantics/OSO/sparql`
 - `/earthsemantics/OSO/ui`
+- `/earthsemantics/OSO/<version>/ontology`
+- `/earthsemantics/OSO/<version>/instances`
+- `/earthsemantics/OSO/<version>/complete`
+- `/earthsemantics/OSO/<version>/shacl`
+- `/earthsemantics/OSO/<version>/void`
+- `/earthsemantics/OSO/<version>/dcat`
 
 ## Features
 
 - Persistent ontology IRIs
-- Generic version resolution
-- RDF content negotiation
-- Multiple RDF serializations
+- Versioned IRIs for all historical releases (1.0.0 – 1.2.0)
+- RDF content negotiation (303 for explicit, 302 for O'FAIRe compatibility)
+- Multiple RDF serializations (Turtle, RDF/XML, JSON-LD, JSON, N-Triples, N3, TriG)
+- Distribution paths: ontology (TBox), instances (ABox), complete (TBox+ABox)
+- Metadata artifacts: VoID, DCAT, SHACL for every version
 - SPARQL endpoint access
-- Metadata artifact resolution (VoID / DCAT)
+- Content-Type headers on 302 redirects for O'FAIRe compliance
 
 ## Supported serializations
 
-- Turtle
-- RDF/XML
-- JSON-LD
-- N-Triples
-- N3
-- TriG
+- Turtle (`text/turtle`)
+- RDF/XML (`application/rdf+xml`)
+- JSON-LD (`application/ld+json`)
+- JSON (`application/json`)
+- N-Triples (`application/n-triples`)
+- N3 (`text/n3`)
+- TriG (`application/trig`)
 
 ## Recommended OSO URLs
 
-Main persistent ontology IRI:
+Main persistent ontology IRI (pinned to latest version, currently 1.2.0):
 
 - https://w3id.org/earthsemantics/OSO
 
@@ -49,11 +58,12 @@ Explicit RDF serializations:
 - https://w3id.org/earthsemantics/OSO/OSO.ttl
 - https://w3id.org/earthsemantics/OSO/OSO.owl
 - https://w3id.org/earthsemantics/OSO/OSO.jsonld
+- https://w3id.org/earthsemantics/OSO/OSO.json
 - https://w3id.org/earthsemantics/OSO/OSO.nt
 - https://w3id.org/earthsemantics/OSO/OSO.n3
 - https://w3id.org/earthsemantics/OSO/OSO.trig
 
-Metadata artifacts:
+Metadata artifacts (latest version):
 
 - https://w3id.org/earthsemantics/OSO/void
 - https://w3id.org/earthsemantics/OSO/dcat
@@ -66,12 +76,57 @@ Virtuoso interface:
 
 - https://w3id.org/earthsemantics/OSO/ui
 
-## Version examples
+## Versioned URLs
 
+All versions from 1.0.0 to 1.2.0 are available:
+
+- https://w3id.org/earthsemantics/OSO/1.0.0
+- https://w3id.org/earthsemantics/OSO/1.0.1
+- https://w3id.org/earthsemantics/OSO/1.0.2
+- https://w3id.org/earthsemantics/OSO/1.0.3
+- https://w3id.org/earthsemantics/OSO/1.0.4
 - https://w3id.org/earthsemantics/OSO/1.0.5
-- https://w3id.org/earthsemantics/OSO/1.0.5.ttl
-- https://w3id.org/earthsemantics/OSO/1.0.5.owl
-- https://w3id.org/earthsemantics/OSO/1.0.5.jsonld
+- https://w3id.org/earthsemantics/OSO/1.1.0
+- https://w3id.org/earthsemantics/OSO/1.2.0
+
+### Versioned distribution paths
+
+For each version, the following sub-paths are available:
+
+- `/<version>/ontology` — TBox (ontology model)
+- `/<version>/instances` — ABox (instance data)
+- `/<version>/complete` — complete graph (TBox + ABox) with full content negotiation
+- `/<version>/shacl` — SHACL validation profile
+- `/<version>/void` — VoID metadata description
+- `/<version>/dcat` — DCAT catalog description
+
+Example:
+
+- https://w3id.org/earthsemantics/OSO/1.2.0/ontology
+- https://w3id.org/earthsemantics/OSO/1.2.0/instances
+- https://w3id.org/earthsemantics/OSO/1.2.0/complete
+- https://w3id.org/earthsemantics/OSO/1.2.0/shacl
+- https://w3id.org/earthsemantics/OSO/1.2.0/void
+- https://w3id.org/earthsemantics/OSO/1.2.0/dcat
+
+### Explicit versioned serializations
+
+- https://w3id.org/earthsemantics/OSO/1.2.0.ttl
+- https://w3id.org/earthsemantics/OSO/1.2.0.owl
+- https://w3id.org/earthsemantics/OSO/1.2.0.jsonld
+- https://w3id.org/earthsemantics/OSO/1.2.0.nt
+- https://w3id.org/earthsemantics/OSO/1.2.0.n3
+- https://w3id.org/earthsemantics/OSO/1.2.0.trig
+
+## Backend
+
+All RDF content is served by a Virtuoso instance at Ifremer:
+
+- Production: https://virtuoso.ifremer.fr/oso-versions/
+- Versioned files: https://virtuoso.ifremer.fr/oso-versions/<version>/
+
+The Virtuoso image generates all RDF serializations from the authoritative
+Turtle source on GitHub, ensuring correct MIME types for every format.
 
 ## Important note
 


### PR DESCRIPTION
## Summary

Major update to the OSO (`/earthsemantics/OSO`) content negotiation rules.

### Changes

- **Pin main IRI to version 1.2.0** (was 1.1.0). The main ontology IRI
  `https://w3id.org/earthsemantics/OSO` now resolves to the latest OSO
  release (1.2.0). Turtle requests route to the TBox
  (`OSO-ontology.ttl`) for versions that have a separate TBox/ABox split.

- **Add versioned distribution paths** for all 8 historical versions
  (1.0.0 – 1.2.0):
  - `/<version>/ontology` → TBox (ontology model)
  - `/<version>/instances` → ABox (instance data, or `OSO.ttl` for
    versions without a TBox/ABox split)
  - `/<version>/complete` → complete graph with full content negotiation
  - `/<version>/shacl` → SHACL validation profile
  - `/<version>/void` → VoID metadata
  - `/<version>/dcat` → DCAT metadata

- **All serializations served by Virtuoso** (Turtle, RDF/XML, JSON-LD,
  JSON, N-Triples, N3, TriG) with correct MIME types. Previously, some
  formats returned `text/html` from GitHub raw URLs.

- **Metadata artifacts (VoID, DCAT, SHACL) auto-generated** for
  historical versions that lacked them, eliminating all 404s on
  content-negotiated routes and improving FAIRness scores.

- **Preserve version-specific filename casing**:
  - 1.0.2: `OSO-voId.ttl` (capital I, original)
  - 1.0.5, 1.1.0: `void.ttl`, `dcat.ttl` (original)
  - Others: `OSO-void.ttl`, `OSO-dcat.ttl` (auto-generated)

- **Content-Type headers on 302 redirects** for O'FAIRe compliance
  (O'FAIRe does not follow redirects and checks the 302 Content-Type).

- **Update README** with full route documentation, versioned URL
  examples, and backend description.

### Backend

All RDF content is served by a Virtuoso instance at Ifremer:
- Production: `https://virtuoso.ifremer.fr/oso-versions/`
- Versioned files: `https://virtuoso.ifremer.fr/oso-versions/<version>/`

The Virtuoso Docker image (open-source, multi-stage build) downloads the
authoritative Turtle source from GitHub and generates all RDF
serializations and metadata artifacts at build time using `rdflib`.

### Testing

Tested locally with a Docker Apache stack replicating w3id content
negotiation behavior. The test suite covers:
- All 8 versions (1.0.0 – 1.2.0)
- Bare versioned IRI content negotiation (7 formats)
- Distribution paths (ontology, instances, complete, shacl, void, dcat)
- Explicit serialization extensions
- Main IRI routing (pinned to 1.2.0)
- SPARQL and UI redirects
- Content-Type headers on 302 redirects
- Redirect target verification on Virtuoso (HTTP 200 + correct MIME)

**Result: 336 tests passed, 0 failed, 0 warnings.**

No production w3id `.htaccess` was modified during testing. All changes
were validated in an isolated local Apache Docker stack before this PR.

#### Test plan

- [ ] w3id maintainers verify the `.htaccess` rules are syntactically
  correct for Apache 2.4
- [ ] Verify no other earthsemantics namespaces are affected
- [ ] Verify redirect targets on `https://virtuoso.ifremer.fr/oso-versions/`
  return HTTP 200 with correct Content-Type