### PR TITLE
sstim: add persistent routes for the two JSON Schema contracts

### DIFF
--- a/sstim/.htaccess
+++ b/sstim/.htaccess
@@ -1,7 +1,7 @@
 # SSTIM — Sensory Stimulation Ontology
 # Persistent identifier base: https://w3id.org/sstim
 # Target:                     https://w3c-cg.github.io/sstim/ontology/
-# Maintainer:                 Renato Fabbri <renato.fabbri@gmail.com>
+# Maintainer:                 Renato Fabbri <renato.fabbri@gmail.com>, GitHub @ttm
 # Source repository:          https://github.com/laBioSynCare/laBioSynCare.github.io
 
 Options +FollowSymLinks
@@ -158,6 +158,17 @@ RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/turtle|application/x-turtle|\*/\*)\
 RewriteRule ^$ https://w3c-cg.github.io/sstim/ontology/sstim-namespace.ttl [R=303,L]
 RewriteRule ^$ - [R=406,L]
 # END audited SSTIM manifest routes
+
+# -------------------------------------------------------------------------
+# SSTIM's own JSON Schema contracts. Single-format JSON documents, so they get
+# a plain route rather than a negotiated one, matching manifest-schema/1 above.
+# These carry the schemas' `$id`, which is an identity with no concrete
+# counterpart field: unlike a dcat:downloadURL, which pairs with an accessURL
+# PURL one line above it, a `$id` is the only URI the schema has. A persistent
+# one is therefore the right kind, and it is why these routes exist.
+# -------------------------------------------------------------------------
+RewriteRule ^schemas/preset\.schema\.json$ https://w3c-cg.github.io/sstim/schemas/preset.schema.json [R=303,L]
+RewriteRule ^schemas/session\.schema\.json$ https://w3c-cg.github.io/sstim/schemas/session.schema.json [R=303,L]
 
 # -------------------------------------------------------------------------
 # Stable BSC catalog identities. Programme, framework, application, and


### PR DESCRIPTION
## Brief Description

Adds two redirects under the existing `sstim` directory, for SSTIM's preset and session JSON Schema contracts:

```
/sstim/schemas/preset.schema.json   -> https://w3c-cg.github.io/sstim/schemas/preset.schema.json
/sstim/schemas/session.schema.json  -> https://w3c-cg.github.io/sstim/schemas/session.schema.json
```

These carry the two schemas' `$id`. A JSON Schema's `$id` is the only URI the schema has, so a persistent one replaces rather than duplicates an existing identifier. The ontology's other artifacts already pair a w3id `dcat:accessURL` with a concrete `dcat:downloadURL`, so they needed no new route; these two had no such pairing.

Plain rules rather than content-negotiated ones, matching `manifest-schema/1` directly above them: both are single-format JSON documents.

The same commit names the maintainer's GitHub account in the directory header, which previously gave only a name and an email.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

**How they were tested.** Both rules were resolved through the route simulator this directory is maintained with, under `Accept:` empty, `*/*`, `application/json` and `text/html`, each returning `303` to the target above. A near miss (`schemas/other.schema.json`) returns `404`, so the patterns are anchored. Both targets currently serve `200 application/json`.

## New ID Directory Checklist

Not applicable: `sstim/` already exists (added in #6378, retargeted in #6609).

## Update ID Directory Checklist

- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers

- [ ] Please squash commits for me. (Not needed: this is a single commit.)
