### PR TITLE
Add Hungarian Water Ontology W3ID redirects

### DIFF
--- a/hungarian-water-ontology/.htaccess
+++ b/hungarian-water-ontology/.htaccess
@@ -1,0 +1,23 @@
+# Persistent identifiers for the Hungarian Water Ontology.
+# Project contact: https://github.com/hampg
+
+Options +FollowSymLinks
+RewriteEngine On
+
+# Human-facing project landing page.
+RewriteRule ^$ https://github.com/hampg/hungarian-water-ontology [R=302,L]
+
+# The mappings module is more specific than the core ontology.
+RewriteRule ^core/mappings(/.*)?$ https://raw.githubusercontent.com/hampg/hungarian-water-ontology/main/water_ontology_core/mappings/water-core-mappings.ttl [R=303,L]
+RewriteRule ^core(/.*)?$ https://raw.githubusercontent.com/hampg/hungarian-water-ontology/main/water_ontology_core/ontology/water-core.ttl [R=303,L]
+RewriteRule ^hydrometry(/.*)?$ https://raw.githubusercontent.com/hampg/hungarian-water-ontology/main/water_ontology_hydrometry/ontology/hydrometry-observation-profile.ttl [R=303,L]
+RewriteRule ^hydromet(/.*)?$ https://raw.githubusercontent.com/hampg/hungarian-water-ontology/main/water_ontology_hydromet/ontology/hydromet-profiles.ttl [R=303,L]
+RewriteRule ^governance(/.*)?$ https://raw.githubusercontent.com/hampg/hungarian-water-ontology/main/water_ontology_governance/ontology/water-governance-profiles.ttl [R=303,L]
+RewriteRule ^groundwater(/.*)?$ https://raw.githubusercontent.com/hampg/hungarian-water-ontology/main/water_ontology_groundwater/ontology/groundwater-profiles.ttl [R=303,L]
+RewriteRule ^inland(/.*)?$ https://raw.githubusercontent.com/hampg/hungarian-water-ontology/main/water_ontology_inland/ontology/inland-water-profiles.ttl [R=303,L]
+RewriteRule ^surface-flood(/.*)?$ https://raw.githubusercontent.com/hampg/hungarian-water-ontology/main/water_ontology_surface_flood/ontology/surface-flood-profiles.ttl [R=303,L]
+RewriteRule ^quality(/.*)?$ https://raw.githubusercontent.com/hampg/hungarian-water-ontology/main/water_ontology_quality/ontology/water-quality-profiles.ttl [R=303,L]
+RewriteRule ^utility(/.*)?$ https://raw.githubusercontent.com/hampg/hungarian-water-ontology/main/water_ontology_utility/ontology/water-utility-profiles.ttl [R=303,L]
+RewriteRule ^pilot(/.*)?$ https://raw.githubusercontent.com/hampg/hungarian-water-ontology/main/water_ontology_pilot/ontology/water-pilot-profile.ttl [R=303,L]
+RewriteRule ^legal-world-interface(/.*)?$ https://raw.githubusercontent.com/hampg/hungarian-water-ontology/main/water_ontology_interface/ontology/legal-world-interface.ttl [R=303,L]
+RewriteRule ^spatial-planning(/.*)?$ https://raw.githubusercontent.com/hampg/hungarian-water-ontology/main/spatial_planning_interface/ontology/spatial-planning-profiles.ttl [R=303,L]

--- a/hungarian-water-ontology/README.md
+++ b/hungarian-water-ontology/README.md
@@ -1,0 +1,17 @@
+# Hungarian Water Ontology W3ID namespace
+
+This directory maintains the persistent namespace:
+
+```text
+https://w3id.org/hungarian-water-ontology/
+```
+
+It redirects the ontology and individual IRIs to the public source repository:
+
+https://github.com/hampg/hungarian-water-ontology
+
+The current public release is `v1.0.0`. W3ID identifiers are persistent; the
+targets may be updated when the repository, documentation host or archival
+location changes.
+
+Contact and maintainer: https://github.com/hampg


### PR DESCRIPTION
Adds the persistent namespace `https://w3id.org/hungarian-water-ontology/` for the public Hungarian Water Ontology project. Redirects route module and entity IRIs to public Turtle resources in https://github.com/hampg/hungarian-water-ontology. Contact: https://github.com/hampg