### PR TITLE
sstim: route three new public preset identities

### DIFF
--- a/ids/sstim/.htaccess
+++ b/ids/sstim/.htaccess
@@ -248,15 +248,15 @@ RewriteRule ^(implementation/bsclab|implementation/biosyncare|implementation/bsc
 # -------------------------------------------------------------------------
 # BEGIN audited BSC preset and reference routes
 RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/html|application/xhtml\+xml)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
-RewriteRule ^implementation/bsclab/preset/(heal-theta-breathing-seed|perform-alpha-10-seed)/?$ https://w3c-cg.github.io/sstim/graph/#bsclab-preset:$1 [R=303,L,NE]
+RewriteRule ^implementation/bsclab/preset/(heal-theta-breathing-seed|perform-alpha-10-seed|support-smr-focus-seed|indulge-alpha-warmth-seed|transcend-theta-drift-seed)/?$ https://w3c-cg.github.io/sstim/graph/#bsclab-preset:$1 [R=303,L,NE]
 
 RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/html|application/xhtml\+xml)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
 RewriteRule ^ref/(INGENDOH_2023|PICTON_2003|SKOE_KRAUS_2010|ZACCARO_2018|VIALATTE_2010|PETIT_2021|STEIN_STANFORD_2008|KLIMESCH_1999|KLIMESCH_2012|FRIES_2009|BUZSAKI_2004)/?$ https://w3c-cg.github.io/sstim/graph/#sstim-ref:$1 [R=303,L,NE]
 
 RewriteCond %{HTTP_ACCEPT} ^$ [OR]
 RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/turtle|application/x-turtle|\*/\*)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]
-RewriteRule ^implementation/bsclab/preset/(heal-theta-breathing-seed|perform-alpha-10-seed)/?$ https://w3c-cg.github.io/sstim/ontology/instances/presets/$1.ttl [R=303,L]
-RewriteRule ^implementation/bsclab/preset/(heal-theta-breathing-seed|perform-alpha-10-seed)/?$ - [R=406,L]
+RewriteRule ^implementation/bsclab/preset/(heal-theta-breathing-seed|perform-alpha-10-seed|support-smr-focus-seed|indulge-alpha-warmth-seed|transcend-theta-drift-seed)/?$ https://w3c-cg.github.io/sstim/ontology/instances/presets/$1.ttl [R=303,L]
+RewriteRule ^implementation/bsclab/preset/(heal-theta-breathing-seed|perform-alpha-10-seed|support-smr-focus-seed|indulge-alpha-warmth-seed|transcend-theta-drift-seed)/?$ - [R=406,L]
 
 RewriteCond %{HTTP_ACCEPT} ^$ [OR]
 RewriteCond %{HTTP_ACCEPT} (?:^|,)\s*(?:text/turtle|application/x-turtle|\*/\*)\s*(?=;|,|$)(?![^,]*;\s*q\s*=\s*0(?:\.0*)?\s*(?:;|,|$)) [NC]


### PR DESCRIPTION
<!-- Recommended W3ID Pull Request Details. Please adjust as needed. -->
## Brief Description

The SSTIM reference preset catalog grew from two public records to five, one per catalog group. This adds the three new identities to the existing audited preset alternation in `ids/sstim/.htaccess`:

- `support-smr-focus-seed`
- `indulge-alpha-warmth-seed`
- `transcend-theta-drift-seed`

Three lines changed, all inside the block already delimited by `BEGIN/END audited BSC preset and reference routes`. No new rule, no new target pattern, no content-type change, and no change to any existing identity.

That block is an exact audited inventory rather than a namespace wildcard, deliberately, so adding a public record is an intentional registry update. Version snapshots are unaffected: they keep the wildcard patterns added in #6548, so cutting a release still needs no PR here.

## General Checklist
<!-- For all ID related PRs. -->
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

Testing: the three redirect targets are published and return `200`:

```
https://w3c-cg.github.io/sstim/ontology/instances/presets/support-smr-focus-seed.ttl
https://w3c-cg.github.io/sstim/ontology/instances/presets/indulge-alpha-warmth-seed.ttl
https://w3c-cg.github.io/sstim/ontology/instances/presets/transcend-theta-drift-seed.ttl
```

These rules are also executed in the source repository's CI against every committed preset, which fails if a public record lacks an exact route, or if a route points at a file that does not own that subject.

## New ID Directory Checklist
<!-- For new ID PRs. -->

Not applicable; `ids/sstim/` already exists.

## Update ID Directory Checklist
<!-- For updated ID PRs. -->
- [x] GitHub username ids are listed in the changed maintainer details.
- [x] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

The maintainer line in `ids/sstim/.htaccess` reads `Renato Fabbri <renato.fabbri@gmail.com>, GitHub @ttm`, which is the account submitting this PR.

## Optional Requests for W3ID Maintainers
<!-- Optional requests for any PR. -->
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.

---

Drafted with LLM assistance and reviewed before submission.
