### PR TITLE
Support RIPE-KG versions and SPARQL POST requests

### DIFF
--- a/ripe/.htaccess
+++ b/ripe/.htaccess
@@ -2,6 +2,8 @@ Options -MultiViews
 
 Header always set Access-Control-Allow-Origin "*"
 Header always set Vary "Accept"
+Header always set Access-Control-Allow-Methods "GET, HEAD, POST, OPTIONS"
+Header always set Access-Control-Allow-Headers "Accept, Content-Type"
 
 AddType application/rdf+xml .owl
 AddType text/turtle .ttl
@@ -31,6 +33,15 @@ RewriteRule ^ripe-o(/1\.0\.0)?/?$ https://ripe-observatory.github.io/RIPE-O/rele
 RewriteRule ^ripe-o(/1\.0\.0)?/?$ https://ripe-observatory.github.io/RIPE-O/release/1.0.0/index-en.html [R=303,L]
 
 # RIPE Knowledge Graph and INSPECT-AI software
+RewriteCond %{REQUEST_METHOD} =OPTIONS
+RewriteRule ^ripe-kg(?:/.*)?$ - [R=204,L]
+
+RewriteRule ^ripe-kg/([0-9]+\.[0-9]+\.[0-9]+)/api/(sparql|health)/?$ https://ripe-kg.inspectai.app/$1/api/$2 [R=307,NE,L]
+RewriteRule ^ripe-kg/api/(sparql|health)/?$ https://ripe-kg.inspectai.app/api/$1 [R=307,NE,L]
+RewriteRule ^ripe-kg/([0-9]+\.[0-9]+\.[0-9]+)/?$ https://ripe-kg.inspectai.app/$1 [R=303,NE,L]
+
+RewriteRule ^ripe-kg/([0-9]+\.[0-9]+\.[0-9]+)/(.+)$ https://ripe-kg.inspectai.app/$1/ripe-kg/$2 [R=303,NE,L]
+
 RewriteRule ^ripe-kg/?$ https://ripe-kg.inspectai.app/ [R=303,L]
 RewriteRule ^ripe-kg/(.+)$ https://ripe-kg.inspectai.app/ripe-kg/$1 [R=303,NE,L]
 RewriteRule ^inspect-ai/?$ https://github.com/RIPE-Observatory/INSPECT-AI_open_source [R=303,L]

--- a/ripe/README.md
+++ b/ripe/README.md
@@ -9,6 +9,9 @@ This W3ID provides persistent identifiers for the Research Integrity Provenance 
 - `https://w3id.org/ripe/ripe-o/1.0.0` identifies version 1.0.0 of the RIPE ontology document.
 - `https://w3id.org/ripe/ripe-kg` redirects to the RIPE Knowledge Graph interface.
 - `https://w3id.org/ripe/ripe-kg/...` redirects to RIPE Knowledge Graph resources.
+- `https://w3id.org/ripe/ripe-kg/1.0.0` and `/1.1.0` identify dataset versions and redirect to `https://ripe-kg.inspectai.app/1.0.0` and `/1.1.0`.
+- Append `/api/sparql` to query a version. API redirects preserve POST requests.
+- Stable RDF entity identifiers and RIPE-O version identifiers remain unchanged.
 - `https://w3id.org/ripe/inspect-ai` redirects to the INSPECT-AI open-source repository.
 
 ## Maintainers


### PR DESCRIPTION
RIPE-KG now serves versions 1.0.0 and 1.1.0 at explicit URLs. Add their dataset and resource redirects, preserve SPARQL POST bodies with 307, and answer browser preflight requests with 204 and CORS headers.

Validated the rules with Apache 2.4, including a POST followed through to the public API (ASK returned true), versioned resource destinations, and OPTIONS headers. Stable entity identifiers and existing RIPE-O routes are unchanged.

Encoded slashes remain an upstream dependency: `/ripe/ripe-kg/work/10.1055%2Fs-0043-119221` is rejected before these rules run. This is the existing infrastructure issue #2934; `AllowEncodedSlashes NoDecode` requires server/virtual-host configuration and cannot be set in this namespace's `.htaccess`. The application resolves the published identifier correctly; this PR does not rewrite the RDF identifiers or claim to fix that server-level rejection.
