### PR TITLE
Expand redirects for NeXus Ontology

### DIFF
--- a/ids/PaN/NeXus/.htaccess
+++ b/ids/PaN/NeXus/.htaccess
@@ -1,9 +1,70 @@
 Header set Access-Control-Allow-Origin *
-Options +FollowSymLinks
 RewriteEngine On
 
-# Root: Redirect to github repository
-RewriteRule ^$ https://github.com/nexusformat/NeXusOntology [R=303,L]
+## REDIRECTIONS SUPPORTING THE LATEST RELEASE
 
-# Redirect definitions path to the raw OWL file
-RewriteRule ^definitions$ https://raw.githubusercontent.com/nexusformat/NeXusOntology/refs/heads/main/ontology/NeXusOntology.owl [R=303,L]
+# /definitions/latest behaves like bare /definitions (internal rewrite).
+RewriteRule ^definitions/latest/?$ definitions [L]
+
+# Download artefacts
+RewriteRule ^definitions/NeXusOntology\.owl$    https://fairmat-nfdi.github.io/NeXusOntology/latest/NeXusOntology_full.owl [R=307,L]
+RewriteRule ^definitions/NeXusOntology\.ttl$    https://fairmat-nfdi.github.io/NeXusOntology/latest/NeXusOntology_full.ttl [R=307,L]
+RewriteRule ^definitions/NeXusOntology\.nt$     https://fairmat-nfdi.github.io/NeXusOntology/latest/NeXusOntology_full.nt [R=307,L]
+RewriteRule ^definitions/NeXusOntology\.jsonld$ https://fairmat-nfdi.github.io/NeXusOntology/latest/NeXusOntology_full.jsonld [R=307,L]
+RewriteRule ^definitions/NeXusOntology_reasoned\.owl$ https://fairmat-nfdi.github.io/NeXusOntology/latest/NeXusOntology_full_reasoned.owl [R=307,L]
+
+# Describe IRI (RDF/XML)
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^definitions$ https://fairmat-nfdi.github.io/NeXusOntology/latest/NeXusOntology_full.owl [R=307,L]
+
+# Describe IRI (Turtle)
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^definitions$ https://fairmat-nfdi.github.io/NeXusOntology/latest/NeXusOntology_full.ttl [R=307,L]
+
+# Describe IRI (N-Triples)
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^definitions$ https://fairmat-nfdi.github.io/NeXusOntology/latest/NeXusOntology_full.nt [R=307,L]
+
+# Describe IRI (JSON-LD)
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^definitions$ https://fairmat-nfdi.github.io/NeXusOntology/latest/NeXusOntology_full.jsonld [R=307,L]
+
+# Documentation (default). Makes #NXentry land on the right section.
+RewriteRule ^definitions/$ /PaN/NeXus/definitions [R=308]
+RewriteRule ^definitions$  https://fairmat-nfdi.github.io/NeXusOntology/latest/index-en.html [R=307,L]
+
+
+## REDIRECTIONS SUPPORTING SPECIFIC VERSIONS
+# Follows nexusformat/definitions tags (v2025.11, v2026.01, ...).
+
+# Download artefacts
+RewriteRule ^definitions/(v[0-9]{4}\.[0-9]{2})/NeXusOntology\.owl$    https://fairmat-nfdi.github.io/NeXusOntology/$1/NeXusOntology_full.owl [R=307,L]
+RewriteRule ^definitions/(v[0-9]{4}\.[0-9]{2})/NeXusOntology\.ttl$    https://fairmat-nfdi.github.io/NeXusOntology/$1/NeXusOntology_full.ttl [R=307,L]
+RewriteRule ^definitions/(v[0-9]{4}\.[0-9]{2})/NeXusOntology\.nt$     https://fairmat-nfdi.github.io/NeXusOntology/$1/NeXusOntology_full.nt [R=307,L]
+RewriteRule ^definitions/(v[0-9]{4}\.[0-9]{2})/NeXusOntology\.jsonld$ https://fairmat-nfdi.github.io/NeXusOntology/$1/NeXusOntology_full.jsonld [R=307,L]
+RewriteRule ^definitions/(v[0-9]{4}\.[0-9]{2})/NeXusOntology_reasoned\.owl$ https://fairmat-nfdi.github.io/NeXusOntology/$1/NeXusOntology_full_reasoned.owl [R=307,L]
+
+# Describe IRI (RDF/XML)
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^definitions/(v[0-9]{4}\.[0-9]{2})$ https://fairmat-nfdi.github.io/NeXusOntology/$1/NeXusOntology_full.owl [R=307,L]
+
+# Describe IRI (Turtle)
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^definitions/(v[0-9]{4}\.[0-9]{2})$ https://fairmat-nfdi.github.io/NeXusOntology/$1/NeXusOntology_full.ttl [R=307,L]
+
+# Describe IRI (N-Triples)
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^definitions/(v[0-9]{4}\.[0-9]{2})$ https://fairmat-nfdi.github.io/NeXusOntology/$1/NeXusOntology_full.nt [R=307,L]
+
+# Describe IRI (JSON-LD)
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^definitions/(v[0-9]{4}\.[0-9]{2})$ https://fairmat-nfdi.github.io/NeXusOntology/$1/NeXusOntology_full.jsonld [R=307,L]
+
+# Documentation
+RewriteRule ^definitions/(v[0-9]{4}\.[0-9]{2})/$ /PaN/NeXus/definitions/$1 [R=308]
+RewriteRule ^definitions/(v[0-9]{4}\.[0-9]{2})$  https://fairmat-nfdi.github.io/NeXusOntology/$1/index-en.html [R=307,L]
+
+
+## ROOT
+
+RewriteRule ^$ https://github.com/nexusformat/NeXusOntology [R=303,L]

--- a/ids/PaN/NeXus/.htaccess
+++ b/ids/PaN/NeXus/.htaccess
@@ -6,4 +6,4 @@ RewriteEngine On
 RewriteRule ^$ https://github.com/nexusformat/NeXusOntology [R=303,L]
 
 # Redirect definitions path to the raw OWL file
-RewriteRule ^nexusformat/definitions$ https://raw.githubusercontent.com/nexusformat/NeXusOntology/refs/heads/main/ontology/NeXusOntology.owl [R=303,L]
+RewriteRule ^definitions$ https://raw.githubusercontent.com/nexusformat/NeXusOntology/refs/heads/main/ontology/NeXusOntology.owl [R=303,L]

--- a/ids/PaN/NeXus/README.md
+++ b/ids/PaN/NeXus/README.md
@@ -1,13 +1,33 @@
 # NeXus Ontology
 
-This folder uses .htaccess rules to provide stable, resolvable URI for NeXus Ontology.
+This folder uses .htaccess rules to provide stable, resolvable URIs for the
+NeXus Ontology.
 
 ## Description
+
 Github repository:
-- /PaN/NeXus/ → https://github.com/nexusformat/NeXusOntology
+- /PaN/NeXus/ → https://github.com/FAIRmat-NFDI/NeXusOntology
 
 NeXus Ontology:
-- /PaN/NeXus/definitions → https://raw.githubusercontent.com/nexusformat/NeXusOntology/refs/heads/main/ontology/NeXusOntology.owl
+- /PaN/NeXus/definitions → documentation for the latest release
+- /PaN/NeXus/definitions/latest → same as above
+- /PaN/NeXus/definitions/v2026.01 (or any other release, e.g. v2025.11) →
+  documentation for that specific version
+- /PaN/NeXus/definitions/NeXusOntology.{owl,ttl,nt,jsonld} → the latest
+  release's ontology file, in the given format
+- /PaN/NeXus/definitions/vX.Y/NeXusOntology.{owl,ttl,nt,jsonld} → same, for
+  that specific version
+- /PaN/NeXus/definitions/NeXusOntology_reasoned.owl → the latest release's
+  ontology with inferred axioms materialized (via a reasoner), not just
+  asserted ones
+- /PaN/NeXus/definitions/vX.Y/NeXusOntology_reasoned.owl → same, for that
+  specific version
+- Content negotiation (`Accept: text/turtle`, `application/rdf+xml`,
+  `application/n-triples`, `application/ld+json`) is supported on both the
+  latest and versioned namespaces; browsers get the HTML documentation
+
+Entity IRIs are hash IRIs, e.g. /PaN/NeXus/definitions#NXentry, and resolve
+to that entity's own section of the documentation.
 
 ## Contact
 
@@ -15,4 +35,4 @@ NeXus Ontology:
 [Helmholtz Zentrum Berlin](https://www.helmholtz-berlin.de/), Germany, [@hgoerzig](https://github.com/hgoerzig)
 
 * Aaron Brewster (NIAC Chair) (nexus-committee@nexusformat.org),
-[Lawrence Berkeley National Laboratory](https://www.lbl.gov/), USA
+[Lawrence Berkeley National Laboratory](https://www.lbl.gov/), USA, [@phyy-nx](https://github.com/phyy-nx)

--- a/ids/PaN/NeXus/README.md
+++ b/ids/PaN/NeXus/README.md
@@ -7,7 +7,7 @@ Github repository:
 - /PaN/NeXus/ → https://github.com/nexusformat/NeXusOntology
 
 NeXus Ontology:
-- /PaN/NeXus/nexusformat/definitions → https://raw.githubusercontent.com/nexusformat/NeXusOntology/refs/heads/main/ontology/NeXusOntology.owl
+- /PaN/NeXus/definitions → https://raw.githubusercontent.com/nexusformat/NeXusOntology/refs/heads/main/ontology/NeXusOntology.owl
 
 ## Contact
 


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
This PR provides a fuller redirect scheme for NeXus Ontology, taking inspiration from PaNET's existing pattern. 

- Per-version redirects (v2025.11, v2026.01, ...) alongside latest, so older releases stay reachable after newer ones publish.
- Content negotiation — RDF/XML, Turtle, N-Triples, JSON-LD for clients that ask; HTML docs for browsers.
- Individual NeXus classes (e.g. #NXentry) resolve to their own section of the documentation.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

*Note: Although this PR is submitted from my personal fork, [nexusformat](https://github.com/nexusformat) are the long-term maintainers of this namespace.*