### PR TITLE
shapetrees: serve the rendered specification and primer, not just the vocabulary

### DIFF
--- a/shapetrees/.htaccess
+++ b/shapetrees/.htaccess
@@ -1,8 +1,41 @@
 # shapetrees
 #
-# https://w3id.org/shapetrees redirects to
-# https://raw.githubusercontent.com/shapetrees/specification/refs/heads/main/shapetrees.ttl
+# Shape Trees, a W3C Solid Community Group work effort.
+# Maintained at https://github.com/shapetrees/specification
+#
+# The documents were formerly published at shapetrees.org; that domain expired
+# and is now squatted. They live on GitHub Pages instead, one Pages site per
+# source repository, so this serves the rendered documents as well as the
+# vocabulary.
 
+Options +FollowSymLinks
 RewriteEngine on
-RewriteRule ^$ https://raw.githubusercontent.com/shapetrees/specification/refs/heads/main/shapetrees.ttl [R=302,L]
-RewriteRule ^(.+)$ https://raw.githubusercontent.com/shapetrees/specification/refs/heads/main/shapetrees.ttl [R=302,L]
+RewriteBase /shapetrees
+
+# ---------------------------------------------------------------------------
+# The vocabulary
+#
+# Terms are named https://w3id.org/shapetrees#managedBy, #manages, and so on,
+# so the namespace URI itself must serve the vocabulary to RDF clients and the
+# human-readable landing page to everyone else.
+# ---------------------------------------------------------------------------
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/(n-triples|ld\+json|rdf\+xml|trig|n-quads)
+RewriteRule ^$ https://shapetrees.github.io/specification/shapetrees.ttl [R=302,L]
+
+RewriteRule ^shapetrees\.ttl$ https://shapetrees.github.io/specification/shapetrees.ttl [R=302,L]
+RewriteRule ^shapetrees-schema\.shex$ https://shapetrees.github.io/specification/shapetrees-schema.shex [R=302,L]
+
+# ---------------------------------------------------------------------------
+# The documents, keeping the /TR/ paths the shapetrees.org site used
+# ---------------------------------------------------------------------------
+
+RewriteRule ^TR/specification/?(.*)$ https://shapetrees.github.io/specification/$1 [R=302,L]
+RewriteRule ^TR/primer/?(.*)$        https://shapetrees.github.io/primer/$1        [R=302,L]
+
+# ---------------------------------------------------------------------------
+# The landing page, and anything else that used to be served from the site root
+# ---------------------------------------------------------------------------
+
+RewriteRule ^(.*)$ https://shapetrees.github.io/$1 [R=302,L]

--- a/shapetrees/README.md
+++ b/shapetrees/README.md
@@ -3,6 +3,17 @@
 New namespace for https://github.com/shapetrees/specification
 Previously used domain expired and now someone squats it.
 
+Serves the vocabulary at the namespace URI, content negotiated against the
+Shape Trees home page, and the two documents under the `/TR/` paths the old
+site used:
+
+| Request | Redirects to |
+| --- | --- |
+| `/shapetrees` with an RDF `Accept` header | `https://shapetrees.github.io/specification/shapetrees.ttl` |
+| `/shapetrees` from a browser | `https://shapetrees.github.io/` |
+| `/shapetrees/TR/specification/` | `https://shapetrees.github.io/specification/` |
+| `/shapetrees/TR/primer/` | `https://shapetrees.github.io/primer/` |
+
 ## Maintainers
 * Eric Prud'hommeaux @ericprud
 * Justin Bingham @justinwb


### PR DESCRIPTION
The `shapetrees` entry currently sends every path to the raw `shapetrees.ttl`. That is right for the namespace URI itself, but it means the two documents the namespace is supposed to name are unreachable: `https://w3id.org/shapetrees/TR/specification/` and `https://w3id.org/shapetrees/TR/primer/` both hand back the Turtle file.

Those documents now exist again. They were published at `shapetrees.org` until that domain expired, and have been rebuilt on GitHub Pages, one Pages site per source repository:

| Request | Redirects to |
| --- | --- |
| `/shapetrees` with an RDF `Accept` header | `https://shapetrees.github.io/specification/shapetrees.ttl` |
| `/shapetrees` from a browser | `https://shapetrees.github.io/` |
| `/shapetrees/TR/specification/` | `https://shapetrees.github.io/specification/` |
| `/shapetrees/TR/primer/` | `https://shapetrees.github.io/primer/` |
| anything else under `/shapetrees/` | the same path on `https://shapetrees.github.io/` |

Two changes beyond the new `/TR/` paths are worth flagging:

- The vocabulary moves from `raw.githubusercontent.com` to GitHub Pages, so it is served as `text/turtle` rather than `text/plain`.
- It is served only to clients that ask for RDF. A browser following `https://w3id.org/shapetrees` now lands on the Shape Trees home page instead of downloading a Turtle file. RDF clients are unaffected.

Redirects are `302` so the Pages hosts can be moved later without poisoning caches.

I am one of the listed maintainers of this entry (@ericprud). The rules were tested under Apache 2.4 with `mod_rewrite`, checking each row above plus a browser `Accept` header, which correctly falls through to the home page.