### PR TITLE
Added redirection for PIIRRITE

### DIFF
--- a/ids/piirrite/.htaccess
+++ b/ids/piirrite/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine On
+RewriteBase /piirrite/
+RewriteRule ^core$ https://aiicante2.github.io/PIIRRITE-ontology/Documentation/index-en.html [R=302,L]

--- a/ids/piirrite/README.md
+++ b/ids/piirrite/README.md
@@ -1,0 +1,42 @@
+\# piirrite / PIIRRITE
+
+
+
+Permanent identifier for \*\*PIIRRITE\*\*, an ontology for inclusive itinerary and user requirements modeling.
+
+
+
+\- Identifier: https://w3id.org/piirrite/core
+
+\- Current version: \[1.0.0]
+
+\- Source repository: https://github.com/AIicante2/PIIRRITE-ontology
+
+\- Public documentation: https://aiicante2.github.io/PIIRRITE-ontology/Documentation/index-en.html
+
+
+
+Content negotiation on the ontology IRI redirects to GitHub Pages:
+
+
+
+| Accept | Target |
+
+| --- | --- |
+
+| `text/html` (and typical browsers) | `index-en.html` |
+
+| default (no `Accept`) | `index-en.html` |
+
+
+
+This identifier is not active until the pull request is merged by the w3id.org maintainers.
+
+
+
+\## Maintainer
+
+
+
+Salomon VAN GINNEKEN, salomon.van-ginneken@univ-lyon2.fr, https://github.com/AIicante2
+


### PR DESCRIPTION
## Brief Description
Added redirection for the PIIRRITE ontology.

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Optional Requests for W3ID Maintainers
- [x] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
