### PR TITLE
Add gto: persistent identifiers for GoTriple resources

### DIFF
--- a/ids/gto/.htaccess
+++ b/ids/gto/.htaccess
@@ -1,0 +1,44 @@
+# # /gto/
+#
+# GoTriple — persistent identifiers for the resources published by the GoTriple
+# discovery platform (https://www.gotriple.eu), the discovery service for the
+# social sciences and humanities built by the TRIPLE project.
+#
+#     https://w3id.org/gto/{type}/{reference}
+#
+# {type} is the entity type spelled out (document, dataset, media-object,
+# semantic-artefact, project, profile). {reference} is the ARK name of the
+# resource without its NAAN, so the w3id IRI and the ARK of the same resource
+# share their last segment by construction.
+#
+# Scope: resources only. The TRIPLE ontology is a separate namespace on purpose
+# (https://gotriple.eu/ontology/triple) and is not served from here.
+# Naming rules:
+# https://github.com/atrium-research/triple-ontology/blob/main/URI-CONVENTIONS.md
+#
+# ## Contact
+# This space is administered by:
+#
+# Alessandro Bertozzi
+# GitHub username: AlessandroBertozzi
+
+# "always": every response here is a redirect, and a CORS check applies to each
+# hop of the chain — the default (2xx only) would never fire.
+Header always set Access-Control-Allow-Origin "*"
+Options +FollowSymLinks
+RewriteEngine on
+
+# The prefix root is not a resource: send a human to the knowledge graph itself.
+RewriteRule ^$ https://kg.gotriple.eu/ [R=302,L]
+
+# Every resource is forwarded to its complete ARK on the GoTriple knowledge
+# graph, path and Accept header untouched: the {type} segment is dropped,
+# because the ARK name is already unique inside NAAN 64989 and identifies the
+# resource on its own.
+#
+#     /gto/document/x54g7  ->  https://kg.gotriple.eu/ark:64989/x54g7
+#
+# The host and the NAAN below are deployment facts, not naming decisions:
+# updating them is a routine pull request here, while the w3id IRIs above never
+# move. That indirection is the reason this space exists.
+RewriteRule ^[^/]+/(.+)$ https://kg.gotriple.eu/ark:64989/$1 [R=302,L]

--- a/ids/gto/README.md
+++ b/ids/gto/README.md
@@ -1,0 +1,60 @@
+# /gto/
+
+Persistent identifiers for the resources published by
+[GoTriple](https://www.gotriple.eu), the discovery platform for the social
+sciences and humanities built by the [TRIPLE](https://project.gotriple.eu)
+project.
+
+    https://w3id.org/gto/{type}/{reference}
+
+| segment | value |
+|---|---|
+| `{type}` | the entity type spelled out: `document`, `dataset`, `media-object`, `semantic-artefact`, `project`, `profile` |
+| `{reference}` | the ARK name of the resource, without its NAAN |
+
+`{reference}` is deliberately the same string as the last segment of the
+resource's ARK, so `<https://w3id.org/gto/document/x54g7>` and
+`ark:64989/x54g7` denote the same resource by construction rather than by a
+lookup table.
+
+## Resolution
+
+This space holds a single rule: every request is forwarded with a `302` to the
+resource's **complete ARK** on the GoTriple knowledge graph, path and `Accept` header
+untouched.
+
+    https://w3id.org/gto/document/x54g7
+      302 -> https://kg.gotriple.eu/ark:64989/x54g7
+
+The `{type}` segment is not carried over: the ARK name is already unique inside
+NAAN `64989`, so it identifies the resource on its own. Content negotiation
+(HTML for people, RDF for machines) and the `404` of an unknown name are decided
+by the knowledge graph, not here.
+
+The target and the NAAN are deployment facts rather than naming decisions, and
+changing them is a routine pull request against this repository; the
+`w3id.org/gto/…` IRIs themselves never move, which is the point of this
+indirection.
+
+The prefix root, `https://w3id.org/gto/`, is not a resource: it redirects to
+<https://kg.gotriple.eu>, the knowledge graph these identifiers belong to. The
+rules that govern the space are the
+[URI conventions](https://github.com/atrium-research/triple-ontology/blob/main/URI-CONVENTIONS.md)
+of the TRIPLE ontology.
+
+## Not in this space
+
+The TRIPLE ontology is a **different namespace on purpose**: terms
+(`triple:Document`, `triple:hasContentType`) live at
+`https://gotriple.eu/ontology/triple/` and are versioned with the ontology,
+while resource IRIs are minted continuously and must survive independently of
+any ontology release. The ontology is documented at
+<https://github.com/atrium-research/triple-ontology> and is not served from
+here.
+
+## Contact
+
+This space is administered by:
+
+Alessandro Bertozzi — GitHub username:
+[AlessandroBertozzi](https://github.com/AlessandroBertozzi)


### PR DESCRIPTION
## Brief Description

New top-level identifier `gto` for the resources published by
[GoTriple](https://www.gotriple.eu), the discovery platform for the social
sciences and humanities built by the TRIPLE project.

    https://w3id.org/gto/{type}/{reference}

`{type}` is the entity type spelled out (`document`, `dataset`, `media-object`,
`semantic-artefact`, `project`, `profile`); `{reference}` is the ARK name of the
resource, without its NAAN, so the w3id IRI and the ARK of the same resource
share their last segment by construction.

Two redirects only:

| request | code | target |
|---|---|---|
| `/gto/` | 302 | `https://kg.gotriple.eu/` |
| `/gto/{type}/{reference}` | 302 | `https://kg.gotriple.eu/ark:64989/{reference}` |

Resources resolve to their complete ARK (NAAN 64989) on the GoTriple knowledge
graph. Content negotiation and the 404 of an unknown name are that server's
responsibility, not this layer's. The `{type}` segment is not carried over: ARK
names are unique inside the NAAN. Nothing about the entity types is encoded in
the `.htaccess`, so this space will not need another pull request here when a
type is added. The target host and the NAAN are deployment facts rather than
naming decisions; the `w3id.org/gto/…` IRIs themselves never move, which is why
they are minted here.

Out of scope on purpose: the TRIPLE ontology is a different namespace
(`https://gotriple.eu/ontology/triple/`), documented at
https://github.com/atrium-research/triple-ontology, and is not served from this
space.

Maintainer: Alessandro Bertozzi, GitHub username `AlessandroBertozzi`.

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.
