### PR TITLE
Add Martialis id

### DIFF
--- a/ids/martialis/.htaccess
+++ b/ids/martialis/.htaccess
@@ -1,0 +1,25 @@
+# Martialis — martial arts lineage ontology and SKOS vocabularies
+# https://github.com/Martial-IS/martialis-db
+#
+# Covers the ontology (https://w3id.org/martialis/ontology, including its
+# #fragment terms and the /ontology/shapes SHACL namespace) and the SKOS
+# controlled vocabularies (https://w3id.org/martialis/vocab/...). Entity
+# data (https://martial.is/entity/..., /agent/...) is not part of this
+# registration and is not covered here.
+#
+# The target, martial.is, already performs content negotiation
+# (Turtle, JSON-LD, HTML) at every path below, so this is a plain
+# path-preserving redirect rather than per-format rules.
+#
+# Contact:
+#
+# This space is administered by:
+#
+# Frederico Muñoz
+# GitHub username: fsmunoz
+
+RewriteEngine on
+
+RewriteRule ^ontology(/.*)?$ https://martial.is/ontology$1 [R=302,L]
+RewriteRule ^vocab(/.*)?$    https://martial.is/vocab$1    [R=302,L]
+RewriteRule ^$               https://martial.is/           [R=302,L]

--- a/ids/martialis/README.md
+++ b/ids/martialis/README.md
@@ -1,0 +1,30 @@
+# Martialis
+
+Permanent identifiers for the Martialis martial arts lineage ontology
+and its SKOS controlled vocabularies.
+
+## Redirects
+
+The following endpoints are included, all 302 (we are pointing to the
+ontology/vocab/shapes):
+
+- `https://w3id.org/martialis/ontology`: ontology (OWL/Turtle), also
+  the base for its `#fragment` class and property terms.
+- `https://w3id.org/martialis/ontology/shapes`: SHACL shapes namespace
+  (`#fragment` terms), separate from the ontology's own so that a bare
+  dereference lands on the page that documents it.
+- `https://w3id.org/martialis/vocab`: merged SKOS vocabulary index,
+  and `https://w3id.org/martialis/vocab/<scheme>[/<concept>]` for an
+  individual concept scheme or concept.
+- `https://w3id.org/martialis/` redirects to the homepage.
+
+All three redirect with path preserved to the same paths on
+`martial.is`, which already performs content negotiation there
+(Turtle, JSON-LD, RDF/XML, HTML, ...). Entity data
+(`https://martial.is/entity/<ULID>`, `/agent/<ULID>`) remains on
+`martial.is` and is not part of this registration.
+
+## Maintainer
+
+Frederico Muñoz (https://github.com/fsmunoz), Martialis Project
+Homepage: https://martial.is


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description

Adds a new id for Martialis, an ontology for martial arts knowledge transmission. 

It covers the ontology, shapes, and vocabulary endpoints, which are being served by the server (JSON-LD, Turtle).

<!-- Brief description of the purpose of this PR. -->

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
<!-- For new ID PRs. -->
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.
