### PR TITLE
Add /ageayurveda/ namespace

### DIFF
--- a/ids/ageayurveda/.htaccess
+++ b/ids/ageayurveda/.htaccess
@@ -1,0 +1,28 @@
+# # /ageayurveda/
+#
+# Permanent identifiers for Age Ayurveda's openly licensed reference works.
+#
+# https://w3id.org/ageayurveda/nighantu
+#   redirects to the Age Ayurveda Nighantu, a referenced encyclopedia of Ayurvedic
+#   materia medica (779 pages, CC BY 4.0). Sub-paths are preserved, so
+#   https://w3id.org/ageayurveda/nighantu/herb/ashwagandha/ resolves to that monograph.
+#
+# The target is currently a GitHub Pages address and will move to a subdomain of
+# ageayurveda.com. That is precisely why a permanent identifier is wanted: citations
+# made against w3id.org survive the move.
+#
+# ## Contact
+# This space is administered by:
+#
+# Age Ayurveda
+# Email: contact@ageayurveda.com
+# GitHub username: Jairaj1234-dancer
+
+RewriteEngine on
+
+# Project: the Nighantu, with sub-paths preserved.
+RewriteRule ^nighantu/?$ https://jairaj1234-dancer.github.io/nighantu/ [R=302,L]
+RewriteRule ^nighantu/(.*)$ https://jairaj1234-dancer.github.io/nighantu/$1 [R=302,L]
+
+# Anything else under this namespace goes to the organisation's site.
+RewriteRule ^$ https://ageayurveda.com/ [R=302,L]

--- a/ids/ageayurveda/README.md
+++ b/ids/ageayurveda/README.md
@@ -1,0 +1,37 @@
+# Age Ayurveda
+
+Permanent identifiers for openly licensed reference works published by Age Ayurveda
+(Nitya Naturals Pvt Ltd, Prayagraj, India).
+
+## Identifiers
+
+| Identifier | Resolves to | What it is |
+| --- | --- | --- |
+| `https://w3id.org/ageayurveda/nighantu` | https://jairaj1234-dancer.github.io/nighantu/ | The Age Ayurveda Nighantu |
+| `https://w3id.org/ageayurveda/nighantu/<path>` | the same path on that site | Any individual entry |
+
+## About the Nighantu
+
+A *nighantu* is the classical Ayurvedic lexicon of medicinal substances. This is a modern
+one: 779 pages covering single herbs, classical formulations and traditional instruments,
+each with a definitional summary, structured identification and pharmacology, classical
+text references, and published research cited by PubMed identifier and DOI. It also
+publishes a cross-referenced index of 2,210 papers.
+
+Content is licensed [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/); the source
+code is MIT. Provenance, including what the work derives from and its known limitations,
+is stated at
+https://github.com/Jairaj1234-dancer/nighantu/blob/main/PROVENANCE.md
+
+The repository is archived by Software Heritage:
+`swh:1:snp:e844fab74cc615fd98733fa08c781feb61adb05e`
+
+## Why a permanent identifier
+
+The site is presently hosted at a GitHub Pages address and will move to a subdomain of
+ageayurveda.com. Citations already made against a w3id.org identifier will continue to
+resolve after that move, which is the whole reason for requesting one.
+
+## Contact
+
+Age Ayurveda · contact@ageayurveda.com · GitHub: Jairaj1234-dancer


### PR DESCRIPTION
Requesting `https://w3id.org/ageayurveda/` for openly licensed reference works published by Age Ayurveda (Nitya Naturals Pvt Ltd, Prayagraj, India).

Following the naming policy's stated practice of claiming a top-level directory and adding project-specific second-level identifiers, rather than claiming a generic term. The first project under it is `ageayurveda/nighantu`.

**What it resolves to**

`https://w3id.org/ageayurveda/nighantu` and any sub-path resolve to the Age Ayurveda Nighantu: a 779-page referenced encyclopedia of Ayurvedic materia medica, covering single herbs, classical formulations and traditional instruments. Each entry carries a definitional summary, structured identification and pharmacology, classical text references, and published research cited by PubMed identifier and DOI. It also publishes a cross-referenced index of 2,210 papers with JSON and CSV downloads.

Content is CC BY 4.0, code is MIT, and provenance is stated openly, including what the work derives from and where it is weakest.

**Why a permanent identifier is wanted**

The site is currently at a GitHub Pages address and will move to a subdomain of ageayurveda.com. Citations made against a w3id.org identifier will survive that move, which is exactly the case this service exists for. The redirect target will be updated by a follow-up PR once the move happens.

**Files added**

- `ids/ageayurveda/.htaccess` — 302 redirects, sub-paths preserved
- `ids/ageayurveda/README.md` — identifier table and contact details

The repository is also archived by Software Heritage: `swh:1:snp:e844fab74cc615fd98733fa08c781feb61adb05e`

Contact: contact@ageayurveda.com