### PR TITLE
Add vvprov: verification and validation provenance profile for CodeMeta

### DIFF
--- a/ids/vvprov/.htaccess
+++ b/ids/vvprov/.htaccess
@@ -1,0 +1,22 @@
+# # /vvprov/
+#
+# vvprov — verification and validation provenance profile for CodeMeta.
+# Namespace IRI: https://w3id.org/vvprov/terms#
+#
+# https://w3id.org/vvprov/               redirects to https://anatodu.github.io/vvprov/
+# https://w3id.org/vvprov/terms          redirects to https://anatodu.github.io/vvprov/terms/
+# https://w3id.org/vvprov/context.jsonld redirects to https://anatodu.github.io/vvprov/context.jsonld
+#
+# Repository: https://github.com/AnatoDu/vvprov
+#
+# ## Contact
+# This space is administered by:
+#
+# Anatoliy A. Durkin, Pitirim Sorokin Syktyvkar State University
+# durkinaa@syktsu.ru
+# GitHub username: AnatoDu
+
+RewriteEngine on
+RewriteRule ^terms/?$          https://anatodu.github.io/vvprov/terms/         [R=302,L]
+RewriteRule ^context\.jsonld$  https://anatodu.github.io/vvprov/context.jsonld [R=302,L]
+RewriteRule ^$                 https://anatodu.github.io/vvprov/               [R=302,L]

--- a/ids/vvprov/README.md
+++ b/ids/vvprov/README.md
@@ -12,4 +12,4 @@ of research software).
 
 Repository: https://github.com/AnatoDu/vvprov
 
-Maintainer: Anatoliy A. Durkin, Pitirim Sorokin Syktyvkar State University — durkinaa@syktsu.ru
+Maintainer: Anatoliy A. Durkin, Pitirim Sorokin Syktyvkar State University — durkinaa@syktsu.ru, GitHub: @AnatoDu

--- a/ids/vvprov/README.md
+++ b/ids/vvprov/README.md
@@ -1,0 +1,15 @@
+# vvprov
+
+Permanent identifiers for **vvprov**, a verification and validation provenance
+profile for CodeMeta (machine-readable verification records in `codemeta.json`
+of research software).
+
+| Identifier | Resolves to |
+|---|---|
+| https://w3id.org/vvprov/ | project page |
+| https://w3id.org/vvprov/terms | term definitions; fragments name the terms, e.g. `…/terms#status` |
+| https://w3id.org/vvprov/context.jsonld | JSON-LD context |
+
+Repository: https://github.com/AnatoDu/vvprov
+
+Maintainer: Anatoliy A. Durkin, Pitirim Sorokin Syktyvkar State University — durkinaa@syktsu.ru


### PR DESCRIPTION
## Brief Description
Add a new ID directory `ids/vvprov/` for **vvprov**, a verification and validation provenance profile for CodeMeta (machine-readable verification records in `codemeta.json` of research software). Three redirects: the project page, the term definitions (`/terms`, fragments name the terms) and the JSON-LD context (`/context.jsonld`), all pointing to GitHub Pages of https://github.com/AnatoDu/vvprov. Maintainer contact and GitHub username are in the `.htaccess` comment and in `README.md`.

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
