### PR TITLE
cdisc/usdm/v4: re-pin to v0.7.0 release

### DIFF
--- a/ids/cdisc/usdm/v4/.htaccess
+++ b/ids/cdisc/usdm/v4/.htaccess
@@ -5,7 +5,7 @@
 # source. Slash semantics (since v0.3): each minted IRI dereferences
 # individually — class IRIs to per-class HTML anchors, property IRIs
 # to property anchors on the rendered page; the canonical Turtle
-# (version-pinned at the v0.6.0 tag) is served for tools requesting
+# (version-pinned at the v0.7.0 tag) is served for tools requesting
 # RDF. Version IRIs (bare-numeric paths, e.g. /0.3.1) dereference to
 # their own tag-pinned Turtle via one generic rule. Fixed paths serve
 # the JSON-LD instance context (/context.jsonld) and the two SHACL
@@ -35,14 +35,14 @@ RewriteRule ^([0-9]+\.[0-9]+\.[0-9]+)$ https://raw.githubusercontent.com/kerfors
 # resolves regardless of Accept header (JSON-LD processors typically
 # send application/ld+json; browsers must not fall through to the
 # HTML anchor rule).
-RewriteRule ^context\.jsonld$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.6.0/usdm_v4.context.jsonld [R=303,L]
+RewriteRule ^context\.jsonld$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.7.0/usdm_v4.context.jsonld [R=303,L]
 
 # SHACL shapes graphs — fixed paths matching the graph IRIs
 # <.../v4/shapes> (structural) and <.../v4/shapes-ct> (terminology),
 # version-pinned like the canonical Turtle (decision D6,
 # docs/iri-and-governance.md). Must precede the Accept-based rules.
-RewriteRule ^shapes$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.6.0/usdm_v4.shapes.ttl [R=303,L]
-RewriteRule ^shapes-ct$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.6.0/usdm_v4.shapes-ct.ttl [R=303,L]
+RewriteRule ^shapes$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.7.0/usdm_v4.shapes.ttl [R=303,L]
+RewriteRule ^shapes-ct$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.7.0/usdm_v4.shapes-ct.ttl [R=303,L]
 
 # JSON-LD
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
@@ -56,9 +56,9 @@ RewriteRule ^(.*)$ https://kerfors.github.io/usdm-rdf/ontology.owl [R=303,L]
 RewriteCond %{HTTP_ACCEPT} application/n-triples
 RewriteRule ^(.*)$ https://kerfors.github.io/usdm-rdf/ontology.nt [R=303,L]
 
-# Turtle — canonical, version-pinned at the v0.6.0 tag
+# Turtle — canonical, version-pinned at the v0.7.0 tag
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^(.*)$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.6.0/usdm_v4.ttl [R=303,L]
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.7.0/usdm_v4.ttl [R=303,L]
 
 # HTML for browsers — namespace root and per-IRI variants
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
@@ -71,4 +71,4 @@ RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 RewriteRule ^(.+)$ https://kerfors.github.io/usdm-rdf/index.html#$1 [R=303,NE,L]
 
 # Default fallback (no Accept header, programmatic clients): canonical Turtle
-RewriteRule ^(.*)$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.6.0/usdm_v4.ttl [R=303,L]
+RewriteRule ^(.*)$ https://raw.githubusercontent.com/kerfors/usdm-rdf/refs/tags/v0.7.0/usdm_v4.ttl [R=303,L]


### PR DESCRIPTION
## Brief Description
Re-pins the version-pinned redirect targets for `https://w3id.org/cdisc/usdm/v4/` from the `v0.6.0` tag to the `v0.7.0` tag of `kerfors/usdm-rdf`: five rules (canonical Turtle, default fallback, `/context.jsonld`, `/shapes`, `/shapes-ct`) plus the two comment lines naming the tag. No new paths, no structural change to the rules.

All five target URLs verified HTTP 200 at the v0.7.0 tag before opening this PR. Previous re-pins of this directory: #6303 (v0.6.0), #6302 (v0.5.0), #6190, #6189, #6012.

## General Checklist
- [ ] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.