### PR TITLE
Add greek-coptic-spellings namespace

### DIFF
--- a/greek-coptic-spellings/.htaccess
+++ b/greek-coptic-spellings/.htaccess
@@ -1,0 +1,39 @@
+# # /greek-coptic-spellings/
+#
+# Persistent identifiers for individual spelling deviations in the dataset
+# "Greek Loanword Spellings in Coptic": places where the Coptic spelling of a
+# Greek loanword departs from the form its Greek lemma leads one to expect, in
+# manuscripts of the 3rd-13th centuries.
+#
+# https://w3id.org/greek-coptic-spellings/deviation/<id> redirects to that one
+# record in the dataset's browsing interface.
+#
+# 302 rather than 301 throughout: the identifiers are permanent, but the hosting
+# of the interface they resolve to is not promised to be.
+#
+# ## Contact
+# This space is administered by:
+#
+# Kierán Meinhardt
+# GitHub username: kmein
+# ORCID: https://orcid.org/0009-0000-1250-807X
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# A single spelling deviation, e.g. /deviation/71615-3
+#
+# Anchored regex rather than a substring match: some identifiers carry a
+# two-digit index (114524-10 ... 114524-15), so an unanchored search for
+# "114524-1" would select those alongside the intended record.
+RewriteRule ^deviation/(.+)$ https://kmein.github.io/greek-coptic-data/?deviation_id_regex=\%5E$1\%24 [NE,R=302,L]
+
+# The dataset itself: content negotiation between the human landing page and the
+# machine-readable CLDF/JSON-LD descriptor.
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+RewriteCond %{HTTP_ACCEPT} application/json
+RewriteRule ^dataset/?$ https://kmein.github.io/greek-coptic-data/cldf-metadata.json [NE,R=302,L]
+RewriteRule ^dataset/?$ https://kmein.github.io/greek-coptic-data/ [NE,R=302,L]
+
+# Anything else lands on the dataset.
+RewriteRule ^$ https://kmein.github.io/greek-coptic-data/ [NE,R=302,L]

--- a/greek-coptic-spellings/README.md
+++ b/greek-coptic-spellings/README.md
@@ -1,0 +1,29 @@
+# /greek-coptic-spellings/
+
+Persistent identifiers for individual spelling deviations in the dataset **Greek Loanword
+Spellings in Coptic**: the places where the Coptic spelling of a Greek loanword departs
+from the form its Greek lemma leads one to expect, in manuscripts of the 3rd–13th centuries.
+
+Each identifier resolves to that one record in the dataset's browsing interface:
+
+    https://w3id.org/greek-coptic-spellings/deviation/71615-3
+
+Identifiers take the form `{attestation}-{position}` and are derived from the data rather
+than assigned by row order, so they remain stable across rebuilds of the dataset.
+
+`https://w3id.org/greek-coptic-spellings/dataset` resolves to the dataset itself, serving
+the CLDF (CSVW/JSON-LD) descriptor to clients that ask for JSON and the landing page
+otherwise.
+
+## Links
+
+- Dataset and interface: https://kmein.github.io/greek-coptic-data/
+- Archived release: https://doi.org/10.5281/zenodo.22172183
+- Source database: DDGLC, Freie Universität Berlin, https://dioskoros.org/
+
+## Contact
+
+Kierán Meinhardt, Freie Universität Berlin
+<kieran.meinhardt@fu-berlin.de>
+GitHub username: kmein
+ORCID: https://orcid.org/0009-0000-1250-807X


### PR DESCRIPTION
Persistent identifiers for individual spelling deviations in the dataset "Greek Loanword Spellings in Coptic": places where the Coptic spelling of a Greek loanword departs from the form its Greek lemma leads one to expect, in manuscripts of the 3rd-13th centuries.

https://w3id.org/greek-coptic-spellings/deviation/<id> resolves to that one record in the dataset's browsing interface. /dataset serves the CLDF (CSVW/JSON-LD) descriptor to clients asking for JSON and the landing page otherwise.

Redirects are 302: the identifiers are permanent, the hosting they resolve to is not promised to be.

Contact: Kierán Meinhardt (GitHub kmein), kieran.meinhardt@fu-berlin.de

Tested against a local Apache checkout with mod_rewrite and AllowOverride All; all four rules verified to produce the intended targets.

<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.