### PR TITLE
Add botx permanent identifier

### DIFF
--- a/botx/.htaccess
+++ b/botx/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine on
+RewriteRule ^(.*)$ https://sites.google.com/view/aethk/home/$1 [R=303,L]

--- a/botx/README.md
+++ b/botx/README.md
@@ -1,0 +1,7 @@
+# botx
+
+Permanent redirect namespace for development resources.
+
+Maintainer: aethk
+
+Contact: https://github.com/aethk


### PR DESCRIPTION
This PR adds a new permanent identifier namespace botx, redirecting to https://sites.google.com/view/aethk/home