### PR TITLE
cpcp: add /cpcp/ namespace for the Coordination Protocol Contract Package

### DIFF
--- a/cpcp/.htaccess
+++ b/cpcp/.htaccess
@@ -1,0 +1,31 @@
+# # /cpcp/
+#
+# Coordination Protocol Contract Package (CPCP): a JSON-RPC-LD profile
+# specifying envelopes, refusal taxonomy, idempotency, layer authority and
+# operation identity for machine-to-machine coordination seams.
+#
+# https://w3id.org/cpcp/ redirects to
+# https://github.com/laquereric/coordination-protocol-contract-package
+#
+# IRI shapes in use:
+#   https://w3id.org/cpcp/ns#                    term namespace (@vocab)
+#   https://w3id.org/cpcp/ontology/base/1.0.0    ontology and version IRI
+#   https://w3id.org/cpcp/osi8/<seam>#<Method>   operation identity
+#
+# ## Contact
+# This space is administered by:
+#
+# Eric Laquer
+# GitHub username: laquereric
+
+RewriteEngine on
+
+# RDF clients asking for the term namespace or the ontology get Turtle.
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(ns|ontology/base(/.*)?)?$ https://raw.githubusercontent.com/laquereric/coordination-protocol-contract-package/main/ontology/cpcp-base.ttl [R=303,L]
+
+# Everything else goes to the contract repository.
+RewriteRule ^(.*)$ https://github.com/laquereric/coordination-protocol-contract-package [R=302,L]

--- a/cpcp/README.md
+++ b/cpcp/README.md
@@ -1,0 +1,33 @@
+# /cpcp/
+
+`https://w3id.org/cpcp/` is the permanent namespace for the **Coordination
+Protocol Contract Package (CPCP)** — a [JSON-RPC-LD](https://github.com/laquereric/json-rpc-ld)
+profile that specifies envelopes, a refusal taxonomy, idempotency rules, layer
+authority and operation identity for machine-to-machine coordination seams.
+
+The normative contract, the OWL/Turtle ontology, and the method and seam
+registries are published at:
+
+* Contract and ontology — <https://github.com/laquereric/coordination-protocol-contract-package>
+* Method and seam registries — <https://github.com/laquereric/cpcp_registry>
+
+## Identifiers
+
+| IRI shape | Purpose |
+|---|---|
+| `https://w3id.org/cpcp/ns#` | term namespace (JSON-LD `@vocab`), e.g. `cpcp:Note` |
+| `https://w3id.org/cpcp/ontology/base/1.0.0` | ontology IRI and `owl:versionIRI` |
+| `https://w3id.org/cpcp/osi8/<seam>#<Method>` | operation identity, e.g. `.../persist#path.set` |
+
+## Redirects
+
+`.htaccess` resolves requests as follows:
+
+* An RDF request (`text/turtle`, `application/x-turtle`, `text/n3`,
+  `application/rdf+xml`) for `/cpcp/`, `/cpcp/ns` or `/cpcp/ontology/base/…`
+  is redirected (303) to the Turtle document `ontology/cpcp-base.ttl`.
+* Every other request is redirected (302) to the contract repository.
+
+## Maintainer
+
+Eric Laquer — GitHub: [@laquereric](https://github.com/laquereric)


### PR DESCRIPTION
This adds the `/cpcp/` top-level identifier for the **Coordination Protocol
Contract Package (CPCP)**, a JSON-RPC-LD profile specifying envelopes, a
refusal taxonomy, idempotency rules, layer authority and operation identity
for machine-to-machine coordination seams.

**Redirect target:** <https://github.com/laquereric/coordination-protocol-contract-package> (public)

### Identifiers in use

| IRI shape | Purpose |
|---|---|
| `https://w3id.org/cpcp/ns#` | term namespace (JSON-LD `@vocab`) |
| `https://w3id.org/cpcp/ontology/base/1.0.0` | ontology IRI and `owl:versionIRI` |
| `https://w3id.org/cpcp/osi8/<seam>#<Method>` | operation identity |

### Behaviour

* RDF requests (`text/turtle`, `application/x-turtle`, `text/n3`,
  `application/rdf+xml`) for `/cpcp/`, `/cpcp/ns` or `/cpcp/ontology/base/...`
  get a 303 to the published Turtle ontology
  ([`ontology/cpcp-base.ttl`](https://raw.githubusercontent.com/laquereric/coordination-protocol-contract-package/main/ontology/cpcp-base.ttl), currently returns 200).
* All other requests get a 302 to the contract repository.

Both `.htaccess` and `README.md` are included, with maintainer and GitHub
account recorded in each. Single squashed commit; `cpcp/` did not previously
exist in this repository.

### Contact

Eric Laquer — GitHub: [@laquereric](https://github.com/laquereric)
