### PR TITLE
Add MODAVIS permanent identifiers

### DIFF
--- a/modavis/.htaccess
+++ b/modavis/.htaccess
@@ -1,0 +1,76 @@
+# MODAVIS Ontology Network permanent identifiers.
+# Versioned targets are immutable; stable ontology and vocabulary routes may
+# advance under the MODAVIS release and persistence policy.
+# Maintainer: Dominik Ukolov (ORCID: 0000-0002-7904-3892)
+# GitHub: @modavis-project
+
+Options -MultiViews
+RewriteEngine On
+
+# Network landing page.
+RewriteRule ^$ https://modavis-project.github.io/modavis-ontology-network/index.html [R=303,L]
+
+# Stable ontology identifiers follow the current compatible release. Only these
+# moving aliases need to change when a later release becomes current.
+RewriteRule ^ontology/?$ https://w3id.org/modavis/ontology/0.1.0 [R=302,L]
+RewriteRule ^ontology/([a-z][a-z0-9-]*)/?$ https://w3id.org/modavis/ontology/$1/0.1.0 [R=302,L]
+
+# Versioned aggregate ontology. The version is delegated to the matching
+# project-controlled publication path.
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^ontology/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://modavis-project.github.io/modavis-ontology-network/ontology/$1/ontology.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^ontology/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://modavis-project.github.io/modavis-ontology-network/ontology/$1/ontology.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^ontology/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://modavis-project.github.io/modavis-ontology-network/ontology/$1/ontology.rdf [R=303,L]
+RewriteRule ^ontology/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://modavis-project.github.io/modavis-ontology-network/ontology/$1/index.html [R=303,L]
+
+# Versioned ontology modules. Module and version availability are determined by
+# the publication site rather than enumerated in W3ID.
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^ontology/([a-z][a-z0-9-]*)/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://modavis-project.github.io/modavis-ontology-network/ontology/$1/$2/$1.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^ontology/([a-z][a-z0-9-]*)/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://modavis-project.github.io/modavis-ontology-network/ontology/$1/$2/$1.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^ontology/([a-z][a-z0-9-]*)/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://modavis-project.github.io/modavis-ontology-network/ontology/$1/$2/$1.rdf [R=303,L]
+RewriteRule ^ontology/([a-z][a-z0-9-]*)/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://modavis-project.github.io/modavis-ontology-network/ontology/$1/$2/index.html [R=303,L]
+
+# Combined controlled vocabulary. The stable vocabulary IRI follows the current
+# release; scheme and concept IRIs resolve to its aggregate representation.
+RewriteRule ^vocab/?$ https://w3id.org/modavis/vocab/0.1.0 [R=302,L]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^vocab/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://modavis-project.github.io/modavis-ontology-network/vocab/$1/vocab.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^vocab/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://modavis-project.github.io/modavis-ontology-network/vocab/$1/vocab.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^vocab/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://modavis-project.github.io/modavis-ontology-network/vocab/$1/vocab.rdf [R=303,L]
+RewriteRule ^vocab/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://modavis-project.github.io/modavis-ontology-network/vocab/$1/index.html [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^vocab/(.*[^/])/?$ https://modavis-project.github.io/modavis-ontology-network/vocab/0.1.0/vocab.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^vocab/(.*[^/])/?$ https://modavis-project.github.io/modavis-ontology-network/vocab/0.1.0/vocab.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^vocab/(.*[^/])/?$ https://modavis-project.github.io/modavis-ontology-network/vocab/0.1.0/vocab.rdf [R=303,L]
+RewriteRule ^vocab/(.*[^/])/?$ https://modavis-project.github.io/modavis-ontology-network/vocab/0.1.0/index.html#$1 [R=303,L,NE]
+
+# Versioned JSON-LD context.
+RewriteRule ^context/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://modavis-project.github.io/modavis-ontology-network/context/$1/context.jsonld [R=303,L]
+
+# Versioned SHACL profiles.
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^shapes/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://modavis-project.github.io/modavis-ontology-network/shapes/$1/$2/shapes.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^shapes/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://modavis-project.github.io/modavis-ontology-network/shapes/$1/$2/shapes.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^shapes/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://modavis-project.github.io/modavis-ontology-network/shapes/$1/$2/shapes.rdf [R=303,L]
+RewriteRule ^shapes/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://modavis-project.github.io/modavis-ontology-network/shapes/$1/$2/index.html [R=303,L]
+
+# Versioned release catalog.
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^release/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://modavis-project.github.io/modavis-ontology-network/release/$1/catalog.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^release/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://modavis-project.github.io/modavis-ontology-network/release/$1/catalog.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^release/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://modavis-project.github.io/modavis-ontology-network/release/$1/catalog.rdf [R=303,L]
+RewriteRule ^release/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://modavis-project.github.io/modavis-ontology-network/release/$1/index.html [R=303,L]

--- a/modavis/README.md
+++ b/modavis/README.md
@@ -1,0 +1,29 @@
+# MODAVIS permanent identifiers
+
+This directory defines the W3ID namespace for the [MODAVIS Ontology
+Network](https://github.com/modavis-project/modavis-ontology-network) and the
+[Virtual Acoustic Object (VAO) Standard](https://github.com/modavis-project/vao-standard).
+
+The namespace root is:
+
+```text
+https://w3id.org/modavis/
+```
+
+The ontology-network routes cover ontology modules, controlled vocabularies,
+JSON-LD context, SHACL profiles, and release metadata. Stable ontology and
+vocabulary identifiers resolve to the current compatible release; identifiers
+that include `0.1.0` resolve to immutable versioned representations. Content
+negotiation is available for HTML, Turtle, JSON-LD, and RDF/XML where those
+representations are published.
+
+VAO uses the child namespace `https://w3id.org/modavis/vao/`. Its versioned
+schema, profile, vocabulary, context, mapping, and specification identifiers
+are maintained in [`vao/`](vao/).
+
+## Maintainer
+
+- Dominik Ukolov — [ORCID 0000-0002-7904-3892](https://orcid.org/0000-0002-7904-3892)
+- GitHub: [@modavis-project](https://github.com/modavis-project)
+- Affiliation: Digital Humanities (Image/Object), Friedrich Schiller University
+  Jena; Research Group DIGITAL ORGANOLOGY, Leipzig University

--- a/modavis/vao/.htaccess
+++ b/modavis/vao/.htaccess
@@ -1,0 +1,37 @@
+# Virtual Acoustic Object (VAO) Standard permanent identifiers.
+# Versioned targets follow the matching immutable release tag.
+# Maintainer: Dominik Ukolov (ORCID: 0000-0002-7904-3892)
+# GitHub: @modavis-project
+
+Options -MultiViews
+RewriteEngine On
+
+# Versioned machine artifacts. Availability is determined by the matching
+# immutable release tag rather than enumerated in W3ID.
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/schema/([a-z0-9-]+)\.json$ https://raw.githubusercontent.com/modavis-project/vao-standard/v$1/Schemas/vao-$2-$1.schema.json [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/context\.jsonld$ https://raw.githubusercontent.com/modavis-project/vao-standard/v$1/Schemas/vao-context-$1.jsonld [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/(vocabulary|modavis-mapping|shapes)/?$ https://raw.githubusercontent.com/modavis-project/vao-standard/v$1/Schemas/vao-$2-$1.ttl [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/specification-bundle/?$ https://raw.githubusercontent.com/modavis-project/vao-standard/v$1/Schemas/vao-release-bundle-$1.json [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/security/?$ https://raw.githubusercontent.com/modavis-project/vao-standard/v$1/Docs/SECURITY_CONSIDERATIONS.md [R=303,L]
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://github.com/modavis-project/vao-standard/blob/v$1/Docs/VAO_STANDARD_$1.md [R=303,L]
+
+# Versioned profile identifiers. The profile filenames are part of the
+# published release layout; only the version is variable.
+RewriteRule ^profile/core/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raw.githubusercontent.com/modavis-project/vao-standard/v$1/Docs/VAO_CORE_PROFILE_$1.md [R=303,L]
+RewriteRule ^profile/dynamic-delivery/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raw.githubusercontent.com/modavis-project/vao-standard/v$1/Docs/VAO_DYNAMIC_DELIVERY_PROFILE_$1.md [R=303,L]
+RewriteRule ^profile/scientific/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raw.githubusercontent.com/modavis-project/vao-standard/v$1/Docs/VAO_SCIENTIFIC_PROFILE_$1.md [R=303,L]
+RewriteRule ^profile/multimodal/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raw.githubusercontent.com/modavis-project/vao-standard/v$1/Docs/VAO_MULTIMODAL_PROFILE_$1.md [R=303,L]
+RewriteRule ^profile/physical-instrument/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raw.githubusercontent.com/modavis-project/vao-standard/v$1/Docs/VAO_PHYSICAL_INSTRUMENT_PROFILE_$1.md [R=303,L]
+RewriteRule ^profile/playable/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raw.githubusercontent.com/modavis-project/vao-standard/v$1/Docs/VAO_PLAYABLE_PROFILE_$1.md [R=303,L]
+RewriteRule ^profile/deterministic-runtime/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raw.githubusercontent.com/modavis-project/vao-standard/v$1/Docs/VAO_DETERMINISTIC_RUNTIME_PROFILE_$1.md [R=303,L]
+RewriteRule ^profile/spatial/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raw.githubusercontent.com/modavis-project/vao-standard/v$1/Docs/VAO_SPATIAL_PROFILE_$1.md [R=303,L]
+RewriteRule ^profile/acoustics/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raw.githubusercontent.com/modavis-project/vao-standard/v$1/Docs/VAO_ACOUSTICS_PROFILE_$1.md [R=303,L]
+RewriteRule ^profile/repository/zenodo/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raw.githubusercontent.com/modavis-project/vao-standard/v$1/Docs/VAO_ZENODO_PROFILE_$1.md [R=303,L]
+
+# Stable vocabulary identifiers follow the current compatible VAO release.
+# Vocabulary membership is validated by VAO tooling, not by W3ID.
+RewriteRule ^ontology/?$ https://raw.githubusercontent.com/modavis-project/vao-standard/v0.4.0/Schemas/vao-vocabulary-0.4.0.ttl [R=303,L]
+RewriteRule ^vocab(?:/.*)?$ https://raw.githubusercontent.com/modavis-project/vao-standard/v0.4.0/Schemas/vao-vocabulary-0.4.0.ttl [R=303,L]
+
+# Project discovery entry point; normative records use versioned identifiers.
+RewriteRule ^$ https://github.com/modavis-project/vao-standard [R=302,L]

--- a/modavis/vao/README.md
+++ b/modavis/vao/README.md
@@ -1,0 +1,21 @@
+# VAO permanent identifiers
+
+This directory defines permanent identifiers for the [Virtual Acoustic Object
+(VAO) Standard](https://github.com/modavis-project/vao-standard) under:
+
+```text
+https://w3id.org/modavis/vao/
+```
+
+Version `0.4.0` identifiers resolve to files or documentation pinned to the
+immutable `v0.4.0` release tag. The namespace covers normative schemas,
+JSON-LD context, RDF vocabulary, SHACL shapes, profiles, the MODAVIS mapping,
+and the versioned specification. The unversioned namespace root is a project
+discovery link; no moving `latest` identifier is defined for normative use.
+
+## Maintainer
+
+- Dominik Ukolov — [ORCID 0000-0002-7904-3892](https://orcid.org/0000-0002-7904-3892)
+- GitHub: [@modavis-project](https://github.com/modavis-project)
+- Affiliation: Digital Humanities (Image/Object), Friedrich Schiller University
+  Jena; Research Group DIGITAL ORGANOLOGY, Leipzig University


### PR DESCRIPTION
## Brief Description

Adds the `https://w3id.org/modavis/` namespace for the MODAVIS Ontology Network and its `vao/` child namespace for the Virtual Acoustic Object Standard. Versioned routes resolve to immutable release artifacts; ontology routes support the published HTML, Turtle, JSON-LD, and RDF/XML representations.

Maintainer details and the submitting GitHub account are recorded in both `.htaccess` files and READMEs.

## General Checklist

- [x] Changes have been tested with Apache 2.4.
- [x] The contribution contains one commit.
- [x] The commit includes only redirects and basic identifier information.

## New ID Directory Checklist

- [x] Maintainer details are present in `.htaccess` and `README.md`.
- [x] GitHub username IDs are listed in the maintainer details.

## Verification

- Parent and nested child rules passed Apache syntax and redirect-behavior tests, including content negotiation and negative routes.
- 74 MODAVIS destination artifacts matched the frozen 0.1.0 publication site byte-for-byte.
- 22 VAO raw destinations matched the immutable `v0.4.0` tag byte-for-byte.