### PR TITLE
Update VAO vocabulary redirects for 0.5.0

### DIFF
--- a/modavis/vao/.htaccess
+++ b/modavis/vao/.htaccess
@@ -30,8 +30,8 @@ RewriteRule ^profile/repository/zenodo/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://raw.g
 
 # Stable vocabulary identifiers follow the current compatible VAO release.
 # Vocabulary membership is validated by VAO tooling, not by W3ID.
-RewriteRule ^ontology/?$ https://raw.githubusercontent.com/modavis-project/vao-standard/v0.4.0/Schemas/vao-vocabulary-0.4.0.ttl [R=303,L]
-RewriteRule ^vocab(?:/.*)?$ https://raw.githubusercontent.com/modavis-project/vao-standard/v0.4.0/Schemas/vao-vocabulary-0.4.0.ttl [R=303,L]
+RewriteRule ^ontology/?$ https://raw.githubusercontent.com/modavis-project/vao-standard/v0.5.0/Schemas/vao-vocabulary-0.5.0.ttl [R=303,L]
+RewriteRule ^vocab(?:/.*)?$ https://raw.githubusercontent.com/modavis-project/vao-standard/v0.5.0/Schemas/vao-vocabulary-0.5.0.ttl [R=303,L]
 
 # Project discovery entry point; normative records use versioned identifiers.
 RewriteRule ^$ https://github.com/modavis-project/vao-standard [R=302,L]

--- a/modavis/vao/README.md
+++ b/modavis/vao/README.md
@@ -7,11 +7,13 @@ This directory defines permanent identifiers for the [Virtual Acoustic Object
 https://w3id.org/modavis/vao/
 ```
 
-Version `0.4.0` identifiers resolve to files or documentation pinned to the
-immutable `v0.4.0` release tag. The namespace covers normative schemas,
-JSON-LD context, RDF vocabulary, SHACL shapes, profiles, the MODAVIS mapping,
-and the versioned specification. The unversioned namespace root is a project
-discovery link; no moving `latest` identifier is defined for normative use.
+Version `0.4.0` and `0.5.0` identifiers resolve to files or documentation
+pinned to their matching immutable release tags. The namespace covers
+normative schemas, JSON-LD context, RDF vocabulary, SHACL shapes, profiles,
+the MODAVIS mapping, and the versioned specification. The unversioned
+vocabulary routes resolve to the current compatible vocabulary release. The
+namespace root is a project discovery link; no moving `latest` identifier is
+defined for normative use.
 
 ## Maintainer
 


### PR DESCRIPTION
## Brief Description

Update the stable VAO vocabulary aliases to the released 0.5.0 vocabulary. Version-specific routes remain derived from the requested version and the immutable matching tag. The namespace README now records both public VAO releases.

## General Checklist

- [x] Changes have been tested.
- [x] The pull request contains one commit.
- [x] Changes are limited to redirects and namespace information.

## Update ID Directory Checklist

- [x] The changed files identify `@modavis-project` as maintainer.
- [x] The submitting account is the listed maintainer.

The 0.5.0 target and all versioned VAO 0.5.0 W3ID routes return successful responses. Immutable 0.4.0 routes are unchanged.