### PR TITLE
Add SHAR Production Metadata MCP identifier

### DIFF
--- a/ids/shar-production/.htaccess
+++ b/ids/shar-production/.htaccess
@@ -1,0 +1,10 @@
+# /shar-production/
+#
+# Permanent identifier namespace for public SHAR Production technical artifacts.
+# https://w3id.org/shar-production/production-metadata-mcp redirects to
+# https://github.com/SHARProduction/production-metadata-mcp
+#
+# Contact: SHAR Production <shar@sharprod.com>
+
+RewriteEngine on
+RewriteRule ^production-metadata-mcp/?$ https://github.com/SHARProduction/production-metadata-mcp [R=302,L]

--- a/ids/shar-production/README.md
+++ b/ids/shar-production/README.md
@@ -1,0 +1,9 @@
+# SHAR Production W3ID identifiers
+
+This namespace provides a stable identifier for the public SHAR Production Metadata MCP source.
+
+- Identifier: `https://w3id.org/shar-production/production-metadata-mcp`
+- Destination: `https://github.com/SHARProduction/production-metadata-mcp`
+- Maintainer: SHAR Production — <shar@sharprod.com>
+
+The referenced project is a read-only local MCP tool for validating production-manifest fields and flagging unknown rights status before AI-hybrid video delivery.


### PR DESCRIPTION
Adds a focused SHAR Production namespace with one permanent identifier for the public read-only Metadata MCP source.`n`nRedirect:`n- https://w3id.org/shar-production/production-metadata-mcp`n- https://github.com/SHARProduction/production-metadata-mcp`n`nThe README includes SHAR Production contact information and project context. No generated files or unrelated changes.