### PR TITLE
sstim: route the namespace IRI to the latest release

### DIFF
--- a/sstim/.htaccess
+++ b/sstim/.htaccess
@@ -147,15 +147,31 @@ RewriteRule ^(stimulus|core-shapes|common|technique|configuration|session|eviden
 
 # /sstim is the generated Full namespace catalog. Fragment IRIs such as
 # /sstim#Preset resolve here even when a concern module owns their statements.
+#
+# RDF answers from `latest/`, the newest frozen release, not from the working
+# tree (ADR 0055). Until 2026-08-29 this served the deployment's top-level
+# build, so the ontology IRI returned a graph declaring owl:versionInfo
+# "0.17.0-dev", mod:status "under development" and no owl:versionIRI at all:
+# unpinnable, uncitable, and what LOV and Archivo would have harvested as SSTIM.
+# `latest/` is a stable path written from the newest snapshot on every deploy, so
+# cutting a release still needs no pull request here (ADR 0053).
+#
+# HTML answers the namespace page rather than the application entrance, for the
+# reason the exposure and vocab rules below already give: a server never sees a
+# fragment, so one destination has to serve both /sstim and /sstim#Preset. The
+# namespace page states what this IRI is and which IRIs belong to it, and hands
+# any fragment on to the knowledge browser, which is the only surface that can
+# select the term (measured 2026-08-23: WIDOCO anchors by full IRI, pyLODE by
+# label, so neither could).
 RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*application/ld\+json\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
-RewriteRule ^$ https://w3c-cg.github.io/sstim/ontology/sstim-namespace.jsonld [R=303,L]
+RewriteRule ^$ https://w3c-cg.github.io/sstim/ontology/latest/sstim-namespace.jsonld [R=303,L]
 RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*application/rdf\+xml\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
-RewriteRule ^$ https://w3c-cg.github.io/sstim/ontology/sstim-namespace.rdf [R=303,L]
+RewriteRule ^$ https://w3c-cg.github.io/sstim/ontology/latest/sstim-namespace.rdf [R=303,L]
 RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/html|application/xhtml\+xml)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
-RewriteRule ^$ https://w3c-cg.github.io/sstim/ [R=303,L]
+RewriteRule ^$ https://w3c-cg.github.io/sstim/namespace/ [R=303,L]
 RewriteCond %{HTTP_ACCEPT} ^$ [OR]
 RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/turtle|application/x-turtle|\*/\*)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
-RewriteRule ^$ https://w3c-cg.github.io/sstim/ontology/sstim-namespace.ttl [R=303,L]
+RewriteRule ^$ https://w3c-cg.github.io/sstim/ontology/latest/sstim-namespace.ttl [R=303,L]
 RewriteRule ^$ - [R=406,L]
 # END audited SSTIM manifest routes
 


### PR DESCRIPTION
## Brief Description

Updates only the four negotiated redirects for the bare
`https://w3id.org/sstim` namespace IRI. SSTIM is an OWL/SKOS ontology
published under CC BY 4.0.

RDF clients currently receive the mutable development catalogue. This change
routes them to the stable `latest/` paths generated from the newest frozen
release on every deployment:

| Request | Target |
|---|---|
| Turtle, `*/*`, or no `Accept` | `https://w3c-cg.github.io/sstim/ontology/latest/sstim-namespace.ttl` |
| `application/ld+json` | `https://w3c-cg.github.io/sstim/ontology/latest/sstim-namespace.jsonld` |
| `application/rdf+xml` | `https://w3c-cg.github.io/sstim/ontology/latest/sstim-namespace.rdf` |
| HTML | `https://w3c-cg.github.io/sstim/namespace/` |

The released graph currently declares
`owl:versionIRI <https://w3id.org/sstim/0.16.0>`,
`owl:versionInfo "0.16.0"`, and `mod:status "released"`. The stable
`latest/` path means future releases do not require another w3id.org pull
request.

The HTML target identifies the namespace and current release, documents its
IRI families and negotiated representations, and forwards hash-fragment term
IRIs to the knowledge browser.

No route pattern, `Accept` condition, status code, flag, or non-root route
changes. This PR contains one commit touching only `sstim/.htaccess`.

All four targets were verified returning `200` from the production Community
Group Pages deployment before this PR was opened. Turtle, JSON-LD, and RDF/XML
each parse to the same 11,506-triple graph; the Turtle is byte-identical to the
frozen 0.16.0 snapshot. The production RDF validation, lint/build, and Pages
deployment workflows all pass.

The exact mirror and route negotiation are tested in the SSTIM repository:
`make w3id-routes` passes, as do the 28 focused namespace publication,
target, and negotiation tests.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

Not applicable — `sstim/` is an existing ID directory.

## Update ID Directory Checklist

- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

Maintainer is unchanged: @ttm, listed in both `sstim/.htaccess` and
`sstim/README.md`.

## Optional Requests for W3ID Maintainers

- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
