### PR TITLE
Add persistent identifier for the DAIMO ontology

### DIFF
--- a/ids/pionera/.htaccess
+++ b/ids/pionera/.htaccess
@@ -1,0 +1,103 @@
+# /pionera/
+#
+# Namespace for PIONERA resources. The first registered identifier is DAIMO.
+#
+# https://w3id.org/pionera/daimo          ontology IRI (content negotiation)
+# https://w3id.org/pionera/daimo/0.1.7    current version IRI
+# Canonical term pattern                 https://w3id.org/pionera/daimo#<TermName>
+#
+# Redirect target: GitHub Pages
+#   https://edmundomori.github.io/Papers-DAIMO/
+# Source repository:
+#   https://github.com/EdmundoMori/Papers-DAIMO
+#
+# ## Contact
+# This space is administered by:
+#
+# Edmundo de Elvira Mori Orrillo
+# edmundo.mori@alumnos.upm.es
+# GitHub username: EdmundoMori
+
+Options +FollowSymLinks
+Options -MultiViews
+
+AddType text/turtle         .ttl
+AddType application/rdf+xml .owl .rdf
+AddType application/ld+json .jsonld
+AddType application/n-triples .nt
+
+RewriteEngine On
+
+# --- Namespace root: content negotiation --------------------------------
+
+# HTML for browsers (official w3id vocabulary example / ppop / cosmos)
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^daimo/?$ https://edmundomori.github.io/Papers-DAIMO/index-en.html [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^daimo/?$ https://edmundomori.github.io/Papers-DAIMO/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^daimo/?$ https://edmundomori.github.io/Papers-DAIMO/ontology.owl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^daimo/?$ https://edmundomori.github.io/Papers-DAIMO/ontology.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples [NC]
+RewriteRule ^daimo/?$ https://edmundomori.github.io/Papers-DAIMO/ontology.nt [R=303,L]
+
+# Default when Accept is absent or unmatched: HTML documentation
+RewriteRule ^daimo/?$ https://edmundomori.github.io/Papers-DAIMO/index-en.html [R=303,L]
+
+# --- Versioned IRI 0.1.7 (content negotiation) --------------------------
+
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^daimo/0\.1\.7/?$ https://edmundomori.github.io/Papers-DAIMO/index-en.html [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^daimo/0\.1\.7/?$ https://edmundomori.github.io/Papers-DAIMO/ontology.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^daimo/0\.1\.7/?$ https://edmundomori.github.io/Papers-DAIMO/ontology.owl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^daimo/0\.1\.7/?$ https://edmundomori.github.io/Papers-DAIMO/ontology.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples [NC]
+RewriteRule ^daimo/0\.1\.7/?$ https://edmundomori.github.io/Papers-DAIMO/ontology.nt [R=303,L]
+
+RewriteRule ^daimo/0\.1\.7/?$ https://edmundomori.github.io/Papers-DAIMO/index-en.html [R=303,L]
+
+# --- Prior version IRIs (HTML only; no frozen historical serialisations) -
+
+RewriteRule ^daimo/0\.1\.6/?$ https://edmundomori.github.io/Papers-DAIMO/index-en.html [R=303,L]
+RewriteRule ^daimo/0\.1\.6-swj-submission/?$ https://edmundomori.github.io/Papers-DAIMO/index-en.html [R=303,L]
+RewriteRule ^daimo/0\.1\.5/?$ https://edmundomori.github.io/Papers-DAIMO/index-en.html [R=303,L]
+RewriteRule ^daimo/0\.1\.1/?$ https://edmundomori.github.io/Papers-DAIMO/index-en.html [R=303,L]
+RewriteRule ^daimo/0\.1\.0/?$ https://edmundomori.github.io/Papers-DAIMO/index-en.html [R=303,L]
+
+# --- Direct serialisation access ----------------------------------------
+
+RewriteRule ^daimo\.ttl$     https://edmundomori.github.io/Papers-DAIMO/ontology.ttl     [R=303,L]
+RewriteRule ^daimo\.owl$     https://edmundomori.github.io/Papers-DAIMO/ontology.owl     [R=303,L]
+RewriteRule ^daimo\.jsonld$  https://edmundomori.github.io/Papers-DAIMO/ontology.jsonld  [R=303,L]
+RewriteRule ^daimo\.nt$      https://edmundomori.github.io/Papers-DAIMO/ontology.nt      [R=303,L]
+
+# --- Companion documents cited by the ontology --------------------------
+
+RewriteRule ^daimo/align/?$            https://edmundomori.github.io/Papers-DAIMO/alignment.ttl    [R=303,L]
+RewriteRule ^daimo/align/0\.1\.7/?$    https://edmundomori.github.io/Papers-DAIMO/alignment.ttl    [R=303,L]
+RewriteRule ^daimo/alignment\.ttl$     https://edmundomori.github.io/Papers-DAIMO/alignment.ttl    [R=303,L]
+RewriteRule ^daimo/docs/?$             https://edmundomori.github.io/Papers-DAIMO/index-en.html    [R=303,L]
+RewriteRule ^daimo/shapes/?$           https://edmundomori.github.io/Papers-DAIMO/daimo-shapes.ttl [R=303,L]
+RewriteRule ^daimo/shapes/0\.1\.7/?$   https://edmundomori.github.io/Papers-DAIMO/daimo-shapes.ttl [R=303,L]
+RewriteRule ^daimo/shapes\.ttl$        https://edmundomori.github.io/Papers-DAIMO/daimo-shapes.ttl [R=303,L]
+
+# Publisher IRI currently lands on the DAIMO documentation
+RewriteRule ^$ https://edmundomori.github.io/Papers-DAIMO/index-en.html [R=303,L]

--- a/ids/pionera/README.md
+++ b/ids/pionera/README.md
@@ -1,0 +1,34 @@
+# pionera / DAIMO
+
+Permanent identifier for **DAIMO** (Dataspace AI Model Ontology), an ontology for governed AI model assets in dataspaces.
+
+- Identifier: https://w3id.org/pionera/daimo
+- Current version: 0.1.7
+- Version IRI: https://w3id.org/pionera/daimo/0.1.7
+- Source repository: https://github.com/EdmundoMori/Papers-DAIMO
+- Public documentation: https://edmundomori.github.io/Papers-DAIMO/index-en.html
+
+Content negotiation on the ontology IRI and on `/0.1.7` redirects to GitHub Pages:
+
+| Accept | Target |
+| --- | --- |
+| `text/html` (and typical browsers) | `index-en.html` |
+| `text/turtle` | `ontology.ttl` |
+| `application/rdf+xml` | `ontology.owl` |
+| `application/ld+json` | `ontology.jsonld` |
+| `application/n-triples` | `ontology.nt` |
+| default (no `Accept`) | `index-en.html` |
+
+Companion IRIs:
+
+- https://w3id.org/pionera/daimo/align → `alignment.ttl`
+- https://w3id.org/pionera/daimo/shapes → `daimo-shapes.ttl`
+- https://w3id.org/pionera/daimo/docs → HTML documentation
+
+This identifier is not active until the pull request is merged by the w3id.org maintainers.
+
+## Maintainer
+
+Edmundo de Elvira Mori Orrillo  
+GitHub username: [EdmundoMori](https://github.com/EdmundoMori)  
+edmundo.mori@alumnos.upm.es


### PR DESCRIPTION
## Brief Description

Register `https://w3id.org/pionera/daimo` as the persistent identifier for DAIMO, an ontology for governed AI model assets in dataspaces.

- Identifier: https://w3id.org/pionera/daimo
- Current version: 0.1.7 (`https://w3id.org/pionera/daimo/0.1.7`)
- Source repository: https://github.com/EdmundoMori/Papers-DAIMO
- Public documentation: https://edmundomori.github.io/Papers-DAIMO/index-en.html
- Content negotiation: HTML, Turtle, RDF/XML, JSON-LD, N-Triples (303 to GitHub Pages); default without Accept is HTML
- Maintainer: EdmundoMori

This pull request only adds `ids/pionera/.htaccess` and `ids/pionera/README.md`. The identifier is not active until maintainers merge it.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.