### PR TITLE
Add /soranoha/ identifier for Soranoha

### DIFF
--- a/ids/soranoha/.htaccess
+++ b/ids/soranoha/.htaccess
@@ -1,0 +1,29 @@
+# # /soranoha/
+#
+# Permanent identifiers for Soranoha, a conversion and signed-publication
+# system for Aozora Bunko texts as TEI P5.
+#
+# https://w3id.org/soranoha/ns/...       TEI extension vocabulary namespaces
+# https://w3id.org/soranoha/rights       the published rights statement
+# https://w3id.org/soranoha/mappings/... conversion mapping documents
+# https://w3id.org/soranoha/policies/... policy documents
+# https://w3id.org/soranoha/schemas/...  record schema identifiers
+# https://w3id.org/soranoha/works/...    published work landing pages
+#
+# 302 rather than 301 throughout: the redirect target is a current location,
+# and permanent client-side caching would defeat the purpose of the service.
+#
+# ## Contact
+# Bor Hodošček
+# GitHub username: borh
+# ORCID: https://orcid.org/0000-0003-2246-8774
+
+RewriteEngine on
+
+RewriteRule ^ns/(.*)$       https://soranoha.org/ns/$1       [R=302,L]
+RewriteRule ^rights$        https://soranoha.org/rights      [R=302,L]
+RewriteRule ^mappings/(.*)$ https://soranoha.org/mappings/$1 [R=302,L]
+RewriteRule ^policies/(.*)$ https://soranoha.org/policies/$1 [R=302,L]
+RewriteRule ^schemas/(.*)$  https://soranoha.org/schemas/$1  [R=302,L]
+RewriteRule ^works/(.*)$    https://soranoha.org/works/$1    [R=302,L]
+RewriteRule ^$              https://soranoha.org/            [R=302,L]

--- a/ids/soranoha/README.md
+++ b/ids/soranoha/README.md
@@ -1,0 +1,27 @@
+# /soranoha/
+
+Permanent identifiers for [Soranoha](https://soranoha.org/), a conversion and
+signed-publication system that produces TEI P5 transcriptions and derived
+plaintext and Markdown from [Aozora Bunko](https://www.aozora.gr.jp/) source
+markup.
+
+These identifiers appear in published TEI bytes and in records that are
+content-addressed and signed, so they must remain stable independently of where
+the project is served.
+
+| Prefix | Denotes |
+|---|---|
+| `/soranoha/ns/` | TEI extension vocabulary namespaces |
+| `/soranoha/rights` | The rights statement every release and file cites |
+| `/soranoha/mappings/` | Conversion mapping documents the toolchain names |
+| `/soranoha/policies/` | Policy documents the toolchain names |
+| `/soranoha/schemas/` | Record schema identifiers embedded in published records |
+| `/soranoha/works/` | Landing pages for published works |
+
+All rules redirect with 302, because the target is a current serving location
+rather than a permanent one.
+
+## Contact
+
+Bor Hodošček (GitHub [@borh](https://github.com/borh),
+ORCID [0000-0003-2246-8774](https://orcid.org/0000-0003-2246-8774)).


### PR DESCRIPTION
## Brief Description
Register `/soranoha/` for Soranoha, a conversion and signed-publication system that produces TEI P5 transcriptions of Aozora Bunko texts. The identifiers appear in published TEI and in content-addressed, signed records, so they need a location independent of where the project is served. All rules redirect to `https://soranoha.org/`, which resolves today.

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
- [ ] GitHub username ids are listed in the changed maintainer details.
- [ ] The GitHub account submitting this PR is listed as a maintainer of the directories and files changed in this PR or one or more of those maintainers are tagged to approve these changes.

## Optional Requests for W3ID Maintainers
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.
