### PR TITLE
Add /qpm for the Qualitative Place Model ontology

### DIFF
--- a/qpm/.htaccess
+++ b/qpm/.htaccess
@@ -1,0 +1,31 @@
+# QPM Ontology (Qualitative Place Model) — Cardiff University
+# Maintainer: Alia I. Abdelmoty (GitHub: Aliaia)
+# Redirects https://w3id.org/qpm with content negotiation.
+
+RewriteEngine on
+
+# --- Version 1.0 (https://w3id.org/qpm/1.0), pinned to the v1.0 tag ---
+
+# Tools requesting Turtle -> raw TTL file at the tag
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^1\.0/?$ https://raw.githubusercontent.com/Aliaia/qpm/v1.0/qpm.ttl [R=303,L]
+
+# Tools requesting RDF/XML -> raw OWL file at the tag
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^1\.0/?$ https://raw.githubusercontent.com/Aliaia/qpm/v1.0/qpm.owl [R=303,L]
+
+# Browsers and everything else -> the tagged release
+RewriteRule ^1\.0/?$ https://github.com/Aliaia/qpm/tree/v1.0 [R=303,L]
+
+# --- Current version (https://w3id.org/qpm) ---
+
+# Tools requesting Turtle -> raw TTL file
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^$ https://raw.githubusercontent.com/Aliaia/qpm/main/qpm.ttl [R=303,L]
+
+# Tools requesting RDF/XML -> raw OWL file
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://raw.githubusercontent.com/Aliaia/qpm/main/qpm.owl [R=303,L]
+
+# Browsers and everything else -> GitHub repository page
+RewriteRule ^$ https://github.com/Aliaia/qpm [R=303,L]

--- a/qpm/README.md
+++ b/qpm/README.md
@@ -1,0 +1,46 @@
+# QPM Ontology — w3id Permanent Identifier
+
+**Permanent URI:** https://w3id.org/qpm
+**Version 1.0 URI:** https://w3id.org/qpm/1.0
+
+**Ontology name:** Qualitative Place Model (QPM) Ontology
+**Prefix:** qpm
+**Base IRI:** https://w3id.org/qpm#
+
+## Description
+
+The Qualitative Place Model represents the location of places relationally —
+through containment paths within one or more spatial hierarchies and lateral
+relations (adjacency, direction, proximity) to peer places — rather than
+through coordinate geometry alone. The model stores a minimal generating set of
+relations (one-step containment, topological adjacency, one primary neighbour
+per directional sector) from which the qualitative completion of a scene is
+derived by reasoning. The release includes companion SHACL shapes, a
+property-graph deployment profile, directional composition tables at four and
+eight sectors, a validation suite, and a model-grounding study. Developed at
+Cardiff University.
+
+## Ontology files
+
+* Turtle (canonical): https://raw.githubusercontent.com/Aliaia/qpm/main/qpm.ttl
+* RDF/XML: https://raw.githubusercontent.com/Aliaia/qpm/main/qpm.owl
+* SHACL shapes: https://raw.githubusercontent.com/Aliaia/qpm/main/qpm-shapes.ttl
+* Version 1.0 (tagged): https://github.com/Aliaia/qpm/tree/v1.0
+* GitHub repository: https://github.com/Aliaia/qpm
+
+## Creator and contributors
+
+Creator: Alia I. Abdelmoty. Contributors: Abdurauf Satoti, Hanan Muhajab.
+
+## Citation
+
+Under Preparation and Review
+
+## Contact
+
+* Alia I. Abdelmoty (GitHub: @Aliaia) — AbdelmotyAI@cardiff.ac.uk
+* School of Computer Science & Informatics, Cardiff University, Wales, UK
+
+## Licence
+
+Creative Commons Attribution 4.0 International (CC BY 4.0)


### PR DESCRIPTION
Added `.htaccess` for the QPM ontology with redirects for content negotiation.

## Brief Description

Adds `/qpm`, the persistent identifier for the Qualitative Place Model (QPM)
ontology. `https://w3id.org/qpm` is the ontology IRI declared in the published
OWL file; `https://w3id.org/qpm/1.0` is the version IRI and redirects to the
immutable `v1.0` tag, while `/qpm` follows `main`.

Target: https://github.com/Aliaia/qpm — public, CC BY 4.0, under my control.
All four redirect targets have been verified to resolve. Content negotiation
follows the same pattern as my existing `/ocd` entry.

Maintainer: Alia I. Abdelmoty (GitHub: Aliaia), Cardiff University.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist

Not applicable — this is a new ID directory.

## Optional Requests for W3ID Maintainers

- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.