### PR TITLE
AgoraOWL: resolve vocabularies, terms and distribution artefacts

### DIFF
--- a/ids/AgoraOWL/.htaccess
+++ b/ids/AgoraOWL/.htaccess
@@ -1,7 +1,7 @@
-# Turn off MultiViews
+# AgoraOWL
+
 Options -MultiViews
 
-# Add content types for RDF serializations
 AddType application/rdf+xml .rdf
 AddType application/rdf+xml .owl
 AddType text/turtle .ttl
@@ -11,26 +11,37 @@ AddType application/ld+json .jsonld
 RewriteEngine On
 RewriteBase /
 
-# -----------------------------------------------------------------------------
-# GENERIC RULES (FUTURE-PROOF)
-# This regex matches "latest" OR any "X.Y.Z" semantic version string.
-# $1 captures the folder name (e.g., "latest", "0.2.1", "1.0.0")
-# $3 captures the vocabulary name (if present)
-# -----------------------------------------------------------------------------
+# Distribution artefacts (JSON-LD context, alignment module)
+RewriteRule ^(latest|[0-9]+\.[0-9]+\.[0-9]+)/(context\.jsonld|alignment\.ttl)$ https://khaosresearch.github.io/AgoraOWL/$1/$2 [R=303,L]
+RewriteRule ^(context\.jsonld|alignment\.ttl)$ https://khaosresearch.github.io/AgoraOWL/latest/$1 [R=303,L]
 
-# Rule 1: Vocabularies (e.g., /latest/vocabularies/sector-scheme) - Always serve Turtle
-RewriteRule ^(latest|([0-9]+\.[0-9]+\.[0-9]+))/vocabularies/([a-zA-Z0-9_-]+)$ https://khaosresearch.github.io/AgoraOWL/$1/vocabularies/$3.ttl [R=303,L]
+# Vocabulary index
+RewriteRule ^(latest|[0-9]+\.[0-9]+\.[0-9]+)/vocabularies/?$ https://khaosresearch.github.io/AgoraOWL/$1/vocabularies/index.html [R=303,L]
+RewriteRule ^vocabularies/?$ https://khaosresearch.github.io/AgoraOWL/latest/vocabularies/index.html [R=303,L]
 
-# Rule 2: Versioned/Latest Ontology PID (e.g., /0.2.1 or /latest) - Content Negotiation
-# HTML request (browser) -> Widoco docs index for THAT version
+# Vocabularies: explicit extension
+RewriteRule ^(latest|[0-9]+\.[0-9]+\.[0-9]+)/vocabularies/([A-Za-z0-9_-]+)\.(ttl|html)$ https://khaosresearch.github.io/AgoraOWL/$1/vocabularies/$2.$3 [R=303,L]
+RewriteRule ^vocabularies/([A-Za-z0-9_-]+)\.(ttl|html)$ https://khaosresearch.github.io/AgoraOWL/latest/vocabularies/$1.$2 [R=303,L]
+
+# Vocabularies: content negotiation, versioned
+RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml) [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/
+RewriteRule ^(latest|[0-9]+\.[0-9]+\.[0-9]+)/vocabularies/([A-Za-z0-9_-]+)$ https://khaosresearch.github.io/AgoraOWL/$1/vocabularies/$2.html [R=303,L]
+RewriteRule ^(latest|[0-9]+\.[0-9]+\.[0-9]+)/vocabularies/([A-Za-z0-9_-]+)$ https://khaosresearch.github.io/AgoraOWL/$1/vocabularies/$2.ttl [R=303,L]
+
+# Vocabularies: content negotiation, unversioned -> latest
+RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml) [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/
+RewriteRule ^vocabularies/([A-Za-z0-9_-]+)$ https://khaosresearch.github.io/AgoraOWL/latest/vocabularies/$1.html [R=303,L]
+RewriteRule ^vocabularies/([A-Za-z0-9_-]+)$ https://khaosresearch.github.io/AgoraOWL/latest/vocabularies/$1.ttl [R=303,L]
+
+# Versioned / latest ontology PID: content negotiation
 RewriteCond %{HTTP_ACCEPT} (text/html|application/xhtml\+xml)
 RewriteRule ^(latest|([0-9]+\.[0-9]+\.[0-9]+))$ https://khaosresearch.github.io/AgoraOWL/$1/index-en.html [R=303,L]
 
-# Specific RDF format requests -> Raw file with corresponding extension for THAT version
 RewriteCond %{HTTP_ACCEPT} text/turtle
 RewriteRule ^(latest|([0-9]+\.[0-9]+\.[0-9]+))$ https://khaosresearch.github.io/AgoraOWL/$1/ontology.ttl [R=303,L]
 
-# RDF/XML request -> .owl file
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
 RewriteRule ^(latest|([0-9]+\.[0-9]+\.[0-9]+))$ https://khaosresearch.github.io/AgoraOWL/$1/ontology.owl [R=303,L]
 
@@ -40,41 +51,49 @@ RewriteRule ^(latest|([0-9]+\.[0-9]+\.[0-9]+))$ https://khaosresearch.github.io/
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
 RewriteRule ^(latest|([0-9]+\.[0-9]+\.[0-9]+))$ https://khaosresearch.github.io/AgoraOWL/$1/ontology.jsonld [R=303,L]
 
-# Fallback for versioned/latest PIDs (if Accept header is missing or doesn't match known RDF types) -> Turtle file
 RewriteRule ^(latest|([0-9]+\.[0-9]+\.[0-9]+))$ https://khaosresearch.github.io/AgoraOWL/$1/ontology.ttl [R=303,L]
 
-# -----------------------------------------------------------------------------
-# RULES FOR THE BASE URI ( /AgoraOWL ) -> Redirects to "latest"
-# -----------------------------------------------------------------------------
-
-# Rule 3: HTML request for base URI -> redirect to "latest" docs index
+# Base URI -> latest
 RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 RewriteRule ^$ https://khaosresearch.github.io/AgoraOWL/latest/index-en.html [R=303,L]
 
-# Rule 4: HTML request for a term (e.g., /DataProfile) -> redirect to anchor in "latest" docs
-RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
-RewriteCond %{HTTP_ACCEPT} text/html [OR]
-RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
-RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-# Match only if it's NOT a version string or "latest" or "vocabularies" - i.e., it's likely a term
-RewriteCond %{REQUEST_URI} !^/(latest|([0-9]+\.[0-9]+\.[0-9]+)|vocabularies)/?$
-RewriteRule ^(.+)$ https://khaosresearch.github.io/AgoraOWL/latest/index-en.html#$1 [R=303,NE,L]
-
-# Rule 5: Specific RDF format requests for base URI -> redirect to "latest" raw file
 RewriteCond %{HTTP_ACCEPT} text/turtle
 RewriteRule ^$ https://khaosresearch.github.io/AgoraOWL/latest/ontology.ttl [R=303,L]
 
-# RDF/XML request -> .owl file
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
 RewriteRule ^$ https://khaosresearch.github.io/AgoraOWL/latest/ontology.owl [R=303,L]
 
 RewriteCond %{HTTP_ACCEPT} application/n-triples
 RewriteRule ^$ https://khaosresearch.github.io/AgoraOWL/latest/ontology.nt [R=303,L]
+
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
 RewriteRule ^$ https://khaosresearch.github.io/AgoraOWL/latest/ontology.jsonld [R=303,L]
 
-# Rule 6: Fallback for base URI -> "latest" Turtle file
 RewriteRule ^$ https://khaosresearch.github.io/AgoraOWL/latest/ontology.ttl [R=303,L]
+
+# Term IRIs (e.g. /DataApp, /hasFieldMapping): browsers get the docs anchor,
+# RDF clients get the ontology document that defines the term.
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteCond %{REQUEST_URI} !^/(latest|([0-9]+\.[0-9]+\.[0-9]+)|vocabularies)/?$
+RewriteRule ^([A-Za-z][A-Za-z0-9_-]*)$ https://khaosresearch.github.io/AgoraOWL/latest/index-en.html#$1 [R=303,NE,L]
+
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule ^([A-Za-z][A-Za-z0-9_-]*)$ https://khaosresearch.github.io/AgoraOWL/latest/ontology.owl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteRule ^([A-Za-z][A-Za-z0-9_-]*)$ https://khaosresearch.github.io/AgoraOWL/latest/ontology.nt [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^([A-Za-z][A-Za-z0-9_-]*)$ https://khaosresearch.github.io/AgoraOWL/latest/ontology.jsonld [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^([A-Za-z][A-Za-z0-9_-]*)$ https://khaosresearch.github.io/AgoraOWL/latest/ontology.ttl [R=303,L]
+
+RewriteCond %{REQUEST_URI} !^/(latest|([0-9]+\.[0-9]+\.[0-9]+)|vocabularies)/?$
+RewriteRule ^([A-Za-z][A-Za-z0-9_-]*)$ https://khaosresearch.github.io/AgoraOWL/latest/ontology.ttl [R=303,L]

--- a/ids/AgoraOWL/README.md
+++ b/ids/AgoraOWL/README.md
@@ -1,50 +1,5 @@
 # AgoraOWL
 
-**Persistent identifier (PID) home** for the AgoraOWL ontology and related resources.
-
-This directory hosts the redirection rules (via `.htaccess`) that resolve the PID
-<https://w3id.org/AgoraOWL> and its associated versions and vocabularies.
-
-## 🔗 Resolvable Resources
-
-The redirection rules point to the ontology documentation and files hosted on GitHub Pages:
-**`https://khaosresearch.github.io/AgoraOWL/`**
-
-### Main Ontology (Latest & Versioned)
-
-The base PID <https://w3id.org/AgoraOWL> redirects to the **latest** version. Specific versions can be accessed via `/<version>` (e.g., <https://w3id.org/AgoraOWL/0.0.1>).
-
-- **HTML Docs (for browsers):**
-  - `https://w3id.org/AgoraOWL/` (Redirects to latest docs)
-  - `https://w3id.org/AgoraOWL/0.0.1/` (Redirects to versioned docs)
-
-- **RDF Serializations (for tools, using `Accept` header):**
-  - **Turtle (.ttl):** `https://khaosresearch.github.io/AgoraOWL/latest/ontology.ttl`
-  - **RDF/XML (.owl):** `https://khaosresearch.github.io/AgoraOWL/latest/ontology.owl`
-  - **N-Triples (.nt):** `https://khaosresearch.github.io/AgoraOWL/latest/ontology.nt`
-  - **JSON-LD (.jsonld):** `https://khaosresearch.github.io/AgoraOWL/latest/ontology.jsonld`
-
-### Modular Vocabularies
-
-Vocabulary PIDs are resolvable _per version_. For example:
-<https://w3id.org/AgoraOWL/latest/vocabularies/sector-scheme>
-
-This PID will redirect to the raw `.ttl` file:
-
-- `https://khaosresearch.github.io/AgoraOWL/latest/vocabularies/sector-scheme.ttl`
-- `https://khaosresearch.github.io/AgoraOWL/0.0.1/vocabularies/agro-vocab.ttl`
-
-## 📦 Content Negotiation
-
-The `.htaccess` provides content negotiation based on the `Accept` header:
-
-- `text/html` → HTML documentation (e.g., `.../latest/index-en.html`)
-- `text/turtle` → Turtle file (e.g., `.../latest/ontology.ttl`)
-- `application/rdf+xml` → RDF/XML file (e.g., `.../latest/ontology.owl`)
-- `application/n-triples` → N-Triples file (e.g., `.../latest/ontology.nt`)
-- `application/ld+json` → JSON-LD file (e.g., `.../latest/ontology.jsonld`)
-- Default/Fallback → Turtle file (e.g., `.../latest/ontology.ttl`)
-
 ## 🧭 Scope
 
 **AgoraOWL** is an ontology aligned with **IDSA** and connected to **BIGOWL** (Data, Algorithms, Problems, Workflows).


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description
Fixes AgoraOWL redirects for term IRIs, vocabularies, and two new files
(context.jsonld, alignment.ttl) that currently 404. Existing URLs unaffected.


## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [ ] Maintainer details are in `.htaccess` or `README.md`.
- [ ] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
