### PR TITLE
Add /aias for the AIAS ontologies

### DIFF
--- a/aias/.htaccess
+++ b/aias/.htaccess
@@ -1,0 +1,151 @@
+# https://w3id.org/aias/ redirects via HTTP 303 using content negotiation to
+# the AIAS ontologies, hosted on GitHub Pages at
+# https://schiesem.github.io/aias/
+#
+# AIAS is an information model for artificial intelligence applications in
+# automated plants. It consists of four ontology design patterns, one per
+# subdomain, and an alignment ontology tying them together.
+#
+# The IRIs resolve as follows:
+#
+#   https://w3id.org/aias                       the alignment, current version
+#   https://w3id.org/aias/1.0.0                 the alignment, that version
+#   https://w3id.org/aias/odp/<name>            a pattern, current version
+#   https://w3id.org/aias/odp/<name>/<version>  a pattern, that version
+#
+# where <name> is one of vdi3682, iso7498, iso22989, iec60050.
+#
+# An IRI without a version resolves to 1.0.0, the published one. Version 2.0.0
+# is reachable under its own IRI and this default moves to it once it is
+# released.
+
+# ## Contact
+# This space is administered by:
+#
+# Marvin Schieseck
+# Email: marvin.schieseck@hsu.hamburg
+# GitHub: https://github.com/schiesem
+
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+AddType application/rdf+xml .owl
+AddType text/turtle .ttl
+AddType application/n-triples .nt
+AddType application/n-triples .n3
+AddType application/ld+json .jsonld
+
+RewriteEngine On
+
+#################################################################
+#    A pattern with an explicit version
+#    /odp/<name>/<version>
+#################################################################
+
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^odp/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://schiesem.github.io/aias/odps/$1/v$2/docs/index-en.html [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^odp/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://schiesem.github.io/aias/odps/$1/v$2/docs/ontology.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^odp/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://schiesem.github.io/aias/odps/$1/v$2/docs/ontology.nt [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^odp/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://schiesem.github.io/aias/odps/$1/v$2/docs/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^odp/([^/]+)/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://schiesem.github.io/aias/odps/$1/v$2/docs/ontology.owl [R=303,L]
+
+#################################################################
+#    A pattern without a version, which is 1.0.0
+#    /odp/<name>
+#################################################################
+
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^odp/([^/]+)/?$ https://schiesem.github.io/aias/odps/$1/v1.0.0/docs/index-en.html [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^odp/([^/]+)/?$ https://schiesem.github.io/aias/odps/$1/v1.0.0/docs/ontology.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^odp/([^/]+)/?$ https://schiesem.github.io/aias/odps/$1/v1.0.0/docs/ontology.nt [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^odp/([^/]+)/?$ https://schiesem.github.io/aias/odps/$1/v1.0.0/docs/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^odp/([^/]+)/?$ https://schiesem.github.io/aias/odps/$1/v1.0.0/docs/ontology.owl [R=303,L]
+
+#################################################################
+#    The alignment with an explicit version
+#    /<version>
+#################################################################
+
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://schiesem.github.io/aias/alignment/aias/v$1/docs/index-en.html [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://schiesem.github.io/aias/alignment/aias/v$1/docs/ontology.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://schiesem.github.io/aias/alignment/aias/v$1/docs/ontology.nt [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://schiesem.github.io/aias/alignment/aias/v$1/docs/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)/?$ https://schiesem.github.io/aias/alignment/aias/v$1/docs/ontology.owl [R=303,L]
+
+#################################################################
+#    The alignment without a version, which is 1.0.0
+#    the bare namespace root
+#################################################################
+
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://schiesem.github.io/aias/alignment/aias/v1.0.0/docs/index-en.html [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://schiesem.github.io/aias/alignment/aias/v1.0.0/docs/ontology.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^$ https://schiesem.github.io/aias/alignment/aias/v1.0.0/docs/ontology.nt [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/\* [OR]
+RewriteCond %{HTTP_ACCEPT} \*/turtle
+RewriteRule ^$ https://schiesem.github.io/aias/alignment/aias/v1.0.0/docs/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^$ https://schiesem.github.io/aias/alignment/aias/v1.0.0/docs/ontology.owl [R=303,L]
+
+#################################################################
+#    Anything else: the repository
+#################################################################
+
+RewriteRule ^(.*)$ https://github.com/schiesem/aias [R=303,L]

--- a/aias/README.md
+++ b/aias/README.md
@@ -1,0 +1,101 @@
+# AIAS Ontologies
+
+[![Format](https://img.shields.io/badge/Format-JSON_LD-blue.svg)](https://schiesem.github.io/aias/alignment/aias/v1.0.0/docs/ontology.jsonld) [![Format](https://img.shields.io/badge/Format-RDF/XML-blue.svg)](https://schiesem.github.io/aias/alignment/aias/v1.0.0/docs/ontology.owl) [![Format](https://img.shields.io/badge/Format-N_Triples-blue.svg)](https://schiesem.github.io/aias/alignment/aias/v1.0.0/docs/ontology.nt) [![Format](https://img.shields.io/badge/Format-TTL-blue.svg)](https://schiesem.github.io/aias/alignment/aias/v1.0.0/docs/ontology.ttl)
+
+AIAS is an information model for describing artificial intelligence
+applications in automated plants, together with the plant they run in and the
+technical process they observe or steer. It consists of four ontology design
+patterns, one per subdomain, and an alignment ontology tying them together.
+
+## Key Features
+
+Three standards describe an AI application in a plant, and each describes a
+part of it. The questions that matter cross the boundaries, and the alignment
+is what lets them be asked. The model covers the following key features:
+
+* Describes the technical process (VDI/VDE 3682), the communication
+  (ISO/IEC 7498-1), the control (IEC 60050-351) and the artificial
+  intelligence (ISO/IEC 22989) of a plant in one connected model
+* Places a process step and an inference under one function class, so a single
+  assignment states which resource carries out which function, whichever
+  subdomain that function comes from
+* Distinguishes open-loop from closed-loop control by structure rather than by
+  name, following the action path and action of IEC 60050-351
+* Records the direction of a communication, so a model can say which component
+  sends and which receives
+* Traces a model back to the data it was trained on and to the device that
+  recorded that data
+
+## Namespace
+
+| IRI | Resolves to |
+|---|---|
+| `https://w3id.org/aias` | the alignment ontology, current version |
+| `https://w3id.org/aias/1.0.0` | the alignment ontology, that version |
+| `https://w3id.org/aias/odp/<name>` | a pattern, current version |
+| `https://w3id.org/aias/odp/<name>/<version>` | a pattern, that version |
+
+`<name>` is one of `vdi3682`, `iso7498`, `iso22989`, `iec60050`. An IRI
+without a version resolves to 1.0.0, the published one.
+
+A browser is served the documentation, a reasoner the ontology in whichever
+serialization it accepts, both through an HTTP 303 redirect.
+
+## Contact
+
+Marvin Schieseck<br>
+Email: marvin.schieseck@hsu.hamburg<br>
+GitHub: https://github.com/schiesem<br>
+Institute: Helmut-Schmidt-Universität / Universität der Bundeswehr Hamburg
+
+## Documentation
+
+The ontology specifications were generated with the help of the WIDOCO wizard.
+
+| Pattern | Documentation | Visualization |
+|---|---|---|
+| VDI 3682 ODP | [![Documentation](https://img.shields.io/badge/Documentation-Ontology_Specification-blue.svg)](https://schiesem.github.io/aias/odps/vdi3682/v1.0.0/docs/index-en.html) | [![WebVowl](https://img.shields.io/badge/Visualize_with-WebVowl-blue.svg)](https://schiesem.github.io/aias/odps/vdi3682/v1.0.0/docs/webvowl/index.html#) |
+| ISO/IEC 7498-1 ODP | [![Documentation](https://img.shields.io/badge/Documentation-Ontology_Specification-blue.svg)](https://schiesem.github.io/aias/odps/iso7498/v1.0.0/docs/index-en.html) | [![WebVowl](https://img.shields.io/badge/Visualize_with-WebVowl-blue.svg)](https://schiesem.github.io/aias/odps/iso7498/v1.0.0/docs/webvowl/index.html#) |
+| ISO/IEC 22989 ODP | [![Documentation](https://img.shields.io/badge/Documentation-Ontology_Specification-blue.svg)](https://schiesem.github.io/aias/odps/iso22989/v1.0.0/docs/index-en.html) | [![WebVowl](https://img.shields.io/badge/Visualize_with-WebVowl-blue.svg)](https://schiesem.github.io/aias/odps/iso22989/v1.0.0/docs/webvowl/index.html#) |
+| IEC 60050-351 ODP | [![Documentation](https://img.shields.io/badge/Documentation-Ontology_Specification-blue.svg)](https://schiesem.github.io/aias/odps/iec60050/v1.0.0/docs/index-en.html) | [![WebVowl](https://img.shields.io/badge/Visualize_with-WebVowl-blue.svg)](https://schiesem.github.io/aias/odps/iec60050/v1.0.0/docs/webvowl/index.html#) |
+| AIAS Alignment | [![Documentation](https://img.shields.io/badge/Documentation-Ontology_Specification-blue.svg)](https://schiesem.github.io/aias/alignment/aias/v1.0.0/docs/index-en.html) | [![WebVowl](https://img.shields.io/badge/Visualize_with-WebVowl-blue.svg)](https://schiesem.github.io/aias/alignment/aias/v1.0.0/docs/webvowl/index.html#) |
+
+Sources: https://github.com/schiesem/aias
+
+## How to cite
+
+If you want to use these ontologies in your own research, please cite as:
+
+```
+Schieseck, M., Topalis, P., Reinpold, L., Gehlhoff, F., & Fay, A. (2024).
+A Formal Model for Artificial Intelligence Applications in Automation Systems.
+2024 IEEE 29th International Conference on Emerging Technologies and Factory
+Automation (ETFA), Padova, Italy. IEEE. https://doi.org/10.1109/ETFA61755.2024.10710890
+```
+
+If you are using a BiBTeX file, you can copy the following:
+
+```
+@inproceedings{Schieseck2024FormalModel,
+  author    = {Marvin Schieseck and Philip Topalis and Lasse Reinpold and
+               Felix Gehlhoff and Alexander Fay},
+  title     = {A Formal Model for Artificial Intelligence Applications in
+               Automation Systems},
+  booktitle = {2024 IEEE 29th International Conference on Emerging Technologies
+               and Factory Automation (ETFA)},
+  year      = {2024},
+  address   = {Padova, Italy},
+  month     = sep,
+  publisher = {IEEE},
+  doi       = {10.1109/ETFA61755.2024.10710890}
+}
+```
+
+[![DOI](https://img.shields.io/badge/DOI-10.1109/ETFA61755.2024.10710890-blue.svg)](https://doi.org/10.1109/ETFA61755.2024.10710890)
+
+## License
+
+All resources are licensed under Creative Commons Attribution 4.0
+International.
+
+[![License](https://img.shields.io/badge/License-CC_BY_4.0-blue.svg)](https://creativecommons.org/licenses/by/4.0/)

--- a/aias/README.md
+++ b/aias/README.md
@@ -1,37 +1,19 @@
 # AIAS Ontologies
 
-[![Format](https://img.shields.io/badge/Format-JSON_LD-blue.svg)](https://schiesem.github.io/aias/alignment/aias/v1.0.0/docs/ontology.jsonld) [![Format](https://img.shields.io/badge/Format-RDF/XML-blue.svg)](https://schiesem.github.io/aias/alignment/aias/v1.0.0/docs/ontology.owl) [![Format](https://img.shields.io/badge/Format-N_Triples-blue.svg)](https://schiesem.github.io/aias/alignment/aias/v1.0.0/docs/ontology.nt) [![Format](https://img.shields.io/badge/Format-TTL-blue.svg)](https://schiesem.github.io/aias/alignment/aias/v1.0.0/docs/ontology.ttl)
+This namespace is for the AIAS ontologies, an information model for artificial
+intelligence applications in automated plants. It consists of four ontology
+design patterns, after VDI/VDE 3682, ISO/IEC 7498-1, ISO/IEC 22989 and
+IEC 60050-351, and an alignment ontology tying them together.
 
-AIAS is an information model for describing artificial intelligence
-applications in automated plants, together with the plant they run in and the
-technical process they observe or steer. It consists of four ontology design
-patterns, one per subdomain, and an alignment ontology tying them together.
-
-## Key Features
-
-Three standards describe an AI application in a plant, and each describes a
-part of it. The questions that matter cross the boundaries, and the alignment
-is what lets them be asked. The model covers the following key features:
-
-* Describes the technical process (VDI/VDE 3682), the communication
-  (ISO/IEC 7498-1), the control (IEC 60050-351) and the artificial
-  intelligence (ISO/IEC 22989) of a plant in one connected model
-* Places a process step and an inference under one function class, so a single
-  assignment states which resource carries out which function, whichever
-  subdomain that function comes from
-* Distinguishes open-loop from closed-loop control by structure rather than by
-  name, following the action path and action of IEC 60050-351
-* Records the direction of a communication, so a model can say which component
-  sends and which receives
-* Traces a model back to the data it was trained on and to the device that
-  recorded that data
+Sources, documentation and everything else:
+https://github.com/schiesem/aias
 
 ## Namespace
 
 | IRI | Resolves to |
 |---|---|
 | `https://w3id.org/aias` | the alignment ontology, current version |
-| `https://w3id.org/aias/1.0.0` | the alignment ontology, that version |
+| `https://w3id.org/aias/<version>` | the alignment ontology, that version |
 | `https://w3id.org/aias/odp/<name>` | a pattern, current version |
 | `https://w3id.org/aias/odp/<name>/<version>` | a pattern, that version |
 
@@ -41,61 +23,7 @@ without a version resolves to 1.0.0, the published one.
 A browser is served the documentation, a reasoner the ontology in whichever
 serialization it accepts, both through an HTTP 303 redirect.
 
-## Contact
+## Contacts
 
-Marvin Schieseck<br>
-Email: marvin.schieseck@hsu.hamburg<br>
-GitHub: https://github.com/schiesem<br>
-Institute: Helmut-Schmidt-Universität / Universität der Bundeswehr Hamburg
-
-## Documentation
-
-The ontology specifications were generated with the help of the WIDOCO wizard.
-
-| Pattern | Documentation | Visualization |
-|---|---|---|
-| VDI 3682 ODP | [![Documentation](https://img.shields.io/badge/Documentation-Ontology_Specification-blue.svg)](https://schiesem.github.io/aias/odps/vdi3682/v1.0.0/docs/index-en.html) | [![WebVowl](https://img.shields.io/badge/Visualize_with-WebVowl-blue.svg)](https://schiesem.github.io/aias/odps/vdi3682/v1.0.0/docs/webvowl/index.html#) |
-| ISO/IEC 7498-1 ODP | [![Documentation](https://img.shields.io/badge/Documentation-Ontology_Specification-blue.svg)](https://schiesem.github.io/aias/odps/iso7498/v1.0.0/docs/index-en.html) | [![WebVowl](https://img.shields.io/badge/Visualize_with-WebVowl-blue.svg)](https://schiesem.github.io/aias/odps/iso7498/v1.0.0/docs/webvowl/index.html#) |
-| ISO/IEC 22989 ODP | [![Documentation](https://img.shields.io/badge/Documentation-Ontology_Specification-blue.svg)](https://schiesem.github.io/aias/odps/iso22989/v1.0.0/docs/index-en.html) | [![WebVowl](https://img.shields.io/badge/Visualize_with-WebVowl-blue.svg)](https://schiesem.github.io/aias/odps/iso22989/v1.0.0/docs/webvowl/index.html#) |
-| IEC 60050-351 ODP | [![Documentation](https://img.shields.io/badge/Documentation-Ontology_Specification-blue.svg)](https://schiesem.github.io/aias/odps/iec60050/v1.0.0/docs/index-en.html) | [![WebVowl](https://img.shields.io/badge/Visualize_with-WebVowl-blue.svg)](https://schiesem.github.io/aias/odps/iec60050/v1.0.0/docs/webvowl/index.html#) |
-| AIAS Alignment | [![Documentation](https://img.shields.io/badge/Documentation-Ontology_Specification-blue.svg)](https://schiesem.github.io/aias/alignment/aias/v1.0.0/docs/index-en.html) | [![WebVowl](https://img.shields.io/badge/Visualize_with-WebVowl-blue.svg)](https://schiesem.github.io/aias/alignment/aias/v1.0.0/docs/webvowl/index.html#) |
-
-Sources: https://github.com/schiesem/aias
-
-## How to cite
-
-If you want to use these ontologies in your own research, please cite as:
-
-```
-Schieseck, M., Topalis, P., Reinpold, L., Gehlhoff, F., & Fay, A. (2024).
-A Formal Model for Artificial Intelligence Applications in Automation Systems.
-2024 IEEE 29th International Conference on Emerging Technologies and Factory
-Automation (ETFA), Padova, Italy. IEEE. https://doi.org/10.1109/ETFA61755.2024.10710890
-```
-
-If you are using a BiBTeX file, you can copy the following:
-
-```
-@inproceedings{Schieseck2024FormalModel,
-  author    = {Marvin Schieseck and Philip Topalis and Lasse Reinpold and
-               Felix Gehlhoff and Alexander Fay},
-  title     = {A Formal Model for Artificial Intelligence Applications in
-               Automation Systems},
-  booktitle = {2024 IEEE 29th International Conference on Emerging Technologies
-               and Factory Automation (ETFA)},
-  year      = {2024},
-  address   = {Padova, Italy},
-  month     = sep,
-  publisher = {IEEE},
-  doi       = {10.1109/ETFA61755.2024.10710890}
-}
-```
-
-[![DOI](https://img.shields.io/badge/DOI-10.1109/ETFA61755.2024.10710890-blue.svg)](https://doi.org/10.1109/ETFA61755.2024.10710890)
-
-## License
-
-All resources are licensed under Creative Commons Attribution 4.0
-International.
-
-[![License](https://img.shields.io/badge/License-CC_BY_4.0-blue.svg)](https://creativecommons.org/licenses/by/4.0/)
+* Marvin Schieseck <marvin.schieseck@hsu.hamburg> (GitHub: schiesem),
+  Helmut-Schmidt-Universität / Universität der Bundeswehr Hamburg


### PR DESCRIPTION
## Brief Description

Adds `/aias` for the AIAS ontologies, an information model for artificial
intelligence applications in automated plants. It consists of four ontology
design patterns after VDI/VDE 3682, ISO/IEC 7498-1, ISO/IEC 22989 and
IEC 60050-351, and an alignment ontology tying them together.

Repository:    https://github.com/schiesem/aias
Documentation: https://schiesem.github.io/aias/

The redirect serves the documentation to a browser and the ontology to a
reasoner, in whichever serialization it accepts. Every target is live.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Optional Requests for W3ID Maintainers

- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.