### PR TITLE
update zcap/.htaccess to redirect to w3c-ccg.github.io not digitalbazaar.github.io

### DIFF
--- a/zcap/.htaccess
+++ b/zcap/.htaccess
@@ -1,16 +1,26 @@
-# Authorization Capabilities (zCap) Context
+# Authorization Capabilities
 #
 # homepage:
-#   https://digitalbazaar.github.io/zcap-context/
+#   https://w3c-ccg.github.io/zcap-spec/
 # maintainers:
 #   @msporny
 #   @dlongley
 #   @dmitrizagidulin
 #   @davidlehn
-#
+#   @gobengo
+
 Header set Access-Control-Allow-Origin *
 Header set Access-Control-Allow-Headers DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified$
 Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^$ https://digitalbazaar.github.io/zcap-context [R=302,L]
-RewriteRule ^v1$ https://digitalbazaar.github.io/zcap-context/contexts/zcap-v1.jsonld [R=302,L]
+
+# /
+# Redirect to zcap spec
+RewriteRule ^$ https://w3c-ccg.github.io/zcap-spec/ [R=302,L]
+
+# /v1
+# Redirect to version 1 of zcap
+# application/json:
+#   the JSON-LD context for version 1, maintained in
+#   <https://github.com/w3c-ccg/zcap-spec/blob/main/context/zcap-v1.jsonld>
+RewriteRule ^v1$ https://w3c-ccg.github.io/zcap-spec/v0/contexts/zcap-v1.jsonld [R=302,L]

--- a/zcap/.htaccess
+++ b/zcap/.htaccess
@@ -23,4 +23,4 @@ RewriteRule ^$ https://w3c-ccg.github.io/zcap-spec/ [R=302,L]
 # application/json:
 #   the JSON-LD context for version 1, maintained in
 #   <https://github.com/w3c-ccg/zcap-spec/blob/main/context/zcap-v1.jsonld>
-RewriteRule ^v1$ https://w3c-ccg.github.io/zcap-spec/v0/contexts/zcap-v1.jsonld [R=302,L]
+RewriteRule ^v1$ https://w3c-ccg.github.io/zcap-spec/latest/contexts/zcap-v1.jsonld [R=302,L]


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
<!-- Brief description of the purpose of this PR. -->

This PR updates `w3id.org/zcap/` to redirect to URLs at `w3c-ccg.github.io` instead of `digitalbazaar.github.io`, reflecting that zcap is now a work item in W3C Credentials Community Group, and the JSON-LD context will be published by the [W3C CCG zcap-spec repo](https://github.com/w3c-ccg/zcap-spec/), not digitalbazaar's zcap-context repo.

My motivation for this PR is to resolve this issue in the zcap-spec https://github.com/w3c-ccg/zcap-spec/issues/89

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
  - I asked an LLM if there are any syntax changes. It said there are none in my changes
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
