### PR TITLE
Request for namespace: rnai-crop-pest

### DIFF
--- a/rnai-crop-pest/.htaccess
+++ b/rnai-crop-pest/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine on
+RewriteRule ^$ https://your-lab.github.io/ontology/rnai.owl [R=303,L]

--- a/rnai-crop-pest/.htaccess
+++ b/rnai-crop-pest/.htaccess
@@ -1,2 +1,2 @@
 RewriteEngine on
-RewriteRule ^$ https://your-lab.github.io/ontology/rnai.owl [R=303,L]
+RewriteRule ^$ https://github.com/DiuDream/rnai-ontology [R=303,L]


### PR DESCRIPTION
This PR requests a permanent redirect for the namespace `/rnai-crop-pest`, which will be used for the RNAi Crop Pest Ontology in academic research.

The target URL currently points to a placeholder and will be updated to the final ontology file URL before merging.

Maintainer: DiuDream (GitHub: https://github.com/DiuDream)

Thanks for reviewing!