### PR TITLE
Add persistent identifier for Medicine Shortage Dashboard

### DIFF
--- a/medicineshortage/.htaccess
+++ b/medicineshortage/.htaccess
@@ -1,0 +1,13 @@
+# Permanent identifiers for the Medicine Shortage Dashboard
+#
+# https://w3id.org/medicineshortage/dashboard
+# redirects to:
+# https://medicineshortage.shinyapps.io/dashboard/
+#
+# Contact
+# Jan Panhuysen
+# Email: j.panhuysen@phd.hertie-school.org
+
+RewriteEngine on
+
+RewriteRule ^dashboard/?$ https://medicineshortage.shinyapps.io/dashboard/ [R=302,L]

--- a/medicineshortage/README.md
+++ b/medicineshortage/README.md
@@ -1,0 +1,18 @@
+# Medicine Shortage Dashboard
+
+This directory provides persistent identifiers for the Medicine Shortage Dashboard.
+
+## Dashboard
+
+https://w3id.org/medicineshortage/dashboard
+
+redirects to the current location of the Medicine Shortage Dashboard.
+
+Current target:
+
+https://medicineshortage.shinyapps.io/dashboard/
+
+## Maintainer
+
+Jan Panhuysen
+Email: j.panhuysen@phd.hertie-school.org

--- a/medicineshortage/README.md
+++ b/medicineshortage/README.md
@@ -15,4 +15,5 @@ https://medicineshortage.shinyapps.io/dashboard/
 ## Maintainer
 
 Jan Panhuysen
+GitHub: @janpanhuysen
 Email: j.panhuysen@phd.hertie-school.org


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->

## Brief Description

Adds a persistent identifier for the Medicine Shortage Dashboard:

https://w3id.org/medicineshortage/dashboard

The identifier currently redirects to:

https://medicineshortage.shinyapps.io/dashboard/

The persistent identifier is intended for citation in academic publications while allowing the underlying hosting location of the dashboard to be updated in the future.

## General Checklist

* [x] Changes have been tested.
* [x] The number of commits is minimal. Squash if needed.
* [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

* [x] Maintainer details are in `.htaccess` or `README.md`.
* [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist

* [ ] GitHub username ids are listed in the changed maintainer details.
* [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers

* [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
