### PR TITLE
Add horizonshield/ (A2A Conduct Extension v1)

### DIFF
--- a/ids/horizonshield/.htaccess
+++ b/ids/horizonshield/.htaccess
@@ -1,0 +1,6 @@
+Options +FollowSymLinks
+RewriteEngine on
+
+# A2A Conduct Extension v1. The identifier compared by implementations is the target URI; this is a convenience redirect.
+RewriteRule ^conduct/v1/?$ https://gate.horizonshield.dev/ext/conduct/v1 [R=302,L]
+RewriteRule ^conduct/?$ https://gate.horizonshield.dev/ext/conduct/v1 [R=302,L]

--- a/ids/horizonshield/README.md
+++ b/ids/horizonshield/README.md
@@ -1,0 +1,8 @@
+# horizonshield
+
+Permanent identifiers for HORIZON SHIELD specifications (The HORIZ音s株式会社, Hiratsuka, Japan).
+
+- https://w3id.org/horizonshield/conduct/v1 redirects to https://gate.horizonshield.dev/ext/conduct/v1
+  (A2A Conduct Extension v1; the target serves JSON by default and the specification text with Accept: text/markdown)
+
+Contact: ogasurfproject@gmail.com  (GitHub: ogasurfproject-jpg)


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
Adds horizonshield/ with a redirect for the A2A Conduct Extension v1 specification (https://w3id.org/horizonshield/conduct/v1 to https://gate.horizonshield.dev/ext/conduct/v1). Owner: ogasurfproject-jpg.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.