### PR TITLE
Fix /PaN/NeXus/definitions/latest 404 (follow-up to #6625)

### DIFF
--- a/ids/PaN/NeXus/.htaccess
+++ b/ids/PaN/NeXus/.htaccess
@@ -3,8 +3,8 @@ RewriteEngine On
 
 ## REDIRECTIONS SUPPORTING THE LATEST RELEASE
 
-# /definitions/latest behaves like bare /definitions (internal rewrite).
-RewriteRule ^definitions/latest/?$ definitions [L]
+# /definitions/latest[/...] behaves like bare /definitions[/...] (internal rewrite).
+RewriteRule ^definitions/latest(/.*)?$ /PaN/NeXus/definitions$1 [L]
 
 # Download artefacts
 RewriteRule ^definitions/NeXusOntology\.owl$    https://fairmat-nfdi.github.io/NeXusOntology/latest/NeXusOntology_full.owl [R=307,L]


### PR DESCRIPTION
## Brief Description
<!--Follow-up to #6625. The `/PaN/NeXus/definitions/latest`  added in that PR
returns 404. The internal-rewrite target was a bare relative path (`definitions`), which resolves as a missing file instead of re-entering the rewrite ruleset. So none of the 'definitions' rules below it apply.-->

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal.
- [x] Commits only include redirects and basic information. 
