### PR TITLE
Add MODAVIS Release 1.5 identity redirects

### DIFF
--- a/modavis/.htaccess
+++ b/modavis/.htaccess
@@ -10,6 +10,16 @@ RewriteEngine On
 # Network landing page.
 RewriteRule ^$ https://modavis-project.github.io/modavis-ontology-network/index.html [R=303,L]
 
+# MODAVIS persistent entity, name, location, alias, and dataset identifiers.
+# The MODAVIS identity resolver performs content negotiation and redirects to
+# the public Navigator or immutable linked-data representations.
+RewriteRule ^entity/(.+)$ https://id.modavis.org/resolve/entity/$1 [R=302,L,NE]
+RewriteRule ^name/(.+)$ https://id.modavis.org/resolve/name/$1 [R=302,L,NE]
+RewriteRule ^location/(.+)$ https://id.modavis.org/resolve/location/$1 [R=302,L,NE]
+RewriteRule ^alias/([^/]+)/(.+)$ https://id.modavis.org/resolve/alias/$1/$2 [R=302,L,NE]
+RewriteRule ^dataset/pod$ https://id.modavis.org/resolve/dataset/pod [R=302,L,NE]
+RewriteRule ^dataset/pod/version/(.+)$ https://id.modavis.org/resolve/dataset/pod/version/$1 [R=302,L,NE]
+
 # Stable ontology identifiers follow the current compatible release. Only these
 # moving aliases need to change when a later release becomes current.
 RewriteRule ^ontology/?$ https://w3id.org/modavis/ontology/0.1.0 [R=302,L]

--- a/modavis/README.md
+++ b/modavis/README.md
@@ -1,7 +1,8 @@
 # MODAVIS permanent identifiers
 
-This directory defines the W3ID namespace for the [MODAVIS Ontology
-Network](https://github.com/modavis-project/modavis-ontology-network) and the
+This directory defines the W3ID namespace for MODAVIS persistent identifiers,
+the [MODAVIS Ontology
+Network](https://github.com/modavis-project/modavis-ontology-network), and the
 [Virtual Acoustic Object (VAO) Standard](https://github.com/modavis-project/vao-standard).
 
 The namespace root is:
@@ -16,6 +17,13 @@ vocabulary identifiers resolve to the current compatible release; identifiers
 that include `0.1.0` resolve to immutable versioned representations. Content
 negotiation is available for HTML, Turtle, JSON-LD, and RDF/XML where those
 representations are published.
+
+MODAVIS entity, name, location, alias, and dataset identifiers are delegated to
+the identity resolver at `https://id.modavis.org/`. The resolver preserves the
+W3ID identifier as the canonical identity and directs clients to the public
+Navigator or the appropriate linked-data representation. Versioned dataset
+identifiers, including the piep organ dataset Release 1.5, resolve to immutable
+release representations.
 
 VAO uses the child namespace `https://w3id.org/modavis/vao/`. Its versioned
 schema, profile, vocabulary, context, mapping, and specification identifiers


### PR DESCRIPTION
## Brief Description

Adds the maintained MODAVIS routes for persistent entity, structured-name, location, governed alias, and dataset identifiers. The redirects delegate content negotiation to id.modavis.org and support the public piep organ dataset Release 1.5.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal.
- [x] The commit includes only redirects and basic information.

## Update ID Directory Checklist

- [x] The existing maintainer details include the GitHub username.
- [x] The submitting account, @modavis-project, is the registered maintainer.

## Validation

- Apache 2.4 configuration syntax passed locally.
- All six rewrite patterns returned the intended 302 targets in a local Apache checkout.
- Live destination checks passed for entity, name, location, current dataset, and versioned Release 1.5 dataset routes with HTML and JSON-LD negotiation.
- The governed alias route is installed but intentionally returns 404 until an alias is entered in the MODAVIS alias registry.