### PR TITLE
Add REWT namespace for Rivers of England and Wales, Temporally

### DIFF
--- a/rewt/.htaccess
+++ b/rewt/.htaccess
@@ -1,0 +1,38 @@
+# w3id.org redirects for REWT — Rivers of England and Wales, Temporally.
+#
+# Maintainer: Stephen Gadd — https://github.com/docuracy
+#
+# Namespace layout — identifiers are grouped by entity type, because the same
+# stretch of river must carry one identifier across every published edition of
+# the dataset. Partitioning by edition would mint a second identifier for a
+# reach the moment a later edition described it again.
+#
+#   /rewt/                    → project documentation
+#   /rewt/docs/{path}         → a documentation page
+#   /rewt/link/{id}           → a watercourse link
+#   /rewt/node/{id}           → a hydro node
+#   /rewt/basin/{id}          → a delineated basin
+#   /rewt/course/{id}         → a reconstructed historical course
+#   /rewt/correction/{id}     → a curated judgement, with its reason and evidence
+#   /rewt/context             → JSON-LD context document
+#
+# Entity-level rules will be added in a follow-up pull request once the static
+# API and the map viewer they resolve to are deployed; see README.md for the
+# intended URI scheme. Only rules with live targets are enabled here.
+#
+# Note on fragments: a fragment supplied by the client (…/link/{id}#geometry)
+# is never sent to the server and cannot be routed. Where a rule below writes a
+# fragment of its own, the NE flag stops Apache escaping the '#' to '%23'.
+
+Options +FollowSymLinks
+RewriteEngine on
+
+Header set Access-Control-Allow-Origin *
+Header set Access-Control-Allow-Headers "Accept"
+
+# --- Documentation ---
+RewriteRule ^docs/?$ https://docuracy.github.io/REWT/ [R=303,L]
+RewriteRule ^docs/(.+)$ https://docuracy.github.io/REWT/$1 [R=303,L]
+
+# --- Namespace homepage ---
+RewriteRule ^$ https://docuracy.github.io/REWT/ [R=303,L]

--- a/rewt/README.md
+++ b/rewt/README.md
@@ -1,0 +1,65 @@
+# /rewt/ — REWT: Rivers of England and Wales, Temporally
+
+Permanent identifiers for **REWT**, a routable reconstruction of the river network of
+England and Wales, built so that the water in it can reach the sea, and worked backwards
+from the present-day channel to a series of dated cross-sections between Domesday and 1900.
+
+## Maintainer
+
+- **Stephen Gadd** — <https://github.com/docuracy>
+
+## Homepage
+
+<https://docuracy.github.io/REWT/>
+
+## Namespace layout
+
+Identifiers are grouped by **entity type**, not by edition. The dataset is published in
+successive editions which add evidence and dates to the same watercourses, and a stretch
+of river present in two editions must carry the same identifier in both; partitioning the
+URI space by edition would mint a second identifier for a reach the moment a later edition
+described it again. Editions are recorded in the data, not in the URI path.
+
+| Pattern | Entity type | Example | Status |
+|---------|-------------|---------|--------|
+| `/rewt/` | Project documentation | | enabled |
+| `/rewt/docs/{path}` | A documentation page | `/rewt/docs/evidence` | enabled |
+| `/rewt/link/{id}` | Watercourse link — one stretch of channel | `/rewt/link/4385554389` | forthcoming |
+| `/rewt/node/{id}` | Hydro node — a junction, source or tidal terminus | `/rewt/node/daf1236ba7` | forthcoming |
+| `/rewt/basin/{id}` | Delineated basin | `/rewt/basin/4385554389` | forthcoming |
+| `/rewt/course/{id}` | A reconstructed historical course | | forthcoming |
+| `/rewt/correction/{id}` | A curated judgement, with its reason and evidence | | forthcoming |
+| `/rewt/context` | JSON-LD context document | | forthcoming |
+
+The rules marked *forthcoming* are **not yet enabled**: they will be added in a follow-up
+pull request when the static API and map viewer they resolve to are deployed, so that
+every rule in `.htaccess` has a live target.
+
+### Identifiers
+
+Identifiers in the published data are already CURIE-shaped — `rewt:basin:4385554389` —
+and expand to this namespace by replacing the colons after the prefix with slashes.
+Identifiers carrying an `os:` prefix are the Ordnance Survey's own and are not minted
+here; REWT mints its own wherever an identifier has to remain stable across editions,
+because the Ordnance Survey's technical specification states that the GUID it assigns to
+a watercourse link "is not persistent".
+
+## Content negotiation
+
+Following the pattern already used by the `/mlca/` and `/campop/` namespaces:
+
+- `Accept: application/ld+json` or `application/json` → 303 redirect to static
+  JSON(-LD) files served from GitHub Pages.
+- Default → 303 redirect to the map viewer, which resolves the entity in a hash route.
+
+Dates on evidence are recorded in the Linked Places Format `when` object — timespans with
+an optional `start` and `end`, each either `in` a year or bounded by `earliest` and
+`latest`, with a `certainty` — chosen so that a source which knows only one bound is not
+forced to invent the other. The model is inter-convertible with
+[PLATO, the Place Attestation Ontology](https://doi.org/10.5281/zenodo.21688313).
+
+## Licence
+
+The dataset is built only from openly licensed sources and is intended for public release;
+required attributions travel with it. Documentation and data are published from
+<https://github.com/docuracy/REWT>.


### PR DESCRIPTION
Requesting a new permanent identifier namespace: **`/rewt/`** — REWT, *Rivers of England and Wales, Temporally*, a routable reconstruction of the river network of England and Wales.

- **Maintainer:** Stephen Gadd — https://github.com/docuracy
- **Homepage:** https://docuracy.github.io/REWT/
- **Repository:** https://github.com/docuracy/REWT

Adds `rewt/.htaccess` and `rewt/README.md`, following the pattern of the existing `/mlca/` and `/campop/` namespaces maintained by the same author.

### Enabled in this PR

Only rules with live targets are enabled:

| Rule | Target |
|---|---|
| `/rewt/` | https://docuracy.github.io/REWT/ |
| `/rewt/docs/` | https://docuracy.github.io/REWT/ |
| `/rewt/docs/{path}` | https://docuracy.github.io/REWT/{path} |

All eight URLs these rules can currently produce were checked and return HTTP 200.

### Documented but not enabled

The README sets out the intended entity URI scheme — `/rewt/link/{id}`, `/rewt/node/{id}`, `/rewt/basin/{id}`, `/rewt/course/{id}`, `/rewt/correction/{id}`, `/rewt/context` — with content negotiation to static JSON-LD and to an HTML entity resolver. Those rules will follow in a later pull request once the static API and map viewer they resolve to are deployed, so that every rule in `.htaccess` has a live target.

Identifiers are grouped by entity type rather than by dataset edition: the dataset is published in successive editions which add evidence to the same watercourses, and a stretch of river present in two editions must carry the same identifier in both.