### PR TITLE
Add gridalyn: persistent identifiers for the gridalyn SDK's vocabularies

### DIFF
--- a/ids/gridalyn/.htaccess
+++ b/ids/gridalyn/.htaccess
@@ -1,0 +1,31 @@
+# w3id.org/gridalyn -- persistent identifiers for the vocabularies of the
+# gridalyn SDK (https://github.com/lirei-lab/gridalyn).
+#
+# Maintainer: Nilson Henao <lirei.info@uqtr.ca> (GitHub: @nilsonfh)
+# The source of this file is tools/w3id/gridalyn/ in the gridalyn repository.
+#
+# Each vocabulary is a hash namespace, e.g.
+# https://w3id.org/gridalyn/ontology/flexint#CurtailmentContract. The fragment
+# never reaches the server: a rule matches the vocabulary path, and the client
+# re-applies the fragment to the page it is redirected to, where every term has
+# an anchor of its own. GitHub Pages does no content negotiation, so Turtle and
+# HTML are redirected to separate files here.
+
+Options +FollowSymLinks
+RewriteEngine on
+
+# Turtle, for RDF clients
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^ontology/digital-twin/?$ https://lirei.ca/gridalyn/ontology/digital-twin.ttl [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteRule ^ontology/flexint/?$ https://lirei.ca/gridalyn/ontology/flexint.ttl [R=303,L]
+
+# HTML, for everything else
+RewriteRule ^ontology/digital-twin/?$ https://lirei.ca/gridalyn/reference/ontology/digital-twin/ [R=303,L]
+RewriteRule ^ontology/flexint/?$ https://lirei.ca/gridalyn/reference/ontology/flexint/ [R=303,L]
+
+# The project itself
+RewriteRule ^$ https://lirei.ca/gridalyn/ [R=302,L]

--- a/ids/gridalyn/README.md
+++ b/ids/gridalyn/README.md
@@ -1,0 +1,21 @@
+# gridalyn
+
+Persistent identifiers for the vocabularies of
+[gridalyn](https://github.com/lirei-lab/gridalyn), an open-source Python SDK for
+modelling, simulating and optimizing electric distribution systems and the
+flexibility of their distributed energy resources.
+
+| Identifier | Browser (HTML) | RDF client (Turtle) |
+| --- | --- | --- |
+| `https://w3id.org/gridalyn/ontology/digital-twin#` | https://lirei.ca/gridalyn/reference/ontology/digital-twin/ | https://lirei.ca/gridalyn/ontology/digital-twin.ttl |
+| `https://w3id.org/gridalyn/ontology/flexint#` | https://lirei.ca/gridalyn/reference/ontology/flexint/ | https://lirei.ca/gridalyn/ontology/flexint.ttl |
+
+`https://w3id.org/gridalyn/` redirects to the project documentation.
+
+Both documents are generated from the vocabulary declarations in the gridalyn
+repository and published with its documentation site.
+
+## Contact
+
+- Nilson Henao — lirei.info@uqtr.ca
+- GitHub: [@nilsonfh](https://github.com/nilsonfh)


### PR DESCRIPTION
Adds `ids/gridalyn/` with an `.htaccess` and a `README.md`.

[gridalyn](https://github.com/lirei-lab/gridalyn) is an open-source Python SDK for modelling, simulating and optimizing electric distribution systems and the flexibility of their distributed energy resources. Two of its vocabularies need persistent identifiers:

| Identifier | Browser (HTML) | RDF client (Turtle) |
| --- | --- | --- |
| `https://w3id.org/gridalyn/ontology/digital-twin#` | https://lirei.ca/gridalyn/reference/ontology/digital-twin/ | https://lirei.ca/gridalyn/ontology/digital-twin.ttl |
| `https://w3id.org/gridalyn/ontology/flexint#` | https://lirei.ca/gridalyn/reference/ontology/flexint/ | https://lirei.ca/gridalyn/ontology/flexint.ttl |

Both are hash namespaces, e.g. `https://w3id.org/gridalyn/ontology/flexint#CurtailmentContract`. The fragment never reaches the server: a rule matches the vocabulary path and the client re-applies the fragment to the page it lands on, where every term has an anchor of its own.

The targets are served by GitHub Pages, which does no content negotiation, so the rules do it here: a request whose `Accept` names `text/turtle` (or `application/x-turtle`) gets a 303 to the Turtle file, and anything else a 303 to the reference page. `https://w3id.org/gridalyn/` redirects (302) to the project documentation.

Both documents are generated from the vocabulary declarations in the gridalyn repository and published with its documentation site, where a test fails if either goes stale. The redirect rules in this pull request are kept in that repository too, under `tools/w3id/gridalyn/`.

Contact: Nilson Henao <lirei.info@uqtr.ca> (GitHub [@nilsonfh](https://github.com/nilsonfh)), stated in both the `.htaccess` comments and the `README.md`.
