### PR TITLE
changed rewrite rules for ldac 'terms'

### DIFF
--- a/ldac/.htaccess
+++ b/ldac/.htaccess
@@ -1,6 +1,8 @@
 RewriteEngine On
 
 RewriteRule ^profile$ https://language-research-technology.github.io/ldac-profile/masp-profile/profile-crate/ [R=302,L,QSA]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^terms$ https://language-research-technology.github.io/ldac-profile/masp-schema/schema-crate/ro-crate-metadata.json [R=302,L,QSA]
 RewriteRule ^terms$ https://language-research-technology.github.io/ldac-profile/masp-schema/schema-crate/ [R=302,L,QSA]
 RewriteRule ^context$ https://raw.githubusercontent.com/Language-Research-Technology/ldac-profile/master/context/context.json [R=302,L,QSA]
 RewriteRule ^pilars$ https://pilars-protocols.github.io/pilars/ [R=302,L,QSA]


### PR DESCRIPTION
Add content negotiation for LDAC terms
Update the w3id configuration to support content negotiation for the LDAC vocabulary. Requests for application/ld+json are redirected to the RO-Crate JSON-LD metadata, while other requests continue to resolve to the human-readable HTML representation.

@ptsefton for approval.
