### PR TITLE
Add jinni namespace (Jinni Engineering)

### DIFF
--- a/jinni/.htaccess
+++ b/jinni/.htaccess
@@ -1,0 +1,9 @@
+# https://w3id.org/jinni — Jinni Engineering
+RewriteEngine On
+DirectorySlash Off
+RewriteOptions AllowNoSlash
+Options -Indexes
+
+# Catch-all → landing repo. 302 while the underlying objects await
+# permanent homes; tightens to 301 by follow-up PR at permanence.
+RewriteRule ^(.*)$ https://github.com/vzezin/jinni [R=302,L]

--- a/jinni/README.md
+++ b/jinni/README.md
@@ -1,0 +1,16 @@
+# w3id.org/jinni
+
+Permanent identifier for the **Jinni Engineering** line — the field manual
+*A practical approach to contracting agents* (Zezin & Mizutani), its
+evaluation program, and companion material.
+
+| Identifier | Redirects to |
+|---|---|
+| `https://w3id.org/jinni` (and all subpaths) | <https://github.com/vzezin/jinni> |
+
+Redirects are deliberately **302**: the underlying objects await permanent
+homes (paper deposit pending); the redirect tightens to 301 by follow-up PR
+at permanence. Leaf routes (e.g. `/manual`, `/paper`) will be minted by
+one-file PRs as their targets stabilize.
+
+Administered by: Vasily Zezin — <vzezin@toliman.org> — GitHub [@vzezin](https://github.com/vzezin).


### PR DESCRIPTION
New namespace for the Jinni Engineering line: the field manual "A practical approach to contracting agents" and its companion material. Landing target: https://github.com/vzezin/jinni (live). Administered by @vzezin (vzezin@toliman.org).