### PR TITLE
greek-coptic-spellings: resolve /dataset to the CSV table on request

### DIFF
--- a/greek-coptic-spellings/.htaccess
+++ b/greek-coptic-spellings/.htaccess
@@ -6,7 +6,9 @@
 # manuscripts of the 3rd-13th centuries.
 #
 # https://w3id.org/greek-coptic-spellings/deviation/<id> redirects to that one
-# record in the dataset's browsing interface.
+# record in the dataset's browsing interface. /dataset negotiates on content
+# type: the CLDF descriptor for JSON, the data table for CSV, the landing page
+# otherwise.
 #
 # 302 rather than 301 throughout: the identifiers are permanent, but the hosting
 # of the interface they resolve to is not promised to be.
@@ -33,6 +35,12 @@ RewriteRule ^deviation/(.+)$ https://kmein.github.io/greek-coptic-data/?deviatio
 RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
 RewriteCond %{HTTP_ACCEPT} application/json
 RewriteRule ^dataset/?$ https://kmein.github.io/greek-coptic-data/cldf-metadata.json [NE,R=302,L]
+
+# ... and the data table itself to a client that asks for CSV, so that the
+# table can be fetched without naming the host it currently sits on.
+RewriteCond %{HTTP_ACCEPT} text/csv
+RewriteRule ^dataset/?$ https://kmein.github.io/greek-coptic-data/deviations.csv [NE,R=302,L]
+
 RewriteRule ^dataset/?$ https://kmein.github.io/greek-coptic-data/ [NE,R=302,L]
 
 # Anything else lands on the dataset.


### PR DESCRIPTION
The `greek-coptic-spellings` namespace (merged in #6615) already negotiates `/dataset` between the CLDF descriptor, for a client asking for JSON, and the human landing page for everything else. This adds one condition so that a client asking for `text/csv` receives the data table itself.

The point is that the table can then be fetched through the permanent identifier rather than by naming the host it happens to sit on today:

```
curl -LH "Accept: text/csv" https://w3id.org/greek-coptic-spellings/dataset
```

Without it, the only way to retrieve the data is the current hosting URL, which is exactly what the identifier exists to avoid committing readers to.

Apologies for bringing this as a second pull request — it belonged in #6615, and I simply did not think of the CSV case when I wrote those rules. Thank you for the extra review.

**Tested** with a local checkout under Apache 2.4, since these rules cannot be verified by reading: the new rule and the five existing ones all resolve to their intended targets. Contact details are in the `.htaccess` header comment and in the namespace `README.md`, unchanged.