### PR TITLE
Add persistent identifiers for the cMod ontology suite

### DIFF
--- a/cMod/.htaccess
+++ b/cMod/.htaccess
@@ -1,0 +1,27 @@
+# cMod – Chronological Model Ontology Suite
+# Persistent identifiers for OCP, OCCP, OULD, and AMO.
+#
+# https://github.com/DigitalizeMe/cMod
+# https://digitalizeme.github.io/cMod/
+#
+# Administered by:
+# Albrecht Vaatz
+# ORCID: 0009-0008-9255-2107
+# GitHub username: DigitalizeMe
+# Email: 97295430+DigitalizeMe@users.noreply.github.com
+#
+# Use 302 (temporary) while the stub is the target, so browsers do not
+# cache the redirect after RDF/HTML content negotiation is added.
+
+Header set Access-Control-Allow-Origin *
+Options +FollowSymLinks
+RewriteEngine on
+
+# Module IRIs (with or without trailing slash or extra path)
+RewriteRule ^(ocp|occp|ould|amo)(/.*)?$ https://digitalizeme.github.io/cMod/ [R=302,L]
+
+# Suite IRI
+RewriteRule ^$ https://digitalizeme.github.io/cMod/ [R=302,L]
+
+# Any other path under /cmod
+RewriteRule ^.+$ https://digitalizeme.github.io/cMod/ [R=302,L]

--- a/cMod/.htaccess
+++ b/cMod/.htaccess
@@ -8,7 +8,8 @@
 # Albrecht Vaatz
 # ORCID: 0009-0008-9255-2107
 # GitHub username: DigitalizeMe
-# Email: 97295430+DigitalizeMe@users.noreply.github.com
+# Email: albrecht.vaatz@mailbox.tu-dresden.de
+# Email 2: 97295430+DigitalizeMe@users.noreply.github.com
 #
 # Use 302 (temporary) while the stub is the target, so browsers do not
 # cache the redirect after RDF/HTML content negotiation is added.

--- a/cMod/README.md
+++ b/cMod/README.md
@@ -11,6 +11,6 @@ This repository is the public home of the suite identifiers. The RDF release fol
 | **OULD** | https://w3id.org/cMod/ould | Updates, linked data, and provenance |
 | **AMO** | https://w3id.org/cMod/amo | Areas, anchors, and spatial scope |
 
-Namespace for terms: append `#` (e.g. `https://w3id.org/cMod/ocp#`).
+Namespace for terms: append `#` (e.g., `https://w3id.org/cMod/ocp#`).
 
 **Maintainer:** Albrecht Vaatz · [ORCID](https://orcid.org/0009-0008-9255-2107) · [DigitalizeMe](https://github.com/DigitalizeMe) · [E-Mail](albrecht.vaatz@mailbox.tu-dresden.de)

--- a/cMod/README.md
+++ b/cMod/README.md
@@ -6,11 +6,11 @@ This repository is the public home of the suite identifiers. The RDF release fol
 
 | Module | IRI | Role |
 |--------|-----|------|
-| **OCP** | https://w3id.org/cmod/ocp | Chronological processes (OWL-Time extension) |
-| **OCCP** | https://w3id.org/cmod/occp | Construction phases and lifecycles |
-| **OULD** | https://w3id.org/cmod/ould | Updates, linked data, and provenance |
-| **AMO** | https://w3id.org/cmod/amo | Areas, anchors, and spatial scope |
+| **OCP** | https://w3id.org/cMod/ocp | Chronological processes (OWL-Time extension) |
+| **OCCP** | https://w3id.org/cMod/occp | Construction phases and lifecycles |
+| **OULD** | https://w3id.org/cMod/ould | Updates, linked data, and provenance |
+| **AMO** | https://w3id.org/cMod/amo | Areas, anchors, and spatial scope |
 
-Namespace for terms: append `#` (e.g. `https://w3id.org/cmod/ocp#`).
+Namespace for terms: append `#` (e.g. `https://w3id.org/cMod/ocp#`).
 
 **Maintainer:** Albrecht Vaatz · [ORCID](https://orcid.org/0009-0008-9255-2107) · [DigitalizeMe](https://github.com/DigitalizeMe)

--- a/cMod/README.md
+++ b/cMod/README.md
@@ -13,4 +13,4 @@ This repository is the public home of the suite identifiers. The RDF release fol
 
 Namespace for terms: append `#` (e.g. `https://w3id.org/cMod/ocp#`).
 
-**Maintainer:** Albrecht Vaatz · [ORCID](https://orcid.org/0009-0008-9255-2107) · [DigitalizeMe](https://github.com/DigitalizeMe)
+**Maintainer:** Albrecht Vaatz · [ORCID](https://orcid.org/0009-0008-9255-2107) · [DigitalizeMe](https://github.com/DigitalizeMe) · [E-Mail](albrecht.vaatz@mailbox.tu-dresden.de)

--- a/cMod/README.md
+++ b/cMod/README.md
@@ -1,0 +1,16 @@
+# cMod – Chronological Model Ontology Suite
+
+A modular ontology suite for chronological processes, construction lifecycles, updates, and spatial scoping of built assets. cMod comprises four coordinated ontologies (OCP, OCCP, OULD, AMO) and builds on OWL-Time, PROV-O, and GeoSPARQL.
+
+This repository is the public home of the suite identifiers. The RDF release follows with the dissertation.
+
+| Module | IRI | Role |
+|--------|-----|------|
+| **OCP** | https://w3id.org/cmod/ocp | Chronological processes (OWL-Time extension) |
+| **OCCP** | https://w3id.org/cmod/occp | Construction phases and lifecycles |
+| **OULD** | https://w3id.org/cmod/ould | Updates, linked data, and provenance |
+| **AMO** | https://w3id.org/cmod/amo | Areas, anchors, and spatial scope |
+
+Namespace for terms: append `#` (e.g. `https://w3id.org/cmod/ocp#`).
+
+**Maintainer:** Albrecht Vaatz · [ORCID](https://orcid.org/0009-0008-9255-2107) · [DigitalizeMe](https://github.com/DigitalizeMe)


### PR DESCRIPTION
This PR reserves https://w3id.org/cMod for the cMod (Chronological Model) ontology suite.

cMod is a modular OWL suite for chronological processes, construction lifecycles, updates, and spatial scoping of built assets. It comprises four ontologies (OCP, OCCP, OULD, AMO) and builds on W3C OWL-Time, PROV-O, and GeoSPARQL.

Requested identifiers (folder `cMod/`):

- https://w3id.org/cMod
- https://w3id.org/cMod/ocp
- https://w3id.org/cMod/occp
- https://w3id.org/cMod/ould
- https://w3id.org/cMod/amo

Until the dissertation is completed, all of these IRIs redirect with HTTP 302 to the public stub page:

https://digitalizeme.github.io/cMod/

RDF serializations and HTML documentation will be attached later via content negotiation. The w3id paths will not change.

Maintainer: Albrecht Vaatz
ORCID: https://orcid.org/0009-0008-9255-2107
E-Mail: albrecht.vaatz@mailbox.tu-dresden.de
GitHub: DigitalizeMe
Repository: https://github.com/DigitalizeMe/cMod