### PR TITLE
pkm: add content negotiation for the PKM vocabulary

### DIFF
--- a/pkm/.htaccess
+++ b/pkm/.htaccess
@@ -1,5 +1,45 @@
-# w3id.org/pkm — KSA Personal Knowledge Management ontology
-# Contact: Doug Warren <doug78645@gmail.com> (GitHub: @dpw67)
+# https://w3id.org/pkm — PKM (Personal Knowledge Management) namespace
+#
+# A SKOS vocabulary and related Linked Data for the Knowledge System
+# Architecture (KSA) project. Served from GitHub Pages at dpw67.github.io/pkm.
+#
+# ## Contact
+# This space is administered by:
+#
+# Doug Warren
+# GitHub username: dpw67
+# Email: doug@warrenweb.net
+
+Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^$ https://dpw67.github.io/pkm/ [R=302,L]
-RewriteRule ^(.+)$ https://dpw67.github.io/pkm/$1 [R=302,L]
+
+# Individual vocabulary terms: /vocab/Recipe -> vocab/terms/Recipe.ttl
+# 303, not 302: a concept is not a document, so the redirect says "here is a
+# document *about* it" (httpRange-14).
+#
+# No dot in the character class, so /vocab/Recipe.ttl and the version IRI
+# /vocab/0.1.1 both fall through to the catch-all rather than matching here.
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/n-triples|text/n3) [NC]
+RewriteRule ^vocab/([A-Za-z][A-Za-z0-9_-]*)$ https://dpw67.github.io/pkm/vocab/terms/$1.ttl [R=303,L]
+
+# The concept scheme itself, as a single document.
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/n-triples|text/n3) [NC]
+RewriteRule ^vocab/?$ https://dpw67.github.io/pkm/vocab/pkm-vocab.ttl [R=303,L]
+
+# Provenance: the people and software credited in the vocabulary, and the
+# documents it cites. Hash URIs, so one file answers for all of them.
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/n-triples|text/n3) [NC]
+RewriteRule ^agents/?$ https://dpw67.github.io/pkm/agents/index.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/n-triples|text/n3) [NC]
+RewriteRule ^resources/?$ https://dpw67.github.io/pkm/resources/index.ttl [R=303,L]
+
+# Declared but not yet populated; the URIs resolve and carry their metadata.
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/n-triples|text/n3) [NC]
+RewriteRule ^ontology/?$ https://dpw67.github.io/pkm/ontology/pkm.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} (text/turtle|application/rdf\+xml|application/n-triples|text/n3) [NC]
+RewriteRule ^taxonomy/?$ https://dpw67.github.io/pkm/taxonomy/pkm-taxonomy.ttl [R=303,L]
+
+# Everything else: HTML. Must stay last.
+RewriteRule ^(.*)$ https://dpw67.github.io/pkm/$1 [R=302,L,QSA]

--- a/pkm/README.md
+++ b/pkm/README.md
@@ -1,24 +1,36 @@
 # pkm
 
-This is a persistent URI namespace at https://w3id.org/pkm with Linked Data resources 
-on Personal Knowledge Management (PKM) for the Knowledge System Architecture (KSA) project, 
-which integrates Obsidian, Neo4j, Claude, diabetes data, Python, and Swift.
+A persistent URI namespace at https://w3id.org/pkm with Linked Data resources on
+Personal Knowledge Management (PKM) for the Knowledge System Architecture (KSA)
+project, which integrates Obsidian, Neo4j, Claude, diabetes data, Python, and Swift.
 
-It documents the following, with PKM extensions based on SKOS, RDF, OWL, schema.org, and LinkML:
-- vocabulary — SKOS terms and definitions (glossary)
-- taxonomy — SKOS concepts and relationships
-- ontology — RDF/OWL classes, instances, properties, and relationships
-- knowledge graph — Neo4j (Cypher) nodes, relationships, and properties
-- tools — Python and Swift apps, services, scripts, intents, Siri
-- resources — related documentation and examples
+Redirects to GitHub Pages at https://dpw67.github.io/pkm/, with content
+negotiation: `Accept: text/turtle` gets RDF, anything else gets HTML.
 
-Schema and examples are provided in Python, Swift, Cypher, SQL, TypeDB, JSON Schema, and JSON.
+## What resolves today
+
+| URI | Contents |
+| --- | --- |
+| `/vocab` | SKOS concept scheme — 223 concepts, 18 collections |
+| `/vocab/{Term}` | An individual concept or collection, 303 to its Turtle file |
+| `/agents#{Name}` | People and software credited in the vocabulary |
+| `/resources#{Name}` | Documents the vocabulary cites |
+| `/ontology`, `/taxonomy` | Declared and resolving; no terms minted yet |
+
+Planned, described but not yet populated: `/shapes` (SHACL, JSON Schema),
+`/examples`, `/graph` (Neo4j, Cypher), `/tools`.
+
+Vocabulary version 0.1.1. Terms are an early draft and may change before 1.0.0.
+Nothing is deleted outright — a retired URI keeps resolving, marked
+`owl:deprecated` and pointed at its replacement with `dcterms:isReplacedBy`.
 
 ## Contact
-This space is administered by Doug Warren.
-Email: doug78645@gmail.com (GitHub: @dpw67)
 
-Additional information is available at https://blog.warrenweb.net.
+This space is administered by Doug Warren.
+Email: doug@warrenweb.net (GitHub: @dpw67)
+
+Source: https://github.com/dpw67/pkm
+Additional information: https://blog.warrenweb.net
 
 ## Maintainers
 - @dpw67


### PR DESCRIPTION
## What

Updates `pkm/.htaccess` to serve RDF to clients that ask for it, and refreshes `pkm/README.md` to describe what now resolves.

The `/pkm` namespace was registered as a plain 302 to GitHub Pages while there was nothing behind it. There is now a published SKOS vocabulary — 223 concepts and 18 collections, each with its own Turtle file — so the redirect needs to distinguish an RDF client from a browser.

## Rules added

| Request | Response |
| --- | --- |
| `/pkm/vocab/Recipe` + `Accept: text/turtle` | 303 → `vocab/terms/Recipe.ttl` |
| `/pkm/vocab` + `Accept: text/turtle` | 303 → `vocab/pkm-vocab.ttl` |
| `/pkm/agents`, `/pkm/resources` | 303 → their `index.ttl` |
| `/pkm/ontology`, `/pkm/taxonomy` | 303 → their Turtle |
| anything else | 302 → GitHub Pages, **unchanged** |

`303 See Other` rather than 302 on the term rule is the httpRange-14 convention: a concept is not a document, so the redirect says "here is a document *about* it."

The term pattern `^vocab/([A-Za-z][A-Za-z0-9_-]*)$` has no dot in the character class, so `/vocab/Recipe.ttl` and the version IRI `/vocab/0.1.1` fall through to the catch-all rather than matching. The catch-all stays last.

## Checks

- Redirect targets verified live: <https://dpw67.github.io/pkm/vocab/terms/Recipe.ttl>, <https://dpw67.github.io/pkm/vocab/pkm-vocab.ttl>, `agents/index.ttl`, `resources/index.ttl`.
- Existing behaviour for every path not listed above is byte-identical.
- Single commit, contact info in both files.

Namespace source: <https://github.com/dpw67/pkm>