### PR TITLE
Fpoi registration

### DIFF
--- a/fpoi/.htaccess
+++ b/fpoi/.htaccess
@@ -1,0 +1,15 @@
+RewriteEngine On
+
+# Failure Pattern Operational Intelligence (FPOI)
+# Project landing page
+RewriteRule ^$ https://linfanluntan.github.io/fpoi-ontology/ [R=302,L]
+
+# Immutable v1.0.1 ontology release (C9 release-provenance commit)
+RewriteRule ^1\.0\.1/?$ https://raw.githubusercontent.com/linfanluntan/fpoi-ontology/a48dce057a2e48fa57075a517f99bff092f6250e/ontology/fpoi_ontology_v1.0.1.ttl [R=302,L]
+
+# Current ontology and SHACL shapes
+RewriteRule ^ontology/?$ https://raw.githubusercontent.com/linfanluntan/fpoi-ontology/main/ontology/fpoi_ontology_v1.0.1.ttl [R=302,L]
+RewriteRule ^shapes/?$ https://raw.githubusercontent.com/linfanluntan/fpoi-ontology/main/shapes/fpoi_shapes_v1.0.1.ttl [R=302,L]
+
+# Repository fallback for other FPOI resources
+RewriteRule ^(.+)$ https://github.com/linfanluntan/fpoi-ontology [R=302,L]

--- a/fpoi/README.md
+++ b/fpoi/README.md
@@ -1,0 +1,29 @@
+# Failure Pattern Operational Intelligence (FPOI)
+
+This directory registers the persistent namespace:
+
+- `https://w3id.org/fpoi/`
+
+for the Failure Pattern Operational Intelligence (FPOI) ontology and associated semantic-validation resources in radiation oncology.
+
+## Project
+
+- Repository: https://github.com/linfanluntan/fpoi-ontology
+- Project landing page: https://linfanluntan.github.io/fpoi-ontology/
+- Zenodo DOI: https://doi.org/10.5281/zenodo.22328034
+- Current ontology release: FPOI v1.0.1
+
+## Redirects
+
+- `https://w3id.org/fpoi/` → project landing page
+- `https://w3id.org/fpoi/1.0.1` → immutable v1.0.1 ontology artifact
+- `https://w3id.org/fpoi/ontology` → current ontology Turtle file
+- `https://w3id.org/fpoi/shapes` → current SHACL shapes
+
+The version-specific v1.0.1 redirect points to the repository release-provenance commit so that the ontology bytes remain stable even if `main` evolves.
+
+## Maintainer
+
+- GitHub: https://github.com/linfanluntan
+
+The maintainer agrees to preserve this namespace and its redirects according to the w3id.org persistence policy.


### PR DESCRIPTION
Brief Description: Adds the persistent namespace https://w3id.org/fpoi/ for the Failure Pattern Operational Intelligence (FPOI) ontology and validation artifacts.

Project repository: https://github.com/linfanluntan/fpoi-ontology
Zenodo DOI: 10.5281/zenodo.22328034
Maintainer GitHub ID: linfanluntan

Check the boxes for:

Changes have been tested.
Number of commits is minimal.
Commits contain only redirects/basic information.
Maintainer details are in README.
GitHub username is listed in maintainer details.
