### PR TITLE
Add OMARO persistent identifiers

### DIFF
--- a/ids/modavis/omaro/.htaccess
+++ b/ids/modavis/omaro/.htaccess
@@ -8,17 +8,26 @@ RewriteEngine On
 
 # The hash-term namespace resolves as the current ontology document.
 RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
-RewriteRule ^$ https://modavis-project.github.io/omaro/ontology/2.2.0/omaro.jsonld [R=303,L]
+RewriteRule ^$ https://modavis-project.github.io/omaro/ontology/0.1.0/omaro.jsonld [R=303,L]
 RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
-RewriteRule ^$ https://modavis-project.github.io/omaro/ontology/2.2.0/omaro.ttl [R=303,L]
+RewriteRule ^$ https://modavis-project.github.io/omaro/ontology/0.1.0/omaro.ttl [R=303,L]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
-RewriteRule ^$ https://modavis-project.github.io/omaro/ontology/2.2.0/omaro.rdf [R=303,L]
-RewriteRule ^$ https://modavis-project.github.io/omaro/ontology/2.2.0/index.html [R=303,L]
+RewriteRule ^$ https://modavis-project.github.io/omaro/ontology/0.1.0/omaro.rdf [R=303,L]
+RewriteRule ^$ https://modavis-project.github.io/omaro/ontology/0.1.0/index.html [R=303,L]
 
 # The stable ontology IRI follows the current compatible ontology release.
-RewriteRule ^ontology/?$ https://w3id.org/modavis/omaro/ontology/2.2.0 [R=302,L]
+RewriteRule ^ontology/?$ https://w3id.org/modavis/omaro/ontology/0.1.0 [R=302,L]
 
-# Versioned ontology 2.2.0.
+# Versioned ontology 0.1.0.
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^ontology/0\.1\.0/?$ https://modavis-project.github.io/omaro/ontology/0.1.0/omaro.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^ontology/0\.1\.0/?$ https://modavis-project.github.io/omaro/ontology/0.1.0/omaro.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^ontology/0\.1\.0/?$ https://modavis-project.github.io/omaro/ontology/0.1.0/omaro.rdf [R=303,L]
+RewriteRule ^ontology/0\.1\.0/?$ https://modavis-project.github.io/omaro/ontology/0.1.0/index.html [R=303,L]
+
+# Historical ontology documents used by existing MODAVIS snapshots.
 RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
 RewriteRule ^ontology/2\.2\.0/?$ https://modavis-project.github.io/omaro/ontology/2.2.0/omaro.jsonld [R=303,L]
 RewriteCond %{HTTP_ACCEPT} text/turtle [NC]

--- a/ids/modavis/omaro/.htaccess
+++ b/ids/modavis/omaro/.htaccess
@@ -1,0 +1,43 @@
+# OMARO permanent identifiers.
+# Versioned ontology and dataset targets are immutable.
+# Maintainer: Dominik Ukolov (ORCID: 0000-0002-7904-3892)
+# GitHub: @modavis-project
+
+Options -MultiViews
+RewriteEngine On
+
+# The hash-term namespace resolves as the current ontology document.
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^$ https://modavis-project.github.io/omaro/ontology/2.2.0/omaro.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^$ https://modavis-project.github.io/omaro/ontology/2.2.0/omaro.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^$ https://modavis-project.github.io/omaro/ontology/2.2.0/omaro.rdf [R=303,L]
+RewriteRule ^$ https://modavis-project.github.io/omaro/ontology/2.2.0/index.html [R=303,L]
+
+# The stable ontology IRI follows the current compatible ontology release.
+RewriteRule ^ontology/?$ https://w3id.org/modavis/omaro/ontology/2.2.0 [R=302,L]
+
+# Versioned ontology 2.2.0.
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^ontology/2\.2\.0/?$ https://modavis-project.github.io/omaro/ontology/2.2.0/omaro.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^ontology/2\.2\.0/?$ https://modavis-project.github.io/omaro/ontology/2.2.0/omaro.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^ontology/2\.2\.0/?$ https://modavis-project.github.io/omaro/ontology/2.2.0/omaro.rdf [R=303,L]
+RewriteRule ^ontology/2\.2\.0/?$ https://modavis-project.github.io/omaro/ontology/2.2.0/index.html [R=303,L]
+
+# The stable dataset IRI follows the current dataset release.
+RewriteRule ^dataset/?$ https://w3id.org/modavis/omaro/dataset/0.1.0 [R=302,L]
+
+# Versioned reference dataset 0.1.0.
+RewriteCond %{HTTP_ACCEPT} application/ld\+json [NC]
+RewriteRule ^dataset/0\.1\.0/?$ https://modavis-project.github.io/omaro/dataset/0.1.0/omaro.jsonld [R=303,L]
+RewriteCond %{HTTP_ACCEPT} text/turtle [NC]
+RewriteRule ^dataset/0\.1\.0/?$ https://modavis-project.github.io/omaro/dataset/0.1.0/omaro.ttl [R=303,L]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [NC]
+RewriteRule ^dataset/0\.1\.0/?$ https://modavis-project.github.io/omaro/dataset/0.1.0/omaro.rdf [R=303,L]
+RewriteRule ^dataset/0\.1\.0/?$ https://modavis-project.github.io/omaro/dataset/0.1.0/index.html [R=303,L]
+
+# Canonical JSON Schemas and SHACL are published with their native filenames.
+RewriteRule ^schema/([A-Za-z0-9._-]+)$ https://modavis-project.github.io/omaro/schema/$1 [R=303,L,NE]

--- a/ids/modavis/omaro/README.md
+++ b/ids/modavis/omaro/README.md
@@ -1,0 +1,25 @@
+# OMARO permanent identifiers
+
+This directory defines the W3ID namespace for **OMARO: Ontology for
+Multiperspectivity, Assertions, and Review in Organology**.
+
+```text
+https://w3id.org/modavis/omaro
+```
+
+The namespace provides content-negotiated HTML, Turtle, JSON-LD, and RDF/XML
+representations for ontology version 2.2.0; a landing page and RDF
+representations for reference dataset 0.1.0; and redirects for the published
+JSON Schema and SHACL files. Versioned targets are immutable. Unversioned
+ontology and dataset routes may advance under the OMARO persistence and release
+policy.
+
+Project repository:
+<https://github.com/modavis-project/omaro>
+
+## Maintainer
+
+- Dominik Ukolov — [ORCID 0000-0002-7904-3892](https://orcid.org/0000-0002-7904-3892)
+- GitHub: [@modavis-project](https://github.com/modavis-project)
+- Affiliation: Digital Humanities (Image/Object), Friedrich Schiller University
+  Jena; Research Group DIGITAL ORGANOLOGY, Leipzig University

--- a/ids/modavis/omaro/README.md
+++ b/ids/modavis/omaro/README.md
@@ -8,7 +8,7 @@ https://w3id.org/modavis/omaro
 ```
 
 The namespace provides content-negotiated HTML, Turtle, JSON-LD, and RDF/XML
-representations for ontology version 2.2.0; a landing page and RDF
+representations for ontology version 0.1.0; a landing page and RDF
 representations for reference dataset 0.1.0; and redirects for the published
 JSON Schema and SHACL files. Versioned targets are immutable. Unversioned
 ontology and dataset routes may advance under the OMARO persistence and release
@@ -23,3 +23,6 @@ Project repository:
 - GitHub: [@modavis-project](https://github.com/modavis-project)
 - Affiliation: Digital Humanities (Image/Object), Friedrich Schiller University
   Jena; Research Group DIGITAL ORGANOLOGY, Leipzig University
+
+The historical `/ontology/2.2.0` route retains the original RDF documents used
+by existing MODAVIS reference snapshots. It does not redirect to 0.1.0.


### PR DESCRIPTION
Adds `/modavis/omaro` for the Ontology for Multiperspectivity, Assertions, and Review in Organology, part of the PhD project MODAVIS (which will actually be submitted today, so this will be one of the last merge requests for now — thanks for checking the previous ones at this point!).

The routes cover ontology 0.1.0, reference dataset 0.1.0, and validation schemas. HTML, Turtle, JSON-LD and RDF/XML requests resolve to the corresponding GitHub Pages files. Versioned ontology and dataset URLs use versioned targets; the unversioned aliases follow the current versions.

The historical ontology 2.2.0 URL keeps its original RDF documents for existing MODAVIS snapshots. It does not redirect to the 0.1.0 ontology.

It was tested with Apache against the existing MODAVIS parent configuration: 65 checks passed for redirects, content negotiation, trailing slashes and unknown versions.

Maintainer: Dominik Ukolov, [ORCID 0000-0002-7904-3892](https://orcid.org/0000-0002-7904-3892), @modavis-project.
