### PR TITLE
Add PurRDF namespace: /purrdf/markdown vocabulary redirect

### DIFF
--- a/ids/purrdf/.htaccess
+++ b/ids/purrdf/.htaccess
@@ -1,0 +1,32 @@
+# # /purrdf/
+#
+# Permanent identifiers for vocabulary namespaces published by the PurRDF project.
+#
+# https://w3id.org/purrdf/markdown
+#   redirects to https://blackcatinformatics.ca/purrdf/markdown
+#   Namespace IRI: https://w3id.org/purrdf/markdown#
+#   Terms are named by fragment (e.g. .../markdown#Document, .../markdown#cites),
+#   so the base URL above is the only one ever dereferenced. A fragment is not
+#   sent to a server, so no per-term rules are needed.
+#
+# 302 rather than 301: the target is provisional. It presently serves a 303
+# onward to the project page, and will change shape once a vocabulary document
+# is published at that address. This entry does not change when it does; a 301
+# would pin a location that is meant to move.
+#
+# Repository: https://github.com/Blackcat-Informatics/purrdf
+#
+# ## Contact
+# This space is administered by:
+#
+# Patrick Audley, Blackcat Informatics Inc.
+# paudley@blackcat.ca
+# GitHub username: paudley
+
+RewriteEngine on
+
+# Vocabulary of the structural Markdown-to-RDF 1.2 slicing law (hash namespace).
+RewriteRule ^markdown/?$ https://blackcatinformatics.ca/purrdf/markdown [R=302,L]
+
+# The namespace root.
+RewriteRule ^$ https://blackcatinformatics.ca/purrdf/ [R=302,L]

--- a/ids/purrdf/README.md
+++ b/ids/purrdf/README.md
@@ -1,0 +1,38 @@
+# /purrdf/
+
+Permanent identifiers for vocabulary namespaces published by the
+[PurRDF](https://github.com/Blackcat-Informatics/purrdf) project.
+
+## Identifiers
+
+| Identifier | Resolves to | What it is |
+| --- | --- | --- |
+| `https://w3id.org/purrdf/markdown` | https://blackcatinformatics.ca/purrdf/markdown | Vocabulary for the structural Markdown-to-RDF 1.2 slicing law |
+| `https://w3id.org/purrdf/` | https://blackcatinformatics.ca/purrdf/ | The project page |
+
+## markdown
+
+`https://w3id.org/purrdf/markdown#` is a hash namespace: terms are named by
+fragment — `#Document`, `#cites`, `#headingText` and so on. A fragment is never
+sent to a server, so the base URL `https://w3id.org/purrdf/markdown` is the only
+one that is ever dereferenced, and one rewrite rule covers the whole vocabulary.
+
+The namespace identifies the vocabulary of a specification that defines a
+deterministic, stand-off function from the bytes of a Markdown document to an
+RDF 1.2 graph projected along that document's own structure. The specification
+is published in the PurRDF repository at `crates/markdown/SPEC.md`.
+
+It is a specification published by this project and offered for use. It is not
+a standard, and it has not been ratified or endorsed by any standards body.
+
+## Why 302 rather than 301
+
+The target is provisional. It currently issues a 303 onward to the PurRDF
+project page. When a vocabulary document (`markdown.ttl` and siblings) is
+generated, the rule at the origin changes shape while this w3id entry stays
+exactly as filed. A 301 would pin a location that is intended to move.
+
+## Maintainer
+
+Patrick Audley, Blackcat Informatics Inc. — paudley@blackcat.ca,
+GitHub: [@paudley](https://github.com/paudley)


### PR DESCRIPTION
## Brief Description

Claims the `purrdf/` top-level directory for the PurRDF project and adds a rule for `markdown` inside it, per the Naming Policy (`https://w3id.org/PROJECT-ID/SUB-ID`). The project expects to register sibling namespaces under the same directory later.

**What the namespace identifies.** `https://w3id.org/purrdf/markdown#` is the vocabulary namespace of a specification defining a deterministic, stand-off function from the bytes of a Markdown document to an RDF 1.2 graph projected along that document's own structure. The specification is published in the PurRDF repository (https://github.com/Blackcat-Informatics/purrdf) at `crates/markdown/SPEC.md`. It is published by that project and offered for use; it is not a standard and has not been ratified or endorsed by any standards body.

**Hash namespace.** Terms are named by fragment — `#Document`, `#cites`, `#headingText`. A fragment is not sent to a server, so `https://w3id.org/purrdf/markdown` is the only URL ever dereferenced and one rewrite rule covers the whole vocabulary. No per-term rules are needed.

**302, not 301.** The target is provisional: it presently issues a 303 onward to the project page and will change shape once a vocabulary document (`markdown.ttl` and siblings) is published at that address. This entry stays exactly as filed when that happens. A 301 would pin a location that is meant to move.

**Maintainer.** Patrick Audley, Blackcat Informatics Inc. — paudley@blackcat.ca, GitHub: @paudley. Recorded in both `.htaccess` and `README.md`.

Rules added in `ids/purrdf/.htaccess`:

```ApacheConf
RewriteRule ^markdown/?$ https://blackcatinformatics.ca/purrdf/markdown [R=302,L]
RewriteRule ^$           https://blackcatinformatics.ca/purrdf/         [R=302,L]
```

## General Checklist
- [x] Changes have been tested.
- [x] The number of commits is minimal. Squash if needed.
- [x] Commits only include redirects and basic information. Serving content and full documentation is not supported on this service.

Testing performed: both redirect targets were confirmed live before filing —
`https://blackcatinformatics.ca/purrdf/markdown` returns `303` to
`https://blackcatinformatics.ca/purrdf/`, which returns `200`. The two patterns were
checked against matching inputs (`markdown`, `markdown/`, ``) and against neighbouring
non-matching ones (`markdownfoo`, `markdown/extra`, `other`), which correctly fall
through rather than redirecting.

## New ID Directory Checklist
- [x] Maintainer details are in `.htaccess` or `README.md`.
- [x] GitHub username ids are listed in the maintainer details.

## Update ID Directory Checklist
<!-- Not applicable: this is a new ID directory. -->

## Optional Requests for W3ID Maintainers
- [ ] Please squash commits for me. I understand this will likely require resyncing my local repository before making further PRs.

<!-- Not needed: this PR is already a single commit. -->
