### PR TITLE
fix(ontouml-models): align W3ID release, model, catalog, and FDP routes

### DIFF
--- a/ids/ontouml-models/.htaccess
+++ b/ids/ontouml-models/.htaccess
@@ -49,8 +49,8 @@ RedirectMatch 302 ^/ontouml-models/shape/(.+[^/])/?$ https://raw.githubuserconte
 ### Canonical model locations
 RedirectMatch 302 ^/ontouml-models/models/([^/]+)/?$ https://github.com/OntoUML/ontouml-models/tree/master/models/$1
 
-### Canonical model artifacts
-RedirectMatch 302 ^/ontouml-models/models/([^/]+)/(ontology\.ttl|ontology\.json|ontology\.vpp|metadata\.yaml|metadata\.ttl|metadata-json\.ttl|metadata-turtle\.ttl|metadata-vpp\.ttl|references\.bib)$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/$1/$2
+### Canonical model subtree
+RedirectMatch 302 ^/ontouml-models/models/([^/]+)/(.+)$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/$1/$2
 
 ### Legacy model-artifact aliases
 RedirectMatch 302 ^/ontouml-models/turtle/([^/]+)$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/$1/ontology.ttl

--- a/ids/ontouml-models/.htaccess
+++ b/ids/ontouml-models/.htaccess
@@ -18,9 +18,6 @@ RedirectMatch 302 ^/ontouml-models/vocabulary/home/?$     https://ontouml.github
 RedirectMatch 302 ^/ontouml-models/vocabulary/docs/?$     https://ontouml.github.io/ontouml-models-vocabulary
 
 ## Vocabulary
-RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
-RewriteCond %{HTTP_ACCEPT} text/\* [OR]
-RewriteCond %{HTTP_ACCEPT} \*/turtle
 RedirectMatch 302 ^/ontouml-models/vocabulary(/|#)?$      https://ontouml.github.io/ontouml-models-vocabulary/ontouml-catalog-metadata-vocabulary.ttl
 
 # CATALOG REDIRECTIONS -----------------------------------------------------------------------------------------------------------
@@ -33,12 +30,12 @@ RedirectMatch 302 ^/ontouml-models/git(/?)$ https://github.com/OntoUML/ontouml-m
 ### Dashboard
 RedirectMatch 302 ^/ontouml-models/dash(board)?(/?)$ https://ontouml-dashboard-995390128580.herokuapp.com/
 
-### Latest release
-RewriteRule ^release/?$ https://github.com/OntoUML/ontouml-models/releases/latest [R=302,L]
-
 ### Direct release Turtle assets
 RewriteRule ^release/latest\.ttl/?$ https://github.com/OntoUML/ontouml-models/releases/latest/download/ontouml-models-latest.ttl [R=302,L]
 RewriteRule ^release/([0-9]{8})\.ttl/?$ https://github.com/OntoUML/ontouml-models/releases/download/$1/ontouml-models-$1.ttl [R=302,L]
+
+### Latest release
+RewriteRule ^release/?$ https://github.com/OntoUML/ontouml-models/releases/latest [R=302,L]
 
 ### Specific release (tag)
 RewriteRule ^release/([0-9]{8})/?$ https://github.com/OntoUML/ontouml-models/releases/tag/$1 [R=302,L]

--- a/ids/ontouml-models/.htaccess
+++ b/ids/ontouml-models/.htaccess
@@ -34,10 +34,14 @@ RedirectMatch 302 ^/ontouml-models/git(/?)$ https://github.com/OntoUML/ontouml-m
 RedirectMatch 302 ^/ontouml-models/dash(board)?(/?)$ https://ontouml-dashboard-995390128580.herokuapp.com/
 
 ### Latest release
-RedirectMatch 302 ^/ontouml-models/release(/?)$ https://github.com/OntoUML/ontouml-models/releases/latest
+RewriteRule ^release/?$ https://github.com/OntoUML/ontouml-models/releases/latest [R=302,L]
+
+### Direct release Turtle assets
+RewriteRule ^release/latest\.ttl/?$ https://github.com/OntoUML/ontouml-models/releases/latest/download/ontouml-models-latest.ttl [R=302,L]
+RewriteRule ^release/([0-9]{8})\.ttl/?$ https://github.com/OntoUML/ontouml-models/releases/download/$1/ontouml-models-$1.ttl [R=302,L]
 
 ### Specific release (tag)
-RedirectMatch 302 ^/ontouml-models/release/(.*)$ https://github.com/OntoUML/ontouml-models/releases/tag/$1
+RewriteRule ^release/([0-9]{8})/?$ https://github.com/OntoUML/ontouml-models/releases/tag/$1 [R=302,L]
 
 ### Shape TTL files
 RedirectMatch 302 ^/ontouml-models/shape/(.+[^/])/?$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/shapes/$1-shape.ttl

--- a/ids/ontouml-models/.htaccess
+++ b/ids/ontouml-models/.htaccess
@@ -64,8 +64,11 @@ RewriteRule ^catalog/metadata\.ttl/?$ https://raw.githubusercontent.com/OntoUML/
 
 ## REDIRECTION TO METADATA STORAGE SERVICE (FAIR Data Point)
 
-### Catalog item page
-RedirectMatch 302 ^/ontouml-models/?$ https://scs-ontouml.eemcs.utwente.nl/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8
+### Catalog landing page
+RedirectMatch 302 ^/ontouml-models/?$ https://github.com/OntoUML/ontouml-models
+
+### Legacy FAIR Data Point
+RedirectMatch 302 ^/ontouml-models/fdp/?$ https://scs-ontouml.eemcs.utwente.nl/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8
 
 ### Explicit semantic FDP routes
 RedirectMatch 302 ^/ontouml-models/catalog/(.+)/?$ https://scs-ontouml.eemcs.utwente.nl/catalog/$1

--- a/ids/ontouml-models/.htaccess
+++ b/ids/ontouml-models/.htaccess
@@ -67,5 +67,7 @@ RewriteRule ^catalog/metadata\.ttl/?$ https://raw.githubusercontent.com/OntoUML/
 ### Catalog item page
 RedirectMatch 302 ^/ontouml-models/?$ https://scs-ontouml.eemcs.utwente.nl/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8
 
-### Generic item page
-RedirectMatch 302 ^/ontouml-models/(.+)/?$ https://scs-ontouml.eemcs.utwente.nl/$1
+### Explicit semantic FDP routes
+RedirectMatch 302 ^/ontouml-models/catalog/(.+)/?$ https://scs-ontouml.eemcs.utwente.nl/catalog/$1
+RedirectMatch 302 ^/ontouml-models/model/(.+)/?$ https://scs-ontouml.eemcs.utwente.nl/model/$1
+RedirectMatch 302 ^/ontouml-models/distribution/(.+)/?$ https://scs-ontouml.eemcs.utwente.nl/distribution/$1

--- a/ids/ontouml-models/.htaccess
+++ b/ids/ontouml-models/.htaccess
@@ -53,9 +53,9 @@ RedirectMatch 302 ^/ontouml-models/models/([^/]+)/?$ https://github.com/OntoUML/
 RedirectMatch 302 ^/ontouml-models/models/([^/]+)/(.+)$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/$1/$2
 
 ### Legacy model-artifact aliases
-RedirectMatch 302 ^/ontouml-models/turtle/([^/]+)$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/$1/ontology.ttl
-RedirectMatch 302 ^/ontouml-models/json/([^/]+)$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/$1/ontology.json
-RedirectMatch 302 ^/ontouml-models/vpp/([^/]+)$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/$1/ontology.vpp
+RedirectMatch 302 ^/ontouml-models/turtle/([^/]+)/?$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/$1/ontology.ttl
+RedirectMatch 302 ^/ontouml-models/json/([^/]+)/?$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/$1/ontology.json
+RedirectMatch 302 ^/ontouml-models/vpp/([^/]+)/?$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/$1/ontology.vpp
 
 ### Direct catalog files
 RewriteRule ^catalog/metadata\.yaml/?$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/catalog.yaml [R=302,L]

--- a/ids/ontouml-models/.htaccess
+++ b/ids/ontouml-models/.htaccess
@@ -57,6 +57,10 @@ RedirectMatch 302 ^/ontouml-models/turtle/([^/]+)$ https://raw.githubusercontent
 RedirectMatch 302 ^/ontouml-models/json/([^/]+)$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/$1/ontology.json
 RedirectMatch 302 ^/ontouml-models/vpp/([^/]+)$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/$1/ontology.vpp
 
+### Direct catalog files
+RewriteRule ^catalog/metadata\.yaml/?$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/catalog.yaml [R=302,L]
+RewriteRule ^catalog/metadata\.ttl/?$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/catalog.ttl [R=302,L]
+
 
 ## REDIRECTION TO METADATA STORAGE SERVICE (FAIR Data Point)
 

--- a/ids/ontouml-models/.htaccess
+++ b/ids/ontouml-models/.htaccess
@@ -46,6 +46,17 @@ RewriteRule ^release/([0-9]{8})/?$ https://github.com/OntoUML/ontouml-models/rel
 ### Shape TTL files
 RedirectMatch 302 ^/ontouml-models/shape/(.+[^/])/?$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/shapes/$1-shape.ttl
 
+### Canonical model locations
+RedirectMatch 302 ^/ontouml-models/models/([^/]+)/?$ https://github.com/OntoUML/ontouml-models/tree/master/models/$1
+
+### Canonical model artifacts
+RedirectMatch 302 ^/ontouml-models/models/([^/]+)/(ontology\.ttl|ontology\.json|ontology\.vpp|metadata\.yaml|metadata\.ttl|metadata-json\.ttl|metadata-turtle\.ttl|metadata-vpp\.ttl|references\.bib)$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/$1/$2
+
+### Legacy model-artifact aliases
+RedirectMatch 302 ^/ontouml-models/turtle/([^/]+)$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/$1/ontology.ttl
+RedirectMatch 302 ^/ontouml-models/json/([^/]+)$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/$1/ontology.json
+RedirectMatch 302 ^/ontouml-models/vpp/([^/]+)$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/$1/ontology.vpp
+
 
 ## REDIRECTION TO METADATA STORAGE SERVICE (FAIR Data Point)
 

--- a/ids/ontouml-models/.htaccess
+++ b/ids/ontouml-models/.htaccess
@@ -8,10 +8,13 @@ AddType text/turtle .ttl
 RedirectMatch 302 ^/ontouml-models/vocabulary/git/?$      https://github.com/OntoUML/ontouml-models-vocabulary/
 
 ## Versioning
-### Specific version
-RedirectMatch 302 ^/ontouml-models/vocabulary/v([^/]+)/?$ https://github.com/OntoUML/ontouml-models-vocabulary/releases/tag/v$1
-### Latest version
-RedirectMatch 302 ^/ontouml-models/vocabulary/latest/?$   https://github.com/OntoUML/ontouml-models-vocabulary/releases/latest
+
+### Specific release tags
+RedirectMatch 302 ^/ontouml-models/vocabulary/release/v([0-9]+\.[0-9]+\.[0-9]+)/?$ https://github.com/OntoUML/ontouml-models-vocabulary/releases/tag/v$1
+RedirectMatch 302 ^/ontouml-models/vocabulary/v([0-9]+\.[0-9]+\.[0-9]+)/?$          https://github.com/OntoUML/ontouml-models-vocabulary/releases/tag/v$1
+
+### Latest release
+RedirectMatch 302 ^/ontouml-models/vocabulary/latest/?$ https://github.com/OntoUML/ontouml-models-vocabulary/releases/latest
 
 ## Documentation
 RedirectMatch 302 ^/ontouml-models/vocabulary/home/?$     https://ontouml.github.io/ontouml-models-vocabulary
@@ -47,7 +50,7 @@ RedirectMatch 302 ^/ontouml-models/shape/(.+[^/])/?$ https://raw.githubuserconte
 RedirectMatch 302 ^/ontouml-models/models/([^/]+)/?$ https://github.com/OntoUML/ontouml-models/tree/master/models/$1
 
 ### Canonical model subtree
-RedirectMatch 302 ^/ontouml-models/models/([^/]+)/(.+)$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/$1/$2
+RedirectMatch 302 ^/ontouml-models/models/([^/]+)/(.+?)/?$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/$1/$2
 
 ### Legacy model-artifact aliases
 RedirectMatch 302 ^/ontouml-models/turtle/([^/]+)/?$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/$1/ontology.ttl
@@ -55,8 +58,8 @@ RedirectMatch 302 ^/ontouml-models/json/([^/]+)/?$ https://raw.githubusercontent
 RedirectMatch 302 ^/ontouml-models/vpp/([^/]+)/?$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/$1/ontology.vpp
 
 ### Direct catalog files
-RewriteRule ^catalog/metadata\.yaml/?$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/catalog.yaml [R=302,L]
-RewriteRule ^catalog/metadata\.ttl/?$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/catalog.ttl [R=302,L]
+RedirectMatch 302 ^/ontouml-models/catalog/metadata\.yaml/?$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/catalog.yaml
+RedirectMatch 302 ^/ontouml-models/catalog/metadata\.ttl/?$ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/catalog.ttl
 
 
 ## REDIRECTION TO METADATA STORAGE SERVICE (FAIR Data Point)


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description

Update `ids/ontouml-models/.htaccess` to align the OntoUML Models W3ID identifiers with the repository’s vocabulary, release, model, catalog, legacy artifact, and FAIR Data Point routes.

The changes add generic SemVer vocabulary-release redirects, direct catalog-release asset redirects, canonical model routes, legacy model-artifact aliases, exact catalog metadata routes, and explicit FDP routes. They also remove overly broad forwarding rules, correct trailing-slash handling, and preserve HTTP 302 behavior.

No content files or full documentation are added or served by this PR.

Static route and regular-expression validation was performed. Apache runtime validation was not available in the validation environment.

## General Checklist

- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## Update ID Directory Checklist

- [x] GitHub username ids are listed in the changed maintainer details. No maintainer details are changed by this PR.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers

- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.

> Before submitting, please squash the current branch history if required and verify the maintainer-authorization requirement above.