### PR TITLE
Add PCNN (post covid netwerk nederland) study variable vocabulary

### DIFF
--- a/ids/pcnn/.htaccess
+++ b/ids/pcnn/.htaccess
@@ -1,0 +1,11 @@
+# PCNN variable vocabulary
+# Maintainer: Hajar Hasannejadasl (https://orcid.org/0000-0001-5262-7399)
+# GitHub: hajarhn
+
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine On
+
+# Whole prefix → GitHub Pages catalogue.
+# /var/{name} is claimed with this prefix; per-item pages can be added later.
+RewriteRule ^(.*)$ https://hajarhn.github.io/PCNN-vars/ [R=302,L]

--- a/ids/pcnn/README.md
+++ b/ids/pcnn/README.md
@@ -1,0 +1,13 @@
+# PCNN
+
+Permanent identifiers for the PCNN post-COVID study variable vocabulary.
+
+- `https://w3id.org/pcnn` → catalogue
+- `https://w3id.org/pcnn/var/{variable_name_CBS}` → reserved for each codebook column
+
+Maintainer: Hajar Hasannejadasl  
+ORCID: https://orcid.org/0000-0001-5262-7399  
+GitHub: @hajarhn  
+Contact: use GitHub issues on hajarhn/PCNN-vars
+
+Target: https://hajarhn.github.io/PCNN-vars/


### PR DESCRIPTION
Register the pcnn prefix for the PCNN study variable vocabulary.

https://w3id.org/pcnn redirects to https://hajarhn.github.io/PCNN-vars/

Maintainer: Hajar Hasannejadasl, ORCID 0000-0001-5262-7399, GitHub @hajarhn