### PR TITLE
Add vizbind id

### DIFF
--- a/ids/vizbind/.htaccess
+++ b/ids/vizbind/.htaccess
@@ -1,0 +1,60 @@
+# === Directory: /vizbind/ ====================================================
+#
+# VizBind: a declarative RDF vocabulary for notation-independent visualisation
+# of RDFS/OWL models.
+#
+# https://w3id.org/vizbind redirects to the vocabulary published at
+# https://mareksuchanek.github.io/vizbind/ (source: github.com/MarekSuchanek/vizbind)
+#
+# VizBind uses a hash namespace, so a client requesting a term such as
+# https://w3id.org/vizbind#Binding strips the fragment and asks for
+# https://w3id.org/vizbind. One rule set therefore covers every term.
+#
+# ## Contact
+# This space is administered by:
+#
+# Marek Suchanek
+# GitHub username: MarekSuchanek
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# === Rewrite Rules ===========================================================
+
+# Documentation, for browsers. Checked first, and guarded so that an Accept
+# header listing both RDF/XML and HTML is not mistaken for a browser request.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteRule ^$ https://mareksuchanek.github.io/vizbind/ [R=303,L]
+
+# Turtle
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/n3
+RewriteRule ^$ https://mareksuchanek.github.io/vizbind/vizbind.ttl [R=303,L]
+
+# RDF/XML
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/owl\+xml
+RewriteRule ^$ https://mareksuchanek.github.io/vizbind/vizbind.rdf [R=303,L]
+
+# JSON-LD
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^$ https://mareksuchanek.github.io/vizbind/vizbind.jsonld [R=303,L]
+
+# Direct access to a particular serialisation
+# e.g. https://w3id.org/vizbind/vizbind.ttl
+RewriteRule ^vizbind\.ttl$    https://mareksuchanek.github.io/vizbind/vizbind.ttl    [R=303,L]
+RewriteRule ^vizbind\.rdf$    https://mareksuchanek.github.io/vizbind/vizbind.rdf    [R=303,L]
+RewriteRule ^vizbind\.jsonld$ https://mareksuchanek.github.io/vizbind/vizbind.jsonld [R=303,L]
+
+# Default for a client that expressed no preference (Accept: */* or none):
+# the vocabulary itself, since browsers are already handled by the first rule.
+RewriteRule ^$ https://mareksuchanek.github.io/vizbind/vizbind.ttl [R=303,L]
+
+# Anything else under /vizbind/ goes to the documentation.
+RewriteRule ^ https://mareksuchanek.github.io/vizbind/ [R=303,L]
+
+# === END =====================================================================

--- a/ids/vizbind/README.md
+++ b/ids/vizbind/README.md
@@ -1,0 +1,29 @@
+## VizBind
+
+A declarative RDF vocabulary for notation-independent visualisation of RDFS/OWL
+models. VizBind describes a visual notation *as data*: a notation is a set of
+binding rules, each separating selection of model constructs (via SPARQL),
+mapping to abstract visual constructs, and engine-agnostic styling.
+
+`https://w3id.org/vizbind` redirects to the published vocabulary at
+<https://mareksuchanek.github.io/vizbind/>, with content negotiation:
+
+| Accept | Redirects to |
+|---|---|
+| `text/html` (browsers) | `https://mareksuchanek.github.io/vizbind/` |
+| `text/turtle` | `.../vizbind.ttl` |
+| `application/rdf+xml` | `.../vizbind.rdf` |
+| `application/ld+json` | `.../vizbind.jsonld` |
+
+VizBind uses a hash namespace, so terms such as `https://w3id.org/vizbind#Binding`
+resolve through the single `https://w3id.org/vizbind` request the client makes
+after stripping the fragment.
+
+The vocabulary accompanies the KEOD 2026 paper *Binding Ontologies to Notation: A
+Declarative RDF Vocabulary for Notation-Independent Visualisation of RDFS/OWL
+Models*, and is licensed under CC BY 4.0.
+
+Source and issue tracker: <https://github.com/MarekSuchanek/vizbind>
+
+Maintainer: Marek Suchánek (@MarekSuchanek), Faculty of Information Technology,
+Czech Technical University in Prague — marek.suchanek@cvut.cz


### PR DESCRIPTION
## Brief Description

Adds a new identifier, `https://w3id.org/vizbind`, for **VizBind** — a declarative RDF
vocabulary for notation-independent visualisation of RDFS/OWL models, published as a
research artifact accompanying a KEOD 2026 paper.

VizBind uses a **hash namespace** (`https://w3id.org/vizbind#Binding` and so on), so
clients strip the fragment and only ever request `https://w3id.org/vizbind`. A single
rule set therefore covers every term in the vocabulary.

The redirect content-negotiates to a GitHub Pages site:

| Accept | Redirects to |
|---|---|
| `text/html` (browsers) | `https://mareksuchanek.github.io/vizbind/` |
| `text/turtle`, `application/x-turtle`, `text/n3` | `.../vizbind.ttl` |
| `application/rdf+xml`, `application/owl+xml` | `.../vizbind.rdf` |
| `application/ld+json` | `.../vizbind.jsonld` |
| none / `*/*` | `.../vizbind.ttl` |

All redirects are `303 See Other`. Source and issue tracker:
<https://github.com/MarekSuchanek/vizbind>

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

Testing: the `.htaccess` was run under a local Apache 2.4 with `mod_rewrite` and
`AllowOverride All`, exercising each `Accept` header and following the redirects through
to the live target. Every serialisation parses as a 313-triple graph, and all five target
files return HTTP 200 with correct content types.

## New ID Directory Checklist

- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

Maintainer details are in both files: Marek Suchánek, GitHub username `MarekSuchanek`.

## Update ID Directory Checklist

Not applicable — this is a new ID directory, not an update to an existing one.

## Optional Requests for W3ID Maintainers

- [x] Please squash commits for me.

The branch is already a single commit (`Add vizbind id`), so no squash is needed.