### PR TITLE
Add persistent identifier for the DIGIBAT ontology (Imperial College London)

### DIFF
--- a/digibat/.htaccess
+++ b/digibat/.htaccess
@@ -1,0 +1,23 @@
+##########################################################################
+# .htaccess file for https://w3id.org/digibat
+# Test at https://htaccess.madewithlove.com/ (strip the leading "digibat/").
+##########################################################################
+
+Options +FollowSymLinks
+RewriteEngine On
+
+# Rule 3: items and runs
+# Source: https://w3id.org/digibat/item/{ID}
+RewriteRule ^item/([A-Za-z0-9._-]+)/?$  https://digibatatimperial.github.io/digibat-ontology/item.html#$1 [R=303,NE,L]
+
+# Rule 2: versioned ontology, content-negotiated
+# Source: https://w3id.org/digibat/{VERSION}
+RewriteCond %{HTTP_ACCEPT} text/html [NC]
+RewriteRule ^([0-9][^/]*)/?$  https://digibatatimperial.github.io/digibat-ontology/versions/$1/digibat.html [R=303,NE,L]
+RewriteRule ^([0-9][^/]*)/?$  https://digibatatimperial.github.io/digibat-ontology/versions/$1/digibat.ttl  [R=303,NE,L]
+
+# Rule 1: latest ontology, content-negotiated
+# Source: https://w3id.org/digibat
+RewriteCond %{HTTP_ACCEPT} text/html [NC]
+RewriteRule ^/?$  https://digibatatimperial.github.io/digibat-ontology/digibat.html [R=303,NE,L]
+RewriteRule ^/?$  https://digibatatimperial.github.io/digibat-ontology/digibat.ttl  [R=303,NE,L]

--- a/digibat/README.md
+++ b/digibat/README.md
@@ -1,0 +1,27 @@
+# DIGIBAT
+
+This [W3ID](https://w3id.org) provides a persistent URI namespace for the DIGIBAT
+platform ontology (Imperial College London, Department of Chemical Engineering): an
+application ontology for automated battery and electrocatalysis research workflows,
+built on EMMO and BattINFO.
+
+Source repository: https://github.com/<ORG>/digibat-ontology
+Documentation and serialisations: https://<ORG>.github.io/digibat-ontology/
+
+## Redirection rules
+
+1. `https://w3id.org/digibat`                    --> `https://digibatatimperial.github.io/digibat-ontology/digibat{.html|.ttl}`
+   Browser requests receive the HTML documentation; RDF requests receive the Turtle file.
+   Alias: `https://w3id.org/digibat/`
+2. `https://w3id.org/digibat/{VERSION}`          --> `https://digibatatimperial.github.io/digibat-ontology/versions/{VERSION}/digibat{.html|.ttl}`
+   `{VERSION}` starts with a digit (e.g. `0.1.0`).
+3. `https://w3id.org/digibat/item/{ID}`          --> `https://digibatatimperial.github.io/digibat-ontology/item.html#{ID}`
+   Persistent identifiers for physical items and runs (e.g. `P042-CEL-7`).
+
+## Contacts
+
+Maintainers:
+- Jingyu Feng ([Jingyu2020](https://github.com/Jingyu2020))
+
+Contact: <group email>
+- digibat@imperial.ac.uk

--- a/digibat/README.md
+++ b/digibat/README.md
@@ -22,6 +22,6 @@ Documentation and serialisations: https://digibatatimperial.github.io/digibat-on
 
 Maintainers:
 - Jingyu Feng ([Jingyu2020](https://github.com/Jingyu2020))
+- DIGIBAT account ([digibatatimperial](https://github.com/digibatatimperial))
 
-Contact: <group email>
-- digibat@imperial.ac.uk
+Contact: digibat@imperial.ac.uk

--- a/digibat/README.md
+++ b/digibat/README.md
@@ -5,8 +5,8 @@ platform ontology (Imperial College London, Department of Chemical Engineering):
 application ontology for automated battery and electrocatalysis research workflows,
 built on EMMO and BattINFO.
 
-Source repository: https://github.com/<ORG>/digibat-ontology
-Documentation and serialisations: https://<ORG>.github.io/digibat-ontology/
+Source repository: https://github.com/digibatatimperial/digibat-ontology
+Documentation and serialisations: https://digibatatimperial.github.io/digibat-ontology/
 
 ## Redirection rules
 


### PR DESCRIPTION
## Brief Description
Adds a new persistent identifier directory `digibat/` for the DIGIBAT platform
ontology (Imperial College London, Department of Chemical Engineering). Redirects
resolve to GitHub Pages under the same organisation:
https://digibatatimperial.github.io/digibat-ontology/

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.