### PR TITLE
json-rpc-ld: add /json-rpc-ld/ namespace for the JSON-RPC-LD vocabulary

### DIFF
--- a/json-rpc-ld/.htaccess
+++ b/json-rpc-ld/.htaccess
@@ -1,0 +1,30 @@
+# # /json-rpc-ld/
+#
+# JSON-RPC-LD: a Linked Data extension for JSON-RPC 2.0. Core OWL vocabulary
+# for envelopes, operations and outcomes (Result / Error), with JSON-LD
+# identity and idempotency terms. Profiles specialize it; it imports nothing.
+#
+# https://w3id.org/json-rpc-ld/ redirects to
+# https://github.com/laquereric/json-rpc-ld
+#
+# IRI shapes in use:
+#   https://w3id.org/json-rpc-ld/ns#                  term namespace (jrl:)
+#   https://w3id.org/json-rpc-ld/ontology/core/1.0.0  ontology and version IRI
+#
+# ## Contact
+# This space is administered by:
+#
+# Eric Laquer
+# GitHub username: laquereric
+
+RewriteEngine on
+
+# RDF clients asking for the term namespace or the ontology get Turtle.
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/n3 [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^(ns|ontology/core(/.*)?)?$ https://raw.githubusercontent.com/laquereric/json-rpc-ld/main/ontology/json-rpc-ld-core.ttl [R=303,L]
+
+# Everything else goes to the specification repository.
+RewriteRule ^(.*)$ https://github.com/laquereric/json-rpc-ld [R=302,L]

--- a/json-rpc-ld/README.md
+++ b/json-rpc-ld/README.md
@@ -1,0 +1,33 @@
+# /json-rpc-ld/
+
+`https://w3id.org/json-rpc-ld/` is the permanent namespace for **JSON-RPC-LD**,
+a Linked Data extension for [JSON-RPC 2.0](https://www.jsonrpc.org/specification).
+
+The core OWL 2 vocabulary defines `Envelope`, `Operation` and `Outcome`
+(`Result` / `Error`), plus the identity and idempotency datatype properties
+(`operationId`, `jsonRpcVersion`, `methodName`, `reason`, `because`). OWL states
+meaning; a profile states closed operational validity in SHACL.
+
+This ontology is the root of its import chain — it imports nothing, and a
+profile that specializes JSON-RPC-LD imports it.
+
+* Specification and ontology — <https://github.com/laquereric/json-rpc-ld>
+
+## Identifiers
+
+| IRI | Purpose |
+|---|---|
+| `https://w3id.org/json-rpc-ld/ns#` | term namespace (`jrl:`), e.g. `jrl:Envelope` |
+| `https://w3id.org/json-rpc-ld/ontology/core/1.0.0` | ontology IRI and `owl:versionIRI` |
+
+## Redirects
+
+* An RDF request (`text/turtle`, `application/x-turtle`, `text/n3`,
+  `application/rdf+xml`) for `/json-rpc-ld/`, `/json-rpc-ld/ns` or
+  `/json-rpc-ld/ontology/core/...` is redirected (303) to the Turtle ontology
+  `ontology/json-rpc-ld-core.ttl`.
+* Every other request is redirected (302) to the specification repository.
+
+## Maintainer
+
+Eric Laquer — GitHub: [@laquereric](https://github.com/laquereric)


### PR DESCRIPTION
This adds the `/json-rpc-ld/` identifier for **JSON-RPC-LD**, a Linked Data
extension for [JSON-RPC 2.0](https://www.jsonrpc.org/specification).

**Redirect target:** <https://github.com/laquereric/json-rpc-ld> (public)

The core OWL 2 vocabulary defines `Envelope`, `Operation` and `Outcome`
(`Result` / `Error`), plus identity and idempotency datatype properties. The
ontology is the root of its import chain — it imports nothing, and profiles
that specialize JSON-RPC-LD import it.

### Identifiers

| IRI | Purpose |
|---|---|
| `https://w3id.org/json-rpc-ld/ns#` | term namespace (`jrl:`) |
| `https://w3id.org/json-rpc-ld/ontology/core/1.0.0` | ontology IRI and `owl:versionIRI` |

### Behaviour

* RDF requests (`text/turtle`, `application/x-turtle`, `text/n3`,
  `application/rdf+xml`) for `/json-rpc-ld/`, `/json-rpc-ld/ns` or
  `/json-rpc-ld/ontology/core/...` get a 303 to the published Turtle ontology
  ([`ontology/json-rpc-ld-core.ttl`](https://raw.githubusercontent.com/laquereric/json-rpc-ld/main/ontology/json-rpc-ld-core.ttl), currently returns 200).
* All other requests get a 302 to the specification repository.

Both `.htaccess` and `README.md` are included, with maintainer and GitHub
account in each. Single squashed commit; `json-rpc-ld/` did not previously
exist in this repository.

Related: #6644 registers `/cpcp/` for a profile that imports this ontology.

### Contact

Eric Laquer — GitHub: [@laquereric](https://github.com/laquereric)
