### PR TITLE
Add og-caie (Ontology-Grounded Contextual AI Evaluation)

### DIFF
--- a/ids/og-caie/.htaccess
+++ b/ids/og-caie/.htaccess
@@ -1,0 +1,12 @@
+# w3id.org/og-caie: Ontology-Grounded Contextual AI Evaluation (OG-CAIE)
+# Executable specification maintained by Dynamical Systems Group and
+# Humane Intelligence. Everything under /og-caie/ redirects to the
+# GitHub Pages site of DynamicalSystemsGroup/og-caie-spec.
+#
+# ## Contact
+# Michael Zargham, zargham@dynamicalsystemsgroup.com
+# GitHub username: mzargham
+Options +FollowSymLinks
+RewriteEngine on
+
+RewriteRule ^(.*)$ https://dynamicalsystemsgroup.github.io/og-caie-spec/$1 [R=302,L]

--- a/ids/og-caie/README.md
+++ b/ids/og-caie/README.md
@@ -1,0 +1,12 @@
+# og-caie
+
+Ontology-Grounded Contextual AI Evaluation (OG-CAIE): vocabulary, Evaluation
+Process Ontology, evaluation records and rulings, published as an executable
+specification at <https://github.com/DynamicalSystemsGroup/og-caie-spec>.
+
+Namespaces under this prefix: `/terms#`, `/epo#`, `/sources#`, `/rulings#`,
+`/run/`.
+
+Maintainers: Michael Zargham (Dynamical Systems Group,
+zargham@dynamicalsystemsgroup.com, GitHub: [@mzargham](https://github.com/mzargham)),
+Julie Hollek (Humane Intelligence, GitHub: [@jkru](https://github.com/jkru)).


### PR DESCRIPTION
Adds `/og-caie/` redirecting to the GitHub Pages site of DynamicalSystemsGroup/og-caie-spec, the executable specification of Ontology-Grounded Contextual AI Evaluation maintained by Dynamical Systems Group and Humane Intelligence. Contact in README.md.