### PR TITLE
shapetrees - redirect to gh pages

### DIFF
--- a/ids/shapetrees/.htaccess
+++ b/ids/shapetrees/.htaccess
@@ -1,8 +1,11 @@
 # shapetrees
 #
-# https://w3id.org/shapetrees redirects to
-# https://raw.githubusercontent.com/shapetrees/specification/refs/heads/main/shapetrees.ttl
+# https://w3id.org/shapetrees -> https://shapetrees.github.io/
+# https://w3id.org/shapetrees/specification -> https://shapetrees.github.io/specification/
+# https://w3id.org/shapetrees/primer -> https://shapetrees.github.io/primer/
 
 RewriteEngine on
-RewriteRule ^$ https://raw.githubusercontent.com/shapetrees/specification/refs/heads/main/shapetrees.ttl [R=302,L]
-RewriteRule ^(.+)$ https://raw.githubusercontent.com/shapetrees/specification/refs/heads/main/shapetrees.ttl [R=302,L]
+
+RewriteRule ^$ https://shapetrees.github.io/ [R=302,L]
+RewriteRule ^specification/?$ https://shapetrees.github.io/specification/ [R=302,L]
+RewriteRule ^primer/?$ https://shapetrees.github.io/primer/ [R=302,L]


### PR DESCRIPTION
Followup after
* #6461 

ShapeTrees only needs permalinks for the homepage, spec and primer. Vocab has always been on W3C namespace.